### PR TITLE
fix: set docker config directory to avoid errors around config.json

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -29,10 +29,18 @@ import (
 
 func Bootstrap(ctx context.Context) error {
 	_ = godotenv.Load()
-	if err := startup.ApplyRequestedRuntimeIdentity(ctx); err != nil {
+	cfg := config.Load()
+	runtimeIdentityCfg := &startup.RuntimeIdentityConfig{
+		PUID:         cfg.PUID,
+		PGID:         cfg.PGID,
+		DockerHost:   cfg.DockerHost,
+		DockerConfig: cfg.DockerConfig,
+		DatabaseURL:  cfg.DatabaseURL,
+	}
+	if err := startup.ApplyRequestedRuntimeIdentity(ctx, runtimeIdentityCfg); err != nil {
 		return fmt.Errorf("apply runtime identity: %w", err)
 	}
-	cfg := config.Load()
+	cfg.DockerConfig = runtimeIdentityCfg.DockerConfig
 
 	SetupGinLogger(cfg)
 	ConfigureGormLogger(cfg)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -54,7 +54,10 @@ type Config struct {
 	OidcProviderName           string `env:"OIDC_PROVIDER_NAME" default:""`
 	OidcProviderLogoUrl        string `env:"OIDC_PROVIDER_LOGO_URL" default:""`
 
+	PUID                    string `env:"PUID" default:""`
+	PGID                    string `env:"PGID" default:""`
 	DockerHost              string `env:"DOCKER_HOST" default:"unix:///var/run/docker.sock"`
+	DockerConfig            string `env:"DOCKER_CONFIG" default:""`
 	ProjectsDirectory       string `env:"PROJECTS_DIRECTORY" default:"/app/data/projects"`
 	ProjectScanMaxDepth     int    `env:"PROJECT_SCAN_MAX_DEPTH" default:"3"`
 	ProjectScanSkipDirs     string `env:"PROJECT_SCAN_SKIP_DIRS" default:".git,node_modules,vendor,.venv,venv,__pycache__,.cache,dist,build,target,.next,.nuxt,.svelte-kit"`

--- a/backend/internal/configschema/schema_test.go
+++ b/backend/internal/configschema/schema_test.go
@@ -33,6 +33,13 @@ func TestGenerate_EnvConfigIncludesTaggedFields(t *testing.T) {
 	assert.True(t, encryptionKey.SupportsFile)
 	assert.Contains(t, encryptionKey.Options, "file")
 
+	dockerConfig, ok := entries["DOCKER_CONFIG"]
+	require.True(t, ok)
+	assert.Equal(t, "DockerConfig", dockerConfig.Field)
+	assert.Equal(t, "string", dockerConfig.Type)
+	assert.Empty(t, dockerConfig.DefaultValue)
+	assert.Equal(t, "config.Config", dockerConfig.Source)
+
 	buildableUsername, ok := entries["AUTO_LOGIN_USERNAME"]
 	require.True(t, ok)
 	assert.True(t, buildableUsername.Conditional)
@@ -198,6 +205,7 @@ var expectedEnvConfigVars = []string{
 	"DATABASE_URL",
 	"DIR_PERM",
 	"DOCKER_API_TIMEOUT",
+	"DOCKER_CONFIG",
 	"DOCKER_HOST",
 	"DOCKER_IMAGE_PULL_TIMEOUT",
 	"EDGE_AGENT",
@@ -234,11 +242,13 @@ var expectedEnvConfigVars = []string{
 	"OIDC_PROVIDER_NAME",
 	"OIDC_SCOPES",
 	"OIDC_SKIP_TLS_VERIFY",
+	"PGID",
 	"PORT",
 	"PROJECTS_DIRECTORY",
 	"PROJECT_SCAN_MAX_DEPTH",
 	"PROJECT_SCAN_SKIP_DIRS",
 	"PROXY_REQUEST_TIMEOUT",
+	"PUID",
 	"REGISTRY_TIMEOUT",
 	"TLS_CERT_FILE",
 	"TLS_ENABLED",

--- a/backend/pkg/libarcane/startup/runtime_identity.go
+++ b/backend/pkg/libarcane/startup/runtime_identity.go
@@ -15,6 +15,7 @@ const (
 	defaultDataDirectory    = "/app/data"
 	defaultBuildsDirectory  = "/builds"
 	defaultDatabaseURL      = "file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate"
+	defaultDockerConfigDir  = "/app/data/.docker"
 	defaultDockerSocketPath = "/var/run/docker.sock"
 	mountInfoPath           = "/proc/self/mountinfo"
 )
@@ -25,12 +26,27 @@ type runtimeIdentityRequest struct {
 	GID           int
 	CredentialUID uint32
 	CredentialGID uint32
+	DockerHost    string
+}
+
+// RuntimeIdentityConfig contains the config-backed environment values used to
+// switch the process runtime identity before the application initializes.
+type RuntimeIdentityConfig struct {
+	PUID         string
+	PGID         string
+	DockerHost   string
+	DockerConfig string
+	DatabaseURL  string
 }
 
 // ApplyRequestedRuntimeIdentity switches the current process to the configured
 // runtime UID/GID before the rest of the app initializes.
-func ApplyRequestedRuntimeIdentity(ctx context.Context) error {
-	req, warning, err := loadRuntimeIdentityRequestInternal(os.Getenv)
+func ApplyRequestedRuntimeIdentity(ctx context.Context, cfg *RuntimeIdentityConfig) error {
+	if cfg == nil {
+		cfg = &RuntimeIdentityConfig{}
+	}
+
+	req, warning, err := loadRuntimeIdentityRequestInternal(cfg)
 	if warning != "" {
 		fmt.Fprintf(os.Stderr, "Runtime identity warning: %s\n", warning)
 	}
@@ -44,18 +60,28 @@ func ApplyRequestedRuntimeIdentity(ctx context.Context) error {
 	// Avoid re-execing forever when the requested runtime identity is already active,
 	// including explicit root requests such as PUID=0/PGID=0.
 	if os.Geteuid() == runtimeUID && os.Getegid() == runtimeGID {
-		return ensureSQLiteFilesExistInternal(os.Getenv("DATABASE_URL"))
+		if err := ensureRuntimeDockerConfigInternal(cfg, os.Setenv, runtimeUID, runtimeGID); err != nil {
+			return err
+		}
+		return ensureSQLiteFilesExistInternal(cfg.DatabaseURL)
 	}
 
 	if os.Geteuid() != 0 {
 		fmt.Fprintf(os.Stderr, "Runtime identity warning: process is not root (euid=%d), cannot switch to PUID=%d PGID=%d; continuing as current user\n",
 			os.Geteuid(), runtimeUID, runtimeGID)
-		return ensureSQLiteFilesExistInternal(os.Getenv("DATABASE_URL"))
+		if err := ensureRuntimeDockerConfigInternal(cfg, os.Setenv, runtimeUID, runtimeGID); err != nil {
+			return err
+		}
+		return ensureSQLiteFilesExistInternal(cfg.DatabaseURL)
 	}
 
 	mountpoints, err := loadMountpointsInternal(mountInfoPath)
 	if err != nil {
 		return fmt.Errorf("load mountpoints: %w", err)
+	}
+
+	if err := ensureRuntimeDockerConfigInternal(cfg, os.Setenv, runtimeUID, runtimeGID); err != nil {
+		return err
 	}
 
 	if err := prepareWritablePathsInternal(runtimeUID, runtimeGID, mountpoints); err != nil {
@@ -65,9 +91,13 @@ func ApplyRequestedRuntimeIdentity(ctx context.Context) error {
 	return reexecWithRuntimeIdentityInternal(ctx, req)
 }
 
-func loadRuntimeIdentityRequestInternal(getenv func(string) string) (runtimeIdentityRequest, string, error) {
-	puid := strings.TrimSpace(getenv("PUID"))
-	pgid := strings.TrimSpace(getenv("PGID"))
+func loadRuntimeIdentityRequestInternal(cfg *RuntimeIdentityConfig) (runtimeIdentityRequest, string, error) {
+	if cfg == nil {
+		cfg = &RuntimeIdentityConfig{}
+	}
+
+	puid := strings.TrimSpace(cfg.PUID)
+	pgid := strings.TrimSpace(cfg.PGID)
 
 	if puid == "" && pgid == "" {
 		return runtimeIdentityRequest{}, "", nil
@@ -93,11 +123,68 @@ func loadRuntimeIdentityRequestInternal(getenv func(string) string) (runtimeIden
 		GID:           gid,
 		CredentialUID: credentialUID,
 		CredentialGID: credentialGID,
+		DockerHost:    cfg.DockerHost,
 	}, "", nil
 }
 
-func runtimeIdentitySupplementaryGroupsInternal(getenv func(string) string, resolveSocketGroup func(string) (uint32, bool)) []uint32 {
-	socketPath, ok := dockerSocketPathInternal(getenv("DOCKER_HOST"))
+func runtimeDockerConfigDirInternal(cfg *RuntimeIdentityConfig) string {
+	if cfg == nil {
+		cfg = &RuntimeIdentityConfig{}
+	}
+
+	configDir := strings.TrimSpace(cfg.DockerConfig)
+	if configDir != "" {
+		return configDir
+	}
+
+	return defaultDockerConfigDir
+}
+
+func ensureRuntimeDockerConfigInternal(cfg *RuntimeIdentityConfig, setenv func(string, string) error, uid int, gid int) error {
+	configDir, err := configureRuntimeDockerConfigEnvInternal(cfg, setenv, uid, gid)
+	if err != nil {
+		return err
+	}
+	if configDir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(configDir, pkgutils.DirPerm); err != nil {
+		return fmt.Errorf("create docker config directory: %w", err)
+	}
+
+	if configDir == defaultDockerConfigDir && os.Geteuid() == 0 {
+		if err := os.Chown(configDir, uid, gid); err != nil {
+			return fmt.Errorf("chown docker config directory: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func configureRuntimeDockerConfigEnvInternal(cfg *RuntimeIdentityConfig, setenv func(string, string) error, uid int, gid int) (string, error) {
+	if cfg == nil {
+		cfg = &RuntimeIdentityConfig{}
+	}
+
+	if uid == 0 && gid == 0 {
+		// Both UID and GID are root; Docker uses /root/.docker by default.
+		return "", nil
+	}
+
+	configDir := runtimeDockerConfigDirInternal(cfg)
+	if strings.TrimSpace(cfg.DockerConfig) == "" {
+		cfg.DockerConfig = configDir
+		if err := setenv("DOCKER_CONFIG", configDir); err != nil {
+			return "", fmt.Errorf("set DOCKER_CONFIG: %w", err)
+		}
+	}
+
+	return configDir, nil
+}
+
+func runtimeIdentitySupplementaryGroupsInternal(dockerHost string, resolveSocketGroup func(string) (uint32, bool)) []uint32 {
+	socketPath, ok := dockerSocketPathInternal(dockerHost)
 	if !ok {
 		return nil
 	}

--- a/backend/pkg/libarcane/startup/runtime_identity_linux.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_linux.go
@@ -18,7 +18,7 @@ func reexecWithRuntimeIdentityInternal(ctx context.Context, req runtimeIdentityR
 		return fmt.Errorf("resolve executable: %w", err)
 	}
 
-	groups := runtimeIdentitySupplementaryGroupsInternal(os.Getenv, resolveSocketGroupInternal)
+	groups := runtimeIdentitySupplementaryGroupsInternal(req.DockerHost, resolveSocketGroupInternal)
 
 	cmd := exec.CommandContext(ctx, executable, os.Args[1:]...) //nolint:gosec // re-executing our own binary with the same args under a different UID/GID
 	cmd.Env = os.Environ()

--- a/backend/pkg/libarcane/startup/runtime_identity_test.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_test.go
@@ -2,6 +2,7 @@ package startup
 
 import (
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -11,31 +12,21 @@ import (
 
 func TestLoadRuntimeIdentityRequest(t *testing.T) {
 	t.Run("disabled when unset", func(t *testing.T) {
-		req, warning, err := loadRuntimeIdentityRequestInternal(func(string) string { return "" })
+		req, warning, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{})
 		require.NoError(t, err)
 		require.Empty(t, warning)
 		require.False(t, req.Enabled)
 	})
 
 	t.Run("warning when partial config", func(t *testing.T) {
-		req, warning, err := loadRuntimeIdentityRequestInternal(func(key string) string {
-			if key == "PUID" {
-				return "1001"
-			}
-			return ""
-		})
+		req, warning, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{PUID: "1001"})
 		require.NoError(t, err)
 		require.Contains(t, warning, "PUID and PGID must both be set")
 		require.False(t, req.Enabled)
 	})
 
 	t.Run("error when invalid numeric value", func(t *testing.T) {
-		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
-			if key == "PUID" {
-				return "abc"
-			}
-			return "1001"
-		})
+		_, _, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{PUID: "abc", PGID: "1001"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid PUID")
 	})
@@ -43,26 +34,16 @@ func TestLoadRuntimeIdentityRequest(t *testing.T) {
 	t.Run("error when value exceeds uint32", func(t *testing.T) {
 		tooLarge := strconv.FormatUint(uint64(math.MaxUint32)+1, 10)
 
-		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
-			if key == "PUID" {
-				return tooLarge
-			}
-			return "1001"
-		})
+		_, _, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{PUID: tooLarge, PGID: "1001"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid PUID")
 	})
 
 	t.Run("enabled when both set", func(t *testing.T) {
-		req, warning, err := loadRuntimeIdentityRequestInternal(func(key string) string {
-			switch key {
-			case "PUID":
-				return "1001"
-			case "PGID":
-				return "2001"
-			default:
-				return ""
-			}
+		req, warning, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{
+			PUID:       "1001",
+			PGID:       "2001",
+			DockerHost: "unix:///tmp/docker.sock",
 		})
 		require.NoError(t, err)
 		require.Empty(t, warning)
@@ -71,24 +52,150 @@ func TestLoadRuntimeIdentityRequest(t *testing.T) {
 		require.Equal(t, 2001, req.GID)
 		require.Equal(t, uint32(1001), req.CredentialUID)
 		require.Equal(t, uint32(2001), req.CredentialGID)
+		require.Equal(t, "unix:///tmp/docker.sock", req.DockerHost)
 	})
 
 	t.Run("error when value is negative", func(t *testing.T) {
-		_, _, err := loadRuntimeIdentityRequestInternal(func(key string) string {
-			if key == "PUID" {
-				return "-1"
-			}
-			return "1001"
-		})
+		_, _, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{PUID: "-1", PGID: "1001"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid PUID")
 	})
 }
 
+func TestRuntimeDockerConfigDir(t *testing.T) {
+	t.Run("defaults to app data docker config when unset", func(t *testing.T) {
+		dir := runtimeDockerConfigDirInternal(&RuntimeIdentityConfig{})
+
+		require.Equal(t, defaultDockerConfigDir, dir)
+	})
+
+	t.Run("preserves explicit docker config", func(t *testing.T) {
+		dir := runtimeDockerConfigDirInternal(&RuntimeIdentityConfig{DockerConfig: "/custom/docker-config"})
+
+		require.Equal(t, "/custom/docker-config", dir)
+	})
+
+	t.Run("root default runtime leaves runtime identity disabled", func(t *testing.T) {
+		req, warning, err := loadRuntimeIdentityRequestInternal(&RuntimeIdentityConfig{})
+
+		require.NoError(t, err)
+		require.Empty(t, warning)
+		require.False(t, req.Enabled)
+	})
+}
+
+func TestConfigureRuntimeDockerConfigEnv(t *testing.T) {
+	t.Run("sets default for non root runtime when unset", func(t *testing.T) {
+		cfg := &RuntimeIdentityConfig{}
+		env := map[string]string{}
+
+		configDir, err := configureRuntimeDockerConfigEnvInternal(
+			cfg,
+			func(key string, value string) error {
+				env[key] = value
+				return nil
+			},
+			1001,
+			1001,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, defaultDockerConfigDir, configDir)
+		require.Equal(t, defaultDockerConfigDir, env["DOCKER_CONFIG"])
+		require.Equal(t, defaultDockerConfigDir, cfg.DockerConfig)
+	})
+
+	t.Run("preserves explicit docker config for non root runtime", func(t *testing.T) {
+		cfg := &RuntimeIdentityConfig{DockerConfig: "/custom/docker-config"}
+		env := map[string]string{}
+		setCalled := false
+
+		configDir, err := configureRuntimeDockerConfigEnvInternal(
+			cfg,
+			func(key string, value string) error {
+				setCalled = true
+				env[key] = value
+				return nil
+			},
+			1001,
+			1001,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, "/custom/docker-config", configDir)
+		require.Empty(t, env["DOCKER_CONFIG"])
+		require.Equal(t, "/custom/docker-config", cfg.DockerConfig)
+		require.False(t, setCalled)
+	})
+
+	t.Run("skips explicit root runtime", func(t *testing.T) {
+		cfg := &RuntimeIdentityConfig{}
+		env := map[string]string{}
+		setCalled := false
+
+		configDir, err := configureRuntimeDockerConfigEnvInternal(
+			cfg,
+			func(key string, value string) error {
+				setCalled = true
+				env[key] = value
+				return nil
+			},
+			0,
+			0,
+		)
+
+		require.NoError(t, err)
+		require.Empty(t, configDir)
+		require.Empty(t, env["DOCKER_CONFIG"])
+		require.Empty(t, cfg.DockerConfig)
+		require.False(t, setCalled)
+	})
+
+	t.Run("sets default for mixed root uid non root gid runtime", func(t *testing.T) {
+		cfg := &RuntimeIdentityConfig{}
+		env := map[string]string{}
+
+		configDir, err := configureRuntimeDockerConfigEnvInternal(
+			cfg,
+			func(key string, value string) error {
+				env[key] = value
+				return nil
+			},
+			0,
+			1001,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, defaultDockerConfigDir, configDir)
+		require.Equal(t, defaultDockerConfigDir, env["DOCKER_CONFIG"])
+		require.Equal(t, defaultDockerConfigDir, cfg.DockerConfig)
+	})
+}
+
+func TestEnsureRuntimeDockerConfigCreatesCustomDirectory(t *testing.T) {
+	customDir := filepath.Join(t.TempDir(), "custom-docker-config")
+	cfg := &RuntimeIdentityConfig{DockerConfig: customDir}
+
+	require.NoError(t, ensureRuntimeDockerConfigInternal(
+		cfg,
+		func(string, string) error {
+			t.Fatal("setenv should not be called for explicit DOCKER_CONFIG")
+			return nil
+		},
+		1001,
+		1001,
+	))
+
+	info, err := os.Stat(customDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Equal(t, customDir, cfg.DockerConfig)
+}
+
 func TestRuntimeIdentitySupplementaryGroups(t *testing.T) {
 	t.Run("maps default docker socket group when docker host unset", func(t *testing.T) {
 		groups := runtimeIdentitySupplementaryGroupsInternal(
-			func(string) string { return "" },
+			"",
 			func(socketPath string) (uint32, bool) {
 				require.Equal(t, defaultDockerSocketPath, socketPath)
 				return 997, true
@@ -100,7 +207,7 @@ func TestRuntimeIdentitySupplementaryGroups(t *testing.T) {
 
 	t.Run("maps custom unix docker host socket group", func(t *testing.T) {
 		groups := runtimeIdentitySupplementaryGroupsInternal(
-			func(string) string { return "unix:///tmp/docker.sock" },
+			"unix:///tmp/docker.sock",
 			func(socketPath string) (uint32, bool) {
 				require.Equal(t, "/tmp/docker.sock", socketPath)
 				return 998, true
@@ -114,7 +221,7 @@ func TestRuntimeIdentitySupplementaryGroups(t *testing.T) {
 		called := false
 
 		groups := runtimeIdentitySupplementaryGroupsInternal(
-			func(string) string { return "tcp://docker:2375" },
+			"tcp://docker:2375",
 			func(string) (uint32, bool) {
 				called = true
 				return 0, false
@@ -127,7 +234,7 @@ func TestRuntimeIdentitySupplementaryGroups(t *testing.T) {
 
 	t.Run("skips socket group when socket lookup fails", func(t *testing.T) {
 		groups := runtimeIdentitySupplementaryGroupsInternal(
-			func(string) string { return "unix:///tmp/missing.sock" },
+			"unix:///tmp/missing.sock",
 			func(string) (uint32, bool) { return 0, false },
 		)
 

--- a/tests/spec/docker-runtime-identity.spec.ts
+++ b/tests/spec/docker-runtime-identity.spec.ts
@@ -40,6 +40,10 @@ function dockerPort(container: string) {
 	return mapping.split(':').at(-1)?.trim() || '';
 }
 
+function dockerLogs(container: string) {
+	return docker(['logs', container]);
+}
+
 function dockerFileStat(volumePath: string, filePath: string) {
 	return docker([
 		'run',
@@ -240,6 +244,14 @@ test.describe.serial('Docker runtime identity', () => {
 			const processStatuses = arcaneProcessStatuses(containerName);
 			expect(processStatuses.some((status) => status.startsWith('1:0:0:0:'))).toBe(true);
 			expect(processStatuses.some((status) => /^(?!1:)\d+:1:1001:1001:/.test(status))).toBe(true);
+
+			const dockerConfigStat = dockerExecAsUser(
+				containerName,
+				'1001:1001',
+				"stat -c '%u:%g' /app/data/.docker"
+			);
+			expect(dockerConfigStat).toBe('1001:1001');
+			expect(dockerLogs(containerName)).not.toContain('/root/.docker/config.json');
 		} finally {
 			cleanupContainer(containerName);
 			cleanupDir(dataDir);


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Docker `config.json` errors when running as a non-root `PUID`/`PGID` identity by creating and setting a dedicated `DOCKER_CONFIG` directory (`/app/data/.docker`) before the process re-executes under the target user, preventing Docker from falling back to `/root/.docker`.

- **`RuntimeIdentityConfig` struct** replaces the `getenv` function-parameter pattern, centralising `PUID`, `PGID`, `DockerHost`, `DockerConfig`, and `DatabaseURL`; `bootstrap.go` loads config first, builds the struct, calls `ApplyRequestedRuntimeIdentity`, then syncs the (potentially defaulted) `DockerConfig` back to the main config.
- **`ensureRuntimeDockerConfigInternal` / `configureRuntimeDockerConfigEnvInternal`** create the docker config directory with `MkdirAll`, chown it when running as root for the default path, and call `os.Setenv(\"DOCKER_CONFIG\", ...)` so the value survives the re-exec via `cmd.Env = os.Environ()`.
- Config schema tests are updated to include `DOCKER_CONFIG`, `PUID`, and `PGID`; unit tests cover the new directory-creation and env-setting logic; an E2E spec validates ownership via `stat`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, the re-exec path correctly propagates DOCKER_CONFIG through os.Setenv before cmd.Env = os.Environ(), and non-root chown is properly gated.

The docker config directory is created and chowned before re-exec, survives identity switch correctly, and unit + E2E tests cover default path, custom path, root skip, and mixed uid/gid cases. No data-loss or security boundary issue introduced.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: set docker config directory to avoi..."](https://github.com/getarcaneapp/arcane/commit/fa894972a976204cc7630bdb96a9136c1961d26e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31449052)</sub>

<!-- /greptile_comment -->