### PR TITLE
fix: git sync validations for project or swarm type

### DIFF
--- a/backend/api/handlers/gitops_syncs.go
+++ b/backend/api/handlers/gitops_syncs.go
@@ -18,6 +18,20 @@ type GitOpsSyncHandler struct {
 	syncService *services.GitOpsSyncService
 }
 
+// validateGitOpsSyncTargetTypeInternal ensures the targetType is one of the allowed
+// values and requires admin privileges for the swarm_stack target. Empty string is
+// treated as the default ("project") and is allowed for non-admins.
+func validateGitOpsSyncTargetTypeInternal(ctx context.Context, targetType string) error {
+	switch targetType {
+	case "", "project":
+		return nil
+	case "swarm_stack":
+		return checkAdminInternal(ctx)
+	default:
+		return huma.Error400BadRequest("invalid targetType: must be \"project\" or \"swarm_stack\"")
+	}
+}
+
 // ============================================================================
 // Input/Output Types
 // ============================================================================
@@ -290,6 +304,10 @@ func (h *GitOpsSyncHandler) CreateSync(ctx context.Context, input *CreateGitOpsS
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	if err := validateGitOpsSyncTargetTypeInternal(ctx, input.Body.TargetType); err != nil {
+		return nil, err
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -375,6 +393,23 @@ func (h *GitOpsSyncHandler) UpdateSync(ctx context.Context, input *UpdateGitOpsS
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	if input.Body.TargetType != nil {
+		if err := validateGitOpsSyncTargetTypeInternal(ctx, *input.Body.TargetType); err != nil {
+			return nil, err
+		}
+	}
+
+	existing, err := h.syncService.GetSyncByID(ctx, input.EnvironmentID, input.SyncID)
+	if err != nil {
+		apiErr := models.ToAPIError(err)
+		return nil, huma.NewError(apiErr.HTTPStatus(), (&common.GitOpsSyncRetrievalError{Err: err}).Error())
+	}
+	if existing.TargetType == "swarm_stack" {
+		if err := checkAdminInternal(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -408,6 +443,17 @@ func (h *GitOpsSyncHandler) DeleteSync(ctx context.Context, input *DeleteGitOpsS
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
+	existing, err := h.syncService.GetSyncByID(ctx, input.EnvironmentID, input.SyncID)
+	if err != nil {
+		apiErr := models.ToAPIError(err)
+		return nil, huma.NewError(apiErr.HTTPStatus(), (&common.GitOpsSyncRetrievalError{Err: err}).Error())
+	}
+	if existing.TargetType == "swarm_stack" {
+		if err := checkAdminInternal(ctx); err != nil {
+			return nil, err
+		}
+	}
+
 	actor := models.User{}
 	if currentUser, exists := humamw.GetCurrentUserFromContext(ctx); exists && currentUser != nil {
 		actor = *currentUser
@@ -435,6 +481,17 @@ func (h *GitOpsSyncHandler) PerformSync(ctx context.Context, input *PerformSyncI
 	}
 	if h.syncService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
+	}
+
+	existing, err := h.syncService.GetSyncByID(ctx, input.EnvironmentID, input.SyncID)
+	if err != nil {
+		apiErr := models.ToAPIError(err)
+		return nil, huma.NewError(apiErr.HTTPStatus(), (&common.GitOpsSyncRetrievalError{Err: err}).Error())
+	}
+	if existing.TargetType == "swarm_stack" {
+		if err := checkAdminInternal(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	actor := models.User{}

--- a/backend/api/handlers/gitops_syncs_test.go
+++ b/backend/api/handlers/gitops_syncs_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	humamw "github.com/getarcaneapp/arcane/backend/api/middleware"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/getarcaneapp/arcane/types/gitops"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// adminCtx returns a context where the auth middleware has marked the user as admin.
+func adminCtx() context.Context {
+	return context.WithValue(context.Background(), humamw.ContextKeyUserIsAdmin, true)
+}
+
+// nonAdminCtx returns a context where the auth middleware has marked the user as non-admin.
+// Equivalent to context.Background() since IsAdminFromContext defaults to false when the key
+// is absent, but the explicit setting makes the test intent clear.
+func nonAdminCtx() context.Context {
+	return context.WithValue(context.Background(), humamw.ContextKeyUserIsAdmin, false)
+}
+
+func TestValidateGitOpsSyncTargetType(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		targetType  string
+		wantErr     bool
+		wantStatus  int
+		wantMessage string
+	}{
+		{name: "empty allowed for non-admin", ctx: nonAdminCtx(), targetType: "", wantErr: false},
+		{name: "project allowed for non-admin", ctx: nonAdminCtx(), targetType: "project", wantErr: false},
+		{name: "swarm_stack forbidden for non-admin", ctx: nonAdminCtx(), targetType: "swarm_stack", wantErr: true, wantStatus: http.StatusForbidden, wantMessage: "admin access required"},
+		{name: "swarm_stack allowed for admin", ctx: adminCtx(), targetType: "swarm_stack", wantErr: false},
+		{name: "unknown value rejected as 400", ctx: nonAdminCtx(), targetType: "garbage", wantErr: true, wantStatus: http.StatusBadRequest, wantMessage: "invalid targetType"},
+		{name: "unknown value rejected as 400 even for admin", ctx: adminCtx(), targetType: "garbage", wantErr: true, wantStatus: http.StatusBadRequest, wantMessage: "invalid targetType"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGitOpsSyncTargetTypeInternal(tt.ctx, tt.targetType)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var statusErr huma.StatusError
+			require.ErrorAs(t, err, &statusErr)
+			require.Equal(t, tt.wantStatus, statusErr.GetStatus())
+			require.Contains(t, statusErr.Error(), tt.wantMessage)
+		})
+	}
+}
+
+// TestGitOpsSyncHandler_CreateSync_TargetTypeGate verifies that the swarm_stack admin
+// gate fires before any service call, matching the precondition used by the test
+// scaffolding (empty service struct — handler must not reach it).
+func TestGitOpsSyncHandler_CreateSync_TargetTypeGate(t *testing.T) {
+	handler := &GitOpsSyncHandler{syncService: &services.GitOpsSyncService{}}
+
+	t.Run("non-admin with swarm_stack body is forbidden", func(t *testing.T) {
+		_, err := handler.CreateSync(nonAdminCtx(), &CreateGitOpsSyncInput{
+			EnvironmentID: "env-1",
+			Body:          gitops.CreateSyncRequest{TargetType: "swarm_stack"},
+		})
+		require.Error(t, err)
+		var statusErr huma.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, http.StatusForbidden, statusErr.GetStatus())
+		require.Contains(t, statusErr.Error(), "admin access required")
+	})
+
+	t.Run("non-admin with unknown targetType is rejected as 400", func(t *testing.T) {
+		_, err := handler.CreateSync(nonAdminCtx(), &CreateGitOpsSyncInput{
+			EnvironmentID: "env-1",
+			Body:          gitops.CreateSyncRequest{TargetType: "garbage"},
+		})
+		require.Error(t, err)
+		var statusErr huma.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
+		require.Contains(t, statusErr.Error(), "invalid targetType")
+	})
+}
+
+// TestGitOpsSyncHandler_UpdateSync_TargetTypeGate verifies that an UpdateSync body
+// setting TargetType=swarm_stack is rejected for non-admins before any service call.
+// (The stored-sync admin check for existing swarm_stack syncs requires a working DB
+// and is covered by manual smoke testing.)
+func TestGitOpsSyncHandler_UpdateSync_TargetTypeGate(t *testing.T) {
+	handler := &GitOpsSyncHandler{syncService: &services.GitOpsSyncService{}}
+
+	swarmType := "swarm_stack"
+	garbageType := "garbage"
+
+	t.Run("non-admin promoting to swarm_stack is forbidden", func(t *testing.T) {
+		_, err := handler.UpdateSync(nonAdminCtx(), &UpdateGitOpsSyncInput{
+			EnvironmentID: "env-1",
+			SyncID:        "sync-1",
+			Body:          gitops.UpdateSyncRequest{TargetType: &swarmType},
+		})
+		require.Error(t, err)
+		var statusErr huma.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, http.StatusForbidden, statusErr.GetStatus())
+		require.Contains(t, statusErr.Error(), "admin access required")
+	})
+
+	t.Run("unknown targetType in update is rejected as 400", func(t *testing.T) {
+		_, err := handler.UpdateSync(nonAdminCtx(), &UpdateGitOpsSyncInput{
+			EnvironmentID: "env-1",
+			SyncID:        "sync-1",
+			Body:          gitops.UpdateSyncRequest{TargetType: &garbageType},
+		})
+		require.Error(t, err)
+		var statusErr huma.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
+		require.Contains(t, statusErr.Error(), "invalid targetType")
+	})
+}
+
+func TestGitOpsSyncHandler_DeleteSync_SwarmStackRequiresAdmin(t *testing.T) {
+	db, err := gorm.Open(glsqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.GitOpsSync{}))
+
+	sync := models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-1"},
+		Name:          "swarm sync",
+		EnvironmentID: "env-1",
+		RepositoryID:  "repo-1",
+		TargetType:    "swarm_stack",
+	}
+	require.NoError(t, db.Create(&sync).Error)
+
+	handler := &GitOpsSyncHandler{
+		syncService: services.NewGitOpsSyncService(&database.DB{DB: db}, nil, nil, nil, nil, nil),
+	}
+
+	_, err = handler.DeleteSync(nonAdminCtx(), &DeleteGitOpsSyncInput{
+		EnvironmentID: "env-1",
+		SyncID:        "sync-1",
+	})
+	require.Error(t, err)
+
+	var statusErr huma.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, http.StatusForbidden, statusErr.GetStatus())
+	require.Contains(t, statusErr.Error(), "admin access required")
+
+	var count int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", "sync-1").Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires admin-only access controls into all four mutating GitOps sync endpoints. It introduces a shared `validateGitOpsSyncTargetTypeInternal` helper and applies it to `CreateSync`, `UpdateSync`, `DeleteSync`, and `PerformSync`, closing the previously identified gap where non-admins could delete a `swarm_stack`-type sync.

- `validateGitOpsSyncTargetTypeInternal` centralises target-type validation: empty and `"project"` are open to all, `"swarm_stack"` requires admin, anything else is a 400.
- `UpdateSync` validates the *requested* new type first, then also gates on the *existing* record's type — correctly blocking both promotion and modification of swarm-stack syncs by non-admins.
- A new test file covers the validator unit tests, `CreateSync`/`UpdateSync` pre-DB gates, and a SQLite-backed integration test for `DeleteSync`; `PerformSync` and the `UpdateSync` existing-record path lack automated coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the access control logic is correct and consistent across all four mutating endpoints.

The handler changes are logically sound: the new validation helper is correctly called in CreateSync, UpdateSync checks both the incoming type and the existing record's type, and DeleteSync/PerformSync both fetch before acting. The previously unguarded delete path is now protected. The only gap is test coverage for PerformSync and the UpdateSync existing-record branch, which does not affect runtime correctness.

No files require special attention for correctness; gitops_syncs_test.go would benefit from an integration test for the PerformSync admin gate.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/api/handlers/gitops_syncs.go`, line 424-447 ([link](https://github.com/getarcaneapp/arcane/blob/8342b773979da4249110f86d2b3db49b0445c245/backend/api/handlers/gitops_syncs.go#L424-L447)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing admin gate on `DeleteSync` for `swarm_stack` syncs**

   `UpdateSync` and `PerformSync` both fetch the existing record and enforce `checkAdminInternal` when its `TargetType == "swarm_stack"`, but `DeleteSync` skips that check entirely. A non-admin user who cannot update or trigger a swarm-stack sync can still delete it by hitting the `DELETE /environments/{id}/gitops-syncs/{syncId}` endpoint, bypassing the access boundary that every other mutating operation now enforces.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/handlers/gitops_syncs.go
   Line: 424-447

   Comment:
   **Missing admin gate on `DeleteSync` for `swarm_stack` syncs**

   `UpdateSync` and `PerformSync` both fetch the existing record and enforce `checkAdminInternal` when its `TargetType == "swarm_stack"`, but `DeleteSync` skips that check entirely. A non-admin user who cannot update or trigger a swarm-stack sync can still delete it by hitting the `DELETE /environments/{id}/gitops-syncs/{syncId}` endpoint, bypassing the access boundary that every other mutating operation now enforces.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fswarm-git-sync-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswarm-git-sync-checks%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fgitops_syncs.go%0ALine%3A%20424-447%0A%0AComment%3A%0A**Missing%20admin%20gate%20on%20%60DeleteSync%60%20for%20%60swarm_stack%60%20syncs**%0A%0A%60UpdateSync%60%20and%20%60PerformSync%60%20both%20fetch%20the%20existing%20record%20and%20enforce%20%60checkAdminInternal%60%20when%20its%20%60TargetType%20%3D%3D%20%22swarm_stack%22%60%2C%20but%20%60DeleteSync%60%20skips%20that%20check%20entirely.%20A%20non-admin%20user%20who%20cannot%20update%20or%20trigger%20a%20swarm-stack%20sync%20can%20still%20delete%20it%20by%20hitting%20the%20%60DELETE%20%2Fenvironments%2F%7Bid%7D%2Fgitops-syncs%2F%7BsyncId%7D%60%20endpoint%2C%20bypassing%20the%20access%20boundary%20that%20every%20other%20mutating%20operation%20now%20enforces.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fgitops_syncs.go%0ALine%3A%20424-447%0A%0AComment%3A%0A**Missing%20admin%20gate%20on%20%60DeleteSync%60%20for%20%60swarm_stack%60%20syncs**%0A%0A%60UpdateSync%60%20and%20%60PerformSync%60%20both%20fetch%20the%20existing%20record%20and%20enforce%20%60checkAdminInternal%60%20when%20its%20%60TargetType%20%3D%3D%20%22swarm_stack%22%60%2C%20but%20%60DeleteSync%60%20skips%20that%20check%20entirely.%20A%20non-admin%20user%20who%20cannot%20update%20or%20trigger%20a%20swarm-stack%20sync%20can%20still%20delete%20it%20by%20hitting%20the%20%60DELETE%20%2Fenvironments%2F%7Bid%7D%2Fgitops-syncs%2F%7BsyncId%7D%60%20endpoint%2C%20bypassing%20the%20access%20boundary%20that%20every%20other%20mutating%20operation%20now%20enforces.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

2. `backend/api/handlers/gitops_syncs.go`, line 424-447 ([link](https://github.com/getarcaneapp/arcane/blob/6bce82aea72979b82e3f837231193ad1fcb4fff4/backend/api/handlers/gitops_syncs.go#L424-L447)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing admin gate on `DeleteSync` for `swarm_stack` syncs**

   `UpdateSync` (line 388–397) and `PerformSync` (line 455–464) both fetch the existing record and enforce `checkAdminInternal` when `existing.TargetType == "swarm_stack"`. `DeleteSync` skips that check entirely — a non-admin who cannot update or trigger a swarm-stack sync can still delete it by hitting `DELETE /environments/{id}/gitops-syncs/{syncId}`, bypassing the access boundary every other mutating operation now enforces. The fix is to call `GetSyncByID` before the delete and return an error if the caller is not an admin and the existing type is `"swarm_stack"`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/handlers/gitops_syncs.go
   Line: 424-447

   Comment:
   **Missing admin gate on `DeleteSync` for `swarm_stack` syncs**

   `UpdateSync` (line 388–397) and `PerformSync` (line 455–464) both fetch the existing record and enforce `checkAdminInternal` when `existing.TargetType == "swarm_stack"`. `DeleteSync` skips that check entirely — a non-admin who cannot update or trigger a swarm-stack sync can still delete it by hitting `DELETE /environments/{id}/gitops-syncs/{syncId}`, bypassing the access boundary every other mutating operation now enforces. The fix is to call `GetSyncByID` before the delete and return an error if the caller is not an admin and the existing type is `"swarm_stack"`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fswarm-git-sync-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswarm-git-sync-checks%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fgitops_syncs.go%0ALine%3A%20424-447%0A%0AComment%3A%0A**Missing%20admin%20gate%20on%20%60DeleteSync%60%20for%20%60swarm_stack%60%20syncs**%0A%0A%60UpdateSync%60%20%28line%20388%E2%80%93397%29%20and%20%60PerformSync%60%20%28line%20455%E2%80%93464%29%20both%20fetch%20the%20existing%20record%20and%20enforce%20%60checkAdminInternal%60%20when%20%60existing.TargetType%20%3D%3D%20%22swarm_stack%22%60.%20%60DeleteSync%60%20skips%20that%20check%20entirely%20%E2%80%94%20a%20non-admin%20who%20cannot%20update%20or%20trigger%20a%20swarm-stack%20sync%20can%20still%20delete%20it%20by%20hitting%20%60DELETE%20%2Fenvironments%2F%7Bid%7D%2Fgitops-syncs%2F%7BsyncId%7D%60%2C%20bypassing%20the%20access%20boundary%20every%20other%20mutating%20operation%20now%20enforces.%20The%20fix%20is%20to%20call%20%60GetSyncByID%60%20before%20the%20delete%20and%20return%20an%20error%20if%20the%20caller%20is%20not%20an%20admin%20and%20the%20existing%20type%20is%20%60%22swarm_stack%22%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fgitops_syncs.go%0ALine%3A%20424-447%0A%0AComment%3A%0A**Missing%20admin%20gate%20on%20%60DeleteSync%60%20for%20%60swarm_stack%60%20syncs**%0A%0A%60UpdateSync%60%20%28line%20388%E2%80%93397%29%20and%20%60PerformSync%60%20%28line%20455%E2%80%93464%29%20both%20fetch%20the%20existing%20record%20and%20enforce%20%60checkAdminInternal%60%20when%20%60existing.TargetType%20%3D%3D%20%22swarm_stack%22%60.%20%60DeleteSync%60%20skips%20that%20check%20entirely%20%E2%80%94%20a%20non-admin%20who%20cannot%20update%20or%20trigger%20a%20swarm-stack%20sync%20can%20still%20delete%20it%20by%20hitting%20%60DELETE%20%2Fenvironments%2F%7Bid%7D%2Fgitops-syncs%2F%7BsyncId%7D%60%2C%20bypassing%20the%20access%20boundary%20every%20other%20mutating%20operation%20now%20enforces.%20The%20fix%20is%20to%20call%20%60GetSyncByID%60%20before%20the%20delete%20and%20return%20an%20error%20if%20the%20caller%20is%20not%20an%20admin%20and%20the%20existing%20type%20is%20%60%22swarm_stack%22%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fswarm-git-sync-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fswarm-git-sync-checks%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapi%2Fhandlers%2Fgitops_syncs_test.go%3A109-118%0A**%60PerformSync%60%20admin%20gate%20has%20no%20automated%20test**%0A%0A%60DeleteSync%60%20has%20a%20SQLite-backed%20integration%20test%20that%20verifies%20a%20non-admin%20cannot%20delete%20a%20%60swarm_stack%60%20sync%2C%20and%20the%20test%20comment%20in%20%60UpdateSync%60%20explicitly%20acknowledges%20the%20existing-record%20path%20is%20%22covered%20by%20manual%20smoke%20testing.%22%20%60PerformSync%60%20follows%20the%20same%20pattern%20but%20has%20neither%20an%20automated%20test%20nor%20a%20comment%20acknowledging%20the%20gap.%20If%20the%20check%20is%20accidentally%20removed%20or%20regressed%2C%20there%20is%20no%20automated%20signal%20%E2%80%94%20consider%20adding%20an%20integration%20test%20mirroring%20%60TestGitOpsSyncHandler_DeleteSync_SwarmStackRequiresAdmin%60%20for%20the%20trigger%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fapi%2Fhandlers%2Fgitops_syncs_test.go%3A109-118%0A**%60PerformSync%60%20admin%20gate%20has%20no%20automated%20test**%0A%0A%60DeleteSync%60%20has%20a%20SQLite-backed%20integration%20test%20that%20verifies%20a%20non-admin%20cannot%20delete%20a%20%60swarm_stack%60%20sync%2C%20and%20the%20test%20comment%20in%20%60UpdateSync%60%20explicitly%20acknowledges%20the%20existing-record%20path%20is%20%22covered%20by%20manual%20smoke%20testing.%22%20%60PerformSync%60%20follows%20the%20same%20pattern%20but%20has%20neither%20an%20automated%20test%20nor%20a%20comment%20acknowledging%20the%20gap.%20If%20the%20check%20is%20accidentally%20removed%20or%20regressed%2C%20there%20is%20no%20automated%20signal%20%E2%80%94%20consider%20adding%20an%20integration%20test%20mirroring%20%60TestGitOpsSyncHandler_DeleteSync_SwarmStackRequiresAdmin%60%20for%20the%20trigger%20path.%0A%0A&repo=getarcaneapp%2Farcane&pr=2589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/api/handlers/gitops_syncs_test.go:109-118
**`PerformSync` admin gate has no automated test**

`DeleteSync` has a SQLite-backed integration test that verifies a non-admin cannot delete a `swarm_stack` sync, and the test comment in `UpdateSync` explicitly acknowledges the existing-record path is "covered by manual smoke testing." `PerformSync` follows the same pattern but has neither an automated test nor a comment acknowledging the gap. If the check is accidentally removed or regressed, there is no automated signal — consider adding an integration test mirroring `TestGitOpsSyncHandler_DeleteSync_SwarmStackRequiresAdmin` for the trigger path.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: git sync validations for project or..."](https://github.com/getarcaneapp/arcane/commit/f501070de792c9357889005fe3280829d10e2063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31895135)</sub>

<!-- /greptile_comment -->