### PR TITLE
feat(cli): arcane-cli update channels and self-update

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -397,6 +397,8 @@ blobs:
         name_template: arcane-cli_darwin_arm64
       - glob: dist/arcane-cli_darwin_arm64_v8.0/arcane-cli_darwin_arm64.sigstore.json
         name_template: arcane-cli_darwin_arm64.sigstore.json
+      - glob: dist/arcane_next-static-*_checksums.txt
+        name_template: arcane-cli_checksums.txt
     include_meta: false
     disable: '{{ if not (index .Env "BUILD_NEXT") }}true{{ end }}'
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -35,8 +35,10 @@ import (
 
 // Version and build information - set via ldflags at build time
 var (
-	Version  = "dev"
-	Revision = "unknown"
+	Version          = "dev"
+	Revision         = "unknown"
+	CLIStableBaseURL = "https://github.com/getarcaneapp/arcane/releases/download"
+	CLINextBaseURL   = "https://bucket.getarcane.app/bin/cli-next"
 )
 
 const (
@@ -259,6 +261,9 @@ func Save(c *types.Config) error {
 	}
 	if cfg.LogLevel != "" {
 		v.Set("log_level", cfg.LogLevel)
+	}
+	if cfg.CLIUpdateChannel != "" {
+		v.Set("cli_update_channel", cfg.CLIUpdateChannel)
 	}
 
 	// Canonical pagination structure.

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -58,6 +58,7 @@ func TestSaveAndLoadRoundTripPaginationCompatibility(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.APIKey = "k_test"
+	cfg.CLIUpdateChannel = "next"
 	cfg.SetDefaultLimit(42)
 	cfg.SetResourceLimit("images", 17)
 	cfg.SetResourceLimit("Containers", 9)
@@ -80,6 +81,9 @@ func TestSaveAndLoadRoundTripPaginationCompatibility(t *testing.T) {
 	if !strings.Contains(text, "resource_limits:") {
 		t.Fatalf("expected saved YAML to include legacy resource_limits key:\n%s", text)
 	}
+	if !strings.Contains(text, "cli_update_channel: next") {
+		t.Fatalf("expected saved YAML to include cli_update_channel key:\n%s", text)
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -101,6 +105,9 @@ func TestSaveAndLoadRoundTripPaginationCompatibility(t *testing.T) {
 	}
 	if got := loaded.LimitFor("containers"); got != 9 {
 		t.Fatalf("containers limit=%d, want 9", got)
+	}
+	if loaded.CLIUpdateChannel != "next" {
+		t.Fatalf("CLIUpdateChannel=%q, want next", loaded.CLIUpdateChannel)
 	}
 }
 

--- a/cli/internal/types/config.go
+++ b/cli/internal/types/config.go
@@ -90,6 +90,8 @@ type Config struct {
 	DefaultEnvironment string `yaml:"default_environment,omitempty" mapstructure:"default_environment"`
 	// LogLevel is the logging level (debug, info, warn, error, fatal, panic)
 	LogLevel string `yaml:"log_level,omitempty" mapstructure:"log_level"`
+	// CLIUpdateChannel controls which channel self-update uses (stable or next).
+	CLIUpdateChannel string `yaml:"cli_update_channel,omitempty" mapstructure:"cli_update_channel"`
 	// Pagination contains global and per-resource pagination configuration.
 	Pagination PaginationConfig `yaml:"pagination,omitempty" mapstructure:"pagination"`
 	// DefaultLimit is a legacy global default list limit for paginated resources.

--- a/cli/pkg/config/cmd.go
+++ b/cli/pkg/config/cmd.go
@@ -48,6 +48,7 @@ var configShowCmd = &cobra.Command{
 		fmt.Printf("Refresh Token:       %s\n", maskAPIKey(cfg.RefreshToken))
 		fmt.Printf("Default Environment: %s\n", maskIfEmpty(cfg.DefaultEnvironment, "0 (local)"))
 		fmt.Printf("Log Level:           %s\n", maskIfEmpty(cfg.LogLevel, "info (default)"))
+		fmt.Printf("CLI Update Channel:  %s\n", maskIfEmpty(cfg.CLIUpdateChannel, "(auto)"))
 		globalLimit := cfg.Pagination.Default.Limit
 		if globalLimit <= 0 {
 			globalLimit = cfg.DefaultLimit
@@ -437,6 +438,14 @@ func applyConfigSetArg(cfg *clitypes.Config, key, value string) (bool, error) {
 	case "log-level", "loglevel", "log_level":
 		cfg.LogLevel = value
 		fmt.Printf("Set log_level = %s\n", value)
+		return true, nil
+	case "cli-update-channel", "cli_update_channel", "cli-channel", "channel":
+		channel := strings.ToLower(strings.TrimSpace(value))
+		if channel != "stable" && channel != "next" {
+			return false, fmt.Errorf("invalid cli update channel %q (expected stable or next)", value)
+		}
+		cfg.CLIUpdateChannel = channel
+		fmt.Printf("Set cli_update_channel = %s\n", channel)
 		return true, nil
 	case "default-limit", "default_limit", "pagination.default.limit":
 		limit, err := parseLimitValue(normalized, value)

--- a/cli/pkg/root.go
+++ b/cli/pkg/root.go
@@ -65,6 +65,7 @@ import (
 	"github.com/getarcaneapp/arcane/cli/pkg/projects"
 	"github.com/getarcaneapp/arcane/cli/pkg/registries"
 	"github.com/getarcaneapp/arcane/cli/pkg/repos"
+	"github.com/getarcaneapp/arcane/cli/pkg/selfupdate"
 	"github.com/getarcaneapp/arcane/cli/pkg/settings"
 	"github.com/getarcaneapp/arcane/cli/pkg/system"
 	"github.com/getarcaneapp/arcane/cli/pkg/templates"
@@ -243,6 +244,7 @@ func init() {
 	rootCmd.AddCommand(jobs.JobsCmd)
 	rootCmd.AddCommand(system.SystemCmd)
 	rootCmd.AddCommand(updater.UpdaterCmd)
+	rootCmd.AddCommand(selfupdate.Cmd)
 	rootCmd.AddCommand(admin.AdminCmd)
 	rootCmd.AddCommand(gitops.GitopsCmd)
 }
@@ -287,17 +289,17 @@ func renderCommandHelp(cmd *cobra.Command) {
 		lipgloss.Println()
 	}
 
-	localFlagRows := collectFlagRows(cmd.NonInheritedFlags())
+	localFlagRows := collectHelpFlagRowsInternal(cmd)
 	if len(localFlagRows) > 0 {
 		lipgloss.Println(helpSectionStyle.Render("Flags"))
 		renderHelpTable([]string{"FLAG", "TYPE", "DEFAULT", "DESCRIPTION"}, localFlagRows)
 		lipgloss.Println()
 	}
 
-	inheritedFlagRows := collectFlagRows(cmd.InheritedFlags())
-	if len(inheritedFlagRows) > 0 {
+	globalFlagRows := collectGlobalHelpFlagRowsInternal(cmd)
+	if len(globalFlagRows) > 0 {
 		lipgloss.Println(helpSectionStyle.Render("Global Flags"))
-		renderHelpTable([]string{"FLAG", "TYPE", "DEFAULT", "DESCRIPTION"}, inheritedFlagRows)
+		renderHelpTable([]string{"FLAG", "TYPE", "DEFAULT", "DESCRIPTION"}, globalFlagRows)
 		lipgloss.Println()
 	}
 
@@ -336,14 +338,41 @@ func collectCommandRows(cmd *cobra.Command) [][]string {
 	return rows
 }
 
+func collectHelpFlagRowsInternal(cmd *cobra.Command) [][]string {
+	if cmd == nil {
+		return nil
+	}
+	if cmd == rootCmd {
+		return collectFlagRowsExcludingInternal(cmd.LocalFlags(), cmd.PersistentFlags())
+	}
+	return collectFlagRows(cmd.NonInheritedFlags())
+}
+
+func collectGlobalHelpFlagRowsInternal(cmd *cobra.Command) [][]string {
+	if cmd == nil {
+		return nil
+	}
+	if cmd == rootCmd || cmd.Runnable() {
+		return collectFlagRows(rootCmd.PersistentFlags())
+	}
+	return nil
+}
+
 func collectFlagRows(flags *pflag.FlagSet) [][]string {
+	return collectFlagRowsExcludingInternal(flags, nil)
+}
+
+func collectFlagRowsExcludingInternal(flags, exclude *pflag.FlagSet) [][]string {
 	if flags == nil {
 		return nil
 	}
 
 	rows := make([][]string, 0)
 	flags.VisitAll(func(f *pflag.Flag) {
-		if f == nil || f.Hidden {
+		if f == nil || f.Hidden || f.Name == "help" {
+			return
+		}
+		if exclude != nil && exclude.Lookup(f.Name) != nil {
 			return
 		}
 

--- a/cli/pkg/selfupdate/cmd.go
+++ b/cli/pkg/selfupdate/cmd.go
@@ -1,0 +1,685 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/getarcaneapp/arcane/cli/internal/config"
+	"github.com/getarcaneapp/arcane/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const (
+	cliUpdateChannelNext   = "next"
+	cliUpdateChannelStable = "stable"
+	cliUpdateHTTPTimeout   = 2 * time.Minute
+	maxCLIChecksumSize     = 1 * 1024 * 1024
+	maxCLIDownloadSize     = 256 * 1024 * 1024
+	maxCLIExtractSize      = 128 * 1024 * 1024
+)
+
+var (
+	cliUpdateVersion string
+	cliUpdateTarget  string
+	cliUpdateDryRun  bool
+	jsonOutput       bool
+)
+
+type cliUpdatePlan struct {
+	Channel      string `json:"channel"`
+	Version      string `json:"version"`
+	ArtifactName string `json:"artifactName"`
+	ArtifactURL  string `json:"artifactUrl"`
+	ChecksumURL  string `json:"checksumUrl"`
+	ArtifactSHA  string `json:"artifactSha"`
+	ExpectedSHA  string `json:"expectedSha,omitempty"`
+	CurrentSHA   string `json:"currentSha"`
+	TargetPath   string `json:"targetPath"`
+	UpdateNeeded bool   `json:"updateNeeded"`
+}
+
+type githubLatestRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// Cmd updates the arcane-cli executable.
+var Cmd = &cobra.Command{
+	Use:          "self-update",
+	Aliases:      []string{"self", "cli"},
+	Short:        "Update arcane-cli",
+	SilenceUsage: true,
+	RunE:         runCLIUpdateCommandInternal,
+}
+
+var selfUpdateRunCmd = &cobra.Command{
+	Use:          "run",
+	Short:        "Update arcane-cli using the configured channel",
+	SilenceUsage: true,
+	RunE:         runCLIUpdateCommandInternal,
+}
+
+var selfUpdateChannelCmd = &cobra.Command{
+	Use:          "channel [stable|next]",
+	Short:        "Set the CLI update channel and update arcane-cli",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return setCLIUpdateChannelAndRunInternal(cmd, args[0])
+	},
+}
+
+func init() {
+	Cmd.AddCommand(selfUpdateRunCmd)
+	Cmd.AddCommand(selfUpdateChannelCmd)
+	stableCmd := newSelfUpdateChannelValueCmdInternal(cliUpdateChannelStable)
+	nextCmd := newSelfUpdateChannelValueCmdInternal(cliUpdateChannelNext)
+	selfUpdateChannelCmd.AddCommand(stableCmd)
+	selfUpdateChannelCmd.AddCommand(nextCmd)
+
+	registerCLIUpdateFlagsInternal(Cmd)
+	registerCLIUpdateFlagsInternal(selfUpdateRunCmd)
+	registerCLIUpdateFlagsInternal(selfUpdateChannelCmd)
+	registerCLIUpdateFlagsInternal(stableCmd)
+	registerCLIUpdateFlagsInternal(nextCmd)
+}
+
+func registerCLIUpdateFlagsInternal(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cliUpdateVersion, "version", "", "Stable release tag to install (default: latest)")
+	cmd.Flags().StringVar(&cliUpdateTarget, "target", "", "Binary path to replace (default: current executable)")
+	cmd.Flags().BoolVar(&cliUpdateDryRun, "dry-run", false, "Check for an update without installing it")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+}
+
+func newSelfUpdateChannelValueCmdInternal(channel string) *cobra.Command {
+	return &cobra.Command{
+		Use:          channel,
+		Short:        fmt.Sprintf("Set the CLI update channel to %s and update arcane-cli", channel),
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setCLIUpdateChannelAndRunInternal(cmd, channel)
+		},
+	}
+}
+
+func setCLIUpdateChannelAndRunInternal(cmd *cobra.Command, channel string) error {
+	channel = normalizeCLIUpdateChannelInternal(channel)
+	if channel != cliUpdateChannelNext && channel != cliUpdateChannelStable {
+		return fmt.Errorf("invalid update channel %q (expected stable or next)", channel)
+	}
+	if err := saveCLIUpdateChannelInternal(channel); err != nil {
+		return err
+	}
+	output.Success("Set CLI update channel to %s", channel)
+	return runCLIUpdateInternal(cmd.Context(), channel)
+}
+
+func runCLIUpdateCommandInternal(cmd *cobra.Command, args []string) error {
+	return runCLIUpdateInternal(cmd.Context(), "")
+}
+
+func runCLIUpdateInternal(ctx context.Context, overrideChannel string) error {
+	plan, err := buildCLIUpdatePlanInternal(ctx, overrideChannel)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		resultBytes, err := json.MarshalIndent(plan, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(resultBytes))
+		return nil
+	}
+
+	output.Header("Arcane CLI Update")
+	output.KeyValue("Channel", plan.Channel)
+	output.KeyValue("Version", plan.Version)
+	output.KeyValue("Current SHA", plan.CurrentSHA)
+	if plan.ExpectedSHA != "" {
+		output.KeyValue("Latest SHA", plan.ExpectedSHA)
+	}
+	output.KeyValue("Artifact SHA", plan.ArtifactSHA)
+
+	if !plan.UpdateNeeded {
+		output.Success("arcane-cli is already up to date")
+		return nil
+	}
+
+	if cliUpdateDryRun {
+		output.Info("Update available: %s", plan.ArtifactURL)
+		return nil
+	}
+
+	if err := installCLIUpdateInternal(ctx, plan); err != nil {
+		return err
+	}
+	output.Success("arcane-cli updated successfully")
+	return nil
+}
+
+func buildCLIUpdatePlanInternal(ctx context.Context, overrideChannel string) (*cliUpdatePlan, error) {
+	targetPath, err := resolveCLIUpdateTargetInternal()
+	if err != nil {
+		return nil, err
+	}
+
+	channel := normalizeCLIUpdateChannelInternal(overrideChannel)
+	if channel == "" {
+		channel, err = configuredCLIUpdateChannelInternal()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if channel == "" {
+		channel = inferCLIUpdateChannelInternal(config.Version)
+	}
+	if channel != cliUpdateChannelNext && channel != cliUpdateChannelStable {
+		return nil, fmt.Errorf("invalid update channel %q (expected next or stable)", channel)
+	}
+
+	currentSHA, err := sha256FileInternal(targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	plan, err := resolveRemoteCLIUpdateInternal(ctx, channel)
+	if err != nil {
+		return nil, err
+	}
+	plan.Channel = channel
+	plan.TargetPath = targetPath
+	plan.CurrentSHA = currentSHA
+	plan.UpdateNeeded = cliUpdateNeededInternal(channel, currentSHA, plan.ExpectedSHA, plan.Version)
+	return plan, nil
+}
+
+func configuredCLIUpdateChannelInternal() (string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+	channel := normalizeCLIUpdateChannelInternal(cfg.CLIUpdateChannel)
+	if channel == "" {
+		return "", nil
+	}
+	if channel != cliUpdateChannelNext && channel != cliUpdateChannelStable {
+		return "", fmt.Errorf("invalid configured CLI update channel %q (expected stable or next)", cfg.CLIUpdateChannel)
+	}
+	return channel, nil
+}
+
+func saveCLIUpdateChannelInternal(channel string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	cfg.CLIUpdateChannel = channel
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}
+
+func resolveCLIUpdateTargetInternal() (string, error) {
+	if strings.TrimSpace(cliUpdateTarget) != "" {
+		return filepath.Abs(strings.TrimSpace(cliUpdateTarget))
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve current executable: %w", err)
+	}
+	return filepath.EvalSymlinks(exe)
+}
+
+func normalizeCLIUpdateChannelInternal(channel string) string {
+	return strings.ToLower(strings.TrimSpace(channel))
+}
+
+func inferCLIUpdateChannelInternal(version string) string {
+	normalized := strings.ToLower(strings.TrimSpace(version))
+	if strings.Contains(normalized, "next") || strings.Contains(normalized, "beta") {
+		return cliUpdateChannelNext
+	}
+	return cliUpdateChannelStable
+}
+
+func resolveRemoteCLIUpdateInternal(ctx context.Context, channel string) (*cliUpdatePlan, error) {
+	if channel == cliUpdateChannelNext {
+		return resolveNextCLIUpdateInternal(ctx)
+	}
+	return resolveStableCLIUpdateInternal(ctx)
+}
+
+func resolveNextCLIUpdateInternal(ctx context.Context) (*cliUpdatePlan, error) {
+	baseURL := strings.TrimSpace(config.CLINextBaseURL)
+	if baseURL == "" {
+		return nil, errors.New("next CLI update base URL is empty")
+	}
+
+	artifactName, err := cliRawArtifactNameInternal()
+	if err != nil {
+		return nil, err
+	}
+	checksumPath, err := cliRawChecksumPathInternal()
+	if err != nil {
+		return nil, err
+	}
+	checksumURL := joinURLPathInternal(baseURL, "arcane-cli_checksums.txt")
+	checksums, err := fetchTextInternal(ctx, checksumURL)
+	if err != nil {
+		return nil, err
+	}
+	expectedSHA, err := findChecksumInternal(checksums, checksumPath, artifactName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cliUpdatePlan{
+		Version:      "next",
+		ArtifactName: artifactName,
+		ArtifactURL:  joinURLPathInternal(baseURL, artifactName),
+		ChecksumURL:  checksumURL,
+		ArtifactSHA:  expectedSHA,
+		ExpectedSHA:  expectedSHA,
+	}, nil
+}
+
+func resolveStableCLIUpdateInternal(ctx context.Context) (*cliUpdatePlan, error) {
+	version := strings.TrimSpace(cliUpdateVersion)
+	if version == "" {
+		latest, err := fetchLatestGitHubReleaseInternal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		version = latest
+	}
+	if version == "" {
+		return nil, errors.New("stable CLI update version is empty")
+	}
+
+	baseURL := strings.TrimSpace(config.CLIStableBaseURL)
+	if baseURL == "" {
+		return nil, errors.New("stable CLI update base URL is empty")
+	}
+
+	artifactName, err := cliArchiveArtifactNameInternal()
+	if err != nil {
+		return nil, err
+	}
+	checksumName := fmt.Sprintf("arcane_%s_checksums.txt", strings.TrimPrefix(version, "v"))
+	versionBaseURL := joinURLPathInternal(baseURL, version)
+	checksumURL := joinURLPathInternal(versionBaseURL, checksumName)
+	checksums, err := fetchTextInternal(ctx, checksumURL)
+	if err != nil {
+		return nil, err
+	}
+	artifactSHA, err := findChecksumInternal(checksums, artifactName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cliUpdatePlan{
+		Version:      version,
+		ArtifactName: artifactName,
+		ArtifactURL:  joinURLPathInternal(versionBaseURL, artifactName),
+		ChecksumURL:  checksumURL,
+		ArtifactSHA:  artifactSHA,
+	}, nil
+}
+
+func cliUpdateNeededInternal(channel, currentSHA, expectedSHA, remoteVersion string) bool {
+	if channel == cliUpdateChannelStable {
+		return normalizeVersionInternal(config.Version) != normalizeVersionInternal(remoteVersion)
+	}
+	return !strings.EqualFold(currentSHA, expectedSHA)
+}
+
+func normalizeVersionInternal(version string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(version)), "v")
+}
+
+func fetchLatestGitHubReleaseInternal(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/getarcaneapp/arcane/releases/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	var latest githubLatestRelease
+	if err := doJSONInternal(req, &latest); err != nil {
+		return "", fmt.Errorf("failed to fetch latest GitHub release: %w", err)
+	}
+	return strings.TrimSpace(latest.TagName), nil
+}
+
+func cliRawArtifactNameInternal() (string, error) {
+	arch, err := cliArtifactArchInternal()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("arcane-cli_%s_%s", runtime.GOOS, arch), nil
+}
+
+func cliArchiveArtifactNameInternal() (string, error) {
+	arch, err := cliArtifactArchInternal()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("arcane-cli_%s_%s.tar.gz", runtime.GOOS, arch), nil
+}
+
+func cliRawChecksumPathInternal() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return fmt.Sprintf("arcane-cli_%s_amd64_v1/arcane-cli", runtime.GOOS), nil
+	case "arm64":
+		return fmt.Sprintf("arcane-cli_%s_arm64_v8.0/arcane-cli", runtime.GOOS), nil
+	case "386":
+		return fmt.Sprintf("arcane-cli_%s_386_sse2/arcane-cli", runtime.GOOS), nil
+	case "arm":
+		return fmt.Sprintf("arcane-cli_%s_arm_7/arcane-cli", runtime.GOOS), nil
+	default:
+		return "", fmt.Errorf("unsupported CLI update architecture %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func cliArtifactArchInternal() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64", "arm64", "386":
+		return runtime.GOARCH, nil
+	case "arm":
+		return "armv7", nil
+	default:
+		return "", fmt.Errorf("unsupported CLI update architecture %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func installCLIUpdateInternal(ctx context.Context, plan *cliUpdatePlan) error {
+	tmpDir, err := os.MkdirTemp("", "arcane-cli-update-*")
+	if err != nil {
+		return fmt.Errorf("failed to create update temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	downloadPath := filepath.Join(tmpDir, plan.ArtifactName)
+	if err := downloadFileInternal(ctx, plan.ArtifactURL, downloadPath); err != nil {
+		return err
+	}
+	if gotSHA, err := sha256FileInternal(downloadPath); err != nil {
+		return err
+	} else if !strings.EqualFold(gotSHA, plan.ArtifactSHA) {
+		return fmt.Errorf("downloaded artifact SHA mismatch: got %s, expected %s", gotSHA, plan.ArtifactSHA)
+	}
+
+	binaryPath := downloadPath
+	if strings.HasSuffix(plan.ArtifactName, ".tar.gz") {
+		extractedPath := filepath.Join(tmpDir, "arcane-cli")
+		if err := extractCLIFromTarGzInternal(downloadPath, extractedPath); err != nil {
+			return err
+		}
+		binaryPath = extractedPath
+	}
+
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		return fmt.Errorf("failed to make downloaded binary executable: %w", err)
+	}
+	return replaceExecutableInternal(binaryPath, plan.TargetPath)
+}
+
+func replaceExecutableInternal(sourcePath, targetPath string) error {
+	targetDir := filepath.Dir(targetPath)
+	tmpTarget, err := os.CreateTemp(targetDir, filepath.Base(targetPath)+".update-*")
+	if err != nil {
+		return fmt.Errorf("failed to create replacement file in %s: %w", targetDir, err)
+	}
+	tmpTargetPath := tmpTarget.Name()
+	cleanup := func() { _ = os.Remove(tmpTargetPath) }
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		_ = tmpTarget.Close()
+		cleanup()
+		return fmt.Errorf("failed to open downloaded binary: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	if _, err := io.Copy(tmpTarget, source); err != nil {
+		_ = tmpTarget.Close()
+		cleanup()
+		return fmt.Errorf("failed to write replacement binary: %w", err)
+	}
+	if err := tmpTarget.Chmod(0o755); err != nil {
+		_ = tmpTarget.Close()
+		cleanup()
+		return fmt.Errorf("failed to chmod replacement binary: %w", err)
+	}
+	if err := tmpTarget.Sync(); err != nil {
+		_ = tmpTarget.Close()
+		cleanup()
+		return fmt.Errorf("failed to sync replacement binary: %w", err)
+	}
+	if err := tmpTarget.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close replacement binary: %w", err)
+	}
+	if err := os.Rename(tmpTargetPath, targetPath); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to replace %s: %w", targetPath, err)
+	}
+
+	dirFile, err := os.Open(targetDir)
+	if err != nil {
+		return fmt.Errorf("failed to open target directory for sync: %w", err)
+	}
+	defer func() { _ = dirFile.Close() }()
+	if err := dirFile.Sync(); err != nil {
+		return fmt.Errorf("failed to sync target directory: %w", err)
+	}
+	return nil
+}
+
+func extractCLIFromTarGzInternal(archivePath, outputPath string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("failed to read gzip archive: %w", err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if path.Base(header.Name) != "arcane-cli" {
+			continue
+		}
+		if header.Size < 0 || header.Size > maxCLIExtractSize {
+			return fmt.Errorf("arcane-cli archive entry has invalid size %d", header.Size)
+		}
+
+		out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+		if err != nil {
+			return fmt.Errorf("failed to create extracted binary: %w", err)
+		}
+		if _, err := io.CopyN(out, tarReader, header.Size); err != nil {
+			_ = out.Close()
+			return fmt.Errorf("failed to extract CLI binary: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("failed to close extracted binary: %w", err)
+		}
+		return nil
+	}
+	return errors.New("archive did not contain arcane-cli")
+}
+
+func fetchTextInternal(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	client := &http.Client{Timeout: cliUpdateHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("failed to fetch %s: HTTP %s", url, resp.Status)
+	}
+	limitedBody := &io.LimitedReader{R: resp.Body, N: maxCLIChecksumSize + 1}
+	body, err := io.ReadAll(limitedBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", url, err)
+	}
+	if len(body) > maxCLIChecksumSize {
+		return "", fmt.Errorf("failed to read %s: checksum response exceeds maximum size of %d bytes", url, maxCLIChecksumSize)
+	}
+	return string(body), nil
+}
+
+func downloadFileInternal(ctx context.Context, url, outputPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: cliUpdateHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("failed to download %s: HTTP %s", url, resp.Status)
+	}
+
+	out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to create download file: %w", err)
+	}
+	limitedBody := &io.LimitedReader{R: resp.Body, N: maxCLIDownloadSize + 1}
+	written, err := io.Copy(out, limitedBody)
+	if err != nil {
+		_ = out.Close()
+		return fmt.Errorf("failed to write download file: %w", err)
+	}
+	if written > maxCLIDownloadSize {
+		_ = out.Close()
+		return fmt.Errorf("downloaded artifact exceeds maximum size of %d bytes", maxCLIDownloadSize)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close download file: %w", err)
+	}
+	return nil
+}
+
+func doJSONInternal(req *http.Request, out any) error {
+	client := &http.Client{Timeout: cliUpdateHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %s", resp.Status)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sha256FileInternal(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s for SHA-256: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("failed to hash %s: %w", path, err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func findChecksumInternal(checksums string, artifactNames ...string) (string, error) {
+	wanted := make(map[string]struct{}, len(artifactNames))
+	for _, artifactName := range artifactNames {
+		artifactName = normalizeChecksumPathInternal(artifactName)
+		if artifactName != "" {
+			wanted[artifactName] = struct{}{}
+		}
+	}
+
+	for _, line := range strings.Split(checksums, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		checksumPath := normalizeChecksumPathInternal(fields[len(fields)-1])
+		if checksumPathMatchesInternal(checksumPath, wanted) {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	return "", fmt.Errorf("checksum for %s not found", strings.Join(artifactNames, " or "))
+}
+
+func normalizeChecksumPathInternal(value string) string {
+	return strings.TrimPrefix(path.Clean(strings.TrimSpace(value)), "./")
+}
+
+func checksumPathMatchesInternal(checksumPath string, wanted map[string]struct{}) bool {
+	if _, ok := wanted[checksumPath]; ok {
+		return true
+	}
+	if _, ok := wanted[path.Base(checksumPath)]; ok {
+		return true
+	}
+	for wantedPath := range wanted {
+		if strings.HasSuffix(checksumPath, "/"+wantedPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinURLPathInternal(baseURL string, parts ...string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	joined := path.Join(parts...)
+	if joined == "." || joined == "" {
+		return baseURL
+	}
+	return baseURL + "/" + strings.TrimLeft(joined, "/")
+}

--- a/cli/pkg/selfupdate/cmd_test.go
+++ b/cli/pkg/selfupdate/cmd_test.go
@@ -1,0 +1,27 @@
+package selfupdate
+
+import "testing"
+
+func TestFindChecksumMatchesNextDistPath(t *testing.T) {
+	checksums := "abc123  dist/arcane-cli_darwin_arm64_v8.0/arcane-cli\n"
+
+	got, err := findChecksumInternal(checksums, "arcane-cli_darwin_arm64_v8.0/arcane-cli", "arcane-cli_darwin_arm64")
+	if err != nil {
+		t.Fatalf("findChecksum returned error: %v", err)
+	}
+	if got != "abc123" {
+		t.Fatalf("findChecksum = %q, want abc123", got)
+	}
+}
+
+func TestFindChecksumMatchesArchiveBasename(t *testing.T) {
+	checksums := "def456  dist/arcane-cli_linux_amd64.tar.gz\n"
+
+	got, err := findChecksumInternal(checksums, "arcane-cli_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatalf("findChecksum returned error: %v", err)
+	}
+	if got != "def456" {
+		t.Fatalf("findChecksum = %q, want def456", got)
+	}
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `self-update` / `arcane self-update` command that supports both a `stable` channel (GitHub releases, tarball + checksum) and a `next` channel (S3-hosted raw binaries + checksum), along with a new `cli_update_channel` config key and corresponding `config set` support. The goreleaser blob config is extended to upload the next-channel checksums file.

- **`cli/pkg/selfupdate/cmd.go`**: Implements channel resolution, per-platform artifact naming, checksum fetch-and-verify, bounded download via `LimitedReader`, and atomic binary replacement using `os.Rename` with directory sync.
- **`cli/pkg/root.go`**: Registers the new command and refactors help rendering so `rootCmd.PersistentFlags()` (global flags) appear correctly in every runnable subcommand's `--help` output.
- **`cli/internal/config` + `cli/pkg/config/cmd.go`**: Add `CLIUpdateChannel` field, save/load round-trip, and `config set channel` support.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the update flow verifies checksums before replacing the binary and uses an atomic rename for the replacement.

The implementation handles the security-sensitive parts carefully: downloads are bounded by a LimitedReader, the downloaded artifact is SHA-256 verified against the published checksum before installation, and binary replacement is done atomically via rename with directory sync. The one minor gap is that the checksum file itself is read into memory without a size cap, but it is fetched over HTTPS from a controlled endpoint.

cli/pkg/selfupdate/cmd.go — the fetchTextInternal helper reads the checksums file with no in-memory size limit.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat%2Farcane-cli-update-channel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Farcane-cli-update-channel%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acli%2Fpkg%2Fselfupdate%2Fcmd.go%3A560-564%0A%60fetchTextInternal%60%20reads%20the%20entire%20checksums%20file%20into%20memory%20with%20no%20size%20bound.%20While%20the%20endpoint%20is%20HTTPS%20and%20controlled%2C%20pairing%20with%20a%20%60LimitedReader%60%20%28as%20is%20already%20done%20in%20%60downloadFileInternal%60%29%20keeps%20the%20pattern%20consistent%20and%20guards%20against%20an%20unexpectedly%20large%20or%20misbehaving%20response.%0A%0A%60%60%60suggestion%0A%09const%20maxChecksumSize%20%3D%201%20*%201024%20*%201024%20%2F%2F%201%20MiB%0A%09body%2C%20err%20%3A%3D%20io.ReadAll%28io.LimitReader%28resp.Body%2C%20maxChecksumSize%29%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20%22%22%2C%20fmt.Errorf%28%22failed%20to%20read%20%25s%3A%20%25w%22%2C%20url%2C%20err%29%0A%09%7D%0A%09return%20string%28body%29%2C%20nil%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acli%2Fpkg%2Fselfupdate%2Fcmd.go%3A560-564%0A%60fetchTextInternal%60%20reads%20the%20entire%20checksums%20file%20into%20memory%20with%20no%20size%20bound.%20While%20the%20endpoint%20is%20HTTPS%20and%20controlled%2C%20pairing%20with%20a%20%60LimitedReader%60%20%28as%20is%20already%20done%20in%20%60downloadFileInternal%60%29%20keeps%20the%20pattern%20consistent%20and%20guards%20against%20an%20unexpectedly%20large%20or%20misbehaving%20response.%0A%0A%60%60%60suggestion%0A%09const%20maxChecksumSize%20%3D%201%20*%201024%20*%201024%20%2F%2F%201%20MiB%0A%09body%2C%20err%20%3A%3D%20io.ReadAll%28io.LimitReader%28resp.Body%2C%20maxChecksumSize%29%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20%22%22%2C%20fmt.Errorf%28%22failed%20to%20read%20%25s%3A%20%25w%22%2C%20url%2C%20err%29%0A%09%7D%0A%09return%20string%28body%29%2C%20nil%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2517&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
cli/pkg/selfupdate/cmd.go:560-564
`fetchTextInternal` reads the entire checksums file into memory with no size bound. While the endpoint is HTTPS and controlled, pairing with a `LimitedReader` (as is already done in `downloadFileInternal`) keeps the pattern consistent and guards against an unexpectedly large or misbehaving response.

```suggestion
	const maxChecksumSize = 1 * 1024 * 1024 // 1 MiB
	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChecksumSize))
	if err != nil {
		return "", fmt.Errorf("failed to read %s: %w", url, err)
	}
	return string(body), nil
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(cli): arcane-cli update channels an..."](https://github.com/getarcaneapp/arcane/commit/07047d605fc382e68fd13cf88a9a3da3ee3d44df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30956830)</sub>

<!-- /greptile_comment -->