### PR TITLE
fix: email parameters being parsed incorrectly

### DIFF
--- a/backend/pkg/utils/notifications/email_sender.go
+++ b/backend/pkg/utils/notifications/email_sender.go
@@ -4,57 +4,141 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/nicholas-fedor/shoutrrr"
+	shoutrrrSMTP "github.com/nicholas-fedor/shoutrrr/pkg/services/email/smtp"
 	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-// BuildSMTPURL converts EmailConfig to Shoutrrr URL format
-// URL example: smtp://user:pass@host:port/?fromAddress=...&toAddresses=...&useHTML=yes
-func BuildSMTPURL(config models.EmailConfig) (string, error) {
-	u := &url.URL{
-		Scheme: "smtp",
-		Host:   fmt.Sprintf("%s:%d", config.SMTPHost, config.SMTPPort),
-		Path:   "/",
+const (
+	defaultSMTPClientHost = "localhost"
+	defaultSMTPTimeout    = 10 * time.Second
+)
+
+type smtpBuildOptions struct {
+	skipTLSVerify bool
+	timeout       time.Duration
+}
+
+func buildSMTPConfigInternal(config models.EmailConfig, options smtpBuildOptions) (*shoutrrrSMTP.Config, error) {
+	port, err := smtpPortFromConfigInternal(config.SMTPPort)
+	if err != nil {
+		return nil, err
+	}
+
+	smtpConfig := &shoutrrrSMTP.Config{
+		Host:          config.SMTPHost,
+		Port:          port,
+		Username:      config.SMTPUsername,
+		Password:      config.SMTPPassword,
+		FromAddress:   config.FromAddress,
+		ToAddresses:   config.ToAddresses,
+		Auth:          shoutrrrSMTP.AuthTypes.None,
+		Encryption:    shoutrrrSMTP.EncMethods.None,
+		UseStartTLS:   false,
+		UseHTML:       true,
+		ClientHost:    defaultSMTPClientHost,
+		Timeout:       smtpTimeoutFromOptionsInternal(options),
+		SkipTLSVerify: options.skipTLSVerify,
 	}
 
 	if config.SMTPUsername != "" || config.SMTPPassword != "" {
-		u.User = url.UserPassword(config.SMTPUsername, config.SMTPPassword)
+		smtpConfig.Auth = shoutrrrSMTP.AuthTypes.Plain
 	}
 
-	q := u.Query()
-	q.Set("fromAddress", config.FromAddress)
-	q.Set("toAddresses", strings.Join(config.ToAddresses, ","))
-	q.Set("useHTML", "yes")
-
-	// TLS Mode Mapping
-	// none -> encryption=None, useStartTLS=no
-	// starttls -> encryption=ExplicitTLS, useStartTLS=yes
-	// ssl -> encryption=ImplicitTLS, useStartTLS=no
 	switch config.TLSMode {
 	case models.EmailTLSModeNone:
-		q.Set("encryption", "None")
-		q.Set("useStartTLS", "no")
+		smtpConfig.Encryption = shoutrrrSMTP.EncMethods.None
+		smtpConfig.UseStartTLS = false
 	case models.EmailTLSModeStartTLS:
-		q.Set("encryption", "ExplicitTLS")
-		q.Set("useStartTLS", "yes")
+		smtpConfig.Encryption = shoutrrrSMTP.EncMethods.Auto
+		smtpConfig.UseStartTLS = true
+		smtpConfig.RequireStartTLS = true
 	case models.EmailTLSModeSSL:
-		q.Set("encryption", "ImplicitTLS")
-		q.Set("useStartTLS", "no")
+		smtpConfig.Encryption = shoutrrrSMTP.EncMethods.ImplicitTLS
 	default:
-		q.Set("encryption", "None")
-		q.Set("useStartTLS", "no")
+		smtpConfig.Encryption = shoutrrrSMTP.EncMethods.None
+		smtpConfig.UseStartTLS = false
 	}
 
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	return smtpConfig, nil
+}
+
+func smtpPortFromConfigInternal(port int) (uint16, error) {
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("invalid SMTP port: %d", port)
+	}
+
+	return uint16(port), nil
+}
+
+func smtpTimeoutFromOptionsInternal(options smtpBuildOptions) time.Duration {
+	if options.timeout > 0 {
+		return options.timeout
+	}
+
+	return defaultSMTPTimeout
+}
+
+func smtpBuildOptionsFromContextInternal(ctx context.Context) smtpBuildOptions {
+	options := smtpBuildOptions{}
+	if ctx == nil {
+		return options
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout := time.Until(deadline)
+		if timeout > 0 && timeout < defaultSMTPTimeout {
+			options.timeout = timeout
+		}
+	}
+
+	return options
+}
+
+func buildSMTPURLInternal(config models.EmailConfig, options smtpBuildOptions) (string, error) {
+	smtpConfig, err := buildSMTPConfigInternal(config, options)
+	if err != nil {
+		return "", fmt.Errorf("failed to build SMTP config: %w", err)
+	}
+
+	u := smtpConfig.GetURL()
+	if u == nil {
+		return "", fmt.Errorf("failed to build SMTP config URL")
+	}
+
+	parsedURL, err := url.Parse(u.String())
+	if err != nil {
+		return "", fmt.Errorf("failed to parse SMTP config URL: %w", err)
+	}
+
+	q := parsedURL.Query()
+	if q.Get("fromname") == "" {
+		q.Del("fromname")
+	}
+	if q.Get("subject") == "" {
+		q.Del("subject")
+	}
+	parsedURL.RawQuery = q.Encode()
+
+	return parsedURL.String(), nil
 }
 
 // SendEmail sends pre-rendered HTML via Shoutrrr
 func SendEmail(ctx context.Context, config models.EmailConfig, subject, htmlBody string) error {
-	shoutrrrURL, err := BuildSMTPURL(config)
+	return sendEmailInternal(ctx, config, subject, htmlBody, smtpBuildOptionsFromContextInternal(ctx))
+}
+
+func sendEmailInternal(ctx context.Context, config models.EmailConfig, subject, htmlBody string, options smtpBuildOptions) error {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("email send canceled: %w", err)
+		}
+	}
+
+	shoutrrrURL, err := buildSMTPURLInternal(config, options)
 	if err != nil {
 		return fmt.Errorf("failed to build shoutrrr URL: %w", err)
 	}

