### PR TITLE
fix: handle directory-sync file paths that Docker previously created as directories

### DIFF
--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
+	git "github.com/getarcaneapp/arcane/backend/pkg/gitutil"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,14 @@ func setupGitOpsSyncDirectoryTestService(t *testing.T) (*GitOpsSyncService, *dat
 	projectService := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
 
 	return NewGitOpsSyncService(db, nil, projectService, nil, nil, settingsService), db, projectsDir
+}
+
+func writeFileInternal(t *testing.T, rootDir, relativePath string, content []byte) {
+	t.Helper()
+
+	targetPath := filepath.Join(rootDir, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o755))
+	require.NoError(t, os.WriteFile(targetPath, content, 0o644))
 }
 
 func TestGitOpsSyncService_SyncProjectDirectory_CreatesProjectPreservingRepoLayout(t *testing.T) {
@@ -190,6 +199,144 @@ services:
 	featureBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "nested", "feature.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(featureBytes), "worker:")
+}
+
+func TestGitOpsSyncService_DirectorySync_RealWalkWithNestedConfig(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+	svc.repoService = &GitRepositoryService{gitClient: git.NewClient("")}
+
+	repoPath := t.TempDir()
+	writeFileInternal(t, repoPath, "traefik (nl10)/docker-compose.yml", []byte(`services:
+  traefik:
+    image: traefik:v3.4
+    volumes:
+      - ./letsencrypt:/letsencrypt
+      - ./logs:/var/log/traefik
+      - ./config/dynamic_config.yml:/etc/traefik/dynamic_config.yml:ro
+`))
+	writeFileInternal(t, repoPath, "traefik (nl10)/config/dynamic_config.yml", []byte(`http:
+  routers:
+    dashboard:
+      rule: Host(`+"`"+`traefik.example.com`+"`"+`)
+`))
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-real-walk"},
+		Name:          "traefik-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "traefik (nl10)/docker-compose.yml",
+		ProjectName:   "traefik (nl10)",
+		SyncDirectory: true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	composeContent, syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
+	require.NoError(t, err)
+	assert.Contains(t, composeContent, "./config/dynamic_config.yml")
+
+	project, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	require.True(t, created)
+	require.True(t, changed)
+	require.ElementsMatch(t, []string{"docker-compose.yml", "config/dynamic_config.yml"}, syncedFiles)
+
+	composePath, detectErr := projects.DetectComposeFile(project.Path)
+	require.NoError(t, detectErr)
+	assert.Equal(t, filepath.Join(project.Path, "docker-compose.yml"), composePath)
+
+	composeInfo, err := os.Stat(filepath.Join(project.Path, "docker-compose.yml"))
+	require.NoError(t, err)
+	assert.False(t, composeInfo.IsDir())
+
+	configPath := filepath.Join(project.Path, "config", "dynamic_config.yml")
+	configInfo, err := os.Stat(configPath)
+	require.NoError(t, err)
+	assert.False(t, configInfo.IsDir())
+
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(configBytes), "dashboard:")
+}
+
+func TestGitOpsSyncService_DirectorySync_OverwritesExistingDirectoryAtFilePath(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+	svc.repoService = &GitRepositoryService{gitClient: git.NewClient("")}
+
+	repoPath := t.TempDir()
+	writeFileInternal(t, repoPath, "traefik (nl10)/docker-compose.yml", []byte(`services:
+  traefik:
+    image: traefik:v3.4
+    volumes:
+      - ./letsencrypt:/letsencrypt
+      - ./logs:/var/log/traefik
+      - ./config/dynamic_config.yml:/etc/traefik/dynamic_config.yml:ro
+`))
+	writeFileInternal(t, repoPath, "traefik (nl10)/config/dynamic_config.yml", []byte(`http:
+  routers:
+    dashboard:
+      rule: Host(`+"`"+`traefik.example.com`+"`"+`)
+`))
+
+	projectPath := filepath.Join(projectsDir, "traefik-project")
+	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, "config", "dynamic_config.yml"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, "letsencrypt"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectPath, "logs"), 0o755))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-directory-docker-dir-conflict"},
+		Name:      "traefik-project",
+		DirName:   ptr("traefik-project"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-docker-dir-conflict"},
+		Name:          "traefik-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "traefik (nl10)/docker-compose.yml",
+		ProjectName:   "traefik-project",
+		ProjectID:     &project.ID,
+		SyncDirectory: true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	_, syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
+	require.NoError(t, err)
+
+	updatedProject, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.NoError(t, err)
+	require.NotNil(t, updatedProject)
+	require.False(t, created)
+	require.True(t, changed)
+	require.ElementsMatch(t, []string{"docker-compose.yml", "config/dynamic_config.yml"}, syncedFiles)
+
+	configPath := filepath.Join(updatedProject.Path, "config", "dynamic_config.yml")
+	configInfo, err := os.Stat(configPath)
+	require.NoError(t, err)
+	assert.False(t, configInfo.IsDir())
+
+	configBytes, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(configBytes), "dashboard:")
+
+	composeInfo, err := os.Stat(filepath.Join(updatedProject.Path, "docker-compose.yml"))
+	require.NoError(t, err)
+	assert.False(t, composeInfo.IsDir())
+
+	dockerArtifactInfo, err := os.Stat(filepath.Join(updatedProject.Path, "letsencrypt"))
+	require.NoError(t, err)
+	assert.True(t, dockerArtifactInfo.IsDir())
+
+	dockerArtifactInfo, err = os.Stat(filepath.Join(updatedProject.Path, "logs"))
+	require.NoError(t, err)
+	assert.True(t, dockerArtifactInfo.IsDir())
 }
 
 func TestGitOpsSyncService_CreateDirectorySyncProjectInternal_RollsBackProjectOnUpdateFailure(t *testing.T) {

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -345,9 +345,13 @@ func TestNewClient(t *testing.T) {
 	})
 }
 
