### PR TITLE
fix: allow force removing of images

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -698,6 +698,7 @@
 	"images_remove_selected_title": "Remove {count} Image(s)",
 	"images_remove_selected_message": "Are you sure you want to remove the selected image(s)? This action cannot be undone.",
 	"images_remove_message": "Are you sure you want to remove this image? This action cannot be undone.",
+	"images_remove_force_label": "Force remove",
 	"images_pull_no_tag": "Cannot pull image without repository tag",
 	"images_untagged": "Untagged",
 	"images_repository": "Repository",

--- a/frontend/src/routes/(app)/images/[imageId]/+page.svelte
+++ b/frontend/src/routes/(app)/images/[imageId]/+page.svelte
@@ -199,12 +199,20 @@
 		openConfirmDialog({
 			title: m.common_remove_title({ resource: m.resource_image() }),
 			message: m.images_remove_message(),
+			checkboxes: [
+				{
+					id: 'force',
+					label: m.images_remove_force_label(),
+					initialState: false
+				}
+			],
 			confirm: {
 				label: m.common_delete(),
 				destructive: true,
-				action: async () => {
+				action: async (checkboxStates) => {
+					const force = !!checkboxStates.force;
 					await handleApiResultWithCallbacks({
-						result: await tryCatch(imageService.deleteImage(id)),
+						result: await tryCatch(imageService.deleteImage(id, { force })),
 						message: m.images_remove_failed(),
 						setLoadingState: (value) => (isLoading.removing = value),
 						onSuccess: async () => {

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -79,16 +79,24 @@
 		openConfirmDialog({
 			title: m.images_remove_selected_title({ count: ids.length }),
 			message: m.images_remove_selected_message({ count: ids.length }),
+			checkboxes: [
+				{
+					id: 'force',
+					label: m.images_remove_force_label(),
+					initialState: false
+				}
+			],
 			confirm: {
 				label: m.common_remove(),
 				destructive: true,
-				action: async () => {
+				action: async (checkboxStates) => {
+					const force = !!checkboxStates.force;
 					isLoading.removing = true;
 					let successCount = 0;
 					let failureCount = 0;
 
 					for (const id of ids) {
-						const result = await tryCatch(imageService.deleteImage(id));
+						const result = await tryCatch(imageService.deleteImage(id, { force }));
 						handleApiResultWithCallbacks({
 							result,
 							message: m.images_remove_failed(),
@@ -123,13 +131,21 @@
 		openConfirmDialog({
 			title: m.common_remove_title({ resource: m.resource_image() }),
 			message: m.images_remove_message(),
+			checkboxes: [
+				{
+					id: 'force',
+					label: m.images_remove_force_label(),
+					initialState: false
+				}
+			],
 			confirm: {
 				label: m.common_remove(),
 				destructive: true,
-				action: async () => {
+				action: async (checkboxStates) => {
+					const force = !!checkboxStates.force;
 					isLoading.removing = true;
 
-					const result = await tryCatch(imageService.deleteImage(id));
+					const result = await tryCatch(imageService.deleteImage(id, { force }));
 					handleApiResultWithCallbacks({
 						result,
 						message: m.images_remove_failed(),


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2527

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Force remove" checkbox to the image deletion confirmation dialog, allowing users to force-remove images (e.g. those in use by containers) from both the image detail page and the image table.

- The `checkboxes` option is wired into all three `openConfirmDialog` call sites (`[imageId]/+page.svelte` and two places in `image-table.svelte`), with the `force` state correctly forwarded to `imageService.deleteImage`.
- The i18n key `images_remove_force_label` is added to `en.json` to label the checkbox.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, opt-in (checkbox defaults to unchecked), and consistent across all affected delete paths.

The force option was already supported by imageService.deleteImage; this PR simply surfaces it in the UI. All three deletion entry points are updated consistently, the checkbox API matches the existing openConfirmDialog contract, and the default is false so existing behavior is unchanged when the box is left unchecked.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow force removing of images"](https://github.com/getarcaneapp/arcane/commit/98750be9d108a4cb6a6bf1714300089d2a35d244) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31399931)</sub>

<!-- /greptile_comment -->