--- a/backend/pkg/utils/notifications/email_sender_test.go
+++ b/backend/pkg/utils/notifications/email_sender_test.go
@@ -1,14 +1,46 @@
 package notifications
 
 import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/textproto"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildSMTPURL(t *testing.T) {
+const smtpTestHost = "localhost."
+const smtpTestConnTimeout = 2 * time.Second
+
+type smtpTestServer struct {
+	listener           net.Listener
+	tlsConfig          *tls.Config
+	supportStartTLS    bool
+	done               chan error
+	mu                 sync.Mutex
+	commands           []string
+	authBeforeTLS      bool
+	authAfterTLS       bool
+	startTLSNegotiated bool
+}
+
+func TestBuildSMTPURLInternal(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  models.EmailConfig
@@ -23,7 +55,7 @@ func TestBuildSMTPURL(t *testing.T) {
 				ToAddresses: []string{"to@example.com"},
 				TLSMode:     models.EmailTLSModeNone,
 			},
-			wantURL: "smtp://smtp.example.com:25/?encryption=None&fromAddress=from%40example.com&toAddresses=to%40example.com&useHTML=yes&useStartTLS=no",
+			wantURL: "smtp://smtp.example.com:25/?auth=None&clienthost=localhost&encryption=None&fromaddress=from%40example.com&timeout=10s&toaddresses=to%40example.com&usehtml=Yes&usestarttls=No",
 		},
 		{
 			name: "SMTP with auth and starttls",
@@ -36,7 +68,7 @@ func TestBuildSMTPURL(t *testing.T) {
 				ToAddresses:  []string{"to1@example.com", "to2@example.com"},
 				TLSMode:      models.EmailTLSModeStartTLS,
 			},
-			wantURL: "smtp://user:password@smtp.example.com:587/?encryption=ExplicitTLS&fromAddress=from%40example.com&toAddresses=to1%40example.com%2Cto2%40example.com&useHTML=yes&useStartTLS=yes",
+			wantURL: "smtp://user:password@smtp.example.com:587/?auth=Plain&clienthost=localhost&encryption=Auto&fromaddress=from%40example.com&requirestarttls=Yes&timeout=10s&toaddresses=to1%40example.com%2Cto2%40example.com&usehtml=Yes&usestarttls=Yes",
 		},
 		{
 			name: "SMTP with SSL/TLS and special characters in credentials",
@@ -49,15 +81,370 @@ func TestBuildSMTPURL(t *testing.T) {
 				ToAddresses:  []string{"to@example.com"},
 				TLSMode:      models.EmailTLSModeSSL,
 			},
-			wantURL: "smtp://user%40example.com:pass%2Fword%21@smtp.example.com:465/?encryption=ImplicitTLS&fromAddress=from%40example.com&toAddresses=to%40example.com&useHTML=yes&useStartTLS=no",
+			wantURL: "smtp://user%40example.com:pass%2Fword%21@smtp.example.com:465/?auth=Plain&clienthost=localhost&encryption=ImplicitTLS&fromaddress=from%40example.com&timeout=10s&toaddresses=to%40example.com&usehtml=Yes&usestarttls=No",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, err := BuildSMTPURL(tt.config)
+			gotURL, err := buildSMTPURLInternal(tt.config, smtpBuildOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantURL, gotURL)
 		})
 	}