-func writeFile(t *testing.T, dir, name string, content []byte) {
+func writeFileInternal(t *testing.T, dir, name string, content []byte) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), content, 0644); err != nil {
+	targetPath := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("failed to create parent directories for %s: %v", name, err)
+	}
+	if err := os.WriteFile(targetPath, content, 0644); err != nil {
 		t.Fatalf("failed to write file %s: %v", name, err)
 	}
 }
@@ -358,9 +362,9 @@ func minimalCompose() []byte {
 
 func TestWalkDirectory_BasicWalk(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "file1.txt", []byte("hello world"))
-	writeFile(t, tmpDir, "file2.txt", []byte("another file"))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "file1.txt", []byte("hello world"))
+	writeFileInternal(t, tmpDir, "file2.txt", []byte("another file"))
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 0)
@@ -377,11 +381,11 @@ func TestWalkDirectory_BasicWalk(t *testing.T) {
 
 func TestWalkDirectory_MaxFilesLimit(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "a.txt", []byte("a"))
-	writeFile(t, tmpDir, "b.txt", []byte("b"))
-	writeFile(t, tmpDir, "c.txt", []byte("c"))
-	writeFile(t, tmpDir, "d.txt", []byte("d"))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "a.txt", []byte("a"))
+	writeFileInternal(t, tmpDir, "b.txt", []byte("b"))
+	writeFileInternal(t, tmpDir, "c.txt", []byte("c"))
+	writeFileInternal(t, tmpDir, "d.txt", []byte("d"))
 
 	client := NewClient("")
 	_, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 3, 0, 0)
@@ -395,11 +399,11 @@ func TestWalkDirectory_MaxFilesLimit(t *testing.T) {
 
 func TestWalkDirectory_MaxFilesUnlimited(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "a.txt", []byte("a"))
-	writeFile(t, tmpDir, "b.txt", []byte("b"))
-	writeFile(t, tmpDir, "c.txt", []byte("c"))
-	writeFile(t, tmpDir, "d.txt", []byte("d"))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "a.txt", []byte("a"))
+	writeFileInternal(t, tmpDir, "b.txt", []byte("b"))
+	writeFileInternal(t, tmpDir, "c.txt", []byte("c"))
+	writeFileInternal(t, tmpDir, "d.txt", []byte("d"))
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 0)
@@ -413,9 +417,9 @@ func TestWalkDirectory_MaxFilesUnlimited(t *testing.T) {
 
 func TestWalkDirectory_MaxTotalSizeLimit(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "big1.txt", []byte(strings.Repeat("x", 40)))
-	writeFile(t, tmpDir, "big2.txt", []byte(strings.Repeat("y", 40)))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "big1.txt", []byte(strings.Repeat("x", 40)))
+	writeFileInternal(t, tmpDir, "big2.txt", []byte(strings.Repeat("y", 40)))
 
 	client := NewClient("")
 	_, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 50, 0)
