### PR TITLE
fix: updater api authorization checks

### DIFF
--- a/backend/api/handlers/updater.go
+++ b/backend/api/handlers/updater.go
@@ -115,6 +115,9 @@ func RegisterUpdater(api huma.API, updaterService *services.UpdaterService) {
 
 // RunUpdater applies pending container updates.
 func (h *UpdaterHandler) RunUpdater(ctx context.Context, input *RunUpdaterInput) (*RunUpdaterOutput, error) {
+	if err := checkAdminInternal(ctx); err != nil {
+		return nil, err
+	}
 	if h.updaterService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
@@ -179,6 +182,9 @@ func (h *UpdaterHandler) GetUpdaterHistory(ctx context.Context, input *GetUpdate
 
 // UpdateContainer updates a single container by pulling the latest image and applying the appropriate update flow.
 func (h *UpdaterHandler) UpdateContainer(ctx context.Context, input *UpdateContainerInput) (*UpdateContainerOutput, error) {
+	if err := checkAdminInternal(ctx); err != nil {
+		return nil, err
+	}
 	if h.updaterService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}

--- a/frontend/src/routes/(app)/containers/+page.svelte
+++ b/frontend/src/routes/(app)/containers/+page.svelte
@@ -8,6 +8,8 @@
 	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '$lib/layouts/index';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import userStore from '$lib/stores/user-store';
+	import { fromStore } from 'svelte/store';
 	import type { ContainerCreateRequest, ContainerStatusCounts } from '$lib/types/container.type';
 	import { createMutation } from '@tanstack/svelte-query';
 	import { BoxIcon } from '$lib/icons';
@@ -103,32 +105,39 @@
 
 	const containerStatusCounts = $derived(containers.counts ?? countsFallback);
 
-	const actionButtons: ActionButton[] = $derived([
-		{
-			id: 'create',
-			action: 'create',
-			label: m.common_create_button({ resource: m.resource_container_cap() }),
-			onclick: () => (isCreateDialogOpen = true),
-			loading: createContainerMutation.isPending,
-			disabled: createContainerMutation.isPending
-		},
-		{
-			id: 'check-updates',
-			action: 'update',
-			label: m.containers_check_updates(),
-			onclick: handleCheckForUpdates,
-			loading: checkUpdatesMutation.isPending,
-			disabled: checkUpdatesMutation.isPending
-		},
-		{
-			id: 'refresh',
-			action: 'restart',
-			label: m.common_refresh(),
-			onclick: refresh,
-			loading: isRefreshing,
-			disabled: isRefreshing
-		}
-	]);
+	const storeUser = fromStore(userStore);
+	const isAdmin = $derived(!!storeUser.current?.roles?.includes('admin'));
+
+	const actionButtons: ActionButton[] = $derived(
+		[
+			{
+				id: 'create',
+				action: 'create',
+				label: m.common_create_button({ resource: m.resource_container_cap() }),
+				onclick: () => (isCreateDialogOpen = true),
+				loading: createContainerMutation.isPending,
+				disabled: createContainerMutation.isPending
+			},
+			isAdmin
+				? {
+						id: 'check-updates',
+						action: 'update',
+						label: m.containers_check_updates(),
+						onclick: handleCheckForUpdates,
+						loading: checkUpdatesMutation.isPending,
+						disabled: checkUpdatesMutation.isPending
+					}
+				: null,
+			{
+				id: 'refresh',
+				action: 'restart',
+				label: m.common_refresh(),
+				onclick: refresh,
+				loading: isRefreshing,
+				disabled: isRefreshing
+			}
+		].filter((b): b is ActionButton => b !== null)
+	);
 
 	const statCards: StatCardConfig[] = $derived([
 		{

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -26,6 +26,8 @@
 	import ContainerStatsSync from './components/container-stats-sync.svelte';
 	import ContainerStatsCell from './components/container-stats-cell.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import userStore from '$lib/stores/user-store';
+	import { fromStore } from 'svelte/store';
 	import IconImage from '$lib/components/icon-image.svelte';
 	import { getArcaneIconUrlFromLabels } from '$lib/utils/arcane-labels';
 	import { createContainerActions } from './container-table.actions';
@@ -146,6 +148,9 @@
 	const isAnyLoading = $derived(
 		Object.values(actionStatus).some((status) => status !== '') || Object.values(isBulkLoading).some((loading) => loading)
 	);
+
+	const storeUser = fromStore(userStore);
+	const isAdmin = $derived(!!storeUser.current?.roles?.includes('admin'));
 
 	let mobileFieldVisibility = $state<Record<string, boolean>>({});
 	let customSettings = $state<Record<string, unknown>>({});
@@ -401,7 +406,7 @@
 					icon={StopIcon}
 				/>
 			{/if}
-			{#if !status && item.updateInfo?.hasUpdate}
+			{#if !status && item.updateInfo?.hasUpdate && isAdmin}
 				<ArcaneButton
 					action="base"
 					tone="ghost"
@@ -424,7 +429,7 @@
 		imageId={item.imageId}
 		repo={imageRef.repo}
 		tag={imageRef.tag}
-		onUpdateContainer={() => handleUpdateContainer(item)}
+		onUpdateContainer={isAdmin ? () => handleUpdateContainer(item) : undefined}
 		debugHasUpdate={false}
 	/>
 {/snippet}
@@ -566,7 +571,7 @@
 									imageId={item.imageId}
 									repo={imageRef.repo}
 									tag={imageRef.tag}
-									onUpdateContainer={() => handleUpdateContainer(item)}
+									onUpdateContainer={isAdmin ? () => handleUpdateContainer(item) : undefined}
 									debugHasUpdate={false}
 								/>
 							</div>
@@ -598,7 +603,7 @@
 
 				<DropdownMenu.Separator />
 
-				{#if item.updateInfo?.hasUpdate}
+				{#if item.updateInfo?.hasUpdate && isAdmin}
 					<DropdownMenu.Item onclick={() => handleUpdateContainer(item)} disabled={status === 'updating' || isAnyLoading}>
 						{#if status === 'updating'}
 							<Spinner class="size-4" />

--- a/frontend/src/routes/(app)/updates/container-updates-table.svelte
+++ b/frontend/src/routes/(app)/updates/container-updates-table.svelte
@@ -16,6 +16,8 @@
 	} from '$lib/services/container-service';
 	import { ContainersIcon, UpdateIcon } from '$lib/icons';
 	import { getContainerDisplayName } from '../containers/container-table.helpers';
+	import userStore from '$lib/stores/user-store';
+	import { fromStore } from 'svelte/store';
 
 	type ContainerUpdateRow = {
 		id: string;
@@ -40,6 +42,9 @@
 	let selectedIds = $state<string[]>([]);
 	let mobileFieldVisibility = $state<MobileFieldVisibility>({});
 	let updatingContainerIds = $state<Record<string, boolean>>({});
+
+	const storeUser = fromStore(userStore);
+	const isAdmin = $derived(!!storeUser.current?.roles?.includes('admin'));
 
 	function formatUpdateValue(updateInfo: ImageUpdateInfoDto | undefined, mode: 'current' | 'latest') {
 		if (!updateInfo) return '-';
@@ -159,15 +164,17 @@
 {/snippet}
 
 {#snippet ActionsCell({ item }: { item: ContainerUpdateRow })}
-	<ArcaneButton
-		action="update"
-		size="sm"
-		customLabel={m.containers_update_container()}
-		onclick={() => handleUpdateContainer(item.container)}
-		loading={!!updatingContainerIds[item.containerId]}
-		disabled={!!updatingContainerIds[item.containerId]}
-		icon={UpdateIcon}
-	/>
+	{#if isAdmin}
+		<ArcaneButton
+			action="update"
+			size="sm"
+			customLabel={m.containers_update_container()}
+			onclick={() => handleUpdateContainer(item.container)}
+			loading={!!updatingContainerIds[item.containerId]}
+			disabled={!!updatingContainerIds[item.containerId]}
+			icon={UpdateIcon}
+		/>
+	{/if}
 {/snippet}
 
 {#snippet ContainerUpdatesMobileCard({ item }: { item: ContainerUpdateRow })}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds missing admin authorization guards to the two mutating updater API endpoints (`RunUpdater` and `UpdateContainer`) on the backend, and conditionally hides update-triggering UI controls from non-admin users across three frontend components.

- **Backend**: `checkAdminInternal` is now called at the top of `RunUpdater` and `UpdateContainer`, matching the pattern already used by every other handler in the package. Read-only endpoints (`GetUpdaterStatus`, `GetUpdaterHistory`) remain accessible to all authenticated users, which is consistent with the frontend design that lets non-admins view status and history but not trigger updates.
- **Frontend**: Three components (`+page.svelte`, `container-table.svelte`, `container-updates-table.svelte`) now derive `isAdmin` reactively via `fromStore(userStore)` + `$derived`, then gate buttons and menu items behind that flag. The role-check expression (`roles?.includes('admin')`) is written out inline in all three files rather than being shared — a minor maintainability concern since the store already has an `isAdmin()` helper.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the backend now correctly blocks non-admin callers from triggering updates, and the frontend hides the corresponding controls.

The backend changes are minimal, follow the established pattern, and close a real auth gap. The frontend changes are straightforward reactive conditionals. The only note is that the inline roles?.includes('admin') expression is duplicated across three components instead of being derived from the store's existing helper, which is a maintainability detail with no functional impact today.

No files require special attention; all changes are narrow and self-contained.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fupdater-findings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdater-findings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2F%2Bpage.svelte%3A108-109%0AThe%20admin%20role%20check%20is%20duplicated%20verbatim%20across%20all%20three%20changed%20components%20%28%60%2Bpage.svelte%60%2C%20%60container-table.svelte%60%2C%20and%20%60container-updates-table.svelte%60%29.%20The%20store%20already%20ships%20a%20non-reactive%20%60isAdmin%28%29%60%20helper%3B%20if%20the%20role%20string%20ever%20changes%20from%20%60'admin'%60%2C%20all%20three%20inline%20derivations%20need%20to%20be%20updated%20independently.%20A%20single%20reactive%20helper%20in%20the%20store%20%28or%20a%20shared%20composable%29%20would%20keep%20this%20in%20one%20place.%0A%0A%60%60%60suggestion%0A%09const%20storeUser%20%3D%20fromStore%28userStore%29%3B%0A%09const%20isAdmin%20%3D%20%24derived%28!!storeUser.current%3F.roles%3F.includes%28'admin'%29%29%3B%20%2F%2F%20TODO%3A%20centralise%20into%20store%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2F%2Bpage.svelte%3A108-109%0AThe%20admin%20role%20check%20is%20duplicated%20verbatim%20across%20all%20three%20changed%20components%20%28%60%2Bpage.svelte%60%2C%20%60container-table.svelte%60%2C%20and%20%60container-updates-table.svelte%60%29.%20The%20store%20already%20ships%20a%20non-reactive%20%60isAdmin%28%29%60%20helper%3B%20if%20the%20role%20string%20ever%20changes%20from%20%60'admin'%60%2C%20all%20three%20inline%20derivations%20need%20to%20be%20updated%20independently.%20A%20single%20reactive%20helper%20in%20the%20store%20%28or%20a%20shared%20composable%29%20would%20keep%20this%20in%20one%20place.%0A%0A%60%60%60suggestion%0A%09const%20storeUser%20%3D%20fromStore%28userStore%29%3B%0A%09const%20isAdmin%20%3D%20%24derived%28!!storeUser.current%3F.roles%3F.includes%28'admin'%29%29%3B%20%2F%2F%20TODO%3A%20centralise%20into%20store%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2588&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/routes/(app)/containers/+page.svelte:108-109
The admin role check is duplicated verbatim across all three changed components (`+page.svelte`, `container-table.svelte`, and `container-updates-table.svelte`). The store already ships a non-reactive `isAdmin()` helper; if the role string ever changes from `'admin'`, all three inline derivations need to be updated independently. A single reactive helper in the store (or a shared composable) would keep this in one place.

```suggestion
	const storeUser = fromStore(userStore);
	const isAdmin = $derived(!!storeUser.current?.roles?.includes('admin')); // TODO: centralise into store
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: updater api authorization checks"](https://github.com/getarcaneapp/arcane/commit/692e2fed466564ce61fac912ae0039f92e883972) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31893817)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->