### PR TITLE
fix: show compose-labeled image updates in project updates

### DIFF
--- a/backend/internal/services/container_service_test.go
+++ b/backend/internal/services/container_service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
+	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
@@ -82,14 +83,15 @@ func TestGroupContainersByProjectUsesNoProjectBucket(t *testing.T) {
 
 func TestBuildContainerFilterAccessors_FiltersStandaloneContainers(t *testing.T) {
 	service := &ContainerService{}
+	updateInfo := &imagetypes.UpdateInfo{HasUpdate: true}
 	items := []containertypes.Summary{
-		{ID: "standalone", Labels: map[string]string{}},
-		{ID: "compose", Labels: map[string]string{"com.docker.compose.project": "alpha"}},
+		{ID: "standalone", Labels: map[string]string{}, UpdateInfo: updateInfo},
+		{ID: "compose", Labels: map[string]string{"com.docker.compose.project": "alpha"}, UpdateInfo: updateInfo},
 	}
 
 	result := pagination.SearchOrderAndPaginate(
 		items,
-		pagination.QueryParams{Filters: map[string]string{"standalone": "true"}},
+		pagination.QueryParams{Filters: map[string]string{"standalone": "true", "updates": "has_update"}},
 		pagination.Config[containertypes.Summary]{FilterAccessors: service.buildContainerFilterAccessors()},
 	)
 

--- a/backend/internal/services/dashboard_service.go
+++ b/backend/internal/services/dashboard_service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/database"
@@ -641,7 +642,8 @@ func (s *DashboardService) getPendingResourceUpdatesCountInternal(ctx context.Co
 	}
 
 	filteredContainers := filterInternalContainers(containers, false)
-	containerCount, err := s.getPendingContainerUpdatesCountForImageIDsInternal(ctx, collectImageIDs(filteredContainers))
+	standaloneContainers := filterStandaloneDockerContainersInternal(filteredContainers)
+	containerCount, err := s.getPendingContainerUpdatesCountForImageIDsInternal(ctx, collectImageIDs(standaloneContainers))
 	if err != nil {
 		return 0, err
 	}
@@ -652,6 +654,17 @@ func (s *DashboardService) getPendingResourceUpdatesCountInternal(ctx context.Co
 	}
 
 	return containerCount + projectCount, nil
+}
+
+func filterStandaloneDockerContainersInternal(containers []dockercontainer.Summary) []dockercontainer.Summary {
+	filtered := make([]dockercontainer.Summary, 0, len(containers))
+	for _, c := range containers {
+		if strings.TrimSpace(c.Labels["com.docker.compose.project"]) != "" {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
 }
 
 func (s *DashboardService) getPendingContainerUpdatesCountForImageIDsInternal(ctx context.Context, imageIDs []string) (int, error) {

--- a/backend/internal/services/dashboard_service_test.go
+++ b/backend/internal/services/dashboard_service_test.go
@@ -520,6 +520,18 @@ func TestDashboardService_GetActionItems_CountsAffectedResources(t *testing.T) {
 			Status:  "Up 2 hours",
 			Labels:  map[string]string{},
 		},
+		{
+			ID:      "compose-updated",
+			Names:   []string{"/compose-app"},
+			Image:   "repo/compose:latest",
+			ImageID: "sha256:image-compose",
+			Created: 1700000001,
+			State:   "running",
+			Status:  "Up 2 hours",
+			Labels: map[string]string{
+				"com.docker.compose.project": "compose-demo",
+			},
+		},
 	}
 	images := []dockerimage.Summary{
 		{ID: "sha256:image-a", RepoTags: []string{"repo/app:latest"}, Created: 1710000000, Size: 100},
@@ -535,6 +547,12 @@ func TestDashboardService_GetActionItems_CountsAffectedResources(t *testing.T) {
 	createDashboardTestImageUpdateRecord(t, db, models.ImageUpdateRecord{
 		ID:         "sha256:image-unused",
 		Repository: "docker.io/repo/unused",
+		Tag:        "latest",
+		HasUpdate:  true,
+	})
+	createDashboardTestImageUpdateRecord(t, db, models.ImageUpdateRecord{
+		ID:         "sha256:image-compose",
+		Repository: "docker.io/repo/compose",
 		Tag:        "latest",
 		HasUpdate:  true,
 	})

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -3420,8 +3420,269 @@ func (s *ProjectService) filterProjectsWithDerivedFiltersInternal(
 
 	items := s.fetchProjectStatusConcurrently(ctx, projectsArray)
 	s.enrichProjectsWithUpdateInfoInternal(ctx, projectsArray, items)
+	items = s.appendDiscoveredComposeProjectUpdatesInternal(ctx, params, projectsArray, items)
 
 	return pagination.SearchOrderAndPaginate(items, params, s.buildProjectDerivedPaginationConfigInternal()), nil
+}
+
+func (s *ProjectService) appendDiscoveredComposeProjectUpdatesInternal(
+	ctx context.Context,
+	params pagination.QueryParams,
+	projectsArray []models.Project,
+	items []project.Details,
+) []project.Details {
+	if !shouldIncludeDiscoveredComposeProjectUpdatesInternal(params) {
+		return items
+	}
+
+	composeContainers, err := projects.ListGlobalComposeContainers(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to list compose containers for project update rows", "error", err)
+		return items
+	}
+
+	knownProjectNames := s.buildKnownComposeProjectNameSetInternal(ctx, projectsArray)
+	discovered := buildDiscoveredComposeProjectUpdateRowsInternal(ctx, composeContainers, knownProjectNames, s.imageService)
+	if len(discovered) == 0 {
+		return items
+	}
+
+	return append(items, discovered...)
+}
+
+func shouldIncludeDiscoveredComposeProjectUpdatesInternal(params pagination.QueryParams) bool {
+	if params.Filters == nil {
+		return false
+	}
+
+	return strings.EqualFold(strings.TrimSpace(params.Filters["updates"]), "has_update")
+}
+
+func (s *ProjectService) buildKnownComposeProjectNameSetInternal(ctx context.Context, projectsArray []models.Project) map[string]struct{} {
+	known := make(map[string]struct{}, len(projectsArray)*2)
+	for _, proj := range projectsArray {
+		addKnownComposeProjectNameInternal(known, proj.Name)
+		if proj.ComposeProjectName != nil {
+			addKnownComposeProjectNameInternal(known, *proj.ComposeProjectName)
+		}
+	}
+
+	if s.db == nil {
+		return known
+	}
+
+	var allProjects []models.Project
+	if err := s.db.WithContext(ctx).Select("name", "compose_project_name").Find(&allProjects).Error; err != nil {
+		slog.WarnContext(ctx, "failed to load known project names for compose update discovery", "error", err)
+		return known
+	}
+
+	for _, proj := range allProjects {
+		addKnownComposeProjectNameInternal(known, proj.Name)
+		if proj.ComposeProjectName != nil {
+			addKnownComposeProjectNameInternal(known, *proj.ComposeProjectName)
+		}
+	}
+
+	return known
+}
+
+func addKnownComposeProjectNameInternal(known map[string]struct{}, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+
+	known[name] = struct{}{}
+	if normalized := normalizeComposeProjectName(name); normalized != "" {
+		known[normalized] = struct{}{}
+	}
+}
+
+func buildDiscoveredComposeProjectUpdateRowsInternal(
+	ctx context.Context,
+	composeContainers []container.Summary,
+	knownProjectNames map[string]struct{},
+	imageService *ImageService,
+) []project.Details {
+	containersByProject := make(map[string][]container.Summary)
+	for _, c := range composeContainers {
+		projectName := strings.TrimSpace(c.Labels["com.docker.compose.project"])
+		if projectName == "" {
+			continue
+		}
+		if _, exists := knownProjectNames[projectName]; exists {
+			continue
+		}
+		if normalized := normalizeComposeProjectName(projectName); normalized != "" {
+			if _, exists := knownProjectNames[normalized]; exists {
+				continue
+			}
+		}
+
+		containersByProject[projectName] = append(containersByProject[projectName], c)
+	}
+
+	if len(containersByProject) == 0 {
+		return nil
+	}
+
+	updateInfoByRef := getRuntimeContainerUpdateInfoByRefInternal(ctx, composeContainers, imageService)
+	rows := make([]project.Details, 0, len(containersByProject))
+	for projectName, projectContainers := range containersByProject {
+		runtimeServices := buildDiscoveredRuntimeServicesInternal(projectContainers)
+		imageRefs := buildProjectImageRefsFromRuntimeServicesInternal(runtimeServices)
+		updateInfo := buildProjectUpdateInfoSummaryInternal(imageRefs, updateInfoByRef)
+		if updateInfo == nil || !updateInfo.HasUpdate {
+			continue
+		}
+
+		runningCount := 0
+		for _, runtimeService := range runtimeServices {
+			if runtimeService.Status == "running" {
+				runningCount++
+			}
+		}
+
+		lastCheckedAt := ""
+		if updateInfo.LastCheckedAt != nil {
+			lastCheckedAt = updateInfo.LastCheckedAt.Format(time.RFC3339)
+		}
+
+		rows = append(rows, project.Details{
+			ID:              "compose:" + projectName,
+			Name:            projectName,
+			Path:            "",
+			Status:          resolveDiscoveredProjectStatusInternal(len(runtimeServices), runningCount),
+			ServiceCount:    len(runtimeServices),
+			RunningCount:    runningCount,
+			IsDiscovered:    true,
+			CreatedAt:       lastCheckedAt,
+			UpdatedAt:       lastCheckedAt,
+			RuntimeServices: runtimeServices,
+			UpdateInfo:      updateInfo,
+		})
+	}
+
+	return rows
+}
+
+func getRuntimeContainerUpdateInfoByRefInternal(
+	ctx context.Context,
+	composeContainers []container.Summary,
+	imageService *ImageService,
+) map[string]*imagetypes.UpdateInfo {
+	if imageService == nil || len(composeContainers) == 0 {
+		return nil
+	}
+
+	imageRefs := make([]string, 0, len(composeContainers))
+	imageIDsByRef := make(map[string][]string, len(composeContainers))
+	seenRefs := make(map[string]struct{}, len(composeContainers))
+	for _, c := range composeContainers {
+		imageRef := strings.TrimSpace(c.Image)
+		if imageRef == "" {
+			continue
+		}
+		if _, exists := seenRefs[imageRef]; !exists {
+			seenRefs[imageRef] = struct{}{}
+			imageRefs = append(imageRefs, imageRef)
+		}
+		if imageID := strings.TrimSpace(c.ImageID); imageID != "" {
+			imageIDsByRef[imageRef] = append(imageIDsByRef[imageRef], imageID)
+		}
+	}
+
+	updateInfoByRef := make(map[string]*imagetypes.UpdateInfo, len(imageRefs))
+	if len(imageRefs) > 0 {
+		if refResults, err := imageService.GetUpdateInfoByImageRefs(ctx, imageRefs); err == nil {
+			maps.Copy(updateInfoByRef, refResults)
+		} else {
+			slog.WarnContext(ctx, "failed to fetch compose project update info by image ref", "error", err)
+		}
+	}
+
+	missingImageIDs := make([]string, 0)
+	for _, imageRef := range imageRefs {
+		if updateInfoByRef[imageRef] != nil {
+			continue
+		}
+		missingImageIDs = append(missingImageIDs, imageIDsByRef[imageRef]...)
+	}
+
+	if len(missingImageIDs) == 0 {
+		return updateInfoByRef
+	}
+
+	updateInfoByID, err := imageService.GetUpdateInfoByImageIDs(ctx, missingImageIDs)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to fetch compose project update info by image id", "error", err)
+		return updateInfoByRef
+	}
+
+	for imageRef, imageIDs := range imageIDsByRef {
+		if updateInfoByRef[imageRef] != nil {
+			continue
+		}
+		for _, imageID := range imageIDs {
+			if info := updateInfoByID[imageID]; info != nil {
+				updateInfoByRef[imageRef] = info
+				break
+			}
+		}
+	}
+
+	return updateInfoByRef
+}
+
+func buildDiscoveredRuntimeServicesInternal(containers []container.Summary) []project.RuntimeService {
+	runtimeServices := make([]project.RuntimeService, 0, len(containers))
+	seenServices := make(map[string]struct{}, len(containers))
+	for _, c := range containers {
+		imageRef := strings.TrimSpace(c.Image)
+		if imageRef == "" {
+			continue
+		}
+
+		serviceName := strings.TrimSpace(c.Labels["com.docker.compose.service"])
+		if serviceName == "" {
+			serviceName = c.ID
+		}
+		key := serviceName + "\x00" + imageRef
+		if _, exists := seenServices[key]; exists {
+			continue
+		}
+		seenServices[key] = struct{}{}
+
+		containerName := ""
+		if len(c.Names) > 0 {
+			containerName = strings.TrimPrefix(c.Names[0], "/")
+		}
+
+		runtimeServices = append(runtimeServices, project.RuntimeService{
+			Name:          serviceName,
+			Image:         imageRef,
+			Status:        string(c.State),
+			ContainerID:   c.ID,
+			ContainerName: containerName,
+			Ports:         formatDockerPorts(c.Ports),
+		})
+	}
+
+	return runtimeServices
+}
+
+func resolveDiscoveredProjectStatusInternal(serviceCount int, runningCount int) string {
+	switch {
+	case serviceCount == 0:
+		return string(models.ProjectStatusUnknown)
+	case runningCount >= serviceCount:
+		return string(models.ProjectStatusRunning)
+	case runningCount > 0:
+		return string(models.ProjectStatusPartiallyRunning)
+	default:
+		return string(models.ProjectStatusStopped)
+	}
 }
 
 func (s *ProjectService) buildProjectDerivedPaginationConfigInternal() pagination.Config[project.Details] {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -2097,6 +2097,107 @@ func TestProjectService_ListProjects_FiltersByUpdateStatus(t *testing.T) {
 	}
 }
 
+func TestBuildDiscoveredComposeProjectUpdateRowsInternal(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+	imageService := &ImageService{db: db}
+	now := time.Now().UTC()
+
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             "sha256:media-image",
+		Repository:     "docker.io/library/nginx",
+		Tag:            "latest",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "latest",
+		CheckTime:      now,
+	}).Error)
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             "sha256:known-image",
+		Repository:     "docker.io/library/redis",
+		Tag:            "7",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "7",
+		CheckTime:      now,
+	}).Error)
+
+	rows := buildDiscoveredComposeProjectUpdateRowsInternal(ctx, []container.Summary{
+		{
+			ID:      "media-web",
+			Names:   []string{"/media-web-1"},
+			Image:   "nginx:latest",
+			ImageID: "sha256:media-image",
+			State:   "running",
+			Labels: map[string]string{
+				"com.docker.compose.project": "media",
+				"com.docker.compose.service": "web",
+			},
+		},
+		{
+			ID:      "known-cache",
+			Image:   "redis:7",
+			ImageID: "sha256:known-image",
+			State:   "running",
+			Labels: map[string]string{
+				"com.docker.compose.project": "known",
+				"com.docker.compose.service": "cache",
+			},
+		},
+		{
+			ID:      "plain-container",
+			Image:   "busybox:latest",
+			ImageID: "sha256:plain-image",
+			State:   "running",
+			Labels:  map[string]string{},
+		},
+	}, map[string]struct{}{"known": {}}, imageService)
+
+	require.Len(t, rows, 1)
+	row := rows[0]
+	assert.Equal(t, "compose:media", row.ID)
+	assert.Equal(t, "media", row.Name)
+	assert.True(t, row.IsDiscovered)
+	assert.Equal(t, string(models.ProjectStatusRunning), row.Status)
+	require.NotNil(t, row.UpdateInfo)
+	assert.True(t, row.UpdateInfo.HasUpdate)
+	assert.Equal(t, []string{"nginx:latest"}, row.UpdateInfo.UpdatedImageRefs)
+	require.Len(t, row.RuntimeServices, 1)
+	assert.Equal(t, "web", row.RuntimeServices[0].Name)
+}
+
+func TestBuildDiscoveredComposeProjectUpdateRowsInternal_FallsBackToImageID(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+	imageService := &ImageService{db: db}
+
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             "sha256:media-image",
+		Repository:     "registry.example.test/custom/media",
+		Tag:            "latest",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "latest",
+		CheckTime:      time.Now().UTC(),
+	}).Error)
+
+	rows := buildDiscoveredComposeProjectUpdateRowsInternal(ctx, []container.Summary{
+		{
+			ID:      "media-web",
+			Image:   "nginx:latest",
+			ImageID: "sha256:media-image",
+			State:   "running",
+			Labels: map[string]string{
+				"com.docker.compose.project": "media",
+				"com.docker.compose.service": "web",
+			},
+		},
+	}, map[string]struct{}{}, imageService)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, []string{"nginx:latest"}, rows[0].UpdateInfo.UpdatedImageRefs)
+}
+
 func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/frontend/src/lib/types/project.type.ts
+++ b/frontend/src/lib/types/project.type.ts
@@ -82,6 +82,7 @@ export interface Project {
 	updatedAt: string;
 	createdAt: string;
 	isArchived?: boolean;
+	isDiscovered?: boolean;
 	archivedAt?: string;
 	gitOpsManagedBy?: string;
 	lastSyncCommit?: string;

--- a/frontend/src/routes/(app)/updates/project-updates-table.svelte
+++ b/frontend/src/routes/(app)/updates/project-updates-table.svelte
@@ -107,9 +107,13 @@
 </script>
 
 {#snippet NameCell({ item }: { item: ProjectUpdateRow })}
-	<a class="font-medium hover:underline" href={`/projects/${item.projectId}`}>
-		{item.name}
-	</a>
+	{#if item.project.isDiscovered}
+		<span class="font-medium">{item.name}</span>
+	{:else}
+		<a class="font-medium hover:underline" href={`/projects/${item.projectId}`}>
+			{item.name}
+		</a>
+	{/if}
 {/snippet}
 
 {#snippet ImageCell({ item }: { item: ProjectUpdateRow })}
@@ -156,6 +160,7 @@
 			}
 		]}
 		onclick={(item: ProjectUpdateRow) => {
+			if (item.project.isDiscovered) return;
 			window.location.href = `/projects/${item.projectId}`;
 		}}
 	/>

--- a/types/project/project.go
+++ b/types/project/project.go
@@ -363,6 +363,11 @@ type Details struct {
 	// Required: true
 	IsArchived bool `json:"isArchived"`
 
+	// IsDiscovered indicates whether this row was derived from runtime Compose labels instead of an Arcane project record.
+	//
+	// Required: false
+	IsDiscovered bool `json:"isDiscovered,omitempty"`
+
 	// ArchivedAt is the date and time when the project was archived.
 	//
 	// Required: false


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces discovered (non-Arcane-managed) Docker Compose projects with pending image updates in the project updates table, and simultaneously fixes the standalone container update count to exclude compose containers to avoid double-counting.

- **Backend**: `appendDiscoveredComposeProjectUpdatesInternal` queries running compose containers, skips any whose project name matches a known Arcane project (including a full-DB name lookup so search-narrowed pages still exclude managed projects), fetches update info via ref→image-ID fallback, and injects synthetic `project.Details` rows only when `updates=has_update` is active. `filterStandaloneDockerContainersInternal` strips compose containers from the standalone dashboard count.
- **Frontend**: `project-updates-table.svelte` guards the name anchor and row click handler behind `isDiscovered`, rendering discovered rows as non-navigable spans. The `Project` TypeScript type gains an optional `isDiscovered` field matching the backend's `omitempty` JSON tag.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new discovery path is additive, gated behind the has_update filter, and degrades gracefully when Docker is unavailable.

All changed code paths are well-scoped: discovered rows are only injected when explicitly filtering for updates, the ref→ID fallback lookup is correct, and failure cases (Docker unreachable, DB query errors) all log a warning and return the unmodified item list rather than failing the request. The frontend change is a minimal guard with no impact on existing Arcane-managed project rows.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: show compose-labeled image updates ..."](https://github.com/getarcaneapp/arcane/commit/4b0292a13bc58ea481a599d20f76f21e8c700469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31461576)</sub>

<!-- /greptile_comment -->