@@ -429,9 +433,9 @@ func TestWalkDirectory_MaxTotalSizeLimit(t *testing.T) {
 
 func TestWalkDirectory_MaxTotalSizeUnlimited(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "big1.txt", []byte(strings.Repeat("x", 500)))
-	writeFile(t, tmpDir, "big2.txt", []byte(strings.Repeat("y", 500)))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "big1.txt", []byte(strings.Repeat("x", 500)))
+	writeFileInternal(t, tmpDir, "big2.txt", []byte(strings.Repeat("y", 500)))
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 0)
@@ -445,10 +449,10 @@ func TestWalkDirectory_MaxTotalSizeUnlimited(t *testing.T) {
 
 func TestWalkDirectory_MaxBinarySizeSkips(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
 	// Binary content: null bytes cause isBinaryContent to return true
 	binaryContent := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}
-	writeFile(t, tmpDir, "data.bin", binaryContent)
+	writeFileInternal(t, tmpDir, "data.bin", binaryContent)
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 5)
@@ -462,9 +466,9 @@ func TestWalkDirectory_MaxBinarySizeSkips(t *testing.T) {
 
 func TestWalkDirectory_MaxBinarySizeUnlimited(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
 	binaryContent := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}
-	writeFile(t, tmpDir, "data.bin", binaryContent)
+	writeFileInternal(t, tmpDir, "data.bin", binaryContent)
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 0)
@@ -481,8 +485,8 @@ func TestWalkDirectory_MaxBinarySizeUnlimited(t *testing.T) {
 
 func TestWalkDirectory_LargeTextFileNotSkippedByBinaryLimit(t *testing.T) {
 	tmpDir := t.TempDir()
-	writeFile(t, tmpDir, "compose.yaml", minimalCompose())
-	writeFile(t, tmpDir, "notes.txt", []byte(strings.Repeat("plain text\n", 32)))
+	writeFileInternal(t, tmpDir, "compose.yaml", minimalCompose())
+	writeFileInternal(t, tmpDir, "notes.txt", []byte(strings.Repeat("plain text\n", 32)))
 
 	client := NewClient("")
 	result, err := client.WalkDirectory(context.Background(), tmpDir, "compose.yaml", 0, 0, 16)
@@ -494,6 +498,108 @@ func TestWalkDirectory_LargeTextFileNotSkippedByBinaryLimit(t *testing.T) {
 	}
 	if result.TotalFiles != 2 {
 		t.Errorf("expected 2 files (compose + text), got %d", result.TotalFiles)
+	}
+}
+
+func TestWalkDirectory_ComposeInSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeFileInternal(t, tmpDir, "subdir/docker-compose.yml", minimalCompose())
+	writeFileInternal(t, tmpDir, "subdir/dynamic_config.yml", []byte("http:\n  routers: {}\n"))
+
+	client := NewClient("")
+	result, err := client.WalkDirectory(context.Background(), tmpDir, "subdir/docker-compose.yml", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	paths := make([]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		paths = append(paths, file.RelativePath)
+	}
+
+	expected := []string{"docker-compose.yml", "dynamic_config.yml"}
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
+	}
+	for _, want := range expected {
+		found := false
+		for _, got := range paths {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
+		}
+	}
+}
+
+func TestWalkDirectory_NestedSiblingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeFileInternal(t, tmpDir, "subdir/docker-compose.yml", minimalCompose())
+	writeFileInternal(t, tmpDir, "subdir/config/dynamic_config.yml", []byte("tls:\n  certificates: []\n"))
+
+	client := NewClient("")
+	result, err := client.WalkDirectory(context.Background(), tmpDir, "subdir/docker-compose.yml", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	paths := make([]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		paths = append(paths, file.RelativePath)
+	}
+
+	expected := []string{"docker-compose.yml", "config/dynamic_config.yml"}
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
+	}
+	for _, want := range expected {
+		found := false
+		for _, got := range paths {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
+		}
+	}
+}
+
+func TestWalkDirectory_SpecialCharsInPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeFileInternal(t, tmpDir, "traefik (nl10)/docker-compose.yml", minimalCompose())
+	writeFileInternal(t, tmpDir, "traefik (nl10)/config/dynamic_config.yml", []byte("http:\n  middlewares: {}\n"))
+
+	client := NewClient("")
+	result, err := client.WalkDirectory(context.Background(), tmpDir, "traefik (nl10)/docker-compose.yml", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	paths := make([]string, 0, len(result.Files))
+	for _, file := range result.Files {
+		paths = append(paths, file.RelativePath)
+	}
+
+	expected := []string{"docker-compose.yml", "config/dynamic_config.yml"}
+	if len(paths) != len(expected) {
+		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
+	}
+	for _, want := range expected {
+		found := false
+		for _, got := range paths {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
+		}
 	}
 }
 

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -258,6 +258,41 @@ func IsBinaryProjectFileContent(content []byte) bool {
 	return slices.Contains(content[:checkSize], 0)
 }
 
