### PR TITLE
refactor: create project filesystem architecture

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -64,7 +64,10 @@ func NewProjectService(db *database.DB, settingsService *SettingsService, eventS
 }
 
 func (s *ProjectService) getPathMapper(ctx context.Context) (*projects.PathMapper, error) {
-	configuredPath := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
+	configuredPath := "/app/data/projects"
+	if s.settingsService != nil {
+		configuredPath = s.settingsService.GetStringSetting(ctx, "projectsDirectory", configuredPath)
+	}
 
 	var containerDir, hostDir string
 
@@ -114,13 +117,86 @@ func (s *ProjectService) getPathMapper(ctx context.Context) (*projects.PathMappe
 }
 
 func (s *ProjectService) getProjectsDirectoryInternal(ctx context.Context) (string, error) {
-	projectsDirSetting := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
+	projectsDirSetting := "/app/data/projects"
+	if s.settingsService != nil {
+		projectsDirSetting = s.settingsService.GetStringSetting(ctx, "projectsDirectory", projectsDirSetting)
+	}
 	projectsDir, err := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirSetting))
 	if err != nil {
 		return "", err
 	}
 
 	return filepath.Clean(projectsDir), nil
+}
+
+func (s *ProjectService) buildProjectFilesystemInternal(ctx context.Context, allowDefault bool) (*projects.ProjectFilesystem, error) {
+	projectsDirectorySetting := "/app/data/projects"
+	autoInjectEnv := false
+	if s.settingsService != nil {
+		cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+		projectsDirectorySetting = cfg.ProjectsDirectory.Value
+		autoInjectEnv = utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)
+	}
+
+	projectsDirectory, err := projects.GetProjectsDirectory(ctx, strings.TrimSpace(projectsDirectorySetting))
+	if err != nil {
+		if !allowDefault {
+			return nil, fmt.Errorf("failed to get projects directory: %w", err)
+		}
+		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", err)
+		projectsDirectory = "/app/data/projects"
+	}
+
+	pathMapper, pmErr := s.getPathMapper(ctx)
+	if pmErr != nil {
+		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
+	}
+
+	return projects.NewProjectFilesystem(projects.ProjectFilesystemConfig{
+		ProjectsRoot:  projectsDirectory,
+		AutoInjectEnv: autoInjectEnv,
+		PathMapper:    pathMapper,
+	}), nil
+}
+
+func (s *ProjectService) resolveProjectComposeFileHintInternal(ctx context.Context, proj *models.Project) (string, error) {
+	if proj == nil || proj.GitOpsManagedBy == nil || strings.TrimSpace(*proj.GitOpsManagedBy) == "" {
+		return "", nil
+	}
+
+	var sync models.GitOpsSync
+	if err := s.db.WithContext(ctx).
+		Select("compose_path").
+		Where("id = ?", *proj.GitOpsManagedBy).
+		First(&sync).Error; err == nil {
+		composeFileName := strings.TrimSpace(filepath.Base(sync.ComposePath))
+		if composeFileName != "" && composeFileName != "." {
+			return composeFileName, nil
+		}
+		return "", nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", fmt.Errorf("failed to resolve GitOps compose path for project %s: %w", proj.ID, err)
+	}
+
+	return "", nil
+}
+
+func (s *ProjectService) buildProjectWorkspaceInternal(ctx context.Context, proj *models.Project) (projects.ProjectWorkspace, error) {
+	if proj == nil {
+		return projects.ProjectWorkspace{}, fmt.Errorf("project is nil")
+	}
+
+	composeFileName, err := s.resolveProjectComposeFileHintInternal(ctx, proj)
+	if err != nil {
+		return projects.ProjectWorkspace{}, err
+	}
+
+	return projects.ProjectWorkspace{
+		Name:            proj.Name,
+		DirName:         utils.DerefString(proj.DirName),
+		Path:            proj.Path,
+		ComposeFileName: composeFileName,
+	}, nil
 }
 
 func (s *ProjectService) GetProjectRelativePath(ctx context.Context, projectPath string) string {
@@ -190,7 +266,10 @@ const (
 	imagePullModeAlways
 )
 
-var composePullProjectServicesInternal = projects.ComposePull
+var (
+	composeDownProjectInternal         = projects.ComposeDown
+	composePullProjectServicesInternal = projects.ComposePull
+)
 
 func resolveServiceImagePullMode(svc composetypes.ServiceConfig) imagePullMode {
 	rawPolicy := strings.ToLower(strings.TrimSpace(svc.PullPolicy))
@@ -416,29 +495,17 @@ func (s *ProjectService) resolveProjectComposeFileInternal(ctx context.Context, 
 		return "", fmt.Errorf("project is nil")
 	}
 
-	if proj.GitOpsManagedBy != nil && strings.TrimSpace(*proj.GitOpsManagedBy) != "" {
-		var sync models.GitOpsSync
-		if err := s.db.WithContext(ctx).
-			Select("compose_path").
-			Where("id = ?", *proj.GitOpsManagedBy).
-			First(&sync).Error; err == nil {
-			composeFileName := strings.TrimSpace(filepath.Base(sync.ComposePath))
-			if composeFileName != "" && composeFileName != "." {
-				candidate := filepath.Join(proj.Path, composeFileName)
-				if info, statErr := os.Stat(candidate); statErr == nil {
-					if !info.IsDir() {
-						return candidate, nil
-					}
-				} else if !os.IsNotExist(statErr) {
-					return "", fmt.Errorf("failed to inspect GitOps compose file %s: %w", candidate, statErr)
-				}
-			}
-		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return "", fmt.Errorf("failed to resolve GitOps compose path for project %s: %w", proj.ID, err)
-		}
+	fs, err := s.buildProjectFilesystemInternal(ctx, true)
+	if err != nil {
+		return "", err
 	}
 
-	composeFile, err := projects.DetectComposeFile(proj.Path)
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, proj)
+	if err != nil {
+		return "", err
+	}
+
+	composeFile, err := fs.ResolveComposeFile(workspace)
 	if err != nil {
 		return "", &common.ProjectComposeFileNotFoundError{Err: err}
 	}
@@ -447,29 +514,17 @@ func (s *ProjectService) resolveProjectComposeFileInternal(ctx context.Context, 
 }
 
 func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Context, proj *models.Project) (*composetypes.Project, string, error) {
-	composeFileFullPath, err := s.resolveProjectComposeFileInternal(ctx, proj)
+	fs, err := s.buildProjectFilesystemInternal(ctx, true)
 	if err != nil {
 		return nil, "", err
 	}
 
-	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
-	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
-	if pdErr != nil {
-		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", pdErr)
-		projectsDirectory = "/app/data/projects"
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, proj)
+	if err != nil {
+		return nil, "", err
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
-
-	composeProject, loadErr := projects.LoadComposeProject(ctx, composeFileFullPath, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
-	if loadErr != nil {
-		return nil, "", loadErr
-	}
-
-	return composeProject, composeFileFullPath, nil
+	return fs.LoadComposeProject(ctx, workspace)
 }
 
 func buildSelectedProjectImageRefsInternal(compProj *composetypes.Project, servicesToUpdate []string) []string {
@@ -1022,25 +1077,17 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 }
 
 func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project) ([]string, error) {
-	projectsDir, err := s.getProjectsDirectoryInternal(ctx)
+	fs, err := s.buildProjectFilesystemInternal(ctx, false)
 	if err != nil {
 		return nil, err
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper while resolving project image refs", "projectID", proj.ID, "projectName", proj.Name, "error", pmErr)
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, &proj)
+	if err != nil {
+		return nil, err
 	}
 
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	composeProject, _, loadErr := projects.LoadComposeProjectFromDir(
-		ctx,
-		proj.Path,
-		normalizeComposeProjectName(proj.Name),
-		projectsDir,
-		autoInjectEnv,
-		pathMapper,
-	)
+	composeProject, _, loadErr := fs.LoadComposeProject(ctx, workspace)
 	if loadErr != nil {
 		return nil, fmt.Errorf("load compose project: %w", loadErr)
 	}
@@ -1681,7 +1728,7 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 		return fmt.Errorf("failed to update project status to stopping: %w", err)
 	}
 
-	if err := projects.ComposeDown(ctx, proj, false); err != nil {
+	if err := composeDownProjectInternal(ctx, proj, false); err != nil {
 		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return fmt.Errorf("failed to bring down project: %w", err)
 	}
@@ -1699,39 +1746,49 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 }
 
 func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent string, envContent *string, user models.User) (*models.Project, error) {
-	sanitized := projects.SanitizeProjectName(name)
-
-	projectsDirectory, err := projects.GetProjectsDirectory(ctx, s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects"))
+	fs, err := s.buildProjectFilesystemInternal(ctx, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get projects directory: %w", err)
+		return nil, err
 	}
 
-	basePath := filepath.Join(projectsDirectory, sanitized)
-	projectPath, folderName, err := projects.CreateUniqueDir(projectsDirectory, basePath, name, common.DirPerm)
+	workspace, err := fs.CreateWorkspace(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project directory: %w", err)
 	}
 
+	staged, err := fs.StageCreate(workspace, composeContent, envContent)
+	if err != nil {
+		_ = os.RemoveAll(workspace.Path)
+		return nil, fmt.Errorf("failed to save project files: %w", err)
+	}
+
+	if err := s.validateComposeContentForUpdate(ctx, fs.Config.ProjectsRoot, staged.Stage.Path, staged.Target.Name, composeContent, envContent); err != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
+		_ = os.RemoveAll(workspace.Path)
+		return nil, fmt.Errorf("invalid compose file: %w", err)
+	}
+
+	if err := fs.Promote(staged); err != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
+		_ = os.RemoveAll(workspace.Path)
+		return nil, fmt.Errorf("failed to save project files: %w", err)
+	}
+
 	proj := &models.Project{
-		Name:         name,
-		DirName:      &folderName,
-		Path:         projectPath,
+		Name:         staged.Target.Name,
+		DirName:      &staged.Target.DirName,
+		Path:         staged.Target.Path,
 		Status:       models.ProjectStatusStopped,
 		ServiceCount: 0,
 		RunningCount: 0,
 	}
 
 	if err := s.db.WithContext(ctx).Create(proj).Error; err != nil {
+		_ = os.RemoveAll(staged.Target.Path)
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
 
-	if err := projects.SaveOrUpdateProjectFiles(projectsDirectory, projectPath, composeContent, envContent); err != nil {
-		// Best-effort cleanup to restore pre-transaction behavior.
-		_ = s.db.WithContext(ctx).Delete(proj).Error
-		return nil, fmt.Errorf("failed to save project files: %w", err)
-	}
-
-	metadata := models.JSON{"action": "create", "projectID": proj.ID, "projectName": name, "path": projectPath}
+	metadata := models.JSON{"action": "create", "projectID": proj.ID, "projectName": proj.Name, "path": proj.Path}
 	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectCreate, proj.ID, name, user.ID, user.Username, "0", metadata); logErr != nil {
 		slog.ErrorContext(ctx, "could not log project creation", "error", logErr)
 	}
@@ -1762,7 +1819,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 
 	if removeVolumes {
 		if compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj); lerr == nil {
-			if derr := projects.ComposeDown(ctx, compProj, true); derr != nil {
+			if derr := composeDownProjectInternal(ctx, compProj, true); derr != nil {
 				slog.WarnContext(ctx, "failed to remove volumes", "error", derr)
 			}
 		} else {
@@ -1771,8 +1828,17 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 	}
 
 	if removeFiles {
+		fs, fsErr := s.buildProjectFilesystemInternal(ctx, true)
+		if fsErr != nil {
+			return fsErr
+		}
+		workspace, wsErr := s.buildProjectWorkspaceInternal(ctx, proj)
+		if wsErr != nil {
+			return wsErr
+		}
+
 		slog.DebugContext(ctx, "Removing project files", "path", proj.Path)
-		if err := os.RemoveAll(proj.Path); err != nil {
+		if err := fs.RemoveWorkspace(workspace); err != nil {
 			slog.ErrorContext(ctx, "Failed to remove project files", "path", proj.Path, "error", err)
 			return fmt.Errorf("failed to remove project files: %w", err)
 		}
@@ -2507,20 +2573,19 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 		return fmt.Errorf("failed to update project status to restarting: %w", err)
 	}
 
-	// Get configured projects directory from settings
-	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
-	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
-	if pdErr != nil {
-		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", pdErr)
-		projectsDirectory = "/app/data/projects"
+	fs, err := s.buildProjectFilesystemInternal(ctx, true)
+	if err != nil {
+		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
+		return err
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, proj)
+	if err != nil {
+		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
+		return err
 	}
 
-	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
+	compProj, _, lerr := fs.LoadComposeProject(ctx, workspace)
 	if lerr != nil {
 		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return fmt.Errorf("failed to load compose project: %w", lerr)
@@ -2544,28 +2609,54 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 }
 
 func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, name *string, composeContent, envContent *string, user models.User) (*models.Project, error) {
-	proj, projectsDirectory, err := s.getProjectForUpdate(ctx, projectID)
+	proj, fs, workspace, err := s.getProjectForUpdate(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 	if err := ensureProjectMutableInternal(&proj); err != nil {
 		return nil, err
 	}
+	if isProjectRenameRequestedInternal(proj.Name, name) && proj.Status != models.ProjectStatusStopped {
+		return nil, fmt.Errorf("project must be stopped before renaming (current status: %s)", proj.Status)
+	}
 
-	if err := s.withProjectRenameRollback(ctx, &proj, func() error {
-		if err := s.applyProjectRenameIfNeeded(&proj, name, projectsDirectory); err != nil {
-			return err
-		}
-		if err := s.persistUpdatedProjectFiles(ctx, &proj, projectsDirectory, composeContent, envContent); err != nil {
-			return err
-		}
-		if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
-			return fmt.Errorf("failed to update project: %w", err)
-		}
-		return nil
-	}); err != nil {
+	staged, err := fs.StageUpdate(workspace, name, composeContent, envContent)
+	if err != nil {
 		return nil, err
 	}
+	if composeContent != nil {
+		effectiveEnvContent, envErr := s.resolveEffectiveEnvContentForUpdateInternal(staged.Stage.Path, envContent)
+		if envErr != nil {
+			_ = os.RemoveAll(staged.Stage.Path)
+			return nil, fmt.Errorf("failed to resolve project env state: %w", envErr)
+		}
+		if err := s.validateComposeContentForUpdate(ctx, fs.Config.ProjectsRoot, staged.Stage.Path, staged.Target.Name, *composeContent, effectiveEnvContent); err != nil {
+			_ = os.RemoveAll(staged.Stage.Path)
+			return nil, fmt.Errorf("invalid compose file: %w", err)
+		}
+	}
+	promoteRollback, err := preparePromotedProjectRollbackInternal(fs, staged)
+	if err != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
+		return nil, err
+	}
+	if err := fs.Promote(staged); err != nil {
+		promoteRollback.cleanup()
+		_ = os.RemoveAll(staged.Stage.Path)
+		return nil, err
+	}
+
+	proj.Name = staged.Target.Name
+	proj.DirName = &staged.Target.DirName
+	proj.Path = staged.Target.Path
+
+	if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
+		if rollbackErr := promoteRollback.rollback(); rollbackErr != nil {
+			return nil, fmt.Errorf("failed to update project: %w; filesystem rollback failed: %w", err, rollbackErr)
+		}
+		return nil, fmt.Errorf("failed to update project: %w", err)
+	}
+	promoteRollback.cleanup()
 
 	// When compose content changes, recalculate service counts and status so the
 	// overview doesn't show stale values (e.g. ghost services after removal).
@@ -2595,7 +2686,7 @@ func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, na
 }
 
 func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID string, composeContent string, gitEnvContent *string, user models.User) (*models.Project, error) {
-	proj, projectsDirectory, err := s.getProjectForUpdate(ctx, projectID)
+	proj, fs, workspace, err := s.getProjectForUpdate(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -2603,24 +2694,36 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 		return nil, err
 	}
 
-	envUpdate, err := s.prepareGitSyncEnvUpdateInternal(proj.Path, gitEnvContent)
+	staged, err := fs.StageGitSync(workspace, composeContent, gitEnvContent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve git env state: %w", err)
 	}
-
-	if err := s.validateComposeContentForUpdate(ctx, projectsDirectory, proj.Path, proj.Name, composeContent, envUpdate.effectiveContent); err != nil {
+	effectiveEnvContent, envErr := s.resolveEffectiveEnvContentForUpdateInternal(staged.Stage.Path, nil)
+	if envErr != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
+		return nil, fmt.Errorf("failed to resolve git env state: %w", envErr)
+	}
+	if err := s.validateComposeContentForUpdate(ctx, fs.Config.ProjectsRoot, staged.Stage.Path, staged.Target.Name, composeContent, effectiveEnvContent); err != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
 		return nil, fmt.Errorf("invalid compose file: %w", err)
 	}
-
-	if err := projects.WriteComposeFile(projectsDirectory, proj.Path, composeContent); err != nil {
-		return nil, fmt.Errorf("failed to save compose file: %w", err)
+	promoteRollback, err := preparePromotedProjectRollbackInternal(fs, staged)
+	if err != nil {
+		_ = os.RemoveAll(staged.Stage.Path)
+		return nil, err
 	}
-	if err := s.persistGitSyncEnvFilesInternal(proj.Path, projectsDirectory, envUpdate); err != nil {
+	if err := fs.Promote(staged); err != nil {
+		promoteRollback.cleanup()
+		_ = os.RemoveAll(staged.Stage.Path)
 		return nil, fmt.Errorf("failed to sync git env files: %w", err)
 	}
 	if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
+		if rollbackErr := promoteRollback.rollback(); rollbackErr != nil {
+			return nil, fmt.Errorf("failed to update project: %w; filesystem rollback failed: %w", err, rollbackErr)
+		}
 		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
+	promoteRollback.cleanup()
 
 	// Recalculate service counts and status after compose file sync
 	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
@@ -2644,73 +2747,144 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 	return &proj, nil
 }
 
-func (s *ProjectService) getProjectForUpdate(ctx context.Context, projectID string) (models.Project, string, error) {
+func (s *ProjectService) getProjectForUpdate(ctx context.Context, projectID string) (models.Project, *projects.ProjectFilesystem, projects.ProjectWorkspace, error) {
 	var proj models.Project
 	if err := s.db.WithContext(ctx).First(&proj, "id = ?", projectID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return models.Project{}, "", fmt.Errorf("project not found")
+			return models.Project{}, nil, projects.ProjectWorkspace{}, fmt.Errorf("project not found")
 		}
-		return models.Project{}, "", fmt.Errorf("failed to get project: %w", err)
+		return models.Project{}, nil, projects.ProjectWorkspace{}, fmt.Errorf("failed to get project: %w", err)
 	}
 
-	projectsDirectory, err := projects.GetProjectsDirectory(ctx, s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects"))
+	fs, err := s.buildProjectFilesystemInternal(ctx, false)
 	if err != nil {
-		return models.Project{}, "", fmt.Errorf("failed to get projects directory: %w", err)
+		return models.Project{}, nil, projects.ProjectWorkspace{}, err
 	}
 
-	if err := s.ensureProjectPathUnderRoot(ctx, &proj, false); err != nil {
-		return models.Project{}, "", err
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, &proj)
+	if err != nil {
+		return models.Project{}, nil, projects.ProjectWorkspace{}, err
+	}
+	workspace, err = fs.ResolveExisting(workspace)
+	if err != nil {
+		return models.Project{}, nil, projects.ProjectWorkspace{}, err
+	}
+	proj.Path = workspace.Path
+	if workspace.DirName != "" {
+		proj.DirName = &workspace.DirName
 	}
 
-	return proj, projectsDirectory, nil
+	return proj, fs, workspace, nil
 }
 
-func (s *ProjectService) withProjectRenameRollback(ctx context.Context, proj *models.Project, run func() error) error {
-	originalPath := proj.Path
-	originalDirName := proj.DirName
-
-	if err := run(); err != nil {
-		if proj.Path != originalPath {
-			if renameErr := os.Rename(proj.Path, originalPath); renameErr != nil {
-				slog.WarnContext(ctx, "failed to rollback project directory rename", "from", proj.Path, "to", originalPath, "error", renameErr)
-				return err
-			}
-			proj.Path = originalPath
-			proj.DirName = originalDirName
-		}
-		return err
+func isProjectRenameRequestedInternal(currentName string, nextName *string) bool {
+	if nextName == nil {
+		return false
 	}
 
+	resolved := strings.TrimSpace(*nextName)
+	if resolved == "" {
+		return false
+	}
+
+	return resolved != currentName
+}
+
+type promotedProjectRollbackInternal struct {
+	backupPath string
+	livePath   string
+	targetPath string
+}
+
+func preparePromotedProjectRollbackInternal(fs *projects.ProjectFilesystem, staged *projects.StagedProjectWorkspace) (*promotedProjectRollbackInternal, error) {
+	rollback := &promotedProjectRollbackInternal{}
+	if fs == nil || staged == nil {
+		return rollback, nil
+	}
+
+	livePath, targetPath, err := resolvePromotedProjectRollbackPathsInternal(staged)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(livePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return rollback, nil
+		}
+		return nil, fmt.Errorf("inspect project directory for database rollback: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("project rollback source is not a directory: %s", livePath)
+	}
+
+	backupPath, err := os.MkdirTemp(fs.Config.ProjectsRoot, ".arcane-project-db-rollback-*")
+	if err != nil {
+		return nil, fmt.Errorf("create project database rollback directory: %w", err)
+	}
+	if err := os.Chmod(backupPath, info.Mode().Perm()); err != nil {
+		_ = os.RemoveAll(backupPath)
+		return nil, fmt.Errorf("set project database rollback directory permissions: %w", err)
+	}
+	if err := projects.CopyDirectoryContents(livePath, backupPath); err != nil {
+		_ = os.RemoveAll(backupPath)
+		return nil, fmt.Errorf("snapshot project directory for database rollback: %w", err)
+	}
+
+	rollback.backupPath = backupPath
+	rollback.livePath = livePath
+	rollback.targetPath = targetPath
+	return rollback, nil
+}
+
+func resolvePromotedProjectRollbackPathsInternal(staged *projects.StagedProjectWorkspace) (string, string, error) {
+	currentPath := filepath.Clean(staged.Current.Path)
+	targetPath := filepath.Clean(staged.Target.Path)
+	if currentPath != targetPath {
+		return currentPath, targetPath, nil
+	}
+
+	info, err := os.Lstat(currentPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return currentPath, targetPath, nil
+		}
+		return "", "", fmt.Errorf("inspect project directory for database rollback: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return currentPath, targetPath, nil
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(currentPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve project directory symlink for database rollback: %w", err)
+	}
+	resolvedPath = filepath.Clean(resolvedPath)
+	return resolvedPath, resolvedPath, nil
+}
+
+func (r *promotedProjectRollbackInternal) rollback() error {
+	if r == nil || r.backupPath == "" {
+		return nil
+	}
+	if r.targetPath != "" {
+		_ = os.RemoveAll(r.targetPath)
+	}
+	if r.livePath != "" && r.livePath != r.targetPath {
+		_ = os.RemoveAll(r.livePath)
+	}
+	if err := os.Rename(r.backupPath, r.livePath); err != nil {
+		return fmt.Errorf("restore project directory after database failure: %w", err)
+	}
+	r.backupPath = ""
 	return nil
 }
 
-func (s *ProjectService) persistUpdatedProjectFiles(ctx context.Context, proj *models.Project, projectsDirectory string, composeContent, envContent *string) error {
-	switch {
-	case composeContent != nil:
-		effectiveEnvContent, err := s.resolveEffectiveEnvContentForUpdateInternal(proj.Path, envContent)
-		if err != nil {
-			return fmt.Errorf("invalid compose file: %w", err)
-		}
-		if err := s.validateComposeContentForUpdate(ctx, projectsDirectory, proj.Path, proj.Name, *composeContent, effectiveEnvContent); err != nil {
-			return fmt.Errorf("invalid compose file: %w", err)
-		}
-		if err := projects.WriteComposeFile(projectsDirectory, proj.Path, *composeContent); err != nil {
-			return fmt.Errorf("failed to save project files: %w", err)
-		}
-		if envContent != nil {
-			if err := s.persistEffectiveEnvContentInternal(proj.Path, projectsDirectory, *envContent); err != nil {
-				return fmt.Errorf("failed to save project files: %w", err)
-			}
-		} else if err := s.ensureEffectiveEnvFileInternal(proj.Path, projectsDirectory); err != nil {
-			return fmt.Errorf("failed to save project files: %w", err)
-		}
-	case envContent != nil:
-		if err := s.persistEffectiveEnvContentInternal(proj.Path, projectsDirectory, *envContent); err != nil {
-			return err
-		}
+func (r *promotedProjectRollbackInternal) cleanup() {
+	if r == nil || r.backupPath == "" {
+		return
 	}
-
-	return nil
+	_ = os.RemoveAll(r.backupPath)
+	r.backupPath = ""
 }
 
 func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, projectsDirectory, projectPath, projectName, composeContent string, effectiveEnvContent *string) (err error) {
@@ -2969,231 +3143,6 @@ func (s *ProjectService) resolveStoredEffectiveEnvContentInternal(state projects
 	return state.DirectContent, nil
 }
 
-func (s *ProjectService) persistEffectiveEnvContentInternal(projectPath, projectsDirectory, envContent string) error {
-	state, err := projects.ReadProjectEnvState(projectPath)
-	if err != nil {
-		return fmt.Errorf("read project env state: %w", err)
-	}
-
-	if !state.HasGitSource {
-		if state.HasOverride {
-			if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
-				return err
-			}
-		}
-		return projects.WriteEnvFile(projectsDirectory, projectPath, envContent)
-	}
-
-	overrideContent, err := projects.BuildOverrideEnvContent(state.GitContent, envContent)
-	if err != nil {
-		return fmt.Errorf("build override env content: %w", err)
-	}
-
-	effectiveContent, err := projects.BuildEffectiveEnvContent(state.GitContent, overrideContent)
-	if err != nil {
-		return fmt.Errorf("build effective env content: %w", err)
-	}
-
-	if err := projects.WriteEnvFile(projectsDirectory, projectPath, effectiveContent); err != nil {
-		return err
-	}
-
-	if strings.TrimSpace(overrideContent) == "" {
-		if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
-			return err
-		}
-	} else if err := projects.WriteProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName, overrideContent); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *ProjectService) ensureEffectiveEnvFileInternal(projectPath, projectsDirectory string) error {
-	state, err := projects.ReadProjectEnvState(projectPath)
-	if err != nil {
-		return fmt.Errorf("read project env state: %w", err)
-	}
-
-	if !state.HasGitSource {
-		if state.HasOverride {
-			if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
-				return err
-			}
-			effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
-			if err != nil {
-				return err
-			}
-			return projects.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
-		}
-		return projects.EnsureEnvFile(projectsDirectory, projectPath)
-	}
-
-	effectiveContent, err := projects.BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
-	if err != nil {
-		return fmt.Errorf("build effective env content: %w", err)
-	}
-
-	return projects.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
-}
-
-type gitSyncEnvUpdateInternal struct {
-	state            projects.ProjectEnvState
-	gitEnvContent    *string
-	overrideContent  string
-	effectiveContent *string
-}
-
-func (s *ProjectService) prepareGitSyncEnvUpdateInternal(projectPath string, gitEnvContent *string) (gitSyncEnvUpdateInternal, error) {
-	state, err := projects.ReadProjectEnvState(projectPath)
-	if err != nil {
-		return gitSyncEnvUpdateInternal{}, fmt.Errorf("read project env state: %w", err)
-	}
-
-	update := gitSyncEnvUpdateInternal{
-		state:         state,
-		gitEnvContent: gitEnvContent,
-	}
-
-	if gitEnvContent == nil {
-		effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
-		if err != nil {
-			return gitSyncEnvUpdateInternal{}, err
-		}
-		if effectiveContent == "" && !state.HasEffective && !state.HasGitSource && !state.HasOverride {
-			return update, nil
-		}
-		update.effectiveContent = &effectiveContent
-		return update, nil
-	}
-
-	overrideContent, err := s.resolveOverrideContentForGitSyncInternal(state, *gitEnvContent)
-	if err != nil {
-		return gitSyncEnvUpdateInternal{}, err
-	}
-	update.overrideContent = overrideContent
-
-	effectiveContent, err := projects.BuildEffectiveEnvContent(*gitEnvContent, overrideContent)
-	if err != nil {
-		return gitSyncEnvUpdateInternal{}, fmt.Errorf("build effective env content: %w", err)
-	}
-	update.effectiveContent = &effectiveContent
-
-	return update, nil
-}
-
-func (s *ProjectService) resolveOverrideContentForGitSyncInternal(state projects.ProjectEnvState, gitEnvContent string) (string, error) {
-	switch {
-	case state.HasGitSource:
-		overrideContent, err := projects.BuildOverrideEnvContent(state.GitContent, state.OverrideContent)
-		if err != nil {
-			return "", fmt.Errorf("build override env content: %w", err)
-		}
-		return overrideContent, nil
-	case state.HasOverride:
-		effectiveContent, err := s.resolveStoredEffectiveEnvContentInternal(state)
-		if err != nil {
-			return "", err
-		}
-		overrideContent, err := projects.BuildOverrideEnvContent(gitEnvContent, effectiveContent)
-		if err != nil {
-			return "", fmt.Errorf("build override env content: %w", err)
-		}
-		return overrideContent, nil
-	case strings.TrimSpace(state.DirectContent) != "":
-		overrideContent, err := projects.BuildAdditiveOverrideEnvContent(gitEnvContent, state.DirectContent)
-		if err != nil {
-			return "", fmt.Errorf("build override env content: %w", err)
-		}
-		return overrideContent, nil
-	default:
-		return "", nil
-	}
-}
-
-func (s *ProjectService) persistGitSyncEnvFilesInternal(projectPath, projectsDirectory string, update gitSyncEnvUpdateInternal) error {
-	if update.gitEnvContent == nil {
-		if update.state.HasGitSource {
-			if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.GitSourceEnvFileName); err != nil {
-				return err
-			}
-		}
-		if update.state.HasOverride {
-			if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
-				return err
-			}
-		}
-		if update.effectiveContent != nil || update.state.HasEffective || update.state.HasGitSource || update.state.HasOverride {
-			effectiveContent := ""
-			if update.effectiveContent != nil {
-				effectiveContent = *update.effectiveContent
-			}
-			return projects.WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
-		}
-		return projects.EnsureEnvFile(projectsDirectory, projectPath)
-	}
-
-	if update.effectiveContent == nil {
-		return fmt.Errorf("missing effective env content for git sync update")
-	}
-
-	if err := projects.WriteEnvFile(projectsDirectory, projectPath, *update.effectiveContent); err != nil {
-		return err
-	}
-	if err := projects.WriteProjectFile(projectsDirectory, projectPath, projects.GitSourceEnvFileName, *update.gitEnvContent); err != nil {
-		return err
-	}
-	if strings.TrimSpace(update.overrideContent) == "" {
-		if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {
-			return err
-		}
-	} else if err := projects.WriteProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName, update.overrideContent); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *ProjectService) applyProjectRenameIfNeeded(proj *models.Project, name *string, projectsDirectory string) error {
-	if name == nil {
-		return nil
-	}
-
-	newName := strings.TrimSpace(*name)
-	if newName == "" || proj.Name == newName {
-		return nil
-	}
-
-	if proj.Status != models.ProjectStatusStopped {
-		return fmt.Errorf("project must be stopped before renaming (current status: %s)", proj.Status)
-	}
-
-	newDirName := projects.SanitizeProjectName(newName)
-	if newDirName == "" || strings.Trim(newDirName, "_") == "" {
-		return fmt.Errorf("invalid project name: results in empty directory name")
-	}
-
-	currentPath := filepath.Clean(proj.Path)
-	targetPath := filepath.Clean(filepath.Join(projectsDirectory, newDirName))
-	if currentPath != targetPath {
-		if _, statErr := os.Stat(targetPath); statErr == nil {
-			return fmt.Errorf("project directory already exists: %s", targetPath)
-		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("failed to check project directory rename target: %w", statErr)
-		}
-
-		if err := os.Rename(currentPath, targetPath); err != nil {
-			return fmt.Errorf("failed to rename project directory: %w", err)
-		}
-
-		proj.Path = targetPath
-	}
-
-	proj.DirName = &newDirName
-	proj.Name = newName
-	return nil
-}
-
 func (s *ProjectService) UpdateProjectIncludeFile(ctx context.Context, projectID, relativePath, content string, user models.User) error {
 	proj, err := s.GetProjectFromDatabaseByID(ctx, projectID)
 	if err != nil {
@@ -3235,32 +3184,27 @@ func (s *ProjectService) UpdateProjectIncludeFile(ctx context.Context, projectID
 // If not, it normalizes the path to `<projectsRoot>/<dirName or sanitized project name>`. When persist=true, it saves
 // the updated project path to the database.
 func (s *ProjectService) ensureProjectPathUnderRoot(ctx context.Context, proj *models.Project, persist bool) error {
-	projectsDirectory, err := projects.GetProjectsDirectory(ctx, s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects"))
+	fs, err := s.buildProjectFilesystemInternal(ctx, false)
 	if err != nil {
-		return fmt.Errorf("failed to get projects directory: %w", err)
+		return err
 	}
-
-	rootAbs, _ := filepath.Abs(projectsDirectory)
-	rootAbs = filepath.Clean(rootAbs)
-
-	projPathAbs := proj.Path
-	if abs, aerr := filepath.Abs(proj.Path); aerr == nil {
-		projPathAbs = filepath.Clean(abs)
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, proj)
+	if err != nil {
+		return err
 	}
-
-	if projects.IsSafeSubdirectory(rootAbs, projPathAbs) {
+	normalized, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return err
+	}
+	if normalized.Path == proj.Path {
 		return nil
 	}
 
-	// Attempt to repair using known directory name or sanitized project name
-	dirName := utils.DerefString(proj.DirName)
-	if strings.TrimSpace(dirName) == "" {
-		dirName = projects.SanitizeProjectName(proj.Name)
+	slog.WarnContext(ctx, "Normalizing project path to projects root", "projectID", proj.ID, "oldPath", proj.Path, "newPath", normalized.Path, "root", fs.Config.ProjectsRoot)
+	proj.Path = normalized.Path
+	if normalized.DirName != "" {
+		proj.DirName = &normalized.DirName
 	}
-	candidate := filepath.Join(projectsDirectory, dirName)
-
-	slog.WarnContext(ctx, "Normalizing project path to projects root", "projectID", proj.ID, "oldPath", proj.Path, "newPath", candidate, "root", projectsDirectory)
-	proj.Path = filepath.Clean(candidate)
 
 	if persist {
 		if saveErr := s.db.WithContext(ctx).Save(proj).Error; saveErr != nil {
@@ -3722,18 +3666,22 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 }
 
 func (s *ProjectService) getProjectMetadataForProject(ctx context.Context, p models.Project) projects.ArcaneComposeMetadata {
-	composeFile, err := s.resolveProjectComposeFileInternal(ctx, &p)
+	fs, err := s.buildProjectFilesystemInternal(ctx, true)
 	if err != nil {
 		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}
 	}
 
-	projectsDirectory, projectsDirErr := s.getProjectsDirectoryInternal(ctx)
-	if projectsDirErr != nil {
-		slog.WarnContext(ctx, "failed to resolve projects directory for Arcane compose metadata", "path", composeFile, "error", projectsDirErr)
+	workspace, err := s.buildProjectWorkspaceInternal(ctx, &p)
+	if err != nil {
+		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}
 	}
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
 
-	meta, err := projects.ParseArcaneComposeMetadata(ctx, composeFile, projectsDirectory, autoInjectEnv)
+	composeFile, err := fs.ResolveComposeFile(workspace)
+	if err != nil {
+		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}
+	}
+
+	meta, err := projects.ParseArcaneComposeMetadata(ctx, composeFile, fs.Config.ProjectsRoot, fs.Config.AutoInjectEnv)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to parse Arcane compose metadata", "path", composeFile, "error", err)
 		return projects.ArcaneComposeMetadata{ServiceIcons: map[string]string{}}
@@ -3759,41 +3707,16 @@ func (s *ProjectService) countServicesFromCompose(ctx context.Context, p models.
 // and once for the project name).
 // The effective name is nil when it matches the normalized directory name.
 func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context, dirPath, dirName string) (serviceCount int, composeProjectName *string, err error) {
-	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
-	projectsDirectory, pErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
-	if pErr != nil {
-		return 0, nil, pErr
-	}
-
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
-
-	normName := normalizeComposeProjectName(dirName)
-	autoInjectEnv := utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)
-
-	// First, try loading without forcing a project name so compose-go can
-	// resolve COMPOSE_PROJECT_NAME from the .env file. If this fails (e.g.
-	// no .env and directory name is not a valid compose project name), fall
-	// back to the normalized directory name.
-	proj, _, err := projects.LoadComposeProjectFromDir(ctx, dirPath, "", projectsDirectory, autoInjectEnv, pathMapper)
+	fs, err := s.buildProjectFilesystemInternal(ctx, false)
 	if err != nil {
-		proj, _, err = projects.LoadComposeProjectFromDir(ctx, dirPath, normName, projectsDirectory, autoInjectEnv, pathMapper)
-		if err != nil {
-			return 0, nil, err
-		}
+		return 0, nil, err
 	}
 
-	serviceCount = len(proj.Services)
-
-	// If compose-go resolved a different name (from COMPOSE_PROJECT_NAME),
-	// store it so we can match containers correctly.
-	if proj.Name != "" && proj.Name != normName {
-		composeProjectName = new(proj.Name)
-	}
-
-	return serviceCount, composeProjectName, nil
+	return fs.LoadComposeMetadata(ctx, projects.ProjectWorkspace{
+		Name:    dirName,
+		DirName: dirName,
+		Path:    dirPath,
+	})
 }
 
 func (s *ProjectService) calculateProjectStatus(services []ProjectServiceInfo) models.ProjectStatus {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1016,6 +1016,60 @@ func TestProjectService_UpdateProject_RenameFailsWhenProjectRunning(t *testing.T
 	assert.Equal(t, "Foo", *fromDB.DirName)
 }
 
+func TestProjectService_UpdateProject_RollsBackFilesystemWhenDBSaveFailsAfterRename(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	originalDirName := "Foo"
+	originalPath := filepath.Join(projectsDir, originalDirName)
+	require.NoError(t, os.MkdirAll(originalPath, 0o755))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-rollback"},
+		Name:      "Foo",
+		DirName:   &originalDirName,
+		Path:      originalPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	callbackName := "test:fail_project_update_after_rename"
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "projects" {
+			tx.AddError(errors.New("forced project update failure"))
+		}
+	}))
+	defer func() {
+		db.Callback().Update().Remove(callbackName)
+	}()
+
+	_, err = svc.UpdateProject(ctx, project.ID, new("bar"), nil, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update project")
+
+	assert.DirExists(t, originalPath)
+	assert.NoDirExists(t, filepath.Join(projectsDir, "bar"))
+
+	var fromDB models.Project
+	require.NoError(t, db.First(&fromDB, "id = ?", project.ID).Error)
+	assert.Equal(t, "Foo", fromDB.Name)
+	assert.Equal(t, originalPath, fromDB.Path)
+	require.NotNil(t, fromDB.DirName)
+	assert.Equal(t, "Foo", *fromDB.DirName)
+}
+
 func TestProjectService_UpdateProject_ValidatesComposeUsingExistingProjectName(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -1393,6 +1447,77 @@ func TestProjectService_UpdateProject_UsesGlobalEnvDuringComposeValidation(t *te
 	assert.Equal(t, compose, string(composeBytes))
 }
 
+func TestProjectService_CreateProject_InvalidComposeDoesNotPersistProject(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	created, err := svc.CreateProject(ctx, "broken-project", "services:\n  app:\n    image: nginx:alpine\n    environment:\n      - REQUIRED=${UNTERMINATED\n", nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Nil(t, created)
+
+	var count int64
+	require.NoError(t, db.Model(&models.Project{}).Count(&count).Error)
+	assert.Zero(t, count)
+
+	entries, readErr := os.ReadDir(projectsDir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries)
+}
+
+func TestProjectService_DestroyProject_RemoveFilesFalsePreservesDirectory(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	originalComposeDown := composeDownProjectInternal
+	t.Cleanup(func() { composeDownProjectInternal = originalComposeDown })
+	composeDownProjectInternal = func(context.Context, *composetypes.Project, bool) error {
+		return nil
+	}
+
+	projectPath := createComposeProjectDir(t, projectsDir, "keep-files")
+	dirName := "keep-files"
+	projectRecord := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-keep-files"},
+		Name:      "keep-files",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(projectRecord).Error)
+
+	err = svc.DestroyProject(ctx, projectRecord.ID, false, false, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	assert.DirExists(t, projectPath)
+
+	var count int64
+	require.NoError(t, db.Model(&models.Project{}).Where("id = ?", projectRecord.ID).Count(&count).Error)
+	assert.Zero(t, count)
+}
+
 func TestProjectService_UpdateProject_DoesNotResolveHostEnvThroughGlobalEnvDuringComposeValidation(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -1583,6 +1708,64 @@ func TestProjectService_ApplyGitSyncProjectFiles_MigratesDirectEnvIntoProjectOve
 	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
 }
 
+func TestProjectService_ApplyGitSyncProjectFiles_RollsBackFilesystemWhenDBSaveFails(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "git-sync-db-rollback"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("TOKEN=local\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-db-rollback"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	callbackName := "test:fail_project_git_sync_update"
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Table == "projects" {
+			tx.AddError(errors.New("forced project update failure"))
+		}
+	}))
+	defer func() {
+		db.Callback().Update().Remove(callbackName)
+	}()
+
+	gitEnv := "TOKEN=git\nREMOTE_ONLY=1\n"
+	updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, "services:\n  app:\n    image: nginx:2\n", &gitEnv, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	require.Nil(t, updated)
+	assert.Contains(t, err.Error(), "failed to update project")
+
+	composeBytes, readErr := os.ReadFile(filepath.Join(projectPath, "compose.yaml"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(composeBytes), "nginx:1")
+
+	envBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "TOKEN=local\n", string(envBytes))
+	assert.NoFileExists(t, filepath.Join(projectPath, ".env.git"))
+	assert.NoFileExists(t, filepath.Join(projectPath, "project.env"))
+}
+
 func TestProjectService_ApplyGitSyncProjectFiles_NormalizesStaleCopiedGitOverrides(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -1771,19 +1954,8 @@ func TestProjectService_ApplyGitSyncProjectFiles_UsesGlobalEnvDuringComposeValid
 	assert.Equal(t, compose, string(composeBytes))
 }
 
-func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
-	db := setupProjectTestDB(t)
-	ctx := context.Background()
-
+func TestProjectFilesystem_StageGitSync_UsesPreparedState(t *testing.T) {
 	projectsDir := t.TempDir()
-	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
-
-	settingsService, err := NewSettingsService(ctx, db)
-	require.NoError(t, err)
-
-	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
-
 	dirName := "git-sync-prepared-state"
 	projectPath := filepath.Join(projectsDir, dirName)
 	require.NoError(t, os.MkdirAll(projectPath, 0o755))
@@ -1792,13 +1964,17 @@ func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte("BASE=git\nTOKEN=git\n"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=local\n"), 0o600))
 
-	update, err := svc.prepareGitSyncEnvUpdateInternal(projectPath, new("BASE=git-updated\nTOKEN=git\nREMOTE=1\n"))
+	fs := projects.NewProjectFilesystem(projects.ProjectFilesystemConfig{ProjectsRoot: projectsDir})
+	staged, err := fs.StageGitSync(projects.ProjectWorkspace{
+		Name:    dirName,
+		DirName: dirName,
+		Path:    projectPath,
+	}, "services:\n  app:\n    image: nginx:alpine\n", new("BASE=git-updated\nTOKEN=git\nREMOTE=1\n"))
 	require.NoError(t, err)
-	require.NotNil(t, update.effectiveContent)
 
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=unexpected\n"), 0o600))
 
-	require.NoError(t, svc.persistGitSyncEnvFilesInternal(projectPath, projectsDir, update))
+	require.NoError(t, fs.Promote(staged))
 
 	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
 	require.NoError(t, readErr)

--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -257,7 +257,7 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestor
 			return nil
 		}
 
-		if err := fw.watcher.Add(path); err != nil {
+		if err := fw.addWatchInternal(path); err != nil {
 			slog.Warn("Failed to add directory to watcher",
 				"path", path,
 				"error", err)
@@ -281,6 +281,52 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestor
 		if err := fw.addExistingDirectoriesRecursiveInternal(childPath, ancestors); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (fw *Watcher) addWatchInternal(path string) error {
+	cleanPath := filepath.Clean(path)
+	resolvedPath := ""
+
+	if fw.followSymlinks {
+		info, err := os.Lstat(path)
+		if err != nil {
+			slog.Warn("Failed to inspect symlinked directory for resolved watch",
+				"path", path,
+				"error", err)
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			resolvedPath, err = filepath.EvalSymlinks(path)
+			if err != nil {
+				slog.Warn("Failed to resolve symlinked directory for resolved watch",
+					"path", path,
+					"error", err)
+			} else {
+				resolvedPath = filepath.Clean(resolvedPath)
+				if resolvedPath == cleanPath {
+					resolvedPath = ""
+				} else if err := fw.watcher.Add(resolvedPath); err != nil {
+					slog.Warn("Failed to add resolved symlink target to watcher",
+						"path", path,
+						"resolvedPath", resolvedPath,
+						"error", err)
+					resolvedPath = ""
+				}
+			}
+		}
+	}
+
+	if err := fw.watcher.Add(path); err != nil {
+		if resolvedPath != "" {
+			if removeErr := fw.watcher.Remove(resolvedPath); removeErr != nil {
+				slog.Warn("Failed to roll back resolved symlink target watch",
+					"path", path,
+					"resolvedPath", resolvedPath,
+					"error", removeErr)
+			}
+		}
+		return err
 	}
 
 	return nil

--- a/backend/pkg/projects/filesystem.go
+++ b/backend/pkg/projects/filesystem.go
@@ -1,0 +1,655 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/compose-spec/compose-go/v2/loader"
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+type ProjectFilesystemConfig struct {
+	ProjectsRoot  string
+	AutoInjectEnv bool
+	PathMapper    *PathMapper
+}
+
+type ProjectWorkspace struct {
+	Name            string
+	DirName         string
+	Path            string
+	ComposeFileName string
+}
+
+type StagedProjectWorkspace struct {
+	Current ProjectWorkspace
+	Stage   ProjectWorkspace
+	Target  ProjectWorkspace
+}
+
+type ProjectFilesystem struct {
+	Config     ProjectFilesystemConfig
+	renamePath func(oldPath, newPath string) error
+}
+
+func NewProjectFilesystem(config ProjectFilesystemConfig) *ProjectFilesystem {
+	config.ProjectsRoot = filepath.Clean(config.ProjectsRoot)
+	return &ProjectFilesystem{Config: config, renamePath: os.Rename}
+}
+
+func (fs *ProjectFilesystem) ResolveExisting(workspace ProjectWorkspace) (ProjectWorkspace, error) {
+	if fs == nil {
+		return ProjectWorkspace{}, fmt.Errorf("project filesystem is nil")
+	}
+	if strings.TrimSpace(fs.Config.ProjectsRoot) == "" {
+		return ProjectWorkspace{}, fmt.Errorf("projects root is required")
+	}
+
+	workspace.Name = strings.TrimSpace(workspace.Name)
+	workspace.DirName = strings.TrimSpace(workspace.DirName)
+	workspace.ComposeFileName = strings.TrimSpace(workspace.ComposeFileName)
+
+	if workspace.DirName == "" {
+		switch {
+		case workspace.Path != "":
+			workspace.DirName = filepath.Base(filepath.Clean(workspace.Path))
+		case workspace.Name != "":
+			workspace.DirName = SanitizeProjectName(workspace.Name)
+		}
+	}
+
+	if workspace.DirName == "" || strings.Trim(workspace.DirName, "_") == "" {
+		return ProjectWorkspace{}, fmt.Errorf("invalid project workspace: missing directory name")
+	}
+
+	path := strings.TrimSpace(workspace.Path)
+	if path == "" {
+		path = filepath.Join(fs.Config.ProjectsRoot, workspace.DirName)
+	}
+
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return ProjectWorkspace{}, fmt.Errorf("resolve project path: %w", err)
+	}
+	pathAbs = filepath.Clean(pathAbs)
+
+	rootAbs, err := filepath.Abs(fs.Config.ProjectsRoot)
+	if err != nil {
+		return ProjectWorkspace{}, fmt.Errorf("resolve projects root: %w", err)
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	if !IsSafeSubdirectory(rootAbs, pathAbs) {
+		pathAbs = filepath.Join(rootAbs, workspace.DirName)
+	}
+
+	workspace.Path = pathAbs
+	return workspace, nil
+}
+
+func (fs *ProjectFilesystem) CreateWorkspace(name string) (ProjectWorkspace, error) {
+	if fs == nil {
+		return ProjectWorkspace{}, fmt.Errorf("project filesystem is nil")
+	}
+
+	sanitized := SanitizeProjectName(name)
+	basePath := filepath.Join(fs.Config.ProjectsRoot, sanitized)
+	path, dirName, err := CreateUniqueDir(fs.Config.ProjectsRoot, basePath, name, 0o755)
+	if err != nil {
+		return ProjectWorkspace{}, err
+	}
+
+	return ProjectWorkspace{
+		Name:    name,
+		DirName: dirName,
+		Path:    path,
+	}, nil
+}
+
+func (fs *ProjectFilesystem) ResolveComposeFile(workspace ProjectWorkspace) (string, error) {
+	workspace, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return "", err
+	}
+
+	if workspace.ComposeFileName != "" {
+		candidate := filepath.Join(workspace.Path, filepath.Base(workspace.ComposeFileName))
+		if info, statErr := os.Stat(candidate); statErr == nil {
+			if !info.IsDir() {
+				return candidate, nil
+			}
+		} else if !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("inspect compose file %s: %w", candidate, statErr)
+		}
+	}
+
+	return DetectComposeFile(workspace.Path)
+}
+
+func (fs *ProjectFilesystem) LoadComposeProject(ctx context.Context, workspace ProjectWorkspace) (*composetypes.Project, string, error) {
+	workspace, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return nil, "", err
+	}
+
+	composeFile, err := fs.ResolveComposeFile(workspace)
+	if err != nil {
+		return nil, "", err
+	}
+
+	projectName := loader.NormalizeProjectName(strings.TrimSpace(workspace.Name))
+	project, err := LoadComposeProject(ctx, composeFile, projectName, fs.Config.ProjectsRoot, fs.Config.AutoInjectEnv, fs.Config.PathMapper)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return project, composeFile, nil
+}
+
+func (fs *ProjectFilesystem) LoadComposeMetadata(ctx context.Context, workspace ProjectWorkspace) (serviceCount int, composeProjectName *string, err error) {
+	workspace, err = fs.ResolveExisting(workspace)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	composeFile, err := fs.ResolveComposeFile(workspace)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	normalizedName := loader.NormalizeProjectName(strings.TrimSpace(workspace.Name))
+	project, loadErr := loadComposeProjectInternal(ctx, composeFile, "", fs.Config.ProjectsRoot, fs.Config.AutoInjectEnv, fs.Config.PathMapper, nil, nil, false)
+	if loadErr != nil {
+		project, loadErr = loadComposeProjectInternal(ctx, composeFile, normalizedName, fs.Config.ProjectsRoot, fs.Config.AutoInjectEnv, fs.Config.PathMapper, nil, nil, false)
+		if loadErr != nil {
+			return 0, nil, loadErr
+		}
+	}
+
+	serviceCount = len(project.Services)
+	if project.Name != "" && project.Name != normalizedName {
+		composeProjectName = new(string)
+		*composeProjectName = project.Name
+	}
+
+	return serviceCount, composeProjectName, nil
+}
+
+func (fs *ProjectFilesystem) StageCreate(workspace ProjectWorkspace, composeContent string, envContent *string) (*StagedProjectWorkspace, error) {
+	target, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	stagePath, err := fs.createStageDirectoryInternal()
+	if err != nil {
+		return nil, err
+	}
+
+	stageWorkspace := target
+	stageWorkspace.Path = stagePath
+	if err := WriteProjectFiles(fs.Config.ProjectsRoot, stageWorkspace.Path, composeContent, envContent); err != nil {
+		_ = os.RemoveAll(stageWorkspace.Path)
+		return nil, err
+	}
+
+	return &StagedProjectWorkspace{
+		Current: target,
+		Stage:   stageWorkspace,
+		Target:  target,
+	}, nil
+}
+
+func (fs *ProjectFilesystem) StageUpdate(workspace ProjectWorkspace, name *string, composeContent, envContent *string) (*StagedProjectWorkspace, error) {
+	current, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := fs.resolveTargetWorkspaceInternal(current, name)
+	if err != nil {
+		return nil, err
+	}
+
+	stagePath, err := fs.createStageDirectoryInternal()
+	if err != nil {
+		return nil, err
+	}
+	if err := CopyDirectoryContents(current.Path, stagePath); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, err
+	}
+
+	stageWorkspace := target
+	stageWorkspace.Path = stagePath
+	if err := fs.persistUpdatedProjectFilesInternal(stageWorkspace.Path, composeContent, envContent); err != nil {
+		_ = os.RemoveAll(stageWorkspace.Path)
+		return nil, err
+	}
+
+	return &StagedProjectWorkspace{
+		Current: current,
+		Stage:   stageWorkspace,
+		Target:  target,
+	}, nil
+}
+
+func (fs *ProjectFilesystem) StageGitSync(workspace ProjectWorkspace, composeContent string, gitEnvContent *string) (*StagedProjectWorkspace, error) {
+	current, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	stagePath, err := fs.createStageDirectoryInternal()
+	if err != nil {
+		return nil, err
+	}
+	if err := CopyDirectoryContents(current.Path, stagePath); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, err
+	}
+
+	stageWorkspace := current
+	stageWorkspace.Path = stagePath
+	if err := WriteComposeFile(fs.Config.ProjectsRoot, stageWorkspace.Path, composeContent); err != nil {
+		_ = os.RemoveAll(stageWorkspace.Path)
+		return nil, err
+	}
+
+	envUpdate, err := prepareGitSyncEnvUpdateInternal(stageWorkspace.Path, gitEnvContent)
+	if err != nil {
+		_ = os.RemoveAll(stageWorkspace.Path)
+		return nil, err
+	}
+	if err := persistGitSyncEnvFilesInternal(stageWorkspace.Path, fs.Config.ProjectsRoot, envUpdate); err != nil {
+		_ = os.RemoveAll(stageWorkspace.Path)
+		return nil, err
+	}
+
+	return &StagedProjectWorkspace{
+		Current: current,
+		Stage:   stageWorkspace,
+		Target:  current,
+	}, nil
+}
+
+func (fs *ProjectFilesystem) Promote(stage *StagedProjectWorkspace) error {
+	if fs == nil {
+		return fmt.Errorf("project filesystem is nil")
+	}
+	if stage == nil {
+		return fmt.Errorf("staged workspace is nil")
+	}
+	renamePath := fs.renamePath
+	if renamePath == nil {
+		renamePath = os.Rename
+	}
+
+	target, err := fs.ResolveExisting(stage.Target)
+	if err != nil {
+		return err
+	}
+	current, err := fs.ResolveExisting(stage.Current)
+	if err != nil {
+		return err
+	}
+	currentLivePath, targetLivePath, err := fs.resolvePromotionPathsInternal(current, target)
+	if err != nil {
+		return err
+	}
+
+	stagePath := filepath.Clean(stage.Stage.Path)
+	backupPath, err := fs.reserveHiddenPathInternal(".arcane-project-backup-")
+	if err != nil {
+		return err
+	}
+
+	hadCurrent := false
+	if _, statErr := os.Stat(currentLivePath); statErr == nil {
+		hadCurrent = true
+		if err := renamePath(currentLivePath, backupPath); err != nil {
+			return fmt.Errorf("backup live project directory: %w", err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("inspect live project directory: %w", statErr)
+	}
+
+	if err := renamePath(stagePath, targetLivePath); err != nil {
+		if hadCurrent {
+			if restoreErr := renamePath(backupPath, currentLivePath); restoreErr != nil {
+				_ = os.RemoveAll(stagePath)
+				return fmt.Errorf("promote staged project: %w; restore failed: %w", err, restoreErr)
+			}
+		}
+		_ = os.RemoveAll(stagePath)
+		return fmt.Errorf("promote staged project: %w", err)
+	}
+
+	if hadCurrent {
+		_ = os.RemoveAll(backupPath)
+	}
+
+	return nil
+}
+
+func (fs *ProjectFilesystem) resolvePromotionPathsInternal(current, target ProjectWorkspace) (string, string, error) {
+	currentPath := filepath.Clean(current.Path)
+	targetPath := filepath.Clean(target.Path)
+
+	if currentPath != targetPath {
+		return currentPath, targetPath, nil
+	}
+
+	info, err := os.Lstat(currentPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return currentPath, targetPath, nil
+		}
+		return "", "", fmt.Errorf("inspect project workspace: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return currentPath, targetPath, nil
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(currentPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve project workspace symlink: %w", err)
+	}
+	resolvedPath = filepath.Clean(resolvedPath)
+
+	return resolvedPath, resolvedPath, nil
+}
+
+func (fs *ProjectFilesystem) RemoveWorkspace(workspace ProjectWorkspace) error {
+	workspace, err := fs.ResolveExisting(workspace)
+	if err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(workspace.Path); err != nil {
+		return fmt.Errorf("remove project workspace: %w", err)
+	}
+
+	return nil
+}
+
+func (fs *ProjectFilesystem) resolveTargetWorkspaceInternal(current ProjectWorkspace, name *string) (ProjectWorkspace, error) {
+	target := current
+	if name == nil {
+		return target, nil
+	}
+
+	newName := strings.TrimSpace(*name)
+	if newName == "" || newName == current.Name {
+		return target, nil
+	}
+
+	dirName := SanitizeProjectName(newName)
+	if dirName == "" || strings.Trim(dirName, "_") == "" {
+		return ProjectWorkspace{}, fmt.Errorf("invalid project name: results in empty directory name")
+	}
+
+	target.Name = newName
+	target.DirName = dirName
+	target.Path = filepath.Join(fs.Config.ProjectsRoot, dirName)
+
+	if current.Path != target.Path {
+		if _, err := os.Stat(target.Path); err == nil {
+			return ProjectWorkspace{}, fmt.Errorf("project directory already exists: %s", target.Path)
+		} else if !os.IsNotExist(err) {
+			return ProjectWorkspace{}, fmt.Errorf("failed to check project directory rename target: %w", err)
+		}
+	}
+
+	return target, nil
+}
+
+func (fs *ProjectFilesystem) persistUpdatedProjectFilesInternal(stagePath string, composeContent, envContent *string) error {
+	switch {
+	case composeContent != nil:
+		if err := WriteComposeFile(fs.Config.ProjectsRoot, stagePath, *composeContent); err != nil {
+			return fmt.Errorf("failed to save project files: %w", err)
+		}
+		if envContent != nil {
+			if err := persistEffectiveEnvContentInternal(stagePath, fs.Config.ProjectsRoot, *envContent); err != nil {
+				return fmt.Errorf("failed to save project files: %w", err)
+			}
+		} else if err := ensureEffectiveEnvFileInternal(stagePath, fs.Config.ProjectsRoot); err != nil {
+			return fmt.Errorf("failed to save project files: %w", err)
+		}
+	case envContent != nil:
+		if err := persistEffectiveEnvContentInternal(stagePath, fs.Config.ProjectsRoot, *envContent); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fs *ProjectFilesystem) createStageDirectoryInternal() (string, error) {
+	stagePath, err := os.MkdirTemp(fs.Config.ProjectsRoot, ".arcane-project-stage-*")
+	if err != nil {
+		return "", fmt.Errorf("create project staging directory: %w", err)
+	}
+	if err := os.Chmod(stagePath, 0o755); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return "", fmt.Errorf("set project staging directory permissions: %w", err)
+	}
+	return stagePath, nil
+}
+
+func (fs *ProjectFilesystem) reserveHiddenPathInternal(prefix string) (string, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		candidate := filepath.Join(fs.Config.ProjectsRoot, fmt.Sprintf("%s%d-%d", prefix, time.Now().UnixNano(), attempt))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate, nil
+		} else if err != nil {
+			return "", err
+		}
+	}
+
+	return "", fmt.Errorf("failed to reserve unique project filesystem path")
+}
+
+func resolveStoredEffectiveEnvContentInternal(state ProjectEnvState) (string, error) {
+	if state.HasEffective {
+		return state.EffectiveContent, nil
+	}
+	if state.HasGitSource || state.HasOverride {
+		effectiveContent, err := BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
+		if err != nil {
+			return "", fmt.Errorf("build effective env content: %w", err)
+		}
+		return effectiveContent, nil
+	}
+	return state.DirectContent, nil
+}
+
+func persistEffectiveEnvContentInternal(projectPath, projectsDirectory, envContent string) error {
+	state, err := ReadProjectEnvState(projectPath)
+	if err != nil {
+		return fmt.Errorf("read project env state: %w", err)
+	}
+
+	if !state.HasGitSource {
+		if state.HasOverride {
+			if err := RemoveProjectFile(projectsDirectory, projectPath, OverrideEnvFileName); err != nil {
+				return err
+			}
+		}
+		return WriteEnvFile(projectsDirectory, projectPath, envContent)
+	}
+
+	overrideContent, err := BuildOverrideEnvContent(state.GitContent, envContent)
+	if err != nil {
+		return fmt.Errorf("build override env content: %w", err)
+	}
+
+	effectiveContent, err := BuildEffectiveEnvContent(state.GitContent, overrideContent)
+	if err != nil {
+		return fmt.Errorf("build effective env content: %w", err)
+	}
+
+	if err := WriteEnvFile(projectsDirectory, projectPath, effectiveContent); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(overrideContent) == "" {
+		if err := RemoveProjectFile(projectsDirectory, projectPath, OverrideEnvFileName); err != nil {
+			return err
+		}
+	} else if err := WriteProjectFile(projectsDirectory, projectPath, OverrideEnvFileName, overrideContent); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureEffectiveEnvFileInternal(projectPath, projectsDirectory string) error {
+	state, err := ReadProjectEnvState(projectPath)
+	if err != nil {
+		return fmt.Errorf("read project env state: %w", err)
+	}
+
+	if !state.HasGitSource {
+		if state.HasOverride {
+			if err := RemoveProjectFile(projectsDirectory, projectPath, OverrideEnvFileName); err != nil {
+				return err
+			}
+			effectiveContent, err := resolveStoredEffectiveEnvContentInternal(state)
+			if err != nil {
+				return err
+			}
+			return WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+		}
+		return EnsureEnvFile(projectsDirectory, projectPath)
+	}
+
+	effectiveContent, err := BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
+	if err != nil {
+		return fmt.Errorf("build effective env content: %w", err)
+	}
+
+	return WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+}
+
+type gitSyncEnvUpdateInternal struct {
+	state            ProjectEnvState
+	gitEnvContent    *string
+	overrideContent  string
+	effectiveContent *string
+}
+
+func prepareGitSyncEnvUpdateInternal(projectPath string, gitEnvContent *string) (gitSyncEnvUpdateInternal, error) {
+	state, err := ReadProjectEnvState(projectPath)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, fmt.Errorf("read project env state: %w", err)
+	}
+
+	update := gitSyncEnvUpdateInternal{
+		state:         state,
+		gitEnvContent: gitEnvContent,
+	}
+
+	if gitEnvContent == nil {
+		effectiveContent, err := resolveStoredEffectiveEnvContentInternal(state)
+		if err != nil {
+			return gitSyncEnvUpdateInternal{}, err
+		}
+		if effectiveContent == "" && !state.HasEffective && !state.HasGitSource && !state.HasOverride {
+			return update, nil
+		}
+		update.effectiveContent = &effectiveContent
+		return update, nil
+	}
+
+	overrideContent, err := resolveOverrideContentForGitSyncInternal(state, *gitEnvContent)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, err
+	}
+	update.overrideContent = overrideContent
+
+	effectiveContent, err := BuildEffectiveEnvContent(*gitEnvContent, overrideContent)
+	if err != nil {
+		return gitSyncEnvUpdateInternal{}, fmt.Errorf("build effective env content: %w", err)
+	}
+	update.effectiveContent = &effectiveContent
+
+	return update, nil
+}
+
+func resolveOverrideContentForGitSyncInternal(state ProjectEnvState, gitEnvContent string) (string, error) {
+	switch {
+	case state.HasGitSource:
+		overrideContent, err := BuildOverrideEnvContent(state.GitContent, state.OverrideContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	case state.HasOverride:
+		effectiveContent, err := resolveStoredEffectiveEnvContentInternal(state)
+		if err != nil {
+			return "", err
+		}
+		overrideContent, err := BuildOverrideEnvContent(gitEnvContent, effectiveContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	case strings.TrimSpace(state.DirectContent) != "":
+		overrideContent, err := BuildAdditiveOverrideEnvContent(gitEnvContent, state.DirectContent)
+		if err != nil {
+			return "", fmt.Errorf("build override env content: %w", err)
+		}
+		return overrideContent, nil
+	default:
+		return "", nil
+	}
+}
+
+func persistGitSyncEnvFilesInternal(projectPath, projectsDirectory string, update gitSyncEnvUpdateInternal) error {
+	if update.gitEnvContent == nil {
+		if update.state.HasGitSource {
+			if err := RemoveProjectFile(projectsDirectory, projectPath, GitSourceEnvFileName); err != nil {
+				return err
+			}
+		}
+		if update.state.HasOverride {
+			if err := RemoveProjectFile(projectsDirectory, projectPath, OverrideEnvFileName); err != nil {
+				return err
+			}
+		}
+		if update.effectiveContent != nil || update.state.HasEffective || update.state.HasGitSource || update.state.HasOverride {
+			effectiveContent := ""
+			if update.effectiveContent != nil {
+				effectiveContent = *update.effectiveContent
+			}
+			return WriteEnvFile(projectsDirectory, projectPath, effectiveContent)
+		}
+		return EnsureEnvFile(projectsDirectory, projectPath)
+	}
+
+	if update.effectiveContent == nil {
+		return fmt.Errorf("missing effective env content for git sync update")
+	}
+
+	if err := WriteEnvFile(projectsDirectory, projectPath, *update.effectiveContent); err != nil {
+		return err
+	}
+	if err := WriteProjectFile(projectsDirectory, projectPath, GitSourceEnvFileName, *update.gitEnvContent); err != nil {
+		return err
+	}
+	if strings.TrimSpace(update.overrideContent) == "" {
+		if err := RemoveProjectFile(projectsDirectory, projectPath, OverrideEnvFileName); err != nil {
+			return err
+		}
+	} else if err := WriteProjectFile(projectsDirectory, projectPath, OverrideEnvFileName, update.overrideContent); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/pkg/projects/filesystem_test.go
+++ b/backend/pkg/projects/filesystem_test.go
@@ -1,0 +1,191 @@
+package projects
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectFilesystem_ResolveExisting_NormalizesOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+
+	workspace, err := fs.ResolveExisting(ProjectWorkspace{
+		Name:    "Demo",
+		DirName: "demo",
+		Path:    filepath.Join(root, "..", "escape"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "demo"), workspace.Path)
+}
+
+func TestProjectFilesystem_StageCreateAndPromote_WritesFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+
+	workspace, err := fs.CreateWorkspace("Demo Project")
+	require.NoError(t, err)
+
+	envContent := "TOKEN=secret\n"
+	staged, err := fs.StageCreate(workspace, "services:\n  app:\n    image: nginx:alpine\n", &envContent)
+	require.NoError(t, err)
+	require.NoError(t, fs.Promote(staged))
+
+	composeBytes, err := os.ReadFile(filepath.Join(staged.Target.Path, "compose.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(composeBytes), "nginx:alpine")
+
+	envBytes, err := os.ReadFile(filepath.Join(staged.Target.Path, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, envContent, string(envBytes))
+}
+
+func TestProjectFilesystem_StageCreateAndPromote_PreservesTraversableDirectoryPermissions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+
+	workspace, err := fs.CreateWorkspace("Demo Project")
+	require.NoError(t, err)
+
+	staged, err := fs.StageCreate(workspace, "services:\n  app:\n    image: nginx:alpine\n", nil)
+	require.NoError(t, err)
+	require.NoError(t, fs.Promote(staged))
+
+	info, err := os.Stat(staged.Target.Path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestProjectFilesystem_Promote_RestoresOriginalOnFailure(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:1\n"), 0o600))
+
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+	staged, err := fs.StageUpdate(ProjectWorkspace{
+		Name:    "demo",
+		DirName: "demo",
+		Path:    projectPath,
+	}, nil, ptrString("services:\n  app:\n    image: nginx:2\n"), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(staged.Stage.Path))
+
+	err = fs.Promote(staged)
+	require.Error(t, err)
+
+	composeBytes, readErr := os.ReadFile(filepath.Join(projectPath, "compose.yaml"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(composeBytes), "nginx:1")
+}
+
+func TestProjectFilesystem_Promote_CleansStageWhenRestoreFails(t *testing.T) {
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:1\n"), 0o600))
+
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+	staged, err := fs.StageUpdate(ProjectWorkspace{
+		Name:    "demo",
+		DirName: "demo",
+		Path:    projectPath,
+	}, nil, ptrString("services:\n  app:\n    image: nginx:2\n"), nil)
+	require.NoError(t, err)
+
+	var call int
+	fs.renamePath = func(oldPath, newPath string) error {
+		call++
+		switch call {
+		case 1:
+			return nil
+		case 2:
+			return assert.AnError
+		default:
+			return assert.AnError
+		}
+	}
+
+	err = fs.Promote(staged)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "restore failed")
+
+	_, statErr := os.Stat(staged.Stage.Path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestProjectFilesystem_LoadComposeMetadata_UsesComposeProjectName(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(`name: ${COMPOSE_PROJECT_NAME}
+services:
+  app:
+    image: nginx:alpine
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("COMPOSE_PROJECT_NAME=from-env\n"), 0o600))
+
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+	serviceCount, composeProjectName, err := fs.LoadComposeMetadata(context.Background(), ProjectWorkspace{
+		Name:    "demo",
+		DirName: "demo",
+		Path:    projectPath,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, serviceCount)
+	require.NotNil(t, composeProjectName)
+	assert.Equal(t, "from-env", *composeProjectName)
+}
+
+func TestProjectFilesystem_StageGitSync_PersistsGitEnvState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte("TOKEN=local\nLOCAL_ONLY=1\n"), 0o600))
+
+	fs := NewProjectFilesystem(ProjectFilesystemConfig{ProjectsRoot: root})
+	gitEnv := "TOKEN=git\nREMOTE_ONLY=1\n"
+	staged, err := fs.StageGitSync(ProjectWorkspace{
+		Name:    "demo",
+		DirName: "demo",
+		Path:    projectPath,
+	}, "services:\n  app:\n    image: nginx:2\n", &gitEnv)
+	require.NoError(t, err)
+	require.NoError(t, fs.Promote(staged))
+
+	effectiveBytes, err := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, err)
+	assert.Contains(t, string(effectiveBytes), "TOKEN=git\n")
+	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
+	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=1\n")
+
+	gitBytes, err := os.ReadFile(filepath.Join(projectPath, GitSourceEnvFileName))
+	require.NoError(t, err)
+	assert.Equal(t, gitEnv, string(gitBytes))
+
+	overrideBytes, err := os.ReadFile(filepath.Join(projectPath, OverrideEnvFileName))
+	require.NoError(t, err)
+	assert.Equal(t, "LOCAL_ONLY=1\n", string(overrideBytes))
+}
+
+func ptrString(value string) *string {
+	return &value
+}

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -538,7 +538,3 @@ func IsSafeSubdirectory(baseDir, subdir string) bool {
 	// The path must not escape the base directory
 	return !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
 }
-
-func SaveOrUpdateProjectFiles(projectsRoot, projectPath, composeContent string, envContent *string) error {
-	return WriteProjectFiles(projectsRoot, projectPath, composeContent, envContent)
-}

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -282,20 +282,6 @@ func injectServiceConfiguration(project *composetypes.Project, injectionVars Env
 	}
 }
 
-func LoadComposeProjectFromDir(ctx context.Context, dir, projectName, projectsDirectory string, autoInjectEnv bool, pathMapper *PathMapper) (*composetypes.Project, string, error) {
-	composeFile, err := DetectComposeFile(dir)
-	if err != nil {
-		return nil, "", err
-	}
-
-	proj, err := LoadComposeProject(ctx, composeFile, projectName, projectsDirectory, autoInjectEnv, pathMapper)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return proj, composeFile, nil
-}
-
 func ResolveRelativeProjectPaths(project *composetypes.Project, workdir string) {
 	if project == nil || workdir == "" {
 		return

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -109,9 +109,12 @@ func TestLoadComposeProjectFromDir_SupportsPodmanComposeNames(t *testing.T) {
 			expectedPath := filepath.Join(dir, tc.fileName)
 			require.NoError(t, os.WriteFile(expectedPath, []byte(composeContent), 0o600))
 
-			project, composePath, err := LoadComposeProjectFromDir(
+			composePath, err := DetectComposeFile(dir)
+			require.NoError(t, err)
+
+			project, err := LoadComposeProject(
 				context.Background(),
-				dir,
+				composePath,
 				"podman-project",
 				filepath.Dir(dir),
 				false,
@@ -134,9 +137,12 @@ func TestLoadComposeProjectFromDir_SupportsCustomComposeNames(t *testing.T) {
 	expectedPath := filepath.Join(dir, "radarr.yaml")
 	require.NoError(t, os.WriteFile(expectedPath, []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
 
-	project, composePath, err := LoadComposeProjectFromDir(
+	composePath, err := DetectComposeFile(dir)
+	require.NoError(t, err)
+
+	project, err := LoadComposeProject(
 		context.Background(),
-		dir,
+		composePath,
 		"radarr",
 		filepath.Dir(dir),
 		false,
@@ -156,7 +162,10 @@ func TestLoadComposeProjectFromDir_EmptyProjectsDirectoryDoesNotCreateParentGlob
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
 
-	project, composePath, err := LoadComposeProjectFromDir(context.Background(), projectDir, "nested-services", "", false, nil)
+	composePath, err := DetectComposeFile(projectDir)
+	require.NoError(t, err)
+
+	project, err := LoadComposeProject(context.Background(), composePath, "nested-services", "", false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, project)
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `ProjectFilesystem` abstraction (`backend/pkg/projects/filesystem.go`) that centralises all project directory operations behind a staging/promotion model, replacing scattered `os.Rename`, `os.RemoveAll`, and direct `WriteProjectFiles` calls spread across `project_service.go`. It also adds filesystem rollback when a DB save fails after promotion, and fixes the `0700` staging-directory permission bug by immediately `chmod`ing to `0755`.

- **New `ProjectFilesystem` type** with `StageCreate`, `StageUpdate`, `StageGitSync`, and `Promote`, including atomic backup-and-restore on promotion failure.
- **`preparePromotedProjectRollbackInternal`** in `project_service.go` snapshots the live directory before `Promote` so the filesystem can be restored if the subsequent `db.Save` call fails — covering both `UpdateProject` (including rename) and `ApplyGitSyncProjectFiles`.
- **`addWatchInternal`** in `fswatch/watcher.go` extends symlink-aware watching by also adding the resolved real target when `followSymlinks` is enabled, with rollback if the primary watch add fails.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is well-structured, the staging/promotion model is correct, and integration tests cover the key rollback paths for both rename and git-sync scenarios.

The core logic (staging, promotion, backup/restore) is implemented correctly and covered by new integration tests. No functional defects were found in the changed paths. Style nits around the Internal suffix convention are the only findings.

No files require special attention beyond the minor naming nits in project_service.go and filesystem_test.go.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/pkg/projects/filesystem.go`, line 1316-1327 ([link](https://github.com/getarcaneapp/arcane/blob/11e1389480f6ce47a3e538e2aa81d80430b662d6/backend/pkg/projects/filesystem.go#L1316-L1327)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Orphaned hidden directories when both promotion and restore fail**

   If `os.Rename(stagePath, targetLivePath)` fails and the subsequent restore `os.Rename(backupPath, currentLivePath)` also fails, the function returns immediately without cleaning up either `backupPath` or `stagePath`. Both hidden directories (`.arcane-project-backup-*` and the stage dir) are abandoned under the projects root. Repeated failures would accumulate orphaned directories. Consider adding a best-effort `_ = os.RemoveAll(stagePath)` inside the restore-failure branch before returning.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/filesystem.go
   Line: 1316-1327

   Comment:
   **Orphaned hidden directories when both promotion and restore fail**

   If `os.Rename(stagePath, targetLivePath)` fails and the subsequent restore `os.Rename(backupPath, currentLivePath)` also fails, the function returns immediately without cleaning up either `backupPath` or `stagePath`. Both hidden directories (`.arcane-project-backup-*` and the stage dir) are abandoned under the projects root. Repeated failures would accumulate orphaned directories. Consider adding a best-effort `_ = os.RemoveAll(stagePath)` inside the restore-failure branch before returning.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fprojects-fs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fprojects-fs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Ffilesystem.go%0ALine%3A%201316-1327%0A%0AComment%3A%0A**Orphaned%20hidden%20directories%20when%20both%20promotion%20and%20restore%20fail**%0A%0AIf%20%60os.Rename%28stagePath%2C%20targetLivePath%29%60%20fails%20and%20the%20subsequent%20restore%20%60os.Rename%28backupPath%2C%20currentLivePath%29%60%20also%20fails%2C%20the%20function%20returns%20immediately%20without%20cleaning%20up%20either%20%60backupPath%60%20or%20%60stagePath%60.%20Both%20hidden%20directories%20%28%60.arcane-project-backup-*%60%20and%20the%20stage%20dir%29%20are%20abandoned%20under%20the%20projects%20root.%20Repeated%20failures%20would%20accumulate%20orphaned%20directories.%20Consider%20adding%20a%20best-effort%20%60_%20%3D%20os.RemoveAll%28stagePath%29%60%20inside%20the%20restore-failure%20branch%20before%20returning.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Ffilesystem.go%0ALine%3A%201316-1327%0A%0AComment%3A%0A**Orphaned%20hidden%20directories%20when%20both%20promotion%20and%20restore%20fail**%0A%0AIf%20%60os.Rename%28stagePath%2C%20targetLivePath%29%60%20fails%20and%20the%20subsequent%20restore%20%60os.Rename%28backupPath%2C%20currentLivePath%29%60%20also%20fails%2C%20the%20function%20returns%20immediately%20without%20cleaning%20up%20either%20%60backupPath%60%20or%20%60stagePath%60.%20Both%20hidden%20directories%20%28%60.arcane-project-backup-*%60%20and%20the%20stage%20dir%29%20are%20abandoned%20under%20the%20projects%20root.%20Repeated%20failures%20would%20accumulate%20orphaned%20directories.%20Consider%20adding%20a%20best-effort%20%60_%20%3D%20os.RemoveAll%28stagePath%29%60%20inside%20the%20restore-failure%20branch%20before%20returning.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fprojects-fs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fprojects-fs%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2865%0AThe%20%60rollback%60%20and%20%60cleanup%60%20methods%20on%20the%20unexported%20%60promotedProjectRollbackInternal%60%20type%20are%20missing%20the%20required%20%60Internal%60%20suffix%20per%20the%20team's%20naming%20convention%2C%20which%20requires%20all%20unexported%20functions%20to%20carry%20this%20suffix%20to%20distinguish%20private%20helpers%20from%20the%20public%20API.%0A%0A%60%60%60suggestion%0Afunc%20%28r%20*promotedProjectRollbackInternal%29%20rollbackInternal%28%29%20error%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2882%0AThe%20%60cleanup%60%20method%20is%20also%20missing%20the%20required%20%60Internal%60%20suffix.%20Both%20call-sites%20%28%60promoteRollback.cleanup%28%29%60%29%20would%20need%20to%20be%20updated%20alongside%20the%20rename.%0A%0A%60%60%60suggestion%0Afunc%20%28r%20*promotedProjectRollbackInternal%29%20cleanupInternal%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Fprojects%2Ffilesystem_test.go%3A189-191%0AThe%20test%20helper%20%60ptrString%60%20is%20an%20unexported%20package-level%20function%20without%20the%20required%20%60Internal%60%20suffix.%20The%20naming%20convention%20applies%20to%20all%20unexported%20functions%2C%20including%20test%20helpers.%0A%0A%60%60%60suggestion%0Afunc%20ptrStringInternal%28value%20string%29%20*string%20%7B%0A%09return%20%26value%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2865%0AThe%20%60rollback%60%20and%20%60cleanup%60%20methods%20on%20the%20unexported%20%60promotedProjectRollbackInternal%60%20type%20are%20missing%20the%20required%20%60Internal%60%20suffix%20per%20the%20team's%20naming%20convention%2C%20which%20requires%20all%20unexported%20functions%20to%20carry%20this%20suffix%20to%20distinguish%20private%20helpers%20from%20the%20public%20API.%0A%0A%60%60%60suggestion%0Afunc%20%28r%20*promotedProjectRollbackInternal%29%20rollbackInternal%28%29%20error%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A2882%0AThe%20%60cleanup%60%20method%20is%20also%20missing%20the%20required%20%60Internal%60%20suffix.%20Both%20call-sites%20%28%60promoteRollback.cleanup%28%29%60%29%20would%20need%20to%20be%20updated%20alongside%20the%20rename.%0A%0A%60%60%60suggestion%0Afunc%20%28r%20*promotedProjectRollbackInternal%29%20cleanupInternal%28%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Fpkg%2Fprojects%2Ffilesystem_test.go%3A189-191%0AThe%20test%20helper%20%60ptrString%60%20is%20an%20unexported%20package-level%20function%20without%20the%20required%20%60Internal%60%20suffix.%20The%20naming%20convention%20applies%20to%20all%20unexported%20functions%2C%20including%20test%20helpers.%0A%0A%60%60%60suggestion%0Afunc%20ptrStringInternal%28value%20string%29%20*string%20%7B%0A%09return%20%26value%0A%7D%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
backend/internal/services/project_service.go:2865
The `rollback` and `cleanup` methods on the unexported `promotedProjectRollbackInternal` type are missing the required `Internal` suffix per the team's naming convention, which requires all unexported functions to carry this suffix to distinguish private helpers from the public API.

```suggestion
func (r *promotedProjectRollbackInternal) rollbackInternal() error {
```

### Issue 2 of 3
backend/internal/services/project_service.go:2882
The `cleanup` method is also missing the required `Internal` suffix. Both call-sites (`promoteRollback.cleanup()`) would need to be updated alongside the rename.

```suggestion
func (r *promotedProjectRollbackInternal) cleanupInternal() {
```

### Issue 3 of 3
backend/pkg/projects/filesystem_test.go:189-191
The test helper `ptrString` is an unexported package-level function without the required `Internal` suffix. The naming convention applies to all unexported functions, including test helpers.

```suggestion
func ptrStringInternal(value string) *string {
	return &value
}
```


`````

</details>

<sub>Reviews (6): Last reviewed commit: ["refactor: create project filesystem arch..."](https://github.com/getarcaneapp/arcane/commit/23d007b5f0b590c52a196923f4d526c5fc0af842) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31280614)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->