### PR TITLE
fix: accent color allows non color values to be saved

### DIFF
--- a/backend/internal/huma/handlers/appimages.go
+++ b/backend/internal/huma/handlers/appimages.go
@@ -28,9 +28,10 @@ type GetPWAIconInput struct {
 }
 
 type GetAppImageOutput struct {
-	ContentType  string `header:"Content-Type"`
-	CacheControl string `header:"Cache-Control"`
-	Body         []byte
+	ContentType         string `header:"Content-Type"`
+	CacheControl        string `header:"Cache-Control"`
+	XContentTypeOptions string `header:"X-Content-Type-Options"`
+	Body                []byte
 }
 
 var allowedPWAIconFilenames = map[string]struct{}{
@@ -178,8 +179,9 @@ func (h *AppImagesHandler) getImageWithColor(name string, colorOverride string) 
 	}
 
 	return &GetAppImageOutput{
-		ContentType:  mimeType,
-		CacheControl: cacheControl,
-		Body:         imageData,
+		ContentType:         mimeType,
+		CacheControl:        cacheControl,
+		XContentTypeOptions: "nosniff",
+		Body:                imageData,
 	}, nil
 }

--- a/backend/internal/huma/handlers/appimages_test.go
+++ b/backend/internal/huma/handlers/appimages_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -37,6 +38,59 @@ func TestGetPWAIconReturnsPNGFromEmbeddedBackendAssets(t *testing.T) {
 			require.NotEmpty(t, resp.Body)
 		})
 	}