+func syncedProjectFileMatchesInternal(projectPath string, file SyncFile) (bool, error) {
+	existingPath := filepath.Join(projectPath, file.RelativePath)
+	info, err := os.Stat(existingPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+
+	existingContent, err := os.ReadFile(existingPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return bytes.Equal(existingContent, file.Content), nil
+}
+
+func pathExistsInternal(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 func DirectorySyncContentsChanged(projectPath string, syncFiles []SyncFile, oldSyncedFiles []string, composeFileName string) (bool, error) {
 	if info, err := os.Stat(projectPath); err != nil {
 		if os.IsNotExist(err) {
@@ -271,14 +306,11 @@ func DirectorySyncContentsChanged(projectPath string, syncFiles []SyncFile, oldS
 	newFileSet := make(map[string]struct{}, len(syncFiles))
 	for _, file := range syncFiles {
 		newFileSet[file.RelativePath] = struct{}{}
-		existingContent, err := os.ReadFile(filepath.Join(projectPath, file.RelativePath))
+		matches, err := syncedProjectFileMatchesInternal(projectPath, file)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return true, nil
-			}
 			return false, err
 		}
-		if !bytes.Equal(existingContent, file.Content) {
+		if !matches {
 			return true, nil
 		}
 	}
@@ -287,10 +319,12 @@ func DirectorySyncContentsChanged(projectPath string, syncFiles []SyncFile, oldS
 		if _, exists := newFileSet[oldFile]; exists {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(projectPath, oldFile)); err == nil {
-			return true, nil
-		} else if !os.IsNotExist(err) {
+		exists, err := pathExistsInternal(filepath.Join(projectPath, oldFile))
+		if err != nil {
 			return false, err
+		}
+		if exists {
+			return true, nil
 		}
 	}
 
@@ -301,10 +335,12 @@ func DirectorySyncContentsChanged(projectPath string, syncFiles []SyncFile, oldS
 		if _, exists := newFileSet[candidate]; exists {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(projectPath, candidate)); err == nil {
-			return true, nil
-		} else if !os.IsNotExist(err) {
+		exists, err := pathExistsInternal(filepath.Join(projectPath, candidate))
+		if err != nil {
 			return false, err
+		}
+		if exists {
+			return true, nil
 		}
 	}
 

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -259,6 +259,15 @@ func WriteSyncedDirectory(projectsRoot, projectPath string, files []SyncFile) ([
 			return nil, fmt.Errorf("failed to create directory for %s: %w", file.RelativePath, err)
 		}
 
+		info, err := os.Stat(targetPathClean)
+		if err == nil && info.IsDir() {
+			if err := os.RemoveAll(targetPathClean); err != nil {
+				return nil, fmt.Errorf("failed to replace directory at %s: %w", file.RelativePath, err)
+			}
+		} else if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to inspect target path for %s: %w", file.RelativePath, err)
+		}
+
 		// Write the file
 		if err := os.WriteFile(targetPathClean, file.Content, pkgutils.FilePerm); err != nil {
 			return nil, fmt.Errorf("failed to write file %s: %w", file.RelativePath, err)


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2495

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where Docker had previously created directories at paths that directory-sync expected to be files (e.g., `config/dynamic_config.yml` materialising as a directory). The fix operates on two layers: `WriteSyncedDirectory` now detects and removes a directory at the target path before writing the file, and `DirectorySyncContentsChanged` now correctly treats a directory at a file-expected path as "not matching" (triggering a re-sync) instead of propagating a read error.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; it handles a well-scoped edge case with correct error propagation and no regressions to the happy path.

Both the write path and the change-detection path are updated consistently, the new helpers are minimal and well-tested, and the added tests directly exercise the directory-at-file-path scenario that caused the original bug.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: handle directory-sync file paths th..."](https://github.com/getarcaneapp/arcane/commit/ea27b2ea83ada1651b219d8c3b6625425c9bbad2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30775301)</sub>

<!-- /greptile_comment -->