+}
+
+func TestSendEmailStartTLSRequiresTLSBeforeAuth(t *testing.T) {
+	server := newSMTPTestServerInternal(t, true)
+	defer server.Close()
+
+	config := models.EmailConfig{
+		SMTPHost:     smtpTestHost,
+		SMTPPort:     server.Port(),
+		SMTPUsername: "user",
+		SMTPPassword: "password",
+		FromAddress:  "from@example.com",
+		ToAddresses:  []string{"to@example.com"},
+		TLSMode:      models.EmailTLSModeStartTLS,
+	}
+
+	err := sendEmailInternal(
+		context.Background(),
+		config,
+		"Arcane STARTTLS Test",
+		"<p>Test</p>",
+		smtpBuildOptions{skipTLSVerify: true},
+	)
+	require.NoError(t, err)
+	require.NoError(t, server.Wait())
+
+	assert.True(t, server.StartTLSNegotiated(), "expected STARTTLS to be negotiated")
+	assert.True(t, server.AuthAfterTLS(), "expected AUTH to happen after STARTTLS")
+	assert.False(t, server.AuthBeforeTLS(), "expected no AUTH attempt before STARTTLS")
+	assertCommandOrderInternal(t, server.Commands(), "EHLO", "STARTTLS", "EHLO", "AUTH", "MAIL", "RCPT", "DATA", "QUIT")
+}
+
+func TestSendEmailStartTLSFailsBeforePlainAuthFallback(t *testing.T) {
+	server := newSMTPTestServerInternal(t, false)
+	defer server.Close()
+
+	config := models.EmailConfig{
+		SMTPHost:     smtpTestHost,
+		SMTPPort:     server.Port(),
+		SMTPUsername: "user",
+		SMTPPassword: "password",
+		FromAddress:  "from@example.com",
+		ToAddresses:  []string{"to@example.com"},
+		TLSMode:      models.EmailTLSModeStartTLS,
+	}
+
+	err := SendEmail(context.Background(), config, "Arcane STARTTLS Test", "<p>Test</p>")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "error enabling StartTLS")
+	assert.NotContains(t, err.Error(), "unencrypted connection")
+	require.NoError(t, server.Wait())
+
+	assert.False(t, server.StartTLSNegotiated(), "did not expect STARTTLS to be negotiated")
+	assert.False(t, server.AuthBeforeTLS(), "did not expect plaintext AUTH attempt")
+	assert.False(t, server.AuthAfterTLS(), "did not expect AUTH after failed STARTTLS setup")
+}
+
+func newSMTPTestServerInternal(t *testing.T, supportStartTLS bool) *smtpTestServer {
+	t.Helper()
+
+	serverCert := generateServerCertificateInternal(t, smtpTestHost)
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &smtpTestServer{
+		listener:        listener,
+		tlsConfig:       &tls.Config{Certificates: []tls.Certificate{serverCert}, MinVersion: tls.VersionTLS12},
+		supportStartTLS: supportStartTLS,
+		done:            make(chan error, 1),
+	}
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			server.done <- acceptErr
+			return
+		}
+
+		server.done <- server.handleConnection(conn)
+	}()
+
+	return server
+}
+
+func (s *smtpTestServer) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *smtpTestServer) Close() {
+	_ = s.listener.Close()
+}
+
+func (s *smtpTestServer) Wait() error {
+	select {
+	case err := <-s.done:
+		if err != nil && (isUseOfClosedNetworkConnInternal(err) || isConnectionTimeoutInternal(err)) {
+			return nil
+		}
+		return err
+	case <-time.After(4 * time.Second):
+		return fmt.Errorf("timed out waiting for SMTP test server")
+	}
+}
+
+func (s *smtpTestServer) Commands() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]string, len(s.commands))
+	copy(out, s.commands)
+	return out
+}
+
+func (s *smtpTestServer) AuthBeforeTLS() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authBeforeTLS
+}
+
+func (s *smtpTestServer) AuthAfterTLS() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authAfterTLS
+}
+
+func (s *smtpTestServer) StartTLSNegotiated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.startTLSNegotiated
+}
+
+func (s *smtpTestServer) handleConnection(conn net.Conn) error {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(smtpTestConnTimeout))
+
+	reader := textproto.NewReader(bufio.NewReader(conn))
+	writer := textproto.NewWriter(bufio.NewWriter(conn))
+	tlsActive := false
+
+	if err := writeSMTPResponseInternal(writer, 220, false, "arcane smtp test server"); err != nil {
+		return err
+	}
+
+	for {
+		line, err := reader.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		verb, _, _ := strings.Cut(line, " ")
+		verb = strings.ToUpper(strings.TrimSpace(verb))
+		s.recordCommand(verb, tlsActive)
+
+		switch verb {
+		case "EHLO", "HELO":
+			if s.supportStartTLS && !tlsActive {
+				if err := writeSMTPMultiLineResponseInternal(writer, 250, []string{
+					"arcane smtp test server",
+					"STARTTLS",
+					"AUTH PLAIN",
+				}); err != nil {
+					return err
+				}
+				continue
+			}
+
+			if err := writeSMTPMultiLineResponseInternal(writer, 250, []string{
+				"arcane smtp test server",
+				"AUTH PLAIN",
+			}); err != nil {
+				return err
+			}
+		case "STARTTLS":
+			if !s.supportStartTLS {
+				if err := writeSMTPResponseInternal(writer, 502, false, "STARTTLS not supported"); err != nil {
+					return err
+				}
+				continue
+			}
+
+			if err := writeSMTPResponseInternal(writer, 220, false, "ready to start TLS"); err != nil {
+				return err
+			}
+
+			tlsConn := tls.Server(conn, s.tlsConfig)
+			if err := tlsConn.Handshake(); err != nil {
+				return err
+			}
+
+			conn = tlsConn
+			_ = conn.SetDeadline(time.Now().Add(smtpTestConnTimeout))
+			reader = textproto.NewReader(bufio.NewReader(conn))
+			writer = textproto.NewWriter(bufio.NewWriter(conn))
+			tlsActive = true
+			s.markStartTLSNegotiated()
+		case "AUTH":
+			if err := writeSMTPResponseInternal(writer, 235, false, "2.7.0 Authentication successful"); err != nil {
+				return err
+			}
+		case "MAIL":
+			if err := writeSMTPResponseInternal(writer, 250, false, "2.1.0 Sender OK"); err != nil {
+				return err
+			}
+		case "RCPT":
+			if err := writeSMTPResponseInternal(writer, 250, false, "2.1.5 Recipient OK"); err != nil {
+				return err
+			}
+		case "DATA":
+			if err := writeSMTPResponseInternal(writer, 354, false, "End data with <CR><LF>.<CR><LF>"); err != nil {
+				return err
+			}
+			for {
+				dataLine, dataErr := reader.ReadLine()
+				if dataErr != nil {
+					return dataErr
+				}
+				if dataLine == "." {
+					break
+				}
+			}
+			if err := writeSMTPResponseInternal(writer, 250, false, "2.0.0 queued"); err != nil {
+				return err
+			}
+		case "QUIT":
+			if err := writeSMTPResponseInternal(writer, 221, false, "2.0.0 bye"); err != nil {
+				return err
+			}
+			return nil
+		default:
+			if err := writeSMTPResponseInternal(writer, 502, false, "command not implemented"); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *smtpTestServer) recordCommand(command string, tlsActive bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.commands = append(s.commands, command)
+	if command == "AUTH" {
+		if tlsActive {
+			s.authAfterTLS = true
+		} else {
+			s.authBeforeTLS = true
+		}
+	}
+}
+
+func (s *smtpTestServer) markStartTLSNegotiated() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startTLSNegotiated = true
+}
+
+func writeSMTPMultiLineResponseInternal(writer *textproto.Writer, code int, lines []string) error {
+	for i, line := range lines {
+		if err := writeSMTPResponseInternal(writer, code, i < len(lines)-1, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSMTPResponseInternal(writer *textproto.Writer, code int, continued bool, message string) error {
+	line := fmt.Sprintf("%d %s", code, message)
+	if continued {
+		line = fmt.Sprintf("%d-%s", code, message)
+	}
+	if err := writer.PrintfLine("%s", line); err != nil {
+		return err
+	}
+	return writer.W.Flush()
+}
+
+func assertCommandOrderInternal(t *testing.T, commands []string, expected ...string) {
+	t.Helper()
+
+	start := 0
+	for _, want := range expected {
+		found := false
+		for i := start; i < len(commands); i++ {
+			if commands[i] == want {
+				start = i + 1
+				found = true
+				break
+			}
+		}
+		require.Truef(t, found, "expected command %q in order within %v", want, commands)
+	}
+}
+
+func generateServerCertificateInternal(t *testing.T, host string) tls.Certificate {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          mustSerialNumberInternal(t),
+		Subject:               pkix.Name{CommonName: "Arcane SMTP Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	_, err = x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: mustSerialNumberInternal(t),
+		Subject:      pkix.Name{CommonName: strings.TrimSuffix(host, ".")},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{strings.TrimSuffix(host, "."), host},
+	}
+
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	serverCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	return serverCert
+}
+
+func mustSerialNumberInternal(t *testing.T) *big.Int {
+	t.Helper()
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+	return serialNumber
+}
+
+func isUseOfClosedNetworkConnInternal(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "use of closed network connection")
+}
+
+func isConnectionTimeoutInternal(err error) bool {
+	var netErr net.Error
+	return err != nil && errors.As(err, &netErr) && netErr.Timeout()
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where SMTP email parameters (particularly STARTTLS negotiation and auth) were being parsed incorrectly when constructing the shoutrrr URL via manual string/query-param building. The fix replaces the URL-construction approach with direct population of the `shoutrrrSMTP.Config` struct, which correctly sets `RequireStartTLS`, auth method, and encryption fields before delegating to the library's own `GetURL()` method. A comprehensive integration test using a real in-process SMTP server is added to verify STARTTLS negotiation happens before AUTH.

Key changes:
- `BuildSMTPURL` now delegates to `buildSMTPURLInternal`, which builds a `shoutrrrSMTP.Config` struct and calls `GetURL()` instead of manually constructing query parameters — fixing the root cause of incorrect parameter casing and value encoding
- `EmailTLSModeStartTLS` now correctly sets `RequireStartTLS = true`, preventing credential leakage over plaintext connections
- `sendEmailInternal` respects context cancellation before attempting to send
- `smtpBuildOptionsFromContext` derives a send timeout from any remaining context deadline, capped at the 10-second default
- Several new unexported helpers (`buildSMTPConfig`, `smtpPortFromConfig`, `smtpTimeoutFromOptions`, `smtpBuildOptionsFromContext`) do not follow the project's required `Internal` suffix naming convention for unexported functions, unlike `buildSMTPURLInternal` and `sendEmailInternal` which do comply
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor style issues to address
- The core logic change is well-motivated and backed by solid integration tests. The fix correctly sets RequireStartTLS which prevents credential leakage. The only concerns are non-critical: several unexported helper functions are missing the required "Internal" suffix, and the doc comment example URL is outdated. No runtime errors, security vulnerabilities, or broken logic were found.
- No files require special attention beyond the naming convention violations noted in email_sender.go
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/pkg/utils/notifications/email_sender.go | Replaces the manual URL string construction approach with direct use of the shoutrrr SMTP config struct, correctly setting STARTTLS, RequireStartTLS, and auth fields to fix email parameter parsing. Four new unexported helpers lack the required "Internal" suffix, and the doc comment example URL is stale. |
| backend/pkg/utils/notifications/email_sender_test.go | Adds a self-contained SMTP test server using raw TCP and TLS to verify that STARTTLS negotiation happens before AUTH. Test coverage is thorough, but several test helper functions lack the "Internal" suffix, and the CA PEM from generateServerCertificate is always discarded. |

</details>

</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Femail_sender.go%3A25%0A**Unexported%20functions%20missing%20%22Internal%22%20suffix**%0A%0APer%20the%20project%20naming%20convention%2C%20all%20unexported%20functions%20must%20have%20the%20%60Internal%60%20suffix.%20The%20following%20new%20unexported%20functions%20introduced%20in%20this%20PR%20do%20not%20follow%20this%20convention%3A%0A%0AIn%20%60backend%2Fpkg%2Futils%2Fnotifications%2Femail_sender.go%60%3A%0A-%20%60buildSMTPConfig%60%20%28line%2025%29%20%E2%86%92%20%60buildSMTPConfigInternal%60%0A-%20%60smtpPortFromConfig%60%20%28line%2069%29%20%E2%86%92%20%60smtpPortFromConfigInternal%60%0A-%20%60smtpTimeoutFromOptions%60%20%28line%2077%29%20%E2%86%92%20%60smtpTimeoutFromOptionsInternal%60%0A-%20%60smtpBuildOptionsFromContext%60%20%28line%2085%29%20%E2%86%92%20%60smtpBuildOptionsFromContextInternal%60%0A%0AIn%20%60backend%2Fpkg%2Futils%2Fnotifications%2Femail_sender_test.go%60%3A%0A-%20%60newSMTPTestServer%60%20%28line%20152%29%20%E2%86%92%20%60newSMTPTestServerInternal%60%0A-%20%60writeSMTPMultiLineResponse%60%20%28line%20355%29%20%E2%86%92%20%60writeSMTPMultiLineResponseInternal%60%0A-%20%60writeSMTPResponse%60%20%28line%20364%29%20%E2%86%92%20%60writeSMTPResponseInternal%60%0A-%20%60assertCommandOrder%60%20%28line%20375%29%20%E2%86%92%20%60assertCommandOrderInternal%60%0A-%20%60generateServerCertificate%60%20%28line%20392%29%20%E2%86%92%20%60generateServerCertificateInternal%60%0A-%20%60mustSerialNumber%60%20%28line%20437%29%20%E2%86%92%20%60mustSerialNumberInternal%60%0A-%20%60isUseOfClosedNetworkConn%60%20%28line%20445%29%20%E2%86%92%20%60isUseOfClosedNetworkConnInternal%60%0A-%20%60isConnectionTimeout%60%20%28line%20449%29%20%E2%86%92%20%60isConnectionTimeoutInternal%60%0A%0ANote%20that%20%60buildSMTPURLInternal%60%20and%20%60sendEmailInternal%60%20already%20follow%20this%20convention%20correctly.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Femail_sender_test.go%3A155%0A**Unused%20return%20value%20always%20discarded**%0A%0A%60generateServerCertificate%60%20returns%20%60%28tls.Certificate%2C%20%5B%5Dbyte%29%60%20where%20the%20second%20return%20value%20is%20the%20CA%20certificate%20PEM%20bytes.%20It%20is%20always%20discarded%20here%20with%20%60_%60%2C%20and%20the%20CA%20PEM%20is%20never%20used%20anywhere%20in%20the%20test%20setup%20%E2%80%94%20the%20test%20client%20uses%20%60skipTLSVerify%3A%20true%60%20and%20%60TestSendEmailStartTLSFailsBeforePlainAuthFallback%60%20calls%20%60SendEmail%60%20which%20also%20ends%20up%20with%20an%20error%20before%20TLS%20verification%20matters.%20%0A%0AConsider%20simplifying%20the%20%60generateServerCertificate%60%20signature%20to%20only%20return%20%60tls.Certificate%60%20since%20the%20CA%20PEM%20is%20never%20consumed.%0A%0A%60%60%60suggestion%0A%09serverCert%20%3A%3D%20generateServerCertificate%28t%2C%20smtpTestHost%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Futils%2Fnotifications%2Femail_sender.go%3A101-102%0A**Stale%20doc%20comment%20example%20URL**%0A%0AThe%20example%20URL%20in%20the%20%60BuildSMTPURL%60%20doc%20comment%20still%20references%20the%20old%20query%20parameter%20format%20%28%60fromAddress%60%2C%20%60toAddresses%60%2C%20%60useHTML%60%2C%20%60useStartTLS%60%29.%20The%20actual%20generated%20URL%20now%20uses%20lowercase%20parameter%20names%20%28%60fromaddress%60%2C%20%60toaddresses%60%2C%20%60usehtml%60%2C%20%60usestarttls%60%29%20and%20includes%20additional%20fields%20like%20%60auth%60%2C%20%60clienthost%60%2C%20%60timeout%60%2C%20and%20%60requirestarttls%60.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20current%20output%20format.%0A%0A&repo=getarcaneapp%2Farcane"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: backend/pkg/utils/notifications/email_sender.go
Line: 25

Comment:
**Unexported functions missing "Internal" suffix**

Per the project naming convention, all unexported functions must have the `Internal` suffix. The following new unexported functions introduced in this PR do not follow this convention:

In `backend/pkg/utils/notifications/email_sender.go`:
- `buildSMTPConfig` (line 25) → `buildSMTPConfigInternal`
- `smtpPortFromConfig` (line 69) → `smtpPortFromConfigInternal`
- `smtpTimeoutFromOptions` (line 77) → `smtpTimeoutFromOptionsInternal`
- `smtpBuildOptionsFromContext` (line 85) → `smtpBuildOptionsFromContextInternal`

In `backend/pkg/utils/notifications/email_sender_test.go`:
- `newSMTPTestServer` (line 152) → `newSMTPTestServerInternal`
- `writeSMTPMultiLineResponse` (line 355) → `writeSMTPMultiLineResponseInternal`
- `writeSMTPResponse` (line 364) → `writeSMTPResponseInternal`
- `assertCommandOrder` (line 375) → `assertCommandOrderInternal`
- `generateServerCertificate` (line 392) → `generateServerCertificateInternal`
- `mustSerialNumber` (line 437) → `mustSerialNumberInternal`
- `isUseOfClosedNetworkConn` (line 445) → `isUseOfClosedNetworkConnInternal`
- `isConnectionTimeout` (line 449) → `isConnectionTimeoutInternal`

Note that `buildSMTPURLInternal` and `sendEmailInternal` already follow this convention correctly.

**Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/notifications/email_sender_test.go
Line: 155

Comment:
**Unused return value always discarded**

`generateServerCertificate` returns `(tls.Certificate, []byte)` where the second return value is the CA certificate PEM bytes. It is always discarded here with `_`, and the CA PEM is never used anywhere in the test setup — the test client uses `skipTLSVerify: true` and `TestSendEmailStartTLSFailsBeforePlainAuthFallback` calls `SendEmail` which also ends up with an error before TLS verification matters. 

Consider simplifying the `generateServerCertificate` signature to only return `tls.Certificate` since the CA PEM is never consumed.

```suggestion
	serverCert := generateServerCertificate(t, smtpTestHost)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: backend/pkg/utils/notifications/email_sender.go
Line: 101-102

Comment:
**Stale doc comment example URL**

The example URL in the `BuildSMTPURL` doc comment still references the old query parameter format (`fromAddress`, `toAddresses`, `useHTML`, `useStartTLS`). The actual generated URL now uses lowercase parameter names (`fromaddress`, `toaddresses`, `usehtml`, `usestarttls`) and includes additional fields like `auth`, `clienthost`, `timeout`, and `requirestarttls`. The comment should be updated to reflect the current output format.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: email parameter..."](https://github.com/getarcaneapp/arcane/commit/8372fe173ec4efbcc61890ec943f056093a63a02)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->