+}
+
+func TestGetLogoRejectsXSSPayloadInColorParam(t *testing.T) {
+	handler := &AppImagesHandler{
+		appImagesService: services.NewApplicationImagesService(resources.FS, nil),
+	}
+
+	resp, err := handler.GetLogo(context.Background(), &GetLogoInput{
+		Color: "red}</style><script>alert(1)</script><style>x{",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "image/svg+xml", resp.ContentType)
+	require.Equal(t, "nosniff", resp.XContentTypeOptions)
+
+	body := string(resp.Body)
+	require.NotContains(t, body, "<script>", "injected <script> tag must not appear in response body")
+	require.NotContains(t, body, "</style><script", "style block must not be broken out of")
+	require.Contains(t, body, "fill:oklch(0.606 0.25 292.717)", "should fall back to default accent color")
+}
+
+func TestGetLogoAcceptsValidOklchOverride(t *testing.T) {
+	handler := &AppImagesHandler{
+		appImagesService: services.NewApplicationImagesService(resources.FS, nil),
+	}
+
+	resp, err := handler.GetLogo(context.Background(), &GetLogoInput{
+		Color: "oklch(0.65 0.2 150)",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Body), "fill:oklch(0.65 0.2 150)")
+}
+
+func TestGetLogoAcceptsValidHexOverride(t *testing.T) {
+	handler := &AppImagesHandler{
+		appImagesService: services.NewApplicationImagesService(resources.FS, nil),
+	}
+
+	resp, err := handler.GetLogo(context.Background(), &GetLogoInput{
+		Color: "#abcdef",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Body), "fill:#abcdef")
+}
+
+func TestGetLogoSetsNoSniffHeader(t *testing.T) {
+	handler := &AppImagesHandler{
+		appImagesService: services.NewApplicationImagesService(resources.FS, nil),
+	}
+
+	resp, err := handler.GetLogo(context.Background(), &GetLogoInput{})
+	require.NoError(t, err)
+	require.Equal(t, "nosniff", resp.XContentTypeOptions)
+	require.True(t, strings.HasPrefix(resp.ContentType, "image/svg"))
 }
 
 func TestGetPWAIconRejectsNonPWAAssets(t *testing.T) {

--- a/backend/internal/services/app_images_service.go
+++ b/backend/internal/services/app_images_service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/image"
+	"github.com/getarcaneapp/arcane/types/settings"
 )
 
 type ApplicationImagesService struct {
@@ -70,36 +71,30 @@ func (s *ApplicationImagesService) GetImageWithColor(name string, colorOverride 
 
 	// Apply dynamic color replacement for logo SVGs
 	if (name == "logo" || name == "logo-full") && mimeType == "image/svg+xml" {
-		data = s.applyAccentColorToSVG(data, colorOverride)
+		data = s.applyAccentColorToSVGInternal(data, colorOverride)
 	}
 
 	return data, mimeType, nil
 }
 
-func (s *ApplicationImagesService) applyAccentColorToSVG(svgData []byte, colorOverride string) []byte {
-	var accentColor string
-
-	// Use color override if provided, otherwise get from settings
-	if colorOverride != "" {
+func (s *ApplicationImagesService) applyAccentColorToSVGInternal(svgData []byte, colorOverride string) []byte {
+	accentColor := ""
+	if settings.SafeAccentColor.MatchString(colorOverride) {
 		accentColor = colorOverride
-	} else {
-		cfg := s.settingsService.GetSettingsConfig()
-		if cfg != nil {
-			accentColor = cfg.AccentColor.Value
+	} else if s.settingsService != nil {
+		if cfg := s.settingsService.GetSettingsConfig(); cfg != nil {
+			stored := cfg.AccentColor.Value
+			if stored != "" && stored != "default" && settings.SafeAccentColor.MatchString(stored) {
+				accentColor = stored
+			}
 		}
 	}
-
-	if accentColor == "" || accentColor == "default" {
-		accentColor = "oklch(0.606 0.25 292.717)" // Default purple
+	if accentColor == "" {
+		accentColor = settings.DefaultAccentColor
 	}
 
-	// Replace the hardcoded purple color with the accent color
-	// The SVG uses .st0{fill:#6d28d9} which we'll replace (case-insensitive)
 	svgStr := string(svgData)
-
-	// Replace hex color in style tag (handle both cases)
-	svgStr = strings.ReplaceAll(svgStr, "fill:#6D28D9", fmt.Sprintf("fill:%s", accentColor))
-	svgStr = strings.ReplaceAll(svgStr, "fill:#6d28d9", fmt.Sprintf("fill:%s", accentColor))
-
+	svgStr = strings.ReplaceAll(svgStr, "fill:#6D28D9", "fill:"+accentColor)
+	svgStr = strings.ReplaceAll(svgStr, "fill:#6d28d9", "fill:"+accentColor)
 	return []byte(svgStr)
 }

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -748,6 +748,10 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 			return nil, false, false, false, false, false, nil, fmt.Errorf("invalid cron expression for %s: %w", key, err)
 		}
 
+		if key == "accentColor" && value != "" && value != "default" && !settings.SafeAccentColor.MatchString(value) {
+			return nil, false, false, false, false, false, nil, fmt.Errorf("invalid accentColor value")
+		}
+
 		var valueToSave string
 		var err error
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import Icons from 'unplugin-icons/vite';
 
-const devBackendURL = process.env['DEV_BACKEND_URL'] || 'https://localhost:3552';
+const devBackendURL = process.env['DEV_BACKEND_URL'] || 'http://localhost:3552';
 const parsedDevBackendURL = new URL(devBackendURL);
 
 function parseBooleanEnv(value: string | undefined): boolean | undefined {

--- a/types/settings/accent_color.go
+++ b/types/settings/accent_color.go
@@ -1,0 +1,15 @@
+package settings
+
+import "regexp"
+
+// DefaultAccentColor is the fallback accent color used when no override is
+// provided or the configured value fails validation.
+const DefaultAccentColor = "oklch(0.606 0.25 292.717)"
+
+// SafeAccentColor accepts only safe CSS color tokens: hex, known named colors,
+// rgb()/rgba(), hsl()/hsla(), oklch()/oklab(). Values containing semicolons,
+// angle brackets, or quotes are rejected to prevent CSS/SVG injection when
+// the value is substituted into a style declaration.
+var SafeAccentColor = regexp.MustCompile(
+	`^(?:#[0-9a-fA-F]{3,8}|(?i:aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|rebeccapurple|red|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|teal|thistle|tomato|transparent|turquoise|violet|wheat|white|whitesmoke|yellow|yellowgreen)|(?:rgb|rgba|hsl|hsla|oklch|oklab)\([0-9a-zA-Z%. ,/-]{1,64}\))$`,
+)


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds server-side validation for the accent color setting to prevent CSS/SVG injection, applying a strict regex allowlist (`SafeAccentColor`) at both save time (`settings_service.go`) and render time (`app_images_service.go`), and adds `X-Content-Type-Options: nosniff` to image responses.

- A new `types/settings/accent_color.go` file defines `SafeAccentColor` — a compiled regex covering hex (`#[0-9a-fA-F]{3,8}`), an explicit CSS named-color allowlist, and functional notation (`rgb/rgba/hsl/hsla/oklch/oklab`) — along with the `DefaultAccentColor` constant; the unexported helper is renamed to `applyAccentColorToSVGInternal` per the team's naming convention.
- `frontend/vite.config.ts` changes the default dev backend URL from `https://localhost:3552` to `http://localhost:3552`; this change appears unrelated to the accent color fix and may warrant a quick confirmation that it was intentional.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the validation logic is applied at both the write path (settings save) and the read path (SVG render), the regex uses an explicit named-color allowlist rather than a loose letter pattern, and new tests cover the XSS-payload rejection scenario end-to-end.

The accent-color validation is thorough: the regex anchors with ^ and $, the functional-color character class excludes angle brackets, quotes, semicolons, and parens (preventing break-out), and the named-color branch enumerates only the 148 standard CSS names instead of accepting arbitrary letter sequences. Double-gating at save and render time means a previously stored unsafe value is also caught. The unrelated vite.config.ts change (https to http) is a dev-only default and does not affect production behavior.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: accent color allows non color value..."](https://github.com/getarcaneapp/arcane/commit/cab1ac882da22f293f64f3ca11b0d51e773c8471) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30933100)</sub>

<!-- /greptile_comment -->