### PR TITLE
fix: use in-memory trivy DB backend on 32-bit architectures to prevent mmap allocation failure

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1397,8 +1398,12 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	outputPath := newTrivyOutputPathInternal()
 	defer cleanupTrivyOutputFileInContainerInternal(ctx, dockerClient, containerID, outputPath)
 
+	execCmd := []string{"trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout}
+	execCmd = append(execCmd, trivyDBBackendArgsInternal()...)
+	execCmd = append(execCmd, imageName)
+
 	execCfg := client.ExecCreateOptions{
-		Cmd:          []string{"trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout, imageName},
+		Cmd:          execCmd,
 		AttachStdout: true,
 		AttachStderr: true,
 	}
@@ -2113,6 +2118,23 @@ func cleanupTempFiles(ctx context.Context, tempFiles []string) {
 	}
 }
 
+// trivyDBBackendArgsForArchInternal returns extra Trivy flags that switch the
+// vulnerability DB to an in-memory backend on 32-bit architectures. bbolt's
+// default mmap-based backend can fail with ENOMEM on arm/v7 and 386 because
+// Go's heap reservations fragment the limited 32-bit virtual address space.
+func trivyDBBackendArgsForArchInternal(arch string) []string {
+	switch arch {
+	case "arm", "386", "mips", "mipsle":
+		return []string{"--db-backend", "memory"}
+	default:
+		return nil
+	}
+}
+
+func trivyDBBackendArgsInternal() []string {
+	return trivyDBBackendArgsForArchInternal(runtime.GOARCH)
+}
+
 func (s *VulnerabilityService) buildTrivyCommandArgs(
 	ctx context.Context,
 	imageName string,
@@ -2122,6 +2144,7 @@ func (s *VulnerabilityService) buildTrivyCommandArgs(
 	outputPath string,
 ) ([]string, []string) {
 	cmdArgs := []string{"image", "--format", "json", "--quiet", "--timeout", s.getTrivyScanTimeoutArg()}
+	cmdArgs = append(cmdArgs, trivyDBBackendArgsInternal()...)
 	var tempFiles []string
 
 	if strings.TrimSpace(configContent) != "" {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -290,6 +290,31 @@ func TestBuildTrivyCommandArgs_WithoutCacheDir(t *testing.T) {
 	require.Equal(t, "alpine:3.20", cmdArgs[len(cmdArgs)-1])
 }
 
+func TestTrivyDBBackendArgsForArch(t *testing.T) {
+	memoryBackend := []string{"--db-backend", "memory"}
+
+	tests := []struct {
+		arch string
+		want []string
+	}{
+		{"arm", memoryBackend},
+		{"386", memoryBackend},
+		{"mips", memoryBackend},
+		{"mipsle", memoryBackend},
+		{"amd64", nil},
+		{"arm64", nil},
+		{"ppc64le", nil},
+		{"s390x", nil},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			require.Equal(t, tt.want, trivyDBBackendArgsForArchInternal(tt.arch))
+		})
+	}
+}
+
 func TestBuildTrivyContainerConfig_IncludesEnv(t *testing.T) {
 	config := buildTrivyContainerConfig(
 		DefaultTrivyImage,


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2528

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `ENOMEM`/mmap allocation failure in Trivy's bbolt DB backend on 32-bit architectures by passing `--db-backend memory` when the host reports `arm`, `386`, `mips`, or `mipsle` via `runtime.GOARCH`. The flag is injected into both the in-container exec path and the local `buildTrivyCommandArgs` path.

- Two new unexported helpers (`trivyDBBackendArgsForArchInternal`, `trivyDBBackendArgsInternal`) detect the architecture and return the extra flags; argument ordering (flags before image name) is preserved correctly in both call sites.
- A table-driven test exercises all enumerated architectures, covering both the 32-bit (memory backend) and 64-bit (nil) cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to 32-bit host detection and only alters the Trivy command on those architectures.

The fix is minimal and surgical: two small helpers that gate a flag on a well-defined set of GOARCH values, wired into both scan paths. The default (64-bit) path is completely unaffected; the 32-bit path now passes an extra flag that addresses the reported mmap failure. No error handling, data flow, or interface contracts are changed.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: use in-memory trivy DB backend on 3..."](https://github.com/getarcaneapp/arcane/commit/8ca7dd64f17910382335b6f36103592079d82030) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31394408)</sub>

<!-- /greptile_comment -->