### PR TITLE
fix: incorrect backend arg used for trivy on 32bit hosts

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -1399,7 +1399,7 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	defer cleanupTrivyOutputFileInContainerInternal(ctx, dockerClient, containerID, outputPath)
 
 	execCmd := []string{"trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout}
-	execCmd = append(execCmd, trivyDBBackendArgsInternal()...)
+	execCmd = append(execCmd, trivyScanCacheBackendArgsInternal()...)
 	execCmd = append(execCmd, imageName)
 
 	execCfg := client.ExecCreateOptions{
@@ -2118,21 +2118,21 @@ func cleanupTempFiles(ctx context.Context, tempFiles []string) {
 	}
 }
 
-// trivyDBBackendArgsForArchInternal returns extra Trivy flags that switch the
-// vulnerability DB to an in-memory backend on 32-bit architectures. bbolt's
-// default mmap-based backend can fail with ENOMEM on arm/v7 and 386 because
+// trivyScanCacheBackendArgsForArchInternal returns extra Trivy flags that switch
+// the scan cache to Trivy's documented in-memory backend on 32-bit architectures.
+// The default BoltDB-backed cache can fail with ENOMEM on arm/v7 and 386 because
 // Go's heap reservations fragment the limited 32-bit virtual address space.
-func trivyDBBackendArgsForArchInternal(arch string) []string {
+func trivyScanCacheBackendArgsForArchInternal(arch string) []string {
 	switch arch {
 	case "arm", "386", "mips", "mipsle":
-		return []string{"--db-backend", "memory"}
+		return []string{"--cache-backend", "memory"}
 	default:
 		return nil
 	}
 }
 
-func trivyDBBackendArgsInternal() []string {
-	return trivyDBBackendArgsForArchInternal(runtime.GOARCH)
+func trivyScanCacheBackendArgsInternal() []string {
+	return trivyScanCacheBackendArgsForArchInternal(runtime.GOARCH)
 }
 
 func (s *VulnerabilityService) buildTrivyCommandArgs(
@@ -2144,7 +2144,7 @@ func (s *VulnerabilityService) buildTrivyCommandArgs(
 	outputPath string,
 ) ([]string, []string) {
 	cmdArgs := []string{"image", "--format", "json", "--quiet", "--timeout", s.getTrivyScanTimeoutArg()}
-	cmdArgs = append(cmdArgs, trivyDBBackendArgsInternal()...)
+	cmdArgs = append(cmdArgs, trivyScanCacheBackendArgsInternal()...)
 	var tempFiles []string
 
 	if strings.TrimSpace(configContent) != "" {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -290,8 +290,8 @@ func TestBuildTrivyCommandArgs_WithoutCacheDir(t *testing.T) {
 	require.Equal(t, "alpine:3.20", cmdArgs[len(cmdArgs)-1])
 }
 
-func TestTrivyDBBackendArgsForArch(t *testing.T) {
-	memoryBackend := []string{"--db-backend", "memory"}
+func TestTrivyScanCacheBackendArgsForArch(t *testing.T) {
+	memoryBackend := []string{"--cache-backend", "memory"}
 
 	tests := []struct {
 		arch string
@@ -310,7 +310,9 @@ func TestTrivyDBBackendArgsForArch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.arch, func(t *testing.T) {
-			require.Equal(t, tt.want, trivyDBBackendArgsForArchInternal(tt.arch))
+			got := trivyScanCacheBackendArgsForArchInternal(tt.arch)
+			require.Equal(t, tt.want, got)
+			require.NotContains(t, got, "--db-backend")
 		})
 	}
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2575

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the wrong Trivy CLI flag (`--db-backend`) was being passed on 32-bit hosts; the correct documented flag is `--cache-backend`. The two helper functions are renamed from `trivyDBBackendArgs*` to `trivyScanCacheBackendArgs*` and both call sites are updated.

- The flag change is minimal and targeted: `--cache-backend memory` replaces `--db-backend memory` in both `execTrivyScanInContainer` and `buildTrivyCommandArgs`.
- Tests are updated to match the corrected flag, and a `require.NotContains(t, got, \"--db-backend\")` assertion is added as a regression guard against the old incorrect flag reappearing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-flag correction in a well-tested, isolated code path with no impact on 64-bit hosts.

The diff is a surgical fix replacing one Trivy CLI flag with the correct one. Both call sites are updated, the helper functions are consistently renamed, and the test suite now guards against the old wrong flag reappearing. No logic is altered beyond the flag string itself.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: incorrect backend arg used for triv..."](https://github.com/getarcaneapp/arcane/commit/8d075b565c273ff498f8410544cec7cd1fd747f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31891514)</sub>

<!-- /greptile_comment -->