### PR TITLE
fix: always use dockerhub credentials if available

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -766,6 +766,13 @@ func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx conte
 		return nil, err
 	}
 
+	if isDockerHubRegistryInternal(registryHost) {
+		credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
+		if credErr == nil && len(credentials) > 0 {
+			return s.inspectImageDigestWithCredentialsInternal(ctx, dockerClient, normalizedRef, registryHost, credentials, nil)
+		}
+	}
+
 	inspectResult, err := dockerClient.DistributionInspect(ctx, normalizedRef, client.DistributionInspectOptions{})
 	if err == nil {
 		digest, normalizeErr := imagedigest.Normalize(inspectResult.Descriptor.Digest.String())
@@ -789,7 +796,11 @@ func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx conte
 			fmt.Errorf("distribution inspect: anonymous access unauthorized; credential lookup failed: %w", errors.Join(err, credErr))
 	}
 
-	lastErr := err
+	return s.inspectImageDigestWithCredentialsInternal(ctx, dockerClient, normalizedRef, registryHost, credentials, err)
+}
+
+func (s *ContainerRegistryService) inspectImageDigestWithCredentialsInternal(ctx context.Context, dockerClient RegistryDaemonClient, normalizedRef, registryHost string, credentials []resolvedRegistryCredential, previousErr error) (*registryDigestResult, error) {
+	lastErr := previousErr
 	var lastCred resolvedRegistryCredential
 	for _, credential := range credentials {
 		lastCred = credential
@@ -798,7 +809,7 @@ func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx conte
 			return nil, fmt.Errorf("encode registry auth header for %s: %w", registryHost, encodeErr)
 		}
 
-		inspectResult, err = dockerClient.DistributionInspect(ctx, normalizedRef, client.DistributionInspectOptions{
+		inspectResult, err := dockerClient.DistributionInspect(ctx, normalizedRef, client.DistributionInspectOptions{
 			EncodedRegistryAuth: authHeader,
 		})
 		if err == nil {
@@ -830,6 +841,9 @@ func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx conte
 		partial.AuthMethod = "credential"
 		partial.AuthUsername = lastCred.Username
 		partial.UsedCredential = true
+	}
+	if lastErr == nil {
+		return partial, fmt.Errorf("distribution inspect failed for %s: no credentials available", normalizedRef)
 	}
 	return partial, fmt.Errorf("distribution inspect failed for %s: %w", normalizedRef, lastErr)
 }
@@ -1213,6 +1227,8 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 		"no basic auth credentials",
 		"access denied",
 		"incorrect username or password",
+		"toomanyrequests",
+		"unauthenticated pull rate limit",
 		"status: 401",
 		"status 401",
 		"status: 403",
@@ -1226,6 +1242,10 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 	}
 
 	return false
+}
+
+func isDockerHubRegistryInternal(registryHost string) bool {
+	return utilsregistry.NormalizeRegistryForComparison(registryHost) == "docker.io"
 }
 
 func isDistributionFallbackEligibleInternal(err error) bool {

--- a/backend/internal/services/container_registry_service_test.go
+++ b/backend/internal/services/container_registry_service_test.go
@@ -531,7 +531,7 @@ func TestContainerRegistryService_InspectImageDigest_AnonymousSuccess(t *testing
 	assert.Equal(t, "registry.example.com:5443", result.AuthRegistry)
 }
 
-func TestContainerRegistryService_InspectImageDigest_RetriesWithStoredCredentials(t *testing.T) {
+func TestContainerRegistryService_InspectImageDigest_UsesStoredDockerHubCredentialsOnFirstAttempt(t *testing.T) {
 	_, db := setupImageServiceAuthTest(t)
 	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
 	wantDigest := digest.FromString("stored-credentials").String()
@@ -542,10 +542,6 @@ func TestContainerRegistryService_InspectImageDigest_RetriesWithStoredCredential
 			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
 				calls++
 				assert.Equal(t, "docker.io/library/nginx:latest", imageRef)
-				if calls == 1 {
-					assert.Empty(t, options.EncodedRegistryAuth)
-					return client.DistributionInspectResult{}, errors.New("unauthorized: authentication required")
-				}
 
 				authCfg := decodeRegistryAuth(t, options.EncodedRegistryAuth)
 				assert.Equal(t, "docker-user", authCfg.Username)
@@ -565,7 +561,44 @@ func TestContainerRegistryService_InspectImageDigest_RetriesWithStoredCredential
 
 	result, err := svc.inspectImageDigestInternal(context.Background(), "registry-1.docker.io/library/nginx:latest", nil)
 	require.NoError(t, err)
-	assert.Equal(t, 2, calls)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, wantDigest, result.Digest)
+	assert.Equal(t, "credential", result.AuthMethod)
+	assert.Equal(t, "docker-user", result.AuthUsername)
+	assert.True(t, result.UsedCredential)
+}
+
+func TestContainerRegistryService_InspectImageDigest_UsesStoredDockerHubCredentialsForRegistryImage(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
+	wantDigest := digest.FromString("stored-credentials-rate-limit").String()
+
+	var calls int
+	svc := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				calls++
+				assert.Equal(t, "docker.io/library/registry:3", imageRef)
+
+				authCfg := decodeRegistryAuth(t, options.EncodedRegistryAuth)
+				assert.Equal(t, "docker-user", authCfg.Username)
+				assert.Equal(t, "docker-token", authCfg.Password)
+				assert.Equal(t, "https://index.docker.io/v1/", authCfg.ServerAddress)
+
+				return client.DistributionInspectResult{
+					DistributionInspect: dockerregistry.DistributionInspect{
+						Descriptor: ocispec.Descriptor{
+							Digest: digest.Digest(wantDigest),
+						},
+					},
+				}, nil
+			},
+		}, nil
+	}, nil)
+
+	result, err := svc.inspectImageDigestInternal(context.Background(), "docker.io/library/registry:3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
 	assert.Equal(t, wantDigest, result.Digest)
 	assert.Equal(t, "credential", result.AuthMethod)
 	assert.Equal(t, "docker-user", result.AuthUsername)

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -18,8 +18,10 @@ import (
 	glsqlite "github.com/glebarez/sqlite"
 	dockertypescontainer "github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ref "go.podman.io/image/v5/docker/reference"
@@ -578,6 +580,60 @@ func TestImageUpdateService_CheckMultipleImages_UsesRegistryFallback(t *testing.
 	var saved models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:local-image-id").First(&saved).Error)
 	assert.Equal(t, remoteDigest, stringPtrToString(saved.LatestDigest))
+}
+
+func TestImageUpdateService_CheckMultipleImages_UsesDockerHubCredentialsOnFirstAttempt(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}))
+	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
+
+	localDigest := digest.FromString("batchlocal-rate-limit").String()
+	remoteDigest := digest.FromString("batchremote-rate-limit").String()
+
+	server := newImageUpdateFallbackServer(t, "library/registry:3", localDigest, remoteDigest)
+	defer server.Close()
+
+	var calls int
+	registryService := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				calls++
+				assert.Equal(t, "docker.io/library/registry:3", imageRef)
+
+				authCfg := decodeRegistryAuth(t, options.EncodedRegistryAuth)
+				assert.Equal(t, "docker-user", authCfg.Username)
+				assert.Equal(t, "docker-token", authCfg.Password)
+				assert.Equal(t, "https://index.docker.io/v1/", authCfg.ServerAddress)
+
+				return client.DistributionInspectResult{
+					DistributionInspect: dockerregistry.DistributionInspect{
+						Descriptor: ocispec.Descriptor{
+							Digest: digest.Digest(remoteDigest),
+						},
+					},
+				}, nil
+			},
+		}, nil
+	}, nil)
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	eventService := NewEventService(db, nil, nil)
+	svc := NewImageUpdateService(db, nil, registryService, dockerService, eventService, nil)
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{"docker.io/library/registry:3"}, nil)
+	require.NoError(t, err)
+	require.Contains(t, results, "docker.io/library/registry:3")
+
+	result := results["docker.io/library/registry:3"]
+	require.NotNil(t, result)
+	assert.True(t, result.HasUpdate)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, localDigest, result.CurrentDigest)
+	assert.Equal(t, remoteDigest, result.LatestDigest)
+	assert.Equal(t, "credential", result.AuthMethod)
+	assert.Equal(t, "docker-user", result.AuthUsername)
+	assert.Equal(t, "docker.io", result.AuthRegistry)
+	assert.True(t, result.UsedCredential)
 }
 
 func TestImageUpdateService_CheckMultipleImages_PersistsRefScopedErrorsWhenLocalImageMissing(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR optimizes DockerHub image digest lookups by immediately using stored credentials (when available) instead of attempting an anonymous request first. A new helper `inspectImageDigestWithCredentialsInternal` is extracted from `inspectImageDigestViaDaemonInternal` to share the credential-retry loop between the DockerHub early path and the existing fallback path. Two new rate-limit error substrings are also added to `isUnauthorizedRegistryErrorInternal` so Docker Hub pull-rate-limit responses trigger credential retries.

- **Early credential use for DockerHub**: `inspectImageDigestViaDaemonInternal` now detects DockerHub images and, if credentials are present, bypasses anonymous access entirely and calls `inspectImageDigestWithCredentialsInternal` directly — fixing silent anonymous rate-limit failures.
- **Refactored credential-retry loop**: The credential iteration logic is extracted into `inspectImageDigestWithCredentialsInternal`, called from both the new DockerHub fast-path and the existing unauthorized-fallback path.
- **Rate-limit strings added to unauthorized check**: `"toomanyrequests"` and `"unauthenticated pull rate limit"` are added to the unauthorized error detector, so anonymous rate-limit responses from DockerHub now correctly trigger a credential retry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the DockerHub credential fast-path and is covered by three targeted tests that confirm anonymous access is skipped when credentials are present.

The DockerHub early-credential path correctly guards with len(credentials) > 0 before delegating to inspectImageDigestWithCredentialsInternal, so the lastErr == nil branch inside that helper remains unreachable from current callers. The credential-retry loop itself is unchanged. Adding toomanyrequests to the unauthorized error detector is consistent with DockerHub rate-limit semantics. All new unexported functions follow the Internal naming convention.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: always use dockerhub credentials if..."](https://github.com/getarcaneapp/arcane/commit/0b7ba622d28ea1bb02a4fff7543e111091400cb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31474768)</sub>

<!-- /greptile_comment -->