### PR TITLE
fix: build history not being updated after builds are completed

### DIFF
--- a/frontend/src/routes/(app)/images/builds/+page.svelte
+++ b/frontend/src/routes/(app)/images/builds/+page.svelte
@@ -156,17 +156,18 @@
 	let buildTab = $state('workspace');
 	let rightPanelTab = $state<'config' | 'output'>('config');
 	let showAdvanced = $state(false);
-	let buildHistoryItems = $state<Paginated<ImageBuildRecord>>({
+	const EMPTY_BUILD_HISTORY: Paginated<ImageBuildRecord> = {
 		data: [],
 		pagination: { totalPages: 1, totalItems: 0, currentPage: 1, itemsPerPage: 20 }
-	});
+	};
+
 	let buildHistoryRequestOptions = $state<SearchPaginationSortRequest>({
 		pagination: { page: 1, limit: 20 },
 		sort: { column: 'createdAt', direction: 'desc' }
 	});
 	let buildHistorySelectedIds = $state<string[]>([]);
 	let buildHistoryMobileFieldVisibility = $state<Record<string, boolean>>({});
-	let buildHistorySelected = $state<ImageBuildRecord | null>(null);
+	let buildHistorySelectedOptimistic = $state<ImageBuildRecord | null>(null);
 	let buildHistorySelectedId = $state<string | null>(null);
 	let buildHistoryDetailsOpen = $state(false);
 
@@ -175,42 +176,44 @@
 
 	const buildHistoryQuery = createQuery(() => ({
 		queryKey: queryKeys.images.buildsList(selectedEnvId, buildHistoryRequestOptions),
-		queryFn: () => imageService.getImageBuilds(buildHistoryRequestOptions),
-		onSuccess: (data: Paginated<ImageBuildRecord>) => {
-			buildHistoryItems = data;
-		},
-		onError: (err: unknown) => {
-			const anyErr = err as any;
-			const message = anyErr?.message ? String(anyErr.message) : m.common_error();
-			if (message && message !== buildHistoryQueryLastError) {
-				buildHistoryQueryLastError = message;
-				toast.error(message);
-			}
-		}
+		queryFn: () => imageService.getImageBuilds(buildHistoryRequestOptions)
 	}));
 
-	let buildHistoryQueryLastError = $state<string | null>(null);
+	const buildHistoryItems = $derived<Paginated<ImageBuildRecord>>(buildHistoryQuery.data ?? EMPTY_BUILD_HISTORY);
+
+	let buildHistoryQueryLastError: string | null = null;
+
+	$effect(() => {
+		const err = buildHistoryQuery.error as any;
+		if (!err) return;
+		const message = err?.message ? String(err.message) : m.common_error();
+		if (message && message !== buildHistoryQueryLastError) {
+			buildHistoryQueryLastError = message;
+			toast.error(message);
+		}
+	});
 
 	const buildHistoryDetailQuery = createQuery(() => ({
 		queryKey: buildHistorySelectedId
 			? queryKeys.images.buildRecord(selectedEnvId, buildHistorySelectedId)
 			: (['images', selectedEnvId, 'builds', 'none'] as const),
 		queryFn: () => imageService.getImageBuild(buildHistorySelectedId!),
-		enabled: !!buildHistorySelectedId && buildHistoryDetailsOpen,
-		onSuccess: (data: ImageBuildRecord) => {
-			buildHistorySelected = data;
-		},
-		onError: (err: unknown) => {
-			const anyErr = err as any;
-			const message = anyErr?.message ? String(anyErr.message) : m.common_error();
-			if (message && message !== buildHistoryDetailLastError) {
-				buildHistoryDetailLastError = message;
-				toast.error(message);
-			}
-		}
+		enabled: !!buildHistorySelectedId && buildHistoryDetailsOpen
 	}));
 
-	let buildHistoryDetailLastError = $state<string | null>(null);
+	const buildHistorySelected = $derived<ImageBuildRecord | null>(buildHistoryDetailQuery.data ?? buildHistorySelectedOptimistic);
+
+	let buildHistoryDetailLastError: string | null = null;
+
+	$effect(() => {
+		const err = buildHistoryDetailQuery.error as any;
+		if (!err) return;
+		const message = err?.message ? String(err.message) : m.common_error();
+		if (message && message !== buildHistoryDetailLastError) {
+			buildHistoryDetailLastError = message;
+			toast.error(message);
+		}
+	});
 	const buildHistoryDetailsLoading = $derived(buildHistoryDetailQuery.isPending || buildHistoryDetailQuery.isFetching);
 
 	type ImageBuildRequest = {
@@ -711,12 +714,12 @@
 	async function loadBuildHistory(options: SearchPaginationSortRequest = buildHistoryRequestOptions) {
 		buildHistoryRequestOptions = options;
 		const result = await buildHistoryQuery.refetch();
-		return result.data ?? buildHistoryItems;
+		return result.data ?? buildHistoryQuery.data ?? EMPTY_BUILD_HISTORY;
 	}
 
 	function openBuildDetails(build: ImageBuildRecord) {
 		buildHistorySelectedId = build.id;
-		buildHistorySelected = build;
+		buildHistorySelectedOptimistic = build;
 		buildHistoryDetailsOpen = true;
 	}
 

--- a/frontend/src/routes/(app)/images/builds/build-workspace-browser.svelte
+++ b/frontend/src/routes/(app)/images/builds/build-workspace-browser.svelte
@@ -15,7 +15,7 @@
 	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { queryKeys } from '$lib/query/query-keys';
-	import type { FileContentResponse, FileEntry } from '$lib/types/file-browser.type';
+	import type { FileEntry } from '$lib/types/file-browser.type';
 	import type { FileProvider } from '$lib/components/file-browser';
 	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
@@ -71,11 +71,22 @@
 			? queryKeys.buildWorkspace.content(envId, editorFile.path)
 			: (['build-workspace', envId, 'content', 'none'] as const),
 		queryFn: () => provider.getContent(editorFile!.path),
-		enabled: !!editorFile && editorOpen,
-		onSuccess: (data: FileContentResponse) => {
+		enabled: !!editorFile && editorOpen
+	}));
+
+	let lastSeededPath: string | null = null;
+
+	$effect(() => {
+		if (!editorFile || !editorOpen) {
+			lastSeededPath = null;
+			return;
+		}
+		const data = editorContentQuery.data;
+		if (data && editorFile.path !== lastSeededPath) {
+			lastSeededPath = editorFile.path;
 			editorContent = b64DecodeUnicode(data.content);
 		}
-	}));
+	});
 
 	const editorLoading = $derived(editorContentQuery.isPending || editorContentQuery.isFetching);
 	const editorError = $derived.by(() => {

--- a/go.work.sum
+++ b/go.work.sum
@@ -247,8 +247,11 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
 github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -283,6 +286,7 @@ github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7q
 github.com/cloudflare/circl v1.6.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
+github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
@@ -481,6 +485,7 @@ github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.19.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gocql/gocql v0.0.0-20210515062232-b7ef815b4556 h1:N/MD/sr6o61X+iZBAT2qEUF023s4KbA8RWfKzl0L6MQ=
@@ -955,6 +960,7 @@ github.com/tonistiigi/go-archvariant v1.0.0 h1:5LC1eDWiBNflnTF1prCiX09yfNHIxDC/a
 github.com/tonistiigi/go-archvariant v1.0.0/go.mod h1:TxFmO5VS6vMq2kvs3ht04iPXtu2rUT/erOnGFYfk5Ho=
 github.com/tonistiigi/jaeger-ui-rest v0.0.0-20250408171107-3dd17559e117 h1:XFwyh2JZwR5aiKLXHX2C1n0v5F11dCJpyGL1W/Cpl3U=
 github.com/tonistiigi/jaeger-ui-rest v0.0.0-20250408171107-3dd17559e117/go.mod h1:3Ez1Paeg+0Ghu3KwpEGC1HgZ4CHDlg+Ez/5Baeomk54=
+github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
@@ -1096,6 +1102,7 @@ go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTV
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+golang.org/x/arch v0.24.0 h1:qlJ3M9upxvFfwRM51tTg3Yl+8CP9vCC1E7vlFpgv99Y=
 golang.org/x/arch v0.24.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2585

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the build history list not refreshing after builds complete by migrating `buildHistoryItems` and `buildHistorySelected` from `$state` updated via `onSuccess` callbacks to `$derived` values that reactively track TanStack Query's data properties. The `onError` callbacks are similarly replaced with `$effect` blocks using plain (non-reactive) deduplication variables to fire toasts without creating reactivity loops.

- `buildHistoryItems` is now `$derived(buildHistoryQuery.data ?? EMPTY_BUILD_HISTORY)`, eliminating the stale closure that caused the history to stop updating.
- `buildHistorySelected` is now `$derived(buildHistoryDetailQuery.data ?? buildHistorySelectedOptimistic)`, preserving the optimistic click-to-preview behaviour while keeping the panel in sync with the real query result.
- `build-workspace-browser.svelte` replaces the `onSuccess`-based content seeding with a `$effect` guarded by a plain `lastSeededPath` variable, which incidentally also prevents background refetches from clobbering in-progress user edits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly wires reactive query data into derived state and does not introduce any data-loss or logic regressions.

The core change (converting `$state` + `onSuccess` to `$derived`) is the idiomatic fix for stale query data in Svelte 5. The optimistic-then-real pattern for the detail panel is sound, the error-deduplication guard using a plain variable avoids reactivity loops, and the `lastSeededPath` guard in the workspace browser actually improves on the old code by protecting in-progress edits from background refetches. No logic regressions or new failure modes were identified.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: build history not being updated aft..."](https://github.com/getarcaneapp/arcane/commit/ebe9d34e12c6305bfea42bd0f95927b733a45d93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31886889)</sub>

<!-- /greptile_comment -->