### PR TITLE
fix: remove double loading of env overides and settings, use in memory cache instead

### DIFF
--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -503,7 +503,7 @@ func (s *SettingsService) isEnvOverrideActiveInternal(key string) bool {
 }
 
 func (s *SettingsService) GetSettings(ctx context.Context) (*models.Settings, error) {
-	settings := s.getEffectiveSettingsConfig(ctx)
+	settings := s.getEffectiveSettingsConfigInternal(ctx)
 	return settings, nil
 }
 
@@ -522,7 +522,7 @@ func (s *SettingsService) GetSettingsOrDefaults(ctx context.Context) *models.Set
 	return cfg
 }
 
-func (s *SettingsService) getEffectiveSettingsConfig(ctx context.Context) *models.Settings {
+func (s *SettingsService) getEffectiveSettingsConfigInternal(ctx context.Context) *models.Settings {
 	settings := s.GetSettingsConfig().Clone()
 	s.applyEnvOverrides(ctx, settings)
 	return settings
@@ -656,7 +656,6 @@ func (s *SettingsService) updateSettingValueNoRefreshInternal(ctx context.Contex
 func (s *SettingsService) UpdateSettings(ctx context.Context, updates settings.Update) ([]models.SettingVariable, error) {
 	defaultCfg := s.getDefaultSettings()
 	cfg := s.GetSettingsConfig().Clone()
-	s.applyEnvOverrides(ctx, cfg)
 
 	valuesToUpdate, changedPolling, changedAutoUpdate, changedScheduledPrune, changedVulnerabilityScan, changedAutoHeal, changedTimeouts, err := s.prepareUpdateValues(updates, cfg, defaultCfg)
 	if err != nil {
@@ -1080,7 +1079,7 @@ func (s *SettingsService) setupInstanceID(ctx context.Context) error {
 }
 
 func (s *SettingsService) GetBoolSetting(ctx context.Context, key string, defaultValue bool) bool {
-	cfg := s.getEffectiveSettingsConfig(ctx)
+	cfg := s.getEffectiveSettingsConfigInternal(ctx)
 	val, _, _, err := cfg.FieldByKey(key)
 	if err != nil || val == "" {
 		return defaultValue
@@ -1093,7 +1092,7 @@ func (s *SettingsService) GetBoolSetting(ctx context.Context, key string, defaul
 }
 
 func (s *SettingsService) GetIntSetting(ctx context.Context, key string, defaultValue int) int {
-	cfg := s.getEffectiveSettingsConfig(ctx)
+	cfg := s.getEffectiveSettingsConfigInternal(ctx)
 	val, _, _, err := cfg.FieldByKey(key)
 	if err != nil || val == "" {
 		return defaultValue
@@ -1106,7 +1105,7 @@ func (s *SettingsService) GetIntSetting(ctx context.Context, key string, default
 }
 
 func (s *SettingsService) GetStringSetting(ctx context.Context, key, defaultValue string) string {
-	cfg := s.getEffectiveSettingsConfig(ctx)
+	cfg := s.getEffectiveSettingsConfigInternal(ctx)
 	val, _, _, err := cfg.FieldByKey(key)
 	if err != nil || val == "" {
 		return defaultValue

--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -24,6 +24,7 @@ type Watcher struct {
 	debounce       time.Duration
 	stopCh         chan struct{}
 	stoppedCh      chan struct{}
+	watchAliases   map[string]string
 	mu             sync.Mutex
 	started        bool
 	stopped        bool
@@ -61,6 +62,7 @@ func NewWatcher(watchPath string, opts WatcherOptions) (*Watcher, error) {
 		debounce:       opts.Debounce,
 		stopCh:         make(chan struct{}),
 		stoppedCh:      make(chan struct{}),
+		watchAliases:   make(map[string]string),
 	}, nil
 }
 
@@ -201,9 +203,10 @@ func (fw *Watcher) fireDebounceInternal(ctx context.Context, debouncePending *bo
 // shouldHandleEventInternal's job.
 func (fw *Watcher) handleEventInternal(ctx context.Context, event fsnotify.Event) {
 	if event.Has(fsnotify.Create) {
+		logicalName := fw.logicalPathForWatchEventInternal(event.Name)
 		if fw.isWatchableDirectory(event.Name) {
-			if fw.shouldWatchDir(event.Name) {
-				if err := fw.addExistingDirectories(event.Name); err != nil {
+			if fw.shouldWatchDir(logicalName) {
+				if err := fw.addExistingDirectoriesRecursiveInternal(event.Name, logicalName, map[string]struct{}{}); err != nil {
 					slog.WarnContext(ctx, "Failed to add new directory to watcher",
 						"path", event.Name,
 						"error", err)
@@ -233,10 +236,10 @@ func (fw *Watcher) shouldHandleEventInternal(event fsnotify.Event) bool {
 }
 
 func (fw *Watcher) addExistingDirectories(root string) error {
-	return fw.addExistingDirectoriesRecursiveInternal(root, map[string]struct{}{})
+	return fw.addExistingDirectoriesRecursiveInternal(root, root, map[string]struct{}{})
 }
 
-func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestors map[string]struct{}) error {
+func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, logicalPath string, ancestors map[string]struct{}) error {
 	identity, err := projects.ResolveDirectoryIdentityInternal(path)
 	if err != nil {
 		return err
@@ -249,7 +252,7 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestor
 	defer delete(ancestors, identity)
 
 	if path != fw.watchedPath {
-		depth := fw.dirDepth(path)
+		depth := fw.dirDepth(logicalPath)
 		if depth < 0 {
 			return nil
 		}
@@ -257,9 +260,11 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestor
 			return nil
 		}
 
-		if err := fw.watcher.Add(path); err != nil {
+		watchPath := fw.resolveWatchPathInternal(path)
+		fw.watchAliases[watchPath] = filepath.Clean(logicalPath)
+		if err := fw.watcher.Add(watchPath); err != nil {
 			slog.Warn("Failed to add directory to watcher",
-				"path", path,
+				"path", watchPath,
 				"error", err)
 		}
 
@@ -278,12 +283,55 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, ancestor
 		if !projects.IsProjectDirectoryEntry(entry, childPath, fw.followSymlinks) {
 			continue
 		}
-		if err := fw.addExistingDirectoriesRecursiveInternal(childPath, ancestors); err != nil {
+		childLogicalPath := filepath.Join(logicalPath, entry.Name())
+		if err := fw.addExistingDirectoriesRecursiveInternal(childPath, childLogicalPath, ancestors); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (fw *Watcher) resolveWatchPathInternal(path string) string {
+	if !fw.followSymlinks {
+		return path
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+
+	return resolvedPath
+}
+
+func (fw *Watcher) logicalPathForWatchEventInternal(path string) string {
+	cleanPath := filepath.Clean(path)
+	bestWatchPath := ""
+	bestLogicalPath := ""
+
+	for watchPath, logicalPath := range fw.watchAliases {
+		cleanWatchPath := filepath.Clean(watchPath)
+		if cleanPath != cleanWatchPath && !strings.HasPrefix(cleanPath, cleanWatchPath+string(os.PathSeparator)) {
+			continue
+		}
+		if len(cleanWatchPath) <= len(bestWatchPath) {
+			continue
+		}
+		bestWatchPath = cleanWatchPath
+		bestLogicalPath = logicalPath
+	}
+
+	if bestWatchPath == "" {
+		return cleanPath
+	}
+
+	rel, err := filepath.Rel(bestWatchPath, cleanPath)
+	if err != nil || rel == "." {
+		return filepath.Clean(bestLogicalPath)
+	}
+
+	return filepath.Join(bestLogicalPath, rel)
 }
 
 func (fw *Watcher) dirDepth(path string) int {

--- a/backend/pkg/fswatch/watcher_test.go
+++ b/backend/pkg/fswatch/watcher_test.go
@@ -48,6 +48,48 @@ func TestWatcher_StartWatchesExistingSymlinkDirectoriesWhenEnabled(t *testing.T)
 	}
 }
 
+func TestWatcher_StartWatchesNewDirectoriesInsideSymlinkDirectoriesWhenEnabled(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	targetPath := filepath.Join(targetRoot, "real-project")
+	require.NoError(t, os.MkdirAll(targetPath, 0o755))
+
+	linkPath := filepath.Join(root, "linked-project")
+	require.NoError(t, os.Symlink(targetPath, linkPath))
+
+	changeCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	watcher, err := NewWatcher(root, WatcherOptions{
+		Debounce:          25 * time.Millisecond,
+		MaxDepth:          2,
+		FollowSymlinkDirs: true,
+		OnChange: func(context.Context) {
+			select {
+			case changeCh <- struct{}{}:
+			default:
+			}
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Start(ctx))
+	defer func() {
+		require.NoError(t, watcher.Stop())
+	}()
+
+	nestedPath := filepath.Join(targetPath, "nested-project")
+	require.NoError(t, os.MkdirAll(nestedPath, 0o755))
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, os.WriteFile(filepath.Join(nestedPath, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	select {
+	case <-changeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected compose file in new symlinked directory to trigger watcher callback")
+	}
+}
+
 func TestWatcher_StartIgnoresNonProjectFileWritesInsideProjectDir(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "demo")


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent bugs: a redundant `applyEnvOverrides` call in `UpdateSettings` that applied env overrides to a scratch `cfg` object before passing it to `prepareUpdateValues` (unnecessary since env overrides are applied on read via `getEffectiveSettingsConfigInternal`), and the symlink directory tracking issue in the filesystem watcher where fsnotify events carried real (resolved) paths that couldn't be matched against the logical `watchedPath`, causing new directories inside symlinked subdirectories to be silently skipped.

- **`settings_service.go`**: Renames `getEffectiveSettingsConfig` → `getEffectiveSettingsConfigInternal` at the definition and all four call sites; removes a dead `applyEnvOverrides` call from `UpdateSettings` that applied env overrides to a temporary `cfg` buffer whose results were never used for comparison (the `changedPolling`/`changedAutoUpdate` etc. flags are keyed solely on which update fields are non-nil, not on current vs. new value diffs).
- **`watcher.go`**: Introduces `watchAliases map[string]string` to record the real-path → logical-path mapping for each watched directory, and `logicalPathForWatchEventInternal` to translate incoming fsnotify event paths (which use real/resolved paths) back to the logical path tree rooted at `watchedPath`. `shouldWatchDir` and `dirDepth` are now called with the logical path, so depth limits apply correctly through symlinks.
- **`watcher_test.go`**: Adds a regression test that creates a symlink into a separate temp tree, then creates a nested directory inside the real target and writes a compose file into it, asserting the watcher callback fires.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are safe to merge: the settings fix removes a dead code path that had no effect on outputs, and the watcher alias map is written exclusively during Start (before the watchLoop goroutine starts) and then read/written solely from the single watchLoop goroutine, so there is no concurrent access concern.

The prepareUpdateValues code confirms that changedPolling and sibling booleans are set by which keys appear in the updates struct, not by comparing against cfg values — so removing applyEnvOverrides from UpdateSettings has no observable effect. The watchAliases map is accessed from one goroutine after Start returns, and the Go memory model guarantees visibility of writes done before the go statement. The new test exercises the exact failure scenario described in the previous review thread, and the logic in logicalPathForWatchEventInternal correctly finds the longest-matching ancestor among resolved watch paths.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: remove double loading of env overid..."](https://github.com/getarcaneapp/arcane/commit/c60fc85c2af2cdbcb42662092ba12b9a3d35af49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31461013)</sub>

<!-- /greptile_comment -->