### PR TITLE
fix: allow hiding default networks on typology view

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -837,6 +837,7 @@
 	"networks_topology_hint": "Click a node to open its details.",
 	"networks_topology_legend_networks": "Networks",
 	"networks_topology_legend_containers": "Containers",
+	"networks_topology_default_networks": "Default networks",
 	"networks_total": "Total Networks",
 	"networks_delete_selected_title": "Delete {count} network(s)",
 	"networks_delete_selected_message": "Are you sure you want to delete {count} selected network(s)? This action cannot be undone.",

--- a/frontend/src/lib/components/network-diagram/network-diagram.svelte
+++ b/frontend/src/lib/components/network-diagram/network-diagram.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
+	import { ArcaneButton } from '$lib/components/arcane-button';
 	import StatusBadge from '$lib/components/badges/status-badge.svelte';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { EyeOnIcon } from '$lib/icons';
 	import { m } from '$lib/paraglide/messages';
 	import type { NetworkTopologyDto, TopologyEdgeDto, TopologyNodeDto } from '$lib/types/network.type';
 	import { cn } from '$lib/utils';
 	import { mode } from 'mode-watcher';
+	import { PersistedState } from 'runed';
 	import { onMount } from 'svelte';
 	import {
 		Background,
@@ -57,8 +61,32 @@
 		text: string;
 	};
 
-	const networkNodes = $derived(topology.nodes.filter((node) => node.type === 'network'));
-	const containerNodes = $derived(topology.nodes.filter((node) => node.type === 'container'));
+	const visibleDefaults = new PersistedState<Record<string, boolean>>('arcane-topology-default-networks', {});
+
+	const presentDefaults = $derived(
+		topology.nodes
+			.filter((node) => node.type === 'network' && node.metadata.isDefault)
+			.sort((left, right) => left.name.localeCompare(right.name))
+	);
+	const visibleDefaultsCount = $derived(presentDefaults.filter((node) => visibleDefaults.current[node.id] !== false).length);
+
+	const visibleNetworkIds = $derived(
+		new Set(
+			topology.nodes
+				.filter((node) => node.type === 'network' && (!node.metadata.isDefault || visibleDefaults.current[node.id] !== false))
+				.map((node) => node.id)
+		)
+	);
+	const visibleEdges = $derived(topology.edges.filter((edge) => visibleNetworkIds.has(edge.source)));
+	const visibleContainerIds = $derived(new Set(visibleEdges.map((edge) => edge.target)));
+	const allEdgeTargets = $derived(new Set(topology.edges.map((edge) => edge.target)));
+
+	const networkNodes = $derived(topology.nodes.filter((node) => node.type === 'network' && visibleNetworkIds.has(node.id)));
+	const containerNodes = $derived(
+		topology.nodes.filter(
+			(node) => node.type === 'container' && (visibleContainerIds.has(node.id) || !allEdgeTargets.has(node.id))
+		)
+	);
 	const isDarkMode = $derived(mode.current === 'dark');
 
 	const canvasTheme = $derived(
@@ -336,8 +364,8 @@
 	const diagramNodes = $derived.by<Node<DiagramNodeData>[]>(() => {
 		const networksById = Object.fromEntries(networkNodes.map((node) => [node.id, node]));
 		const sourceOrder = Object.fromEntries(networkNodes.map((node, index) => [node.id, index]));
-		const connectionsByContainer = containerConnections(topology.edges, networksById, sourceOrder);
-		const layout = buildDiagramLayout(networkNodes, topology.edges, containerNodes);
+		const connectionsByContainer = containerConnections(visibleEdges, networksById, sourceOrder);
+		const layout = buildDiagramLayout(networkNodes, visibleEdges, containerNodes);
 
 		const graphNodes: Node<DiagramNodeData>[] = [];
 
@@ -410,7 +438,7 @@
 	});
 
 	const diagramEdges = $derived.by<Edge[]>(() =>
-		topology.edges.map((edge) => ({
+		visibleEdges.map((edge) => ({
 			id: edge.id,
 			source: edge.source,
 			target: edge.target,
@@ -446,6 +474,37 @@
 		<StatusBadge text={m.networks_topology_legend_networks()} variant="violet" minWidth="none" />
 		<StatusBadge text={m.networks_topology_legend_containers()} variant="emerald" minWidth="none" />
 		<p class="text-muted-foreground text-sm">{m.networks_topology_hint()}</p>
+		{#if presentDefaults.length > 0}
+			<div class="ml-auto">
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger>
+						{#snippet child({ props })}
+							<ArcaneButton
+								{...props}
+								action="base"
+								tone="ghost"
+								icon={EyeOnIcon}
+								customLabel={`${m.networks_topology_default_networks()} (${visibleDefaultsCount}/${presentDefaults.length})`}
+								class="border-input hover:bg-card/60 border hover:text-inherit"
+							/>
+						{/snippet}
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content align="end">
+						<DropdownMenu.Label>{m.networks_topology_default_networks()}</DropdownMenu.Label>
+						<DropdownMenu.Separator />
+						{#each presentDefaults as node (node.id)}
+							<DropdownMenu.CheckboxItem
+								checked={visibleDefaults.current[node.id] !== false}
+								onCheckedChange={(checked) =>
+									(visibleDefaults.current = { ...visibleDefaults.current, [node.id]: checked === true })}
+							>
+								{node.name}
+							</DropdownMenu.CheckboxItem>
+						{/each}
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+			</div>
+		{/if}
 	</div>
 
 	{#if topology.nodes.length === 0}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2584

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a dropdown control to the network topology diagram that lets users show or hide individual "default" networks (bridge, host, etc.). Visibility preferences are persisted to `localStorage` via `runed`'s `PersistedState` and keyed on network node IDs.

- Introduces `visibleDefaults` persisted state and derived sets (`visibleNetworkIds`, `visibleEdges`, `visibleContainerIds`) to filter nodes and edges before rendering.
- Adds a `DropdownMenu` with per-network `CheckboxItem` controls; containers connected only to hidden networks are suppressed, while containers with no edges at all remain visible.
- Adds the `networks_topology_default_networks` i18n key.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the filtering logic is self-contained and the previous review concerns about node.name vs node.id keying and disconnected containers have both been addressed.

The visibility filter chain (networks → edges → containers) is correct: containers with no edges remain visible, containers whose only connections are to hidden networks are suppressed, and mixed-connection containers are retained. The PersistedState key and all template bindings consistently use node.id.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: allow hiding default networks on ty..."](https://github.com/getarcaneapp/arcane/commit/0246ad28f80e5aa5090f329c1f6b5d475105aa08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32042305)</sub>

<!-- /greptile_comment -->