### PR TITLE
perf: increase loading times of project list view

### DIFF
--- a/backend/api/handlers/dashboard_test.go
+++ b/backend/api/handlers/dashboard_test.go
@@ -61,6 +61,7 @@ func newDashboardHandlerTestDockerService(
 	t.Cleanup(server.Close)
 
 	return services.NewDockerClientService(
+		context.Background(),
 		nil,
 		&config.Config{DockerHost: server.URL},
 		settingsSvc,

--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -288,6 +288,58 @@ func RegisterProjects(api huma.API, projectService *services.ProjectService) {
 	}, h.GetProject)
 
 	huma.Register(api, huma.Operation{
+		OperationID: "get-project-compose",
+		Method:      http.MethodGet,
+		Path:        "/environments/{id}/projects/{projectId}/compose",
+		Summary:     "Get project compose details",
+		Description: "Get compose content, includes, and service configs for a project",
+		Tags:        []string{"Projects"},
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
+	}, h.GetProjectCompose)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project-files",
+		Method:      http.MethodGet,
+		Path:        "/environments/{id}/projects/{projectId}/files",
+		Summary:     "Get project files",
+		Description: "Get directory files for a project",
+		Tags:        []string{"Projects"},
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
+	}, h.GetProjectFiles)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project-runtime",
+		Method:      http.MethodGet,
+		Path:        "/environments/{id}/projects/{projectId}/runtime",
+		Summary:     "Get project runtime",
+		Description: "Get runtime service state for a project",
+		Tags:        []string{"Projects"},
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
+	}, h.GetProjectRuntime)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project-updates",
+		Method:      http.MethodGet,
+		Path:        "/environments/{id}/projects/{projectId}/updates",
+		Summary:     "Get project updates",
+		Description: "Get image update summary for a project",
+		Tags:        []string{"Projects"},
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
+	}, h.GetProjectUpdates)
+
+	huma.Register(api, huma.Operation{
 		OperationID: "get-project-file",
 		Method:      http.MethodGet,
 		Path:        "/environments/{id}/projects/{projectId}/file",
@@ -642,7 +694,7 @@ func (h *ProjectHandler) GetProject(ctx context.Context, input *GetProjectInput)
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID)
+	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID, project.DetailsOptions{})
 	if err != nil {
 		return nil, huma.Error404NotFound((&common.ProjectDetailsError{Err: err}).Error())
 	}
@@ -653,6 +705,55 @@ func (h *ProjectHandler) GetProject(ctx context.Context, input *GetProjectInput)
 			Data:    details,
 		},
 	}, nil
+}
+
+func (h *ProjectHandler) getProjectDetailsWithOptionsInternal(ctx context.Context, input *GetProjectInput, opts project.DetailsOptions) (*GetProjectOutput, error) {
+	if h.projectService == nil {
+		return nil, huma.Error500InternalServerError("service not available")
+	}
+	if input.ProjectID == "" {
+		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
+	}
+
+	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID, opts)
+	if err != nil {
+		return nil, huma.Error404NotFound((&common.ProjectDetailsError{Err: err}).Error())
+	}
+
+	return &GetProjectOutput{
+		Body: base.ApiResponse[project.Details]{
+			Success: true,
+			Data:    details,
+		},
+	}, nil
+}
+
+func (h *ProjectHandler) GetProjectCompose(ctx context.Context, input *GetProjectInput) (*GetProjectOutput, error) {
+	return h.getProjectDetailsWithOptionsInternal(ctx, input, project.DetailsOptions{
+		IncludeComposeContent: true,
+		IncludeEnvState:       true,
+		IncludeIncludeFiles:   true,
+		IncludeServiceConfigs: true,
+	})
+}
+
+func (h *ProjectHandler) GetProjectFiles(ctx context.Context, input *GetProjectInput) (*GetProjectOutput, error) {
+	return h.getProjectDetailsWithOptionsInternal(ctx, input, project.DetailsOptions{
+		IncludeDirectoryFiles: true,
+	})
+}
+
+func (h *ProjectHandler) GetProjectRuntime(ctx context.Context, input *GetProjectInput) (*GetProjectOutput, error) {
+	return h.getProjectDetailsWithOptionsInternal(ctx, input, project.DetailsOptions{
+		IncludeRuntimeServices: true,
+	})
+}
+
+func (h *ProjectHandler) GetProjectUpdates(ctx context.Context, input *GetProjectInput) (*GetProjectOutput, error) {
+	return h.getProjectDetailsWithOptionsInternal(ctx, input, project.DetailsOptions{
+		IncludeServiceConfigs: true,
+		IncludeUpdateInfo:     true,
+	})
 }
 
 func (h *ProjectHandler) GetProjectFile(ctx context.Context, input *GetProjectFileInput) (*GetProjectFileOutput, error) {
@@ -792,7 +893,7 @@ func (h *ProjectHandler) UpdateProject(ctx context.Context, input *UpdateProject
 		return nil, huma.Error400BadRequest((&common.ProjectUpdateError{Err: err}).Error())
 	}
 
-	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID)
+	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID, project.AllDetails())
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.ProjectDetailsError{Err: err}).Error())
 	}
@@ -827,7 +928,7 @@ func (h *ProjectHandler) UpdateProjectInclude(ctx context.Context, input *Update
 		return nil, huma.Error400BadRequest((&common.ProjectUpdateError{Err: err}).Error())
 	}
 
-	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID)
+	details, err := h.projectService.GetProjectDetails(ctx, input.ProjectID, project.AllDetails())
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.ProjectDetailsError{Err: err}).Error())
 	}

--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -174,8 +174,9 @@ type WebSocketHandler struct {
 		ready       chan struct{}
 		running     bool
 	}
-	cgroupCache *system.CgroupCache
-	gpuMonitor  *system.GPUMonitor
+	containerStatsHubs sync.Map
+	cgroupCache        *system.CgroupCache
+	gpuMonitor         *system.GPUMonitor
 
 	diskUsagePathCache struct {
 		sync.RWMutex
@@ -815,27 +816,65 @@ func (h *WebSocketHandler) ContainerStats(c echo.Context) error {
 	}
 
 	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindContainerStats, containerID))
-	hub := h.startContainerStatsHub(containerID, func() {
+	hub := h.getOrCreateContainerStatsHubInternal(containerID)
+	onRemove := func() {
 		h.wsMetrics.UnregisterConnection(connID)
-	})
+	}
 	// WebSocket connections use context.Background() because they are long-lived and should not
-	// be tied to the HTTP request context. Cleanup is handled via the hub's OnEmpty callback
-	// which triggers when all clients disconnect.
-	wshub.ServeClient(context.Background(), hub, conn)
+	// be tied to the HTTP request context. Cleanup is handled by the shared hub when it idles.
+	wshub.ServeClientWithOnRemove(context.Background(), hub, conn, onRemove)
 	return nil
 }
 
-func (h *WebSocketHandler) startContainerStatsHub(containerID string, onEmptyHook func()) *wshub.Hub {
-	hub := wshub.NewHub(64)
+func (h *WebSocketHandler) getOrCreateContainerStatsHubInternal(containerID string) *wshub.Hub {
+	if existing, ok := h.containerStatsHubs.Load(containerID); ok {
+		return existing.(*wshub.Hub)
+	}
 
+	hub := wshub.NewHub(64)
+	actual, loaded := h.containerStatsHubs.LoadOrStore(containerID, hub)
+	if loaded {
+		return actual.(*wshub.Hub)
+	}
+
+	h.runContainerStatsHubInternal(containerID, hub)
+	return hub
+}
+
+func (h *WebSocketHandler) runContainerStatsHubInternal(containerID string, hub *wshub.Hub) {
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is intentionally retained and invoked by the hub OnEmpty callback.
+	var cleanupTimer *time.Timer
+	var cleanupTimerMu sync.Mutex
 
 	hub.SetOnEmpty(func() {
-		if onEmptyHook != nil {
-			onEmptyHook()
+		cleanupTimerMu.Lock()
+		if cleanupTimer != nil {
+			cleanupTimer.Stop()
 		}
-		slog.Debug("client disconnected, cleaning up container stats hub", "containerID", containerID)
-		cancel()
+		var timer *time.Timer
+		timer = time.AfterFunc(5*time.Second, func() {
+			cleanupTimerMu.Lock()
+			defer cleanupTimerMu.Unlock()
+			if cleanupTimer != timer {
+				return
+			}
+			if existing, ok := h.containerStatsHubs.Load(containerID); ok && existing == hub {
+				h.containerStatsHubs.Delete(containerID)
+			}
+			slog.Debug("container stats hub idle, cleaning up upstream stream", "containerID", containerID)
+			cleanupTimer = nil
+			cancel()
+		})
+		cleanupTimer = timer
+		cleanupTimerMu.Unlock()
+	})
+	hub.SetOnActive(func() {
+		cleanupTimerMu.Lock()
+		if cleanupTimer != nil {
+			cleanupTimer.Stop()
+			cleanupTimer = nil
+		}
+		cleanupTimerMu.Unlock()
 	})
 
 	go hub.Run(ctx)
@@ -861,8 +900,6 @@ func (h *WebSocketHandler) startContainerStatsHub(containerID string, onEmptyHoo
 			}
 		}
 	}()
-
-	return hub
 }
 
 // ContainerExec provides interactive terminal access to a container.

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -68,6 +68,7 @@ func Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize services: %w", err)
 	}
+	defer dockerClientService.Close()
 	defer func(ctx context.Context) {
 		baseCtx := context.WithoutCancel(ctx)
 		shutdownCtx, shutdownCancel := context.WithTimeout(baseCtx, 10*time.Second)
@@ -159,6 +160,9 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 	if err := appServices.Environment.EnsureLocalEnvironment(appCtx, cfg.AppUrl); err != nil {
 		slog.WarnContext(appCtx, "Failed to ensure local environment", "error", err)
 	}
+	if appServices.Project != nil {
+		go appServices.Project.BackfillProjectImageRefs(appCtx)
+	}
 
 	if !cfg.AgentMode {
 		if err := appServices.Environment.ReconcileEdgeStatusesOnStartup(appCtx); err != nil {
@@ -184,6 +188,7 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 		slog.InfoContext(ctx, "Docker API versions detected", "client_api_version", dockerClient.ClientVersion(), "server_api_version", version.APIVersion, "effective_api_version", effectiveAPIVersion)
 		return nil
 	})
+	go dockerClientService.WatchEvents(appCtx)
 	if appServices.Swarm != nil {
 		if err := appServices.Swarm.SyncSwarmEnabledState(appCtx); err != nil {
 			slog.WarnContext(appCtx, "Failed to persist swarm enabled state", "error", err)

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"net/http"
+	"net/http/pprof"
 	"path"
 	"strings"
 
@@ -151,6 +153,16 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *Services)
 	e.Use(middleware.NewCORSMiddleware(cfg).Add())
 
 	apiGroup := e.Group("/api")
+	apiGroup.Use(echomiddleware.GzipWithConfig(echomiddleware.GzipConfig{
+		Level: 5,
+		Skipper: func(c echo.Context) bool {
+			if strings.EqualFold(c.Request().Header.Get(echo.HeaderUpgrade), "websocket") {
+				return true
+			}
+			path := c.Request().URL.Path
+			return strings.Contains(path, "/ws/") || strings.Contains(path, "/logs") || strings.Contains(path, "/terminal")
+		},
+	}))
 
 	apiGroup.Use(middleware.PerIPRateLimitForPaths(
 		[]string{
@@ -232,6 +244,7 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *Services)
 	}
 
 	api.RegisterDiagnosticsRoutes(apiGroup, authMiddleware, ws.DefaultWebSocketMetrics()) //nolint:contextcheck
+	registerPprofRoutesInternal(apiGroup, authMiddleware)                                 //nolint:contextcheck
 
 	// Remaining echo handlers (WebSocket/streaming)
 	ws.NewWebSocketHandler(apiGroup, appServices.Project, appServices.Container, appServices.Swarm, appServices.System, authMiddleware, cfg) //nolint:contextcheck
@@ -254,4 +267,16 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *Services)
 	}
 
 	return e, tunnelServer
+}
+
+func registerPprofRoutesInternal(apiGroup *echo.Group, authMiddleware *middleware.AuthMiddleware) {
+	pprofGroup := apiGroup.Group("/debug/pprof", authMiddleware.WithAdminRequired().Add())
+	pprofGroup.GET("", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
+	pprofGroup.GET("/", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
+	pprofGroup.GET("/cmdline", echo.WrapHandler(http.HandlerFunc(pprof.Cmdline)))
+	pprofGroup.GET("/profile", echo.WrapHandler(http.HandlerFunc(pprof.Profile)))
+	pprofGroup.POST("/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
+	pprofGroup.GET("/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
+	pprofGroup.GET("/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)))
+	pprofGroup.GET("/:name", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
 }

--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -66,7 +66,7 @@ func initializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	svcs.CustomizeSearch = services.NewCustomizeSearchService()
 	svcs.AppImages = services.NewApplicationImagesService(resources.FS, svcs.Settings)
 	svcs.Font = services.NewFontService(resources.FS)
-	dockerClient := services.NewDockerClientService(db, cfg, svcs.Settings)
+	dockerClient := services.NewDockerClientService(ctx, db, cfg, svcs.Settings)
 	svcs.Docker = dockerClient
 	svcs.User = services.NewUserService(db)
 	svcs.Session = services.NewSessionService(db)

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -115,8 +115,13 @@ func Initialize(ctx context.Context, databaseURL string, options MigrationOption
 	}
 
 	// Set connection pool settings
-	sqlDB.SetMaxIdleConns(5)
-	sqlDB.SetMaxOpenConns(20)
+	if db.Name() == "postgres" {
+		sqlDB.SetMaxIdleConns(15)
+		sqlDB.SetMaxOpenConns(50)
+	} else {
+		sqlDB.SetMaxIdleConns(5)
+		sqlDB.SetMaxOpenConns(20)
+	}
 	sqlDB.SetConnMaxLifetime(5 * time.Minute)
 	sqlDB.SetConnMaxIdleTime(3 * time.Minute)
 

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -63,6 +63,12 @@ func (m *AuthMiddleware) WithAdminNotRequired() *AuthMiddleware {
 	return &clone
 }
 
+func (m *AuthMiddleware) WithAdminRequired() *AuthMiddleware {
+	clone := *m
+	clone.options.AdminRequired = true
+	return &clone
+}
+
 func (m *AuthMiddleware) Add() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -24,6 +24,7 @@ type Project struct {
 	RunningCount       int           `json:"running_count" sortable:"true"`
 	GitOpsManagedBy    *string       `json:"gitops_managed_by,omitempty" gorm:"column:gitops_managed_by"`
 	ComposeProjectName *string       `json:"compose_project_name,omitempty" gorm:"column:compose_project_name"`
+	ImageRefsJSON      string        `json:"image_refs_json,omitempty" gorm:"column:image_refs_json"`
 	IsArchived         bool          `json:"is_archived" gorm:"column:is_archived;default:false;index"`
 	ArchivedAt         *time.Time    `json:"archived_at,omitempty" gorm:"column:archived_at"`
 

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -567,6 +567,7 @@ func TestGetOidcConfigurationStatus(t *testing.T) {
 
 	// Explicit env override to false should still be treated as forced
 	t.Setenv("OIDC_ENABLED", "false")
+	s.settingsService.envOverrides = resolveSettingsEnvOverridesInternal()
 	s.config.OidcEnabled = false
 	status, err = s.GetOidcConfigurationStatus(context.Background())
 	if err != nil {
@@ -578,6 +579,7 @@ func TestGetOidcConfigurationStatus(t *testing.T) {
 
 	// Enabled but missing fields
 	t.Setenv("OIDC_ENABLED", "true")
+	s.settingsService.envOverrides = resolveSettingsEnvOverridesInternal()
 	s.config.OidcEnabled = true
 	status, err = s.GetOidcConfigurationStatus(context.Background())
 	if err != nil {

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -23,11 +23,13 @@ import (
 	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils/cache"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
 	"github.com/getarcaneapp/arcane/types/containerregistry"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 )
@@ -40,6 +42,7 @@ type ContainerService struct {
 	settingsService *SettingsService
 	projectService  *ProjectService
 	statsHistory    containerstats.Store
+	updateInfoCache *cache.KeyedCache[string, *imagetypes.UpdateInfo]
 }
 
 const (
@@ -55,14 +58,30 @@ type ContainerListResult struct {
 }
 
 func NewContainerService(db *database.DB, eventService *EventService, dockerService *DockerClientService, imageService *ImageService, settingsService *SettingsService, projectService *ProjectService) *ContainerService {
-	return &ContainerService{
+	svc := &ContainerService{
 		db:              db,
 		eventService:    eventService,
 		dockerService:   dockerService,
 		imageService:    imageService,
 		settingsService: settingsService,
 		projectService:  projectService,
+		updateInfoCache: cache.NewKeyed[string, *imagetypes.UpdateInfo](),
 	}
+	svc.subscribeUpdateInfoCacheInvalidationInternal()
+	return svc
+}
+
+func (s *ContainerService) subscribeUpdateInfoCacheInvalidationInternal() {
+	if s.dockerService == nil || s.updateInfoCache == nil || s.dockerService.EventBus() == nil {
+		return
+	}
+	ch := make(chan events.Message, 16)
+	s.dockerService.EventBus().Subscribe(events.ImageEventType, ch)
+	go func() {
+		for range ch {
+			s.updateInfoCache.InvalidateAll()
+		}
+	}()
 }
 
 func buildCleanNetworkingConfigInternal(containerInspect container.InspectResponse, apiVersion string) *network.NetworkingConfig {
@@ -926,16 +945,25 @@ func (s *ContainerService) ListContainersPaginated(
 	includeInternal bool,
 	groupBy string,
 ) (ContainerListResult, error) {
-	dockerClient, err := s.dockerService.GetClient(ctx)
-	if err != nil {
-		return ContainerListResult{}, fmt.Errorf("failed to connect to Docker: %w", err)
-	}
+	var dockerContainers []container.Summary
+	if includeAll {
+		var err error
+		dockerContainers, err = s.dockerService.listContainersInternal(ctx)
+		if err != nil {
+			return ContainerListResult{}, err
+		}
+	} else {
+		dockerClient, err := s.dockerService.GetClient(ctx)
+		if err != nil {
+			return ContainerListResult{}, fmt.Errorf("failed to connect to Docker: %w", err)
+		}
 
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: includeAll})
-	if err != nil {
-		return ContainerListResult{}, fmt.Errorf("failed to list Docker containers: %w", err)
+		containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
+		if err != nil {
+			return ContainerListResult{}, fmt.Errorf("failed to list Docker containers: %w", err)
+		}
+		dockerContainers = containerList.Items
 	}
-	dockerContainers := containerList.Items
 
 	dockerContainers = filterInternalContainers(dockerContainers, includeInternal)
 	imageIDs := collectImageIDs(dockerContainers)
@@ -1124,13 +1152,32 @@ func (s *ContainerService) getUpdateInfoMap(ctx context.Context, imageIDs []stri
 		return make(map[string]*imagetypes.UpdateInfo)
 	}
 
-	updateInfoMap, err := s.imageService.GetUpdateInfoByImageIDs(ctx, imageIDs)
-	if err != nil {
-		// Log error but continue - update info is optional
-		slog.WarnContext(ctx, "Failed to fetch image update info for containers", "error", err)
-		return make(map[string]*imagetypes.UpdateInfo)
+	if s.updateInfoCache == nil {
+		updateInfoMap, err := s.imageService.GetUpdateInfoByImageIDs(ctx, imageIDs)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to fetch image update info for containers", "error", err)
+			return make(map[string]*imagetypes.UpdateInfo)
+		}
+		return updateInfoMap
 	}
 
+	updateInfoMap := make(map[string]*imagetypes.UpdateInfo, len(imageIDs))
+	for _, imageID := range imageIDs {
+		info, err := s.updateInfoCache.GetOrFetch(ctx, imageID, nil, func(fetchCtx context.Context) (*imagetypes.UpdateInfo, error) {
+			infos, fetchErr := s.imageService.GetUpdateInfoByImageIDs(fetchCtx, []string{imageID})
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			return infos[imageID], nil
+		})
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to fetch image update info for container image", "imageID", imageID, "error", err)
+			continue
+		}
+		if info != nil {
+			updateInfoMap[imageID] = info
+		}
+	}
 	return updateInfoMap
 }
 

--- a/backend/internal/services/dashboard_service.go
+++ b/backend/internal/services/dashboard_service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	dockerutils "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
-	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
 	"github.com/getarcaneapp/arcane/types/base"
 	containertypes "github.com/getarcaneapp/arcane/types/container"
@@ -22,8 +21,6 @@ import (
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	versiontypes "github.com/getarcaneapp/arcane/types/version"
 	dockercontainer "github.com/moby/moby/api/types/container"
-	dockerimage "github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/client"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -78,34 +75,12 @@ func (s *DashboardService) GetSnapshot(ctx context.Context, options DashboardAct
 		return nil, fmt.Errorf("docker service not available")
 	}
 
-	var (
-		dockerContainers []dockercontainer.Summary
-		dockerImages     []dockerimage.Summary
-	)
-
-	g, groupCtx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		containers, err := s.listDashboardContainersInternal(groupCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load dashboard containers: %w", err)
-		}
-		dockerContainers = containers
-		return nil
-	})
-
-	g.Go(func() error {
-		images, err := s.listDashboardImagesInternal(groupCtx)
-		if err != nil {
-			return fmt.Errorf("failed to load dashboard images: %w", err)
-		}
-		dockerImages = images
-		return nil
-	})
-
-	if err := g.Wait(); err != nil {
+	dockerSnapshot, err := s.dockerService.GetSnapshot(ctx, localEnvironmentID)
+	if err != nil {
 		return nil, err
 	}
+	dockerContainers := dockerSnapshot.Containers
+	dockerImages := dockerSnapshot.Images
 
 	filteredContainers := filterInternalContainers(dockerContainers, false)
 	containerItems := make([]containertypes.Summary, 0, len(filteredContainers))
@@ -329,7 +304,7 @@ func (s *DashboardService) buildActionItemsForSnapshotInternal(
 	ctx context.Context,
 	options DashboardActionItemsOptions,
 	containers []dockercontainer.Summary,
-	_ []dockerimage.Summary,
+	_ any,
 ) (*dashboardtypes.ActionItems, error) {
 	if options.DebugAllGood {
 		return &dashboardtypes.ActionItems{Items: []dashboardtypes.ActionItem{}}, nil
@@ -720,56 +695,6 @@ func (s *DashboardService) getExpiringAPIKeysCountInternal(ctx context.Context) 
 	}
 
 	return int(count), nil
-}
-
-func (s *DashboardService) listDashboardContainersInternal(ctx context.Context) ([]dockercontainer.Summary, error) {
-	if s.dockerService == nil {
-		return nil, fmt.Errorf("docker service not available")
-	}
-
-	dockerClient, err := s.dockerService.GetClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
-	}
-
-	apiCtx, cancel := timeouts.WithTimeout(ctx, s.getDockerAPITimeoutSecondsInternal(ctx), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Docker containers: %w", err)
-	}
-
-	return containerList.Items, nil
-}
-
-func (s *DashboardService) listDashboardImagesInternal(ctx context.Context) ([]dockerimage.Summary, error) {
-	if s.dockerService == nil {
-		return nil, fmt.Errorf("docker service not available")
-	}
-
-	dockerClient, err := s.dockerService.GetClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
-	}
-
-	apiCtx, cancel := timeouts.WithTimeout(ctx, s.getDockerAPITimeoutSecondsInternal(ctx), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Docker images: %w", err)
-	}
-
-	return imageList.Items, nil
-}
-
-func (s *DashboardService) getDockerAPITimeoutSecondsInternal(ctx context.Context) int {
-	if s.settingsService == nil {
-		return 0
-	}
-
-	return s.settingsService.GetIntSetting(ctx, "dockerApiTimeout", 0)
 }
 
 func buildDashboardPaginationResponseInternal(totalItems int, limit int) base.PaginationResponse {

--- a/backend/internal/services/docker_client_service.go
+++ b/backend/internal/services/docker_client_service.go
@@ -2,43 +2,70 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/eventbus"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils/cache"
+	dashboardtypes "github.com/getarcaneapp/arcane/types/dashboard"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
+	"golang.org/x/sync/errgroup"
 )
 
 const dockerClientNegotiationTimeout = 5 * time.Second
+const dockerListCacheTTL = 0
 
 type DockerClientService struct {
-	db              *database.DB
-	config          *config.Config
-	settingsService *SettingsService
-	client          *client.Client
-	clientVersion   string
-	clientLastProbe time.Time
-	mu              sync.Mutex
+	db                *database.DB
+	config            *config.Config
+	settingsService   *SettingsService
+	client            *client.Client
+	clientVersion     string
+	clientLastProbe   time.Time
+	mu                sync.Mutex
+	containerCache    *cache.Cache[[]container.Summary]
+	imageCache        *cache.Cache[[]image.Summary]
+	networkCache      *cache.Cache[[]network.Summary]
+	volumeCache       *cache.Cache[*client.VolumeListResult]
+	eventBus          *eventbus.DockerEventBus
+	subscriptionCtx   context.Context
+	subscriptionStop  context.CancelFunc
+	subscriptionUnsub []func()
 }
 
-func NewDockerClientService(db *database.DB, cfg *config.Config, settingsService *SettingsService) *DockerClientService {
-	return &DockerClientService{
-		db:              db,
-		config:          cfg,
-		settingsService: settingsService,
+func NewDockerClientService(ctx context.Context, db *database.DB, cfg *config.Config, settingsService *SettingsService) *DockerClientService {
+	subscriptionCtx, subscriptionStop := context.WithCancel(ctx)
+	svc := &DockerClientService{
+		db:               db,
+		config:           cfg,
+		settingsService:  settingsService,
+		containerCache:   cache.New[[]container.Summary](dockerListCacheTTL),
+		imageCache:       cache.New[[]image.Summary](dockerListCacheTTL),
+		networkCache:     cache.New[[]network.Summary](dockerListCacheTTL),
+		volumeCache:      cache.New[*client.VolumeListResult](dockerListCacheTTL),
+		eventBus:         eventbus.NewDockerEventBus(),
+		subscriptionCtx:  subscriptionCtx,
+		subscriptionStop: subscriptionStop,
 	}
+	svc.subscribeListCacheInvalidationInternal(subscriptionCtx)
+	return svc
 }
 
 func newDockerClientInternal(ctx context.Context, host string) (*client.Client, error) {
@@ -180,21 +207,305 @@ func (s *DockerClientService) DockerHost() string {
 	return s.config.DockerHost
 }
 
+// Close stops Docker event subscriptions owned by this service and closes the
+// cached Docker client.
+func (s *DockerClientService) Close() {
+	s.mu.Lock()
+	if s.subscriptionStop != nil {
+		s.subscriptionStop()
+		s.subscriptionStop = nil
+	}
+	for _, unsubscribe := range s.subscriptionUnsub {
+		unsubscribe()
+	}
+	s.subscriptionUnsub = nil
+	oldClient := s.client
+	s.client = nil
+	s.mu.Unlock()
+
+	closeDockerClientInternal(oldClient, "failed to close Docker client")
+}
+
+func (s *DockerClientService) EventBus() *eventbus.DockerEventBus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.eventBus == nil {
+		s.eventBus = eventbus.NewDockerEventBus()
+	}
+	return s.eventBus
+}
+
+func (s *DockerClientService) ensureListCachesInternal() {
+	s.mu.Lock()
+	if s.containerCache == nil {
+		s.containerCache = cache.New[[]container.Summary](dockerListCacheTTL)
+	}
+	if s.imageCache == nil {
+		s.imageCache = cache.New[[]image.Summary](dockerListCacheTTL)
+	}
+	if s.networkCache == nil {
+		s.networkCache = cache.New[[]network.Summary](dockerListCacheTTL)
+	}
+	if s.volumeCache == nil {
+		s.volumeCache = cache.New[*client.VolumeListResult](dockerListCacheTTL)
+	}
+	s.mu.Unlock()
+}
+
+func (s *DockerClientService) subscribeListCacheInvalidationInternal(ctx context.Context) {
+	s.subscribeCacheInvalidationInternal(ctx, events.ContainerEventType, func() {
+		if s.containerCache != nil {
+			s.containerCache.Invalidate()
+		}
+	})
+	s.subscribeCacheInvalidationInternal(ctx, events.ImageEventType, func() {
+		if s.imageCache != nil {
+			s.imageCache.Invalidate()
+		}
+	})
+	s.subscribeCacheInvalidationInternal(ctx, events.NetworkEventType, func() {
+		if s.networkCache != nil {
+			s.networkCache.Invalidate()
+		}
+	})
+	s.subscribeCacheInvalidationInternal(ctx, events.VolumeEventType, func() {
+		if s.volumeCache != nil {
+			s.volumeCache.Invalidate()
+		}
+	})
+}
+
+func (s *DockerClientService) subscribeCacheInvalidationInternal(ctx context.Context, eventType events.Type, invalidate func()) {
+	ch := make(chan events.Message, 16)
+	unsubscribe := s.EventBus().Subscribe(eventType, ch)
+	s.mu.Lock()
+	s.subscriptionUnsub = append(s.subscriptionUnsub, unsubscribe)
+	s.mu.Unlock()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				invalidate()
+			}
+		}
+	}()
+}
+
+func (s *DockerClientService) invalidateListCachesInternal() {
+	s.ensureListCachesInternal()
+	if s.containerCache != nil {
+		s.containerCache.Invalidate()
+	}
+	if s.imageCache != nil {
+		s.imageCache.Invalidate()
+	}
+	if s.networkCache != nil {
+		s.networkCache.Invalidate()
+	}
+	if s.volumeCache != nil {
+		s.volumeCache.Invalidate()
+	}
+}
+
+func (s *DockerClientService) WatchEvents(ctx context.Context) {
+	eventBackoff := backoff.NewExponentialBackOff()
+	eventBackoff.InitialInterval = 500 * time.Millisecond
+	eventBackoff.MaxInterval = 30 * time.Second
+
+	for ctx.Err() == nil {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to connect to Docker event stream", "error", err)
+			if !sleepDockerEventBackoffInternal(ctx, eventBackoff) {
+				return
+			}
+			continue
+		}
+
+		s.invalidateListCachesInternal()
+		eventBackoff.Reset()
+		result := dockerClient.Events(ctx, client.EventsListOptions{})
+		err = s.consumeEventsInternal(ctx, result.Messages, result.Err)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+			slog.WarnContext(ctx, "Docker event stream stopped", "error", err)
+		}
+		if !sleepDockerEventBackoffInternal(ctx, eventBackoff) {
+			return
+		}
+	}
+}
+
+func (s *DockerClientService) consumeEventsInternal(ctx context.Context, messages <-chan events.Message, errs <-chan error) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-messages:
+			if !ok {
+				return nil
+			}
+			s.EventBus().Publish(msg)
+		case err, ok := <-errs:
+			if !ok {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func sleepDockerEventBackoffInternal(ctx context.Context, eventBackoff *backoff.ExponentialBackOff) bool {
+	delay := eventBackoff.NextBackOff()
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (s *DockerClientService) listContainersInternal(ctx context.Context) ([]container.Summary, error) {
+	s.ensureListCachesInternal()
+	containerCache := s.containerCache
+	return containerCache.GetOrFetch(ctx, func(ctx context.Context) ([]container.Summary, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Docker: %w", err)
+		}
+
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+		defer cancel()
+
+		containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Docker containers: %w", err)
+		}
+		return containerList.Items, nil
+	})
+}
+
+func (s *DockerClientService) listImagesInternal(ctx context.Context) ([]image.Summary, error) {
+	s.ensureListCachesInternal()
+	imageCache := s.imageCache
+	return imageCache.GetOrFetch(ctx, func(ctx context.Context) ([]image.Summary, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Docker: %w", err)
+		}
+
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+		defer cancel()
+
+		imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Docker images: %w", err)
+		}
+		return imageList.Items, nil
+	})
+}
+
+func (s *DockerClientService) listNetworksInternal(ctx context.Context) ([]network.Summary, error) {
+	s.ensureListCachesInternal()
+	networkCache := s.networkCache
+	return networkCache.GetOrFetch(ctx, func(ctx context.Context) ([]network.Summary, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Docker: %w", err)
+		}
+
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+		defer cancel()
+
+		networkList, err := libarcane.NetworkListWithCompatibility(apiCtx, dockerClient, client.NetworkListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Docker networks: %w", err)
+		}
+		return networkList.Items, nil
+	})
+}
+
+func (s *DockerClientService) listVolumesInternal(ctx context.Context) (*client.VolumeListResult, error) {
+	s.ensureListCachesInternal()
+	volumeCache := s.volumeCache
+	return volumeCache.GetOrFetch(ctx, func(ctx context.Context) (*client.VolumeListResult, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to Docker: %w", err)
+		}
+
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+		defer cancel()
+
+		volResp, err := dockerClient.VolumeList(apiCtx, client.VolumeListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list Docker volumes: %w", err)
+		}
+		return &volResp, nil
+	})
+}
+
+func (s *DockerClientService) GetSnapshot(ctx context.Context, envID string) (*dashboardtypes.DockerSnapshot, error) {
+	g, groupCtx := errgroup.WithContext(ctx)
+
+	var containers []container.Summary
+	var images []image.Summary
+	var networks []network.Summary
+	var volumes *client.VolumeListResult
+
+	g.Go(func() error {
+		var err error
+		containers, err = s.listContainersInternal(groupCtx)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		images, err = s.listImagesInternal(groupCtx)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		networks, err = s.listNetworksInternal(groupCtx)
+		if err != nil {
+			slog.WarnContext(groupCtx, "failed to list Docker networks for snapshot", "error", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		volumes, err = s.listVolumesInternal(groupCtx)
+		if err != nil {
+			slog.WarnContext(groupCtx, "failed to list Docker volumes for snapshot", "error", err)
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &dashboardtypes.DockerSnapshot{
+		Containers: containers,
+		Images:     images,
+		Networks:   networks,
+		Volumes:    volumes,
+	}, nil
+}
+
 func (s *DockerClientService) GetAllContainers(ctx context.Context) ([]container.Summary, int, int, int, error) {
-	dockerClient, err := s.GetClient(ctx)
+	containers, err := s.listContainersInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to connect to Docker: %w", err)
+		return nil, 0, 0, 0, err
 	}
-
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker containers: %w", err)
-	}
-	containers := containerList.Items
 
 	var running, stopped, total int
 	for _, c := range containers {
@@ -210,26 +521,15 @@ func (s *DockerClientService) GetAllContainers(ctx context.Context) ([]container
 }
 
 func (s *DockerClientService) GetAllImages(ctx context.Context) ([]image.Summary, int, int, int, error) {
-	dockerClient, err := s.GetClient(ctx)
+	images, err := s.listImagesInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to connect to Docker: %w", err)
+		return nil, 0, 0, 0, err
 	}
 
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
+	containers, err := s.listContainersInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker images: %w", err)
+		return nil, 0, 0, 0, err
 	}
-	images := imageList.Items
-
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker containers: %w", err)
-	}
-	containers := containerList.Items
 
 	inuse, unused, total := countImageUsageInternal(images, containers)
 
@@ -258,20 +558,10 @@ func countImageUsageInternal(images []image.Summary, containers []container.Summ
 }
 
 func (s *DockerClientService) GetAllNetworks(ctx context.Context) (_ []network.Summary, inuseNetworks int, unusedNetworks int, totalNetworks int, error error) {
-	dockerClient, err := s.GetClient(ctx)
+	containers, err := s.listContainersInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to connect to Docker: %w", err)
+		return nil, 0, 0, 0, err
 	}
-
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker containers: %w", err)
-	}
-	containers := containerList.Items
 	inUseByID := make(map[string]bool)
 	inUseByName := make(map[string]bool)
 	for _, c := range containers {
@@ -286,11 +576,10 @@ func (s *DockerClientService) GetAllNetworks(ctx context.Context) (_ []network.S
 		}
 	}
 
-	networkList, err := libarcane.NetworkListWithCompatibility(apiCtx, dockerClient, client.NetworkListOptions{})
+	networks, err := s.listNetworksInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker networks: %w", err)
+		return nil, 0, 0, 0, err
 	}
-	networks := networkList.Items
 
 	var inuse, unused, total int
 	for _, n := range networks {
@@ -312,20 +601,10 @@ func (s *DockerClientService) GetAllNetworks(ctx context.Context) (_ []network.S
 }
 
 func (s *DockerClientService) GetAllVolumes(ctx context.Context) ([]*volume.Volume, int, int, int, error) {
-	dockerClient, err := s.GetClient(ctx)
+	containers, err := s.listContainersInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to connect to Docker: %w", err)
+		return nil, 0, 0, 0, err
 	}
-
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
-	defer cancel()
-
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker containers: %w", err)
-	}
-	containers := containerList.Items
 	ref := make(map[string]int64, len(containers))
 	for _, c := range containers {
 		for _, m := range c.Mounts {
@@ -335,9 +614,9 @@ func (s *DockerClientService) GetAllVolumes(ctx context.Context) ([]*volume.Volu
 		}
 	}
 
-	volResp, err := dockerClient.VolumeList(apiCtx, client.VolumeListOptions{})
+	volResp, err := s.listVolumesInternal(ctx)
 	if err != nil {
-		return nil, 0, 0, 0, fmt.Errorf("failed to list Docker volumes: %w", err)
+		return nil, 0, 0, 0, err
 	}
 	volumeItems := volResp.Items
 	volumes := make([]*volume.Volume, 0, len(volumeItems))

--- a/backend/internal/services/docker_client_service_test.go
+++ b/backend/internal/services/docker_client_service_test.go
@@ -197,7 +197,7 @@ func TestCountImageUsage_NoImages(t *testing.T) {
 }
 
 func newDockerClientServiceForTestInternal(host string) *DockerClientService {
-	return NewDockerClientService(nil, &config.Config{DockerHost: host}, nil)
+	return NewDockerClientService(context.Background(), nil, &config.Config{DockerHost: host}, nil)
 }
 
 func newDockerPingTestServerInternal(t *testing.T, apiVersion string) *httptest.Server {

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/gitops"
+	projecttypes "github.com/getarcaneapp/arcane/types/project"
 	"github.com/getarcaneapp/arcane/types/swarm"
 	"gorm.io/gorm"
 )
@@ -672,7 +673,7 @@ func (s *GitOpsSyncService) performSwarmStackSyncInternal(ctx context.Context, s
 // redeployIfRunningAfterSync redeploys a project only when it is already
 // running and the latest sync actually changed managed content.
 func (s *GitOpsSyncService) redeployIfRunningAfterSync(ctx context.Context, project *models.Project, actor models.User, syncMode string) {
-	details, err := s.projectService.GetProjectDetails(ctx, project.ID)
+	details, err := s.projectService.GetProjectDetails(ctx, project.ID, projecttypes.AllDetails())
 	if err != nil {
 		return
 	}
@@ -990,7 +991,7 @@ func (s *GitOpsSyncService) updateProjectForSyncInternal(ctx context.Context, sy
 
 	// If content changed and project is running, redeploy
 	if contentChanged {
-		details, err := s.projectService.GetProjectDetails(ctx, project.ID)
+		details, err := s.projectService.GetProjectDetails(ctx, project.ID, projecttypes.AllDetails())
 		if err == nil && (details.Status == string(models.ProjectStatusRunning) || details.Status == string(models.ProjectStatusPartiallyRunning)) {
 			slog.InfoContext(ctx, "Redeploying project due to content change from Git sync", "projectName", project.Name, "projectId", project.ID)
 			if err := s.projectService.RedeployProject(ctx, project.ID, actor); err != nil {

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -621,6 +621,9 @@ func TestGitOpsSyncService_GetEffectiveSyncLimits(t *testing.T) {
 		t.Setenv("GIT_SYNC_MAX_FILES", "10000")
 		t.Setenv("GIT_SYNC_MAX_TOTAL_SIZE_MB", "1024")
 		t.Setenv("GIT_SYNC_MAX_BINARY_SIZE_MB", "12")
+		settingsSvcEnv, svcErr := NewSettingsService(ctx, db)
+		require.NoError(t, svcErr)
+		svcEnv := &GitOpsSyncService{settingsService: settingsSvcEnv}
 
 		sync := &models.GitOpsSync{
 			MaxSyncFiles:      500,
@@ -628,7 +631,7 @@ func TestGitOpsSyncService_GetEffectiveSyncLimits(t *testing.T) {
 			MaxSyncBinarySize: 10 * 1024 * 1024,
 		}
 
-		maxFiles, maxTotalSize, maxBinarySize := svc.getEffectiveSyncLimits(ctx, sync)
+		maxFiles, maxTotalSize, maxBinarySize := svcEnv.getEffectiveSyncLimits(ctx, sync)
 
 		require.Equal(t, 10000, maxFiles)
 		require.Equal(t, int64(1024*1024*1024), maxTotalSize)
@@ -639,6 +642,9 @@ func TestGitOpsSyncService_GetEffectiveSyncLimits(t *testing.T) {
 		t.Setenv("GIT_SYNC_MAX_FILES", "0")
 		t.Setenv("GIT_SYNC_MAX_TOTAL_SIZE_MB", "0")
 		t.Setenv("GIT_SYNC_MAX_BINARY_SIZE_MB", "0")
+		settingsSvcEnv, svcErr := NewSettingsService(ctx, db)
+		require.NoError(t, svcErr)
+		svcEnv := &GitOpsSyncService{settingsService: settingsSvcEnv}
 
 		sync := &models.GitOpsSync{
 			MaxSyncFiles:      75,
@@ -646,7 +652,7 @@ func TestGitOpsSyncService_GetEffectiveSyncLimits(t *testing.T) {
 			MaxSyncBinarySize: 2 * 1024 * 1024,
 		}
 
-		maxFiles, maxTotalSize, maxBinarySize := svc.getEffectiveSyncLimits(ctx, sync)
+		maxFiles, maxTotalSize, maxBinarySize := svcEnv.getEffectiveSyncLimits(ctx, sync)
 
 		require.Equal(t, 0, maxFiles)
 		require.Equal(t, int64(0), maxTotalSize)

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +30,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils/cache"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types"
 	"github.com/getarcaneapp/arcane/types/containerregistry"
@@ -49,6 +51,14 @@ type ProjectService struct {
 
 	composeNameCacheMu  sync.RWMutex
 	composeNameToProjID map[string]string
+	composeCache        *cache.KeyedCache[string, composeCacheEntry]
+}
+
+type composeCacheEntry struct {
+	composePath   string
+	composeMtime  time.Time
+	includeMtimes map[string]time.Time
+	project       *composetypes.Project
 }
 
 func NewProjectService(db *database.DB, settingsService *SettingsService, eventService *EventService, imageService *ImageService, dockerService *DockerClientService, buildService *BuildService, cfg *config.Config) *ProjectService {
@@ -60,6 +70,7 @@ func NewProjectService(db *database.DB, settingsService *SettingsService, eventS
 		dockerService:   dockerService,
 		buildService:    buildService,
 		config:          cfg,
+		composeCache:    cache.NewKeyed[string, composeCacheEntry](),
 	}
 }
 
@@ -446,13 +457,15 @@ func (s *ProjectService) resolveProjectComposeFileInternal(ctx context.Context, 
 	return composeFile, nil
 }
 
-func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Context, proj *models.Project) (*composetypes.Project, string, error) {
+func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Context, proj *models.Project, cfg *models.Settings) (*composetypes.Project, string, error) {
 	composeFileFullPath, err := s.resolveProjectComposeFileInternal(ctx, proj)
 	if err != nil {
 		return nil, "", err
 	}
 
-	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
+	if cfg == nil {
+		cfg = s.settingsService.GetSettingsOrDefaults(ctx)
+	}
 	projectsDirectory, pdErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 	if pdErr != nil {
 		slog.WarnContext(ctx, "unable to determine projects directory; using default", "error", pdErr)
@@ -470,6 +483,164 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 	}
 
 	return composeProject, composeFileFullPath, nil
+}
+
+func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, proj *models.Project, cfg *models.Settings) (*composetypes.Project, string, error) {
+	if proj == nil {
+		return nil, "", fmt.Errorf("project is nil")
+	}
+	if s.composeCache == nil {
+		s.composeCache = cache.NewKeyed[string, composeCacheEntry]()
+	}
+
+	entry, err := s.composeCache.GetOrFetch(ctx, proj.ID, validComposeCacheEntryInternal, func(ctx context.Context) (composeCacheEntry, error) {
+		composeProject, composePath, err := s.loadComposeProjectForProjectInternal(ctx, proj, cfg)
+		if err != nil {
+			return composeCacheEntry{}, err
+		}
+
+		entry := composeCacheEntry{
+			composePath:   composePath,
+			includeMtimes: make(map[string]time.Time),
+			project:       composeProject,
+		}
+		if info, statErr := os.Stat(composePath); statErr == nil {
+			entry.composeMtime = info.ModTime()
+		} else {
+			return composeCacheEntry{}, fmt.Errorf("stat compose file: %w", statErr)
+		}
+		if composeProject != nil {
+			for _, composeFile := range composeProject.ComposeFiles {
+				if composeFile == "" || composeFile == composePath {
+					continue
+				}
+				info, statErr := os.Stat(composeFile)
+				if statErr != nil {
+					return composeCacheEntry{}, fmt.Errorf("stat compose include %s: %w", composeFile, statErr)
+				}
+				entry.includeMtimes[composeFile] = info.ModTime()
+			}
+		}
+
+		return entry, nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return entry.project, entry.composePath, nil
+}
+
+func validComposeCacheEntryInternal(entry composeCacheEntry) bool {
+	if entry.project == nil || entry.composePath == "" {
+		return false
+	}
+
+	info, err := os.Stat(entry.composePath)
+	if err != nil || !info.ModTime().Equal(entry.composeMtime) {
+		return false
+	}
+	for includePath, cachedMtime := range entry.includeMtimes {
+		info, err := os.Stat(includePath)
+		if err != nil || !info.ModTime().Equal(cachedMtime) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *ProjectService) invalidateComposeCacheInternal(projectID string) {
+	if s.composeCache == nil || strings.TrimSpace(projectID) == "" {
+		return
+	}
+	s.composeCache.Invalidate(projectID)
+}
+
+func (s *ProjectService) refreshProjectImageRefsInternal(ctx context.Context, proj *models.Project) {
+	if proj == nil || proj.ID == "" {
+		return
+	}
+
+	s.invalidateComposeCacheInternal(proj.ID)
+	refs, err := s.getProjectImageRefsFromComposeInternal(ctx, *proj, nil)
+	if err != nil {
+		if dbErr := s.db.WithContext(ctx).
+			Model(&models.Project{}).
+			Where("id = ?", proj.ID).
+			Update("image_refs_json", "").Error; dbErr != nil {
+			slog.WarnContext(ctx, "failed to clear stale project image refs", "projectID", proj.ID, "error", dbErr)
+		}
+		proj.ImageRefsJSON = ""
+		slog.WarnContext(ctx, "failed to refresh project image refs", "projectID", proj.ID, "projectName", proj.Name, "error", err)
+		return
+	}
+	imageRefsJSON := marshalProjectImageRefsJSONInternal(refs)
+	if err := s.db.WithContext(ctx).
+		Model(&models.Project{}).
+		Where("id = ?", proj.ID).
+		Update("image_refs_json", imageRefsJSON).Error; err != nil {
+		slog.WarnContext(ctx, "failed to persist project image refs", "projectID", proj.ID, "error", err)
+		return
+	}
+	proj.ImageRefsJSON = imageRefsJSON
+}
+
+func (s *ProjectService) HandleProjectFilesChanged(ctx context.Context, paths []string) {
+	if len(paths) == 0 || s.db == nil {
+		return
+	}
+
+	affected, err := s.resolveProjectsByChangedPathsInternal(ctx, paths)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve changed project files", "error", err)
+		return
+	}
+	for i := range affected {
+		s.invalidateComposeCacheInternal(affected[i].ID)
+		s.refreshProjectImageRefsInternal(ctx, &affected[i])
+	}
+}
+
+func (s *ProjectService) BackfillProjectImageRefs(ctx context.Context) {
+	if s.db == nil {
+		return
+	}
+
+	var projectsList []models.Project
+	if err := s.db.WithContext(ctx).
+		Where("image_refs_json = '' OR image_refs_json IS NULL").
+		Find(&projectsList).Error; err != nil {
+		slog.WarnContext(ctx, "failed to list projects for image ref backfill", "error", err)
+		return
+	}
+	for i := range projectsList {
+		s.refreshProjectImageRefsInternal(ctx, &projectsList[i])
+	}
+}
+
+func (s *ProjectService) resolveProjectsByChangedPathsInternal(ctx context.Context, paths []string) ([]models.Project, error) {
+	var projectsList []models.Project
+	if err := s.db.WithContext(ctx).Find(&projectsList).Error; err != nil {
+		return nil, fmt.Errorf("list projects for changed paths: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	affected := make([]models.Project, 0)
+	for _, changedPath := range paths {
+		cleanChangedPath := filepath.Clean(changedPath)
+		for _, proj := range projectsList {
+			projectPath := filepath.Clean(proj.Path)
+			if cleanChangedPath != projectPath && !strings.HasPrefix(cleanChangedPath, projectPath+string(os.PathSeparator)) {
+				continue
+			}
+			if _, ok := seen[proj.ID]; ok {
+				continue
+			}
+			seen[proj.ID] = struct{}{}
+			affected = append(affected, proj)
+		}
+	}
+	return affected, nil
 }
 
 func buildSelectedProjectImageRefsInternal(compProj *composetypes.Project, servicesToUpdate []string) []string {
@@ -557,7 +728,7 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 	}
 
 	// 1. Load project
-	compProj, _, err := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
+	compProj, _, err := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if err != nil {
 		return fmt.Errorf("failed to load compose project: %w", err)
 	}
@@ -655,7 +826,7 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 		return nil, err
 	}
 
-	composeProject, composeFileFullPath, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
+	composeProject, composeFileFullPath, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if derr != nil {
 		return []ProjectServiceInfo{}, fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
@@ -744,35 +915,22 @@ func (s *ProjectService) GetProjectContent(ctx context.Context, projectID string
 	return projects.ReadProjectFiles(proj.Path, composePath)
 }
 
-func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string) (project.Details, error) {
+func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string, opts project.DetailsOptions) (project.Details, error) {
 	proj, err := s.GetProjectFromDatabaseByID(ctx, projectID)
 	if err != nil {
 		return project.Details{}, err
 	}
 	projectsDir, _ := s.getProjectsDirectoryInternal(ctx)
 
-	composeContent, _, _ := s.GetProjectContent(ctx, projectID)
-	envState, err := projects.ReadProjectEnvState(proj.Path)
-	if err != nil {
-		return project.Details{}, fmt.Errorf("failed to read project env state: %w", err)
-	}
-
 	var resp project.Details
 	if err := mapper.MapStruct(proj, &resp); err != nil {
 		return project.Details{}, fmt.Errorf("failed to map project: %w", err)
-	}
-
-	effectiveEnvContent, err := s.resolveStoredEffectiveEnvContentInternal(envState)
-	if err != nil {
-		return project.Details{}, err
 	}
 
 	resp.CreatedAt = proj.CreatedAt.Format(time.RFC3339)
 	resp.UpdatedAt = proj.UpdatedAt.Format(time.RFC3339)
 	resp.IsArchived = proj.IsArchived
 	resp.ArchivedAt = proj.ArchivedAt
-	resp.ComposeContent = composeContent
-	resp.EnvContent = effectiveEnvContent
 	resp.HasBuildDirective = false
 	resp.DirName = utils.DerefString(proj.DirName)
 	resp.RelativePath = s.getProjectRelativePathInternal(projectsDir, proj.Path)
@@ -786,46 +944,72 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 	resp.RunningCount = proj.RunningCount
 	resp.Status = string(proj.Status)
 
+	if opts.IncludeComposeContent {
+		composeContent, _, _ := s.GetProjectContent(ctx, projectID)
+		resp.ComposeContent = composeContent
+	}
+	if opts.IncludeEnvState {
+		envState, err := projects.ReadProjectEnvState(proj.Path)
+		if err != nil {
+			return project.Details{}, fmt.Errorf("failed to read project env state: %w", err)
+		}
+		effectiveEnvContent, err := s.resolveStoredEffectiveEnvContentInternal(envState)
+		if err != nil {
+			return project.Details{}, err
+		}
+		resp.EnvContent = effectiveEnvContent
+	}
+
 	// Enrich with details
 	composeFile, composeFileErr := s.resolveProjectComposeFileInternal(ctx, proj)
 	if composeFileErr == nil {
 		resp.ComposeFileName = filepath.Base(composeFile)
-		s.enrichWithIncludeFiles(ctx, composeFile, &resp)
-		s.enrichWithComposeServiceConfigs(ctx, proj, composeFile, &resp)
+		if opts.IncludeIncludeFiles {
+			s.enrichWithIncludeFiles(ctx, composeFile, &resp)
+		}
+		if opts.IncludeServiceConfigs {
+			s.enrichWithComposeServiceConfigs(ctx, proj, composeFile, &resp)
+		}
 	}
-	s.enrichWithDirectoryFiles(ctx, proj.Path, &resp)
+	if opts.IncludeDirectoryFiles {
+		s.enrichWithDirectoryFiles(ctx, proj.Path, &resp)
+	}
 	s.enrichWithGitOpsInfo(ctx, proj, &resp)
 
 	// Get runtime services and update status/counts
-	services, serr := s.GetProjectServices(ctx, projectID)
-	if serr == nil && services != nil {
-		resp.ServiceCount = len(services)
-		_, runningCount := s.getServiceCounts(services)
-		resp.RunningCount = runningCount
-		resp.Status = string(s.calculateProjectStatus(services))
+	if opts.IncludeRuntimeServices {
+		services, serr := s.GetProjectServices(ctx, projectID)
+		if serr == nil && services != nil {
+			resp.ServiceCount = len(services)
+			_, runningCount := s.getServiceCounts(services)
+			resp.RunningCount = runningCount
+			resp.Status = string(s.calculateProjectStatus(services))
 
-		runtimeServices := make([]project.RuntimeService, len(services))
-		for i, svc := range services {
-			runtimeServices[i] = project.RuntimeService{
-				Name:             svc.Name,
-				Image:            svc.Image,
-				Status:           svc.Status,
-				ContainerID:      svc.ContainerID,
-				ContainerName:    svc.ContainerName,
-				Ports:            svc.Ports,
-				Health:           svc.Health,
-				IconURL:          svc.IconURL,
-				ServiceConfig:    svc.ServiceConfig,
-				RedeployDisabled: svc.RedeployDisabled,
+			runtimeServices := make([]project.RuntimeService, len(services))
+			for i, svc := range services {
+				runtimeServices[i] = project.RuntimeService{
+					Name:             svc.Name,
+					Image:            svc.Image,
+					Status:           svc.Status,
+					ContainerID:      svc.ContainerID,
+					ContainerName:    svc.ContainerName,
+					Ports:            svc.Ports,
+					Health:           svc.Health,
+					IconURL:          svc.IconURL,
+					ServiceConfig:    svc.ServiceConfig,
+					RedeployDisabled: svc.RedeployDisabled,
+				}
+				if svc.RedeployDisabled {
+					resp.RedeployDisabled = true
+				}
 			}
-			if svc.RedeployDisabled {
-				resp.RedeployDisabled = true
-			}
+			resp.RuntimeServices = runtimeServices
 		}
-		resp.RuntimeServices = runtimeServices
 	}
 
-	s.enrichProjectUpdateInfoInternal(ctx, &resp)
+	if opts.IncludeUpdateInfo {
+		s.enrichProjectUpdateInfoInternal(ctx, &resp)
+	}
 
 	return resp, nil
 }
@@ -954,6 +1138,29 @@ func (s *ProjectService) enrichProjectUpdateInfoInternal(ctx context.Context, re
 	resp.UpdateInfo = buildProjectUpdateInfoSummaryInternal(imageRefs, updateInfoByRef)
 }
 
+func parseProjectImageRefsJSONInternal(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var refs []string
+	if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+		return nil
+	}
+	return refs
+}
+
+func marshalProjectImageRefsJSONInternal(refs []string) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(refs)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	ctx context.Context,
 	projectsList []models.Project,
@@ -965,6 +1172,7 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 
 	imageRefsByProjectID := make(map[string][]string, len(projectsList))
 	allImageRefs := make([]string, 0)
+	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
 
 	const maxConcurrentComposeReads = 8
 	type imageRefsResult struct {
@@ -977,6 +1185,12 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 
 	var wg sync.WaitGroup
 	for _, proj := range projectsList {
+		if refs := parseProjectImageRefsJSONInternal(proj.ImageRefsJSON); len(refs) > 0 {
+			imageRefsByProjectID[proj.ID] = refs
+			allImageRefs = append(allImageRefs, refs...)
+			continue
+		}
+
 		wg.Add(1)
 		go func(proj models.Project) {
 			defer wg.Done()
@@ -988,7 +1202,7 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 			}
 			defer func() { <-sem }()
 
-			refs, err := s.getProjectImageRefsFromComposeInternal(ctx, proj)
+			refs, err := s.getProjectImageRefsFromComposeInternal(ctx, proj, cfg)
 			if err != nil {
 				slog.WarnContext(ctx, "failed to resolve project image refs for update summary", "projectID", proj.ID, "projectName", proj.Name, "error", err)
 				return
@@ -1021,28 +1235,10 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	}
 }
 
-func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project) ([]string, error) {
-	projectsDir, err := s.getProjectsDirectoryInternal(ctx)
+func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project, cfg *models.Settings) ([]string, error) {
+	composeProject, _, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
 	if err != nil {
-		return nil, err
-	}
-
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper while resolving project image refs", "projectID", proj.ID, "projectName", proj.Name, "error", pmErr)
-	}
-
-	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
-	composeProject, _, loadErr := projects.LoadComposeProjectFromDir(
-		ctx,
-		proj.Path,
-		normalizeComposeProjectName(proj.Name),
-		projectsDir,
-		autoInjectEnv,
-		pathMapper,
-	)
-	if loadErr != nil {
-		return nil, fmt.Errorf("load compose project: %w", loadErr)
+		return nil, fmt.Errorf("load compose project: %w", err)
 	}
 
 	return buildProjectImageRefsFromComposeServicesInternal(composeProject.Services), nil
@@ -1194,15 +1390,7 @@ func (s *ProjectService) enrichWithGitOpsInfo(ctx context.Context, proj *models.
 }
 
 func (s *ProjectService) enrichWithComposeServiceConfigs(ctx context.Context, proj *models.Project, composeFile string, resp *project.Details) {
-	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
-	projectsDirectory, _ := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
-
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
-
-	composeProj, loadErr := projects.LoadComposeProject(ctx, composeFile, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
+	composeProj, _, loadErr := s.getCachedComposeProjectInternal(ctx, proj, nil)
 	if loadErr != nil {
 		slog.WarnContext(ctx, "failed to load compose service configs", "path", composeFile, "error", loadErr)
 		return
@@ -1615,7 +1803,7 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		resolvedPullPolicy = "missing"
 	}
 
-	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
+	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if derr != nil {
 		return fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
@@ -1671,7 +1859,7 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 		return err
 	}
 
-	proj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
+	proj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if lerr != nil {
 		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return fmt.Errorf("failed to load compose project: %w", lerr)
@@ -1730,6 +1918,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent
 		_ = s.db.WithContext(ctx).Delete(proj).Error
 		return nil, fmt.Errorf("failed to save project files: %w", err)
 	}
+	s.refreshProjectImageRefsInternal(ctx, proj)
 
 	metadata := models.JSON{"action": "create", "projectID": proj.ID, "projectName": name, "path": projectPath}
 	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectCreate, proj.ID, name, user.ID, user.Username, "0", metadata); logErr != nil {
@@ -1761,7 +1950,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 	}
 
 	if removeVolumes {
-		if compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj); lerr == nil {
+		if compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj, nil); lerr == nil {
 			if derr := projects.ComposeDown(ctx, compProj, true); derr != nil {
 				slog.WarnContext(ctx, "failed to remove volumes", "error", derr)
 			}
@@ -1784,6 +1973,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 	if err := s.db.WithContext(ctx).Delete(proj).Error; err != nil {
 		return fmt.Errorf("failed to delete project from database: %w", err)
 	}
+	s.invalidateComposeCacheInternal(projectID)
 
 	metadata := models.JSON{"action": "destroy", "projectID": projectID, "projectName": proj.Name, "removeFiles": removeFiles, "removeVolumes": removeVolumes}
 	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectDelete, projectID, proj.Name, user.ID, user.Username, "0", metadata); logErr != nil {
@@ -1856,7 +2046,7 @@ func (s *ProjectService) PullProjectImages(ctx context.Context, projectID string
 		return err
 	}
 
-	compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj)
+	compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj, nil)
 	if lerr != nil {
 		return fmt.Errorf("failed to load compose project: %w", lerr)
 	}
@@ -1890,7 +2080,7 @@ func (s *ProjectService) BuildProjectServices(ctx context.Context, projectID str
 		return err
 	}
 
-	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb)
+	project, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if derr != nil {
 		return fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
@@ -1912,7 +2102,7 @@ func (s *ProjectService) EnsureProjectImagesPresent(ctx context.Context, project
 		return err
 	}
 
-	compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj)
+	compProj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, proj, nil)
 	if lerr != nil {
 		return fmt.Errorf("failed to load compose project: %w", lerr)
 	}
@@ -2570,6 +2760,7 @@ func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, na
 	// When compose content changes, recalculate service counts and status so the
 	// overview doesn't show stale values (e.g. ghost services after removal).
 	if composeContent != nil {
+		s.refreshProjectImageRefsInternal(ctx, &proj)
 		if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
 			slog.WarnContext(ctx, "failed to update service counts after compose edit", "projectID", proj.ID, "error", err)
 		}
@@ -2621,6 +2812,7 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 	if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
 		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
+	s.refreshProjectImageRefsInternal(ctx, &proj)
 
 	// Recalculate service counts and status after compose file sync
 	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
@@ -3211,6 +3403,7 @@ func (s *ProjectService) UpdateProjectIncludeFile(ctx context.Context, projectID
 	if err := projects.WriteIncludeFile(proj.Path, relativePath, content); err != nil {
 		return fmt.Errorf("failed to update include file: %w", err)
 	}
+	s.refreshProjectImageRefsInternal(ctx, proj)
 
 	// Recalculate service counts since include files can define services
 	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
@@ -4006,7 +4199,7 @@ func (s *ProjectService) getProjectMetadataForProject(ctx context.Context, p mod
 // End Table Functions
 
 func (s *ProjectService) countServicesFromCompose(ctx context.Context, p models.Project) (int, error) {
-	proj, _, err := s.loadComposeProjectForProjectInternal(ctx, &p)
+	proj, _, err := s.loadComposeProjectForProjectInternal(ctx, &p, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	buildtypes "github.com/getarcaneapp/arcane/types/builds"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
+	projecttypes "github.com/getarcaneapp/arcane/types/project"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
@@ -1145,7 +1146,7 @@ services:
 	includePath := filepath.Join(projectPath, "metadata.yaml")
 	assert.NoFileExists(t, includePath)
 
-	details, err := svc.GetProjectDetails(ctx, project.ID)
+	details, err := svc.GetProjectDetails(ctx, project.ID, projecttypes.AllDetails())
 	require.NoError(t, err)
 	require.Len(t, details.IncludeFiles, 1)
 	assert.Equal(t, "metadata.yaml", details.IncludeFiles[0].RelativePath)
@@ -1839,7 +1840,7 @@ func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.
 	}
 	require.NoError(t, db.Create(project).Error)
 
-	details, err := svc.GetProjectDetails(ctx, project.ID)
+	details, err := svc.GetProjectDetails(ctx, project.ID, projecttypes.AllDetails())
 	require.NoError(t, err)
 	assert.Equal(t, "BASE=git\nTOKEN=secret\n", details.EnvContent)
 }
@@ -1971,7 +1972,7 @@ func TestProjectService_GetProjectDetails_IncludesUpdateInfo(t *testing.T) {
 		CheckTime:      time.Now().UTC(),
 	}).Error)
 
-	details, err := svc.GetProjectDetails(ctx, projectRecord.ID)
+	details, err := svc.GetProjectDetails(ctx, projectRecord.ID, projecttypes.AllDetails())
 	require.NoError(t, err)
 	require.NotNil(t, details.UpdateInfo)
 	assert.Equal(t, "has_update", details.UpdateInfo.Status)
@@ -3304,7 +3305,7 @@ func TestProjectService_GetProjectDetails_UsesGitOpsCustomComposeFilename(t *tes
 	assert.Equal(t, composeContent, composeFromContent)
 	assert.Equal(t, "TZ=UTC\n", envFromContent)
 
-	details, err := svc.GetProjectDetails(ctx, syncProjectID)
+	details, err := svc.GetProjectDetails(ctx, syncProjectID, projecttypes.AllDetails())
 	require.NoError(t, err)
 	assert.Equal(t, "radarr.yaml", details.ComposeFileName)
 	assert.Equal(t, composeContent, details.ComposeContent)

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -30,8 +30,9 @@ import (
 )
 
 type SettingsService struct {
-	db     *database.DB
-	config atomic.Pointer[models.Settings]
+	db           *database.DB
+	config       atomic.Pointer[models.Settings]
+	envOverrides []settingsEnvOverride
 
 	OnImagePollingSettingsChanged      func(ctx context.Context)
 	OnAutoUpdateSettingsChanged        func(ctx context.Context)
@@ -42,9 +43,20 @@ type SettingsService struct {
 	OnTimeoutSettingsChanged           func(ctx context.Context, timeoutSettings []libarcane.SettingUpdate)
 }
 
+type settingsEnvOverride struct {
+	fieldIndex int
+	key        string
+	envVarName string
+	value      string
+}
+
 func NewSettingsService(ctx context.Context, db *database.DB) (*SettingsService, error) {
 	svc := &SettingsService{
 		db: db,
+	}
+	svc.envOverrides = resolveSettingsEnvOverridesInternal()
+	if len(svc.envOverrides) > 0 {
+		slog.InfoContext(ctx, "settings env overrides loaded", "count", len(svc.envOverrides))
 	}
 
 	err := svc.LoadDatabaseSettings(ctx)
@@ -449,8 +461,17 @@ func (s *SettingsService) loadDatabaseConfigFromEnv(ctx context.Context, db *dat
 }
 
 func (s *SettingsService) applyEnvOverrides(ctx context.Context, dest *models.Settings) {
-	rt := reflect.ValueOf(dest).Elem().Type()
+	_ = ctx
 	rv := reflect.ValueOf(dest).Elem()
+
+	for _, override := range s.envOverrides {
+		rv.Field(override.fieldIndex).FieldByName("Value").SetString(override.value)
+	}
+}
+
+func resolveSettingsEnvOverridesInternal() []settingsEnvOverride {
+	rt := reflect.TypeFor[models.Settings]()
+	overrides := make([]settingsEnvOverride, 0)
 
 	for i := range rt.NumField() {
 		field := rt.Field(i)
@@ -468,37 +489,27 @@ func (s *SettingsService) applyEnvOverrides(ctx context.Context, dest *models.Se
 			continue
 		}
 
-		// Check if environment variable is set
 		envVarName := utils.CamelCaseToScreamingSnakeCase(key)
 		if val, ok := os.LookupEnv(envVarName); ok && val != "" {
-			slog.DebugContext(ctx, "applyEnvOverrides: applying env override", "key", key, "env", envVarName)
-			rv.Field(i).FieldByName("Value").SetString(utils.TrimQuotes(val))
+			overrides = append(overrides, settingsEnvOverride{
+				fieldIndex: i,
+				key:        key,
+				envVarName: envVarName,
+				value:      utils.TrimQuotes(val),
+			})
 		}
 	}
+
+	return overrides
 }
 
 // isEnvOverrideActiveInternal returns true when the given setting key has an envOverride tag
 // and its corresponding environment variable is currently set to a non-empty value.
 func (s *SettingsService) isEnvOverrideActiveInternal(key string) bool {
-	rt := reflect.TypeFor[models.Settings]()
-	for field := range rt.Fields() {
-		tagValue := field.Tag.Get("key")
-		if tagValue == "" {
-			continue
+	for _, override := range s.envOverrides {
+		if override.key == key {
+			return true
 		}
-
-		tagParts := strings.Split(tagValue, ",")
-		if len(tagParts) == 0 || tagParts[0] != key {
-			continue
-		}
-
-		if !slices.Contains(tagParts[1:], "envOverride") {
-			return false
-		}
-
-		envVarName := utils.CamelCaseToScreamingSnakeCase(key)
-		val, ok := os.LookupEnv(envVarName)
-		return ok && val != ""
 	}
 
 	return false

--- a/backend/internal/services/settings_service_test.go
+++ b/backend/internal/services/settings_service_test.go
@@ -231,160 +231,123 @@ func TestSettingsService_PruneUnknownSettings_RemovesStaleKeys(t *testing.T) {
 func TestSettingsService_GetSettings_EnvOverride_OidcMergeAccounts(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("OIDC_MERGE_ACCOUNTS", "true")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	// Default in DB is false
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.False(t, settings1.OidcMergeAccounts.IsTrue())
-
-	// Env override should take precedence
-	t.Setenv("OIDC_MERGE_ACCOUNTS", "true")
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.True(t, settings2.OidcMergeAccounts.IsTrue())
+	require.True(t, settings.OidcMergeAccounts.IsTrue())
 }
 
 func TestSettingsService_GetSettings_EnvOverride_TrivyScanTimeout(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("TRIVY_SCAN_TIMEOUT", "1800")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 900, settings1.TrivyScanTimeout.AsInt())
-
-	t.Setenv("TRIVY_SCAN_TIMEOUT", "1800")
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 1800, settings2.TrivyScanTimeout.AsInt())
+	require.Equal(t, 1800, settings.TrivyScanTimeout.AsInt())
 }
 
 func TestSettingsService_GetSettings_EnvOverride_TrivyResourceLimits(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("TRIVY_RESOURCE_LIMITS_ENABLED", "false")
+	t.Setenv("TRIVY_CPU_LIMIT", "2.5")
+	t.Setenv("TRIVY_MEMORY_LIMIT_MB", "2048")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.True(t, settings1.TrivyResourceLimitsEnabled.IsTrue())
-	require.Equal(t, "1", settings1.TrivyCpuLimit.Value)
-	require.Equal(t, 0, settings1.TrivyMemoryLimitMb.AsInt())
-
-	t.Setenv("TRIVY_RESOURCE_LIMITS_ENABLED", "false")
-	t.Setenv("TRIVY_CPU_LIMIT", "2.5")
-	t.Setenv("TRIVY_MEMORY_LIMIT_MB", "2048")
-
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.False(t, settings2.TrivyResourceLimitsEnabled.IsTrue())
-	require.Equal(t, "2.5", settings2.TrivyCpuLimit.Value)
-	require.Equal(t, 2048, settings2.TrivyMemoryLimitMb.AsInt())
+	require.False(t, settings.TrivyResourceLimitsEnabled.IsTrue())
+	require.Equal(t, "2.5", settings.TrivyCpuLimit.Value)
+	require.Equal(t, 2048, settings.TrivyMemoryLimitMb.AsInt())
 }
 
 func TestSettingsService_GetSettings_EnvOverride_TrivyNetwork(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("TRIVY_NETWORK", "arcane-external")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "", settings1.TrivyNetwork.Value)
-
-	t.Setenv("TRIVY_NETWORK", "arcane-external")
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "arcane-external", settings2.TrivyNetwork.Value)
+	require.Equal(t, "arcane-external", settings.TrivyNetwork.Value)
 }
 
 func TestSettingsService_GetSettings_EnvOverride_FollowProjectSymlinks(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("FOLLOW_PROJECT_SYMLINKS", "true")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.False(t, settings1.FollowProjectSymlinks.IsTrue())
-
-	t.Setenv("FOLLOW_PROJECT_SYMLINKS", "true")
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.True(t, settings2.FollowProjectSymlinks.IsTrue())
+	require.True(t, settings.FollowProjectSymlinks.IsTrue())
 }
 
 func TestSettingsService_GetSettings_EnvOverride_TrivyRuntimeSecurity(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("TRIVY_SECURITY_OPTS", "label=disable,\nlabel=type:container_runtime_t")
+	t.Setenv("TRIVY_PRIVILEGED", "true")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	settings1, err := svc.GetSettings(ctx)
+	settings, err := svc.GetSettings(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "", settings1.TrivySecurityOpts.Value)
-	require.False(t, settings1.TrivyPrivileged.IsTrue())
-
-	t.Setenv("TRIVY_SECURITY_OPTS", "label=disable,\nlabel=type:container_runtime_t")
-	t.Setenv("TRIVY_PRIVILEGED", "true")
-
-	settings2, err := svc.GetSettings(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "label=disable,\nlabel=type:container_runtime_t", settings2.TrivySecurityOpts.Value)
-	require.True(t, settings2.TrivyPrivileged.IsTrue())
+	require.Equal(t, "label=disable,\nlabel=type:container_runtime_t", settings.TrivySecurityOpts.Value)
+	require.True(t, settings.TrivyPrivileged.IsTrue())
 }
 
 func TestSettingsService_GetStringSetting_EnvOverride_SwarmStackSourcesDirectory(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("SWARM_STACK_SOURCES_DIRECTORY", "/mnt/swarm-from-env")
 
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.UpdateSetting(ctx, "swarmStackSourcesDirectory", "/tmp/swarm-from-db"))
 
-	require.Equal(t, "/tmp/swarm-from-db", svc.GetStringSetting(ctx, "swarmStackSourcesDirectory", "/fallback"))
-
-	t.Setenv("SWARM_STACK_SOURCES_DIRECTORY", "/mnt/swarm-from-env")
-
 	require.Equal(t, "/mnt/swarm-from-env", svc.GetStringSetting(ctx, "swarmStackSourcesDirectory", "/fallback"))
-	require.Equal(t, "/tmp/swarm-from-db", svc.GetSettingsConfig().SwarmStackSourcesDirectory.Value)
+	require.Equal(t, "/mnt/swarm-from-env", svc.GetSettingsConfig().SwarmStackSourcesDirectory.Value)
 }
 
 func TestSettingsService_isEnvOverrideActiveInternal(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
-
-	// Not set => not forced
 	require.False(t, svc.isEnvOverrideActiveInternal("oidcEnabled"))
 
-	// Explicit false still counts as active env override
 	t.Setenv("OIDC_ENABLED", "false")
-	require.True(t, svc.isEnvOverrideActiveInternal("oidcEnabled"))
+	svcWithOverride, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.True(t, svcWithOverride.isEnvOverrideActiveInternal("oidcEnabled"))
 
-	// Empty value should not be treated as active (matches applyEnvOverrides behavior)
-	t.Setenv("OIDC_ENABLED", "")
-	require.False(t, svc.isEnvOverrideActiveInternal("oidcEnabled"))
-
-	// Non-envOverride keys should never be forced via this helper
 	t.Setenv("AUTH_SESSION_TIMEOUT", "120")
-	require.False(t, svc.isEnvOverrideActiveInternal("authSessionTimeout"))
+	svcWithNonOverrideEnv, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.False(t, svcWithNonOverrideEnv.isEnvOverrideActiveInternal("authSessionTimeout"))
 }
 
 func TestSettingsService_GetSetHelpers(t *testing.T) {
@@ -608,11 +571,12 @@ func TestSettingsService_LoadDatabaseSettings_UIConfigurationDisabled_Env(t *tes
 func TestSettingsService_PersistEnvSettingsIfMissing_DoesNotOverrideForcedTrivyImage(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
+	t.Setenv("TRIVY_IMAGE", "ghcr.io/aquasecurity/trivy:latest")
+
 	svc, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, svc.EnsureDefaultSettings(ctx))
 
-	t.Setenv("TRIVY_IMAGE", "ghcr.io/aquasecurity/trivy:latest")
 	require.NoError(t, svc.PersistEnvSettingsIfMissing(ctx))
 
 	var sv models.SettingVariable

--- a/backend/internal/services/swarm_service_test.go
+++ b/backend/internal/services/swarm_service_test.go
@@ -78,11 +78,11 @@ func TestSwarmService_FetchSwarmNodeIdentityViaEdgeInternal_UsesEnvironmentAcces
 func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
-	settingsSvc, err := NewSettingsService(ctx, db)
-	require.NoError(t, err)
-
 	rootDir := t.TempDir()
 	t.Setenv("SWARM_STACK_SOURCES_DIRECTORY", rootDir)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
 
 	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
 

--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -21,10 +21,12 @@ type Watcher struct {
 	maxDepth       int
 	followSymlinks bool
 	onChange       func(ctx context.Context)
+	onChangePaths  func(ctx context.Context, paths []string)
 	debounce       time.Duration
 	stopCh         chan struct{}
 	stoppedCh      chan struct{}
 	watchAliases   map[string]string
+	pendingPaths   map[string]struct{}
 	mu             sync.Mutex
 	started        bool
 	stopped        bool
@@ -35,6 +37,7 @@ type Watcher struct {
 type WatcherOptions struct {
 	Debounce          time.Duration
 	OnChange          func(ctx context.Context)
+	OnChangePaths     func(ctx context.Context, paths []string)
 	MaxDepth          int
 	FollowSymlinkDirs bool
 }
@@ -59,10 +62,12 @@ func NewWatcher(watchPath string, opts WatcherOptions) (*Watcher, error) {
 		maxDepth:       opts.MaxDepth,
 		followSymlinks: opts.FollowSymlinkDirs,
 		onChange:       opts.OnChange,
+		onChangePaths:  opts.OnChangePaths,
 		debounce:       opts.Debounce,
 		stopCh:         make(chan struct{}),
 		stoppedCh:      make(chan struct{}),
 		watchAliases:   make(map[string]string),
+		pendingPaths:   make(map[string]struct{}),
 	}, nil
 }
 
@@ -167,6 +172,7 @@ func (fw *Watcher) processEventInternal(ctx context.Context, event fsnotify.Even
 	if !fw.shouldHandleEventInternal(event) {
 		return false
 	}
+	fw.recordPendingPathInternal(event.Name)
 	if !debounceTimer.Stop() {
 		select {
 		case <-debounceTimer.C:
@@ -193,7 +199,34 @@ func (fw *Watcher) fireDebounceInternal(ctx context.Context, debouncePending *bo
 	if fw.onChange != nil {
 		go fw.onChange(ctx)
 	}
+	if fw.onChangePaths != nil {
+		paths := fw.drainPendingPathsInternal()
+		if len(paths) > 0 {
+			go fw.onChangePaths(ctx, paths)
+		}
+	}
 	return false
+}
+
+func (fw *Watcher) recordPendingPathInternal(path string) {
+	if path == "" {
+		return
+	}
+	fw.mu.Lock()
+	fw.pendingPaths[filepath.Clean(path)] = struct{}{}
+	fw.mu.Unlock()
+}
+
+func (fw *Watcher) drainPendingPathsInternal() []string {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+
+	paths := make([]string, 0, len(fw.pendingPaths))
+	for path := range fw.pendingPaths {
+		paths = append(paths, path)
+		delete(fw.pendingPaths, path)
+	}
+	return paths
 }
 
 // handleEventInternal keeps the underlying fsnotify subscriptions in sync with

--- a/backend/pkg/libarcane/eventbus/docker_event_bus.go
+++ b/backend/pkg/libarcane/eventbus/docker_event_bus.go
@@ -1,0 +1,75 @@
+package eventbus
+
+import (
+	"sync"
+
+	"github.com/moby/moby/api/types/events"
+)
+
+// DockerEventBus is an in-process fan-out point for Docker daemon events.
+//
+// Publishers send the raw Docker event message once, and subscribers register by
+// Docker event type. Consumers should treat messages as invalidation signals
+// rather than authoritative state deltas; after receiving an event they should
+// refetch the resource state they own.
+type DockerEventBus struct {
+	mu   sync.RWMutex
+	subs map[events.Type]map[chan<- events.Message]struct{}
+}
+
+// NewDockerEventBus creates an empty Docker event bus.
+func NewDockerEventBus() *DockerEventBus {
+	return &DockerEventBus{
+		subs: make(map[events.Type]map[chan<- events.Message]struct{}),
+	}
+}
+
+// Subscribe registers ch for messages of eventType and returns a cancellation
+// function that removes the subscription. Delivery is non-blocking, so callers
+// should use a buffered channel sized for their invalidation workload.
+func (b *DockerEventBus) Subscribe(eventType events.Type, ch chan<- events.Message) func() {
+	if b == nil || ch == nil {
+		return func() {}
+	}
+
+	b.mu.Lock()
+	if b.subs[eventType] == nil {
+		b.subs[eventType] = make(map[chan<- events.Message]struct{})
+	}
+	b.subs[eventType][ch] = struct{}{}
+	b.mu.Unlock()
+
+	return func() {
+		b.mu.Lock()
+		if subs := b.subs[eventType]; subs != nil {
+			delete(subs, ch)
+			if len(subs) == 0 {
+				delete(b.subs, eventType)
+			}
+		}
+		b.mu.Unlock()
+	}
+}
+
+// Publish fans out msg to subscribers of msg.Type. Slow or full subscriber
+// channels are skipped so Docker event consumption cannot be blocked by one
+// listener.
+func (b *DockerEventBus) Publish(msg events.Message) {
+	if b == nil {
+		return
+	}
+
+	b.mu.RLock()
+	subs := make([]chan<- events.Message, 0, len(b.subs[msg.Type]))
+	for ch := range b.subs[msg.Type] {
+		subs = append(subs, ch)
+	}
+	b.mu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}

--- a/backend/pkg/libarcane/ws/hub.go
+++ b/backend/pkg/libarcane/ws/hub.go
@@ -13,6 +13,7 @@ type Hub struct {
 	unregister chan *Client
 	broadcast  chan []byte
 	onFirst    func()
+	onActive   func()
 	onEmpty    func()
 }
 
@@ -31,6 +32,12 @@ func (h *Hub) SetOnFirstClient(fn func()) {
 	h.mu.Unlock()
 }
 
+func (h *Hub) SetOnActive(fn func()) {
+	h.mu.Lock()
+	h.onActive = fn
+	h.mu.Unlock()
+}
+
 func (h *Hub) SetOnEmpty(fn func()) {
 	h.mu.Lock()
 	h.onEmpty = fn
@@ -45,14 +52,20 @@ func (h *Hub) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case c := <-h.register:
-			var onFirst func()
+			var onFirst, onActive func()
 			h.mu.Lock()
 			h.clients[c] = struct{}{}
-			if len(h.clients) == 1 && h.onFirst != nil {
-				onFirst = h.onFirst
-				h.onFirst = nil
+			if len(h.clients) == 1 {
+				onActive = h.onActive
+				if h.onFirst != nil {
+					onFirst = h.onFirst
+					h.onFirst = nil
+				}
 			}
 			h.mu.Unlock()
+			if onActive != nil {
+				onActive()
+			}
 			if onFirst != nil {
 				onFirst()
 			}

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -2,6 +2,8 @@ package projects
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -11,8 +13,11 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/dotenv"
+	"github.com/getarcaneapp/arcane/backend/pkg/utils/cache"
 )
 
 const (
@@ -50,6 +55,20 @@ type EnvLoader struct {
 	autoInjectEnv bool
 }
 
+type envFileCacheEntry struct {
+	path   string
+	mtime  time.Time
+	exists bool
+	values EnvMap
+}
+
+var (
+	processEnvOnce      sync.Once
+	processEnvSnapshot  EnvMap
+	globalEnvFileCache  = cache.NewKeyed[string, envFileCacheEntry]()
+	projectEnvFileCache = cache.NewKeyed[string, envFileCacheEntry]()
+)
+
 func NewEnvLoader(projectsDir, workdir string, autoInjectEnv bool) *EnvLoader {
 	return &EnvLoader{
 		projectsDir:   projectsDir,
@@ -63,7 +82,7 @@ func NewEnvLoader(projectsDir, workdir string, autoInjectEnv bool) *EnvLoader {
 // 2. Global .env.global file (from projects directory)
 // 3. Project-specific .env file (from workdir)
 func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injectionVars EnvMap, err error) {
-	envMap = l.loadProcessEnv()
+	envMap = cloneEnvMapInternal(loadProcessEnvSnapshotInternal())
 	injectionVars = make(EnvMap)
 
 	if strings.TrimSpace(l.projectsDir) != "" {
@@ -75,45 +94,38 @@ func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injecti
 
 	projectEnvPath := filepath.Join(l.workdir, EffectiveEnvFileName)
 	if err := l.loadAndMergeProjectEnv(ctx, projectEnvPath, envMap, injectionVars); err != nil {
-		slog.WarnContext(ctx, "Failed to load project env", "path", projectEnvPath, "error", err)
+		if errors.Is(err, os.ErrNotExist) {
+			slog.DebugContext(ctx, "Project .env file does not exist", "path", projectEnvPath)
+		} else {
+			slog.WarnContext(ctx, "Failed to load project env", "path", projectEnvPath, "error", err)
+		}
 	}
 
 	return envMap, injectionVars, nil
 }
 
-func (l *EnvLoader) loadProcessEnv() EnvMap {
-	envMap := make(EnvMap)
-	for _, kv := range os.Environ() {
-		if k, v, ok := strings.Cut(kv, "="); ok {
-			envMap[k] = v
+func loadProcessEnvSnapshotInternal() EnvMap {
+	processEnvOnce.Do(func() {
+		processEnvSnapshot = make(EnvMap)
+		for _, kv := range os.Environ() {
+			if k, v, ok := strings.Cut(kv, "="); ok {
+				processEnvSnapshot[k] = v
+			}
 		}
-	}
-	return envMap
+	})
+	return processEnvSnapshot
 }
 
 func (l *EnvLoader) loadAndMergeGlobalEnv(ctx context.Context, path string, envMap, injectionVars EnvMap) error {
-	slog.DebugContext(ctx, "Checking for global env file", "path", path)
-
-	info, err := os.Stat(path)
+	entry, err := loadCachedEnvFileInternal(ctx, globalEnvFileCache, path, path, envMap)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			slog.DebugContext(ctx, "Global env file does not exist", "path", path)
-		} else {
-			slog.DebugContext(ctx, "Global env file not accessible", "path", path, "error", err)
-		}
 		return err
 	}
-
-	if info.IsDir() {
-		return fmt.Errorf("path is a directory: %s", path)
+	if !entry.exists {
+		return os.ErrNotExist
 	}
 
-	globalEnv, err := ParseProjectEnvFile(path, envMap)
-	if err != nil {
-		return fmt.Errorf("parse env file: %w", err)
-	}
-
-	for k, v := range globalEnv {
+	for k, v := range entry.values {
 		if _, exists := envMap[k]; !exists {
 			envMap[k] = v
 		}
@@ -125,28 +137,16 @@ func (l *EnvLoader) loadAndMergeGlobalEnv(ctx context.Context, path string, envM
 }
 
 func (l *EnvLoader) loadAndMergeProjectEnv(ctx context.Context, path string, envMap, injectionVars EnvMap) error {
-	slog.DebugContext(ctx, "Checking for project .env file", "path", path)
-
-	info, err := os.Stat(path)
+	key := strings.Join([]string{path, l.projectsDir, fmt.Sprint(l.autoInjectEnv), envContextFingerprintInternal(envMap)}, "\x00")
+	entry, err := loadCachedEnvFileInternal(ctx, projectEnvFileCache, key, path, envMap)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			slog.DebugContext(ctx, "Project .env file does not exist", "path", path)
-		} else {
-			slog.DebugContext(ctx, "Project .env file not accessible", "path", path, "error", err)
-		}
 		return err
 	}
-
-	if info.IsDir() {
-		return fmt.Errorf("path is a directory: %s", path)
+	if !entry.exists {
+		return os.ErrNotExist
 	}
 
-	projectEnv, err := ParseProjectEnvFile(path, envMap)
-	if err != nil {
-		return fmt.Errorf("parse env file: %w", err)
-	}
-
-	for k, v := range projectEnv {
+	for k, v := range entry.values {
 		envMap[k] = v
 		if l.autoInjectEnv {
 			injectionVars[k] = v
@@ -157,6 +157,77 @@ func (l *EnvLoader) loadAndMergeProjectEnv(ctx context.Context, path string, env
 	return nil
 }
 
+func loadCachedEnvFileInternal(ctx context.Context, envCache *cache.KeyedCache[string, envFileCacheEntry], key, path string, contextEnv EnvMap) (envFileCacheEntry, error) {
+	return envCache.GetOrFetch(ctx, key, validEnvFileCacheEntryInternal, func(context.Context) (envFileCacheEntry, error) {
+		entry := envFileCacheEntry{path: path}
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return entry, nil
+			}
+			return entry, err
+		}
+		if info.IsDir() {
+			return entry, fmt.Errorf("path is a directory: %s", path)
+		}
+
+		parsed, err := parseProjectEnvFileExistingInternal(path, contextEnv)
+		if err != nil {
+			return entry, fmt.Errorf("parse env file: %w", err)
+		}
+		entry.exists = true
+		entry.mtime = info.ModTime()
+		entry.values = parsed
+		return entry, nil
+	})
+}
+
+func envContextFingerprintInternal(envMap EnvMap) string {
+	if len(envMap) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(envMap))
+	for key := range envMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(envMap[key])
+		b.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func validEnvFileCacheEntryInternal(entry envFileCacheEntry) bool {
+	info, err := os.Stat(entry.path)
+	if err != nil {
+		return !entry.exists && errors.Is(err, os.ErrNotExist)
+	}
+	if info.IsDir() {
+		return false
+	}
+	return entry.exists && info.ModTime().Equal(entry.mtime)
+}
+
+func cloneEnvMapInternal(src EnvMap) EnvMap {
+	dst := make(EnvMap, len(src))
+	maps.Copy(dst, src)
+	return dst
+}
+
+func parseProjectEnvFileExistingInternal(path string, contextEnv EnvMap) (EnvMap, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return parseEnvWithContext(f, contextEnv)
+}
+
 // ParseProjectEnvFile parses a project .env file with variable expansion using the provided
 // context map (e.g. process env). Returns nil without error when the file does not exist.
 // Only the specified file is read — global env files are intentionally not loaded here.
@@ -164,12 +235,7 @@ func ParseProjectEnvFile(path string, contextEnv EnvMap) (EnvMap, error) {
 	if _, err := os.Stat(path); err != nil {
 		return nil, nil //nolint:nilerr // missing .env is not an error
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	return parseEnvWithContext(f, contextEnv)
+	return parseProjectEnvFileExistingInternal(path, contextEnv)
 }
 
 // ParseProjectEnvContent parses project .env content from a string with variable expansion.

--- a/backend/pkg/scheduler/filesystem_watcher_job.go
+++ b/backend/pkg/scheduler/filesystem_watcher_job.go
@@ -152,6 +152,14 @@ func (j *FilesystemWatcherJob) handleFilesystemChange(ctx context.Context) {
 	}
 }
 
+func (j *FilesystemWatcherJob) handleProjectFilePathsChangedInternal(ctx context.Context, paths []string) {
+	if len(paths) == 0 || j.projectService == nil {
+		return
+	}
+	j.handleFilesystemChange(ctx)
+	j.projectService.HandleProjectFilesChanged(ctx, paths)
+}
+
 func (j *FilesystemWatcherJob) handleTemplatesChange(ctx context.Context) {
 	slog.InfoContext(ctx, "Template directory change detected, syncing templates")
 	if j.templateService == nil {
@@ -228,8 +236,8 @@ func (j *FilesystemWatcherJob) logRecursiveProjectsWatchLimitWarningInternal(ctx
 
 func (j *FilesystemWatcherJob) projectWatcherOptionsInternal(followProjectSymlinks bool) fswatch.WatcherOptions {
 	return fswatch.WatcherOptions{
-		Debounce:          3 * time.Second, // Wait 3 seconds after last change before syncing
-		OnChange:          j.handleFilesystemChange,
+		Debounce:          500 * time.Millisecond,
+		OnChangePaths:     j.handleProjectFilePathsChangedInternal,
 		MaxDepth:          j.projectScanDepth,
 		FollowSymlinkDirs: followProjectSymlinks,
 	}

--- a/backend/pkg/utils/cache/cache_util.go
+++ b/backend/pkg/utils/cache/cache_util.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -26,13 +27,78 @@ type Cache[T any] struct {
 	sf singleflight.Group
 }
 
+type KeyedCache[K comparable, T any] struct {
+	mu      sync.RWMutex
+	entries map[K]T
+	sf      singleflight.Group
+}
+
 func New[T any](ttl time.Duration) *Cache[T] {
 	return &Cache[T]{ttl: ttl}
 }
 
+func NewKeyed[K comparable, T any]() *KeyedCache[K, T] {
+	return &KeyedCache[K, T]{
+		entries: make(map[K]T),
+	}
+}
+
+func (c *KeyedCache[K, T]) GetOrFetch(
+	ctx context.Context,
+	key K,
+	valid func(cached T) bool,
+	fetch func(ctx context.Context) (T, error),
+) (T, error) {
+	c.mu.RLock()
+	cached, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok && (valid == nil || valid(cached)) {
+		return cached, nil
+	}
+
+	res, err, _ := c.sf.Do(fmt.Sprint(key), func() (any, error) {
+		c.mu.RLock()
+		cached, ok := c.entries[key]
+		c.mu.RUnlock()
+		if ok && (valid == nil || valid(cached)) {
+			return cached, nil
+		}
+
+		v, err := fetch(ctx)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+
+		c.mu.Lock()
+		c.entries[key] = v
+		c.mu.Unlock()
+		return v, nil
+	})
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	v, _ := res.(T)
+	return v, nil
+}
+
+func (c *KeyedCache[K, T]) Invalidate(key K) {
+	c.mu.Lock()
+	delete(c.entries, key)
+	c.mu.Unlock()
+}
+
+func (c *KeyedCache[K, T]) InvalidateAll() {
+	c.mu.Lock()
+	c.entries = make(map[K]T)
+	c.mu.Unlock()
+}
+
 func (c *Cache[T]) GetOrFetch(ctx context.Context, fetch func(ctx context.Context) (T, error)) (T, error) {
 	c.mu.RLock()
-	if c.set && time.Now().Before(c.exp) {
+	if c.set && (c.ttl <= 0 || time.Now().Before(c.exp)) {
 		v := c.val
 		c.mu.RUnlock()
 		return v, nil
@@ -51,7 +117,9 @@ func (c *Cache[T]) GetOrFetch(ctx context.Context, fetch func(ctx context.Contex
 		c.mu.Lock()
 		c.val = v
 		c.set = true
-		c.exp = time.Now().Add(c.ttl)
+		if c.ttl > 0 {
+			c.exp = time.Now().Add(c.ttl)
+		}
 		c.mu.Unlock()
 		return v, nil
 	})
@@ -65,4 +133,13 @@ func (c *Cache[T]) GetOrFetch(ctx context.Context, fetch func(ctx context.Contex
 
 	v, _ := res.(T)
 	return v, nil
+}
+
+func (c *Cache[T]) Invalidate() {
+	c.mu.Lock()
+	c.set = false
+	var zero T
+	c.val = zero
+	c.exp = time.Time{}
+	c.mu.Unlock()
 }

--- a/backend/pkg/utils/cookie/cookie_util.go
+++ b/backend/pkg/utils/cookie/cookie_util.go
@@ -10,26 +10,26 @@ var (
 	OidcStateCookieName     = "oidc_state"
 )
 
-func isSecure(r *http.Request) bool {
+func isSecureInternal(r *http.Request) bool {
 	return r.TLS != nil
 }
 
-func tokenCookieName(r *http.Request) string {
-	if isSecure(r) {
+func tokenCookieNameInternal(r *http.Request) string {
+	if isSecureInternal(r) {
 		return TokenCookieName
 	}
 	return InsecureTokenCookieName
 }
 
 func ClearTokenCookie(w http.ResponseWriter, r *http.Request) {
-	name := tokenCookieName(r)
+	name := tokenCookieNameInternal(r)
 	http.SetCookie(w, &http.Cookie{ // #nosec G124: Secure mirrors the request's TLS state so the clear directive matches whichever cookie variant (__Host-token vs. token) was originally set.
 		Name:     name,
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   isSecure(r),
+		Secure:   isSecureInternal(r),
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/backend/resources/migrations/postgres/052_add_project_image_refs.down.sql
+++ b/backend/resources/migrations/postgres/052_add_project_image_refs.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects DROP COLUMN image_refs_json;

--- a/backend/resources/migrations/postgres/052_add_project_image_refs.up.sql
+++ b/backend/resources/migrations/postgres/052_add_project_image_refs.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN image_refs_json TEXT NOT NULL DEFAULT '';

--- a/backend/resources/migrations/sqlite/052_add_project_image_refs.down.sql
+++ b/backend/resources/migrations/sqlite/052_add_project_image_refs.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects DROP COLUMN image_refs_json;

--- a/backend/resources/migrations/sqlite/052_add_project_image_refs.up.sql
+++ b/backend/resources/migrations/sqlite/052_add_project_image_refs.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN image_refs_json TEXT NOT NULL DEFAULT '';

--- a/frontend/src/lib/services/project-service.ts
+++ b/frontend/src/lib/services/project-service.ts
@@ -104,11 +104,27 @@ export class ProjectService extends BaseAPIService {
 	}
 
 	async getProjectForEnvironment(environmentId: string, projectId: string): Promise<Project> {
-		const response = await this.handleResponse<{ project?: Project; success?: boolean }>(
-			this.api.get(`/environments/${environmentId}/projects/${projectId}`)
-		);
+		const basePath = `/environments/${environmentId}/projects/${projectId}`;
+		const [summary, compose, files, runtime, updates] = await Promise.all([
+			this.getProjectSection(basePath),
+			this.getProjectSection(`${basePath}/compose`),
+			this.getProjectSection(`${basePath}/files`),
+			this.getProjectSection(`${basePath}/runtime`),
+			this.getProjectSection(`${basePath}/updates`)
+		]);
 
-		return response.project ? response.project : (response as Project);
+		return {
+			...summary,
+			...compose,
+			...files,
+			...runtime,
+			updateInfo: updates.updateInfo ?? compose.updateInfo ?? summary.updateInfo
+		};
+	}
+
+	private async getProjectSection(path: string): Promise<Project> {
+		const response = await this.handleResponse<{ project?: Project; success?: boolean } | Project>(this.api.get(path));
+		return 'project' in response && response.project ? response.project : (response as Project);
 	}
 
 	async getProjectFile(projectId: string, relativePath: string): Promise<IncludeFile> {

--- a/types/dashboard/dashboard.go
+++ b/types/dashboard/dashboard.go
@@ -6,6 +6,10 @@ import (
 	environmenttypes "github.com/getarcaneapp/arcane/types/environment"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	versiontypes "github.com/getarcaneapp/arcane/types/version"
+	dockercontainer "github.com/moby/moby/api/types/container"
+	dockerimage "github.com/moby/moby/api/types/image"
+	dockernetwork "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 )
 
 type ActionItemKind string
@@ -49,6 +53,13 @@ type ActionItems struct {
 }
 
 type SnapshotSettings struct{}
+
+type DockerSnapshot struct {
+	Containers []dockercontainer.Summary `json:"containers"`
+	Images     []dockerimage.Summary     `json:"images"`
+	Networks   []dockernetwork.Summary   `json:"networks"`
+	Volumes    *client.VolumeListResult  `json:"volumes"`
+}
 
 type SnapshotContainers struct {
 	// Data is the first dashboard page of container summaries.

--- a/types/project/project.go
+++ b/types/project/project.go
@@ -202,6 +202,28 @@ type UpdateInfo struct {
 	LastCheckedAt *time.Time `json:"lastCheckedAt,omitempty"`
 }
 
+type DetailsOptions struct {
+	IncludeComposeContent  bool
+	IncludeEnvState        bool
+	IncludeIncludeFiles    bool
+	IncludeServiceConfigs  bool
+	IncludeDirectoryFiles  bool
+	IncludeRuntimeServices bool
+	IncludeUpdateInfo      bool
+}
+
+func AllDetails() DetailsOptions {
+	return DetailsOptions{
+		IncludeComposeContent:  true,
+		IncludeEnvState:        true,
+		IncludeIncludeFiles:    true,
+		IncludeServiceConfigs:  true,
+		IncludeDirectoryFiles:  true,
+		IncludeRuntimeServices: true,
+		IncludeUpdateInfo:      true,
+	}
+}
+
 // CreateReponse is the response when a project is created.
 type CreateReponse struct {
 	// ID is the unique identifier of the project.


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves project list view loading times by introducing event-driven caches for Docker resource lists and compose files, splitting the monolithic project-details endpoint into five focused sub-resource endpoints that the frontend fetches in parallel, and persisting `image_refs_json` in the DB so image-update lookups bypass disk reads on the hot path.

- **Docker cache layer** (`docker_client_service.go`): adds TTL-0 caches for containers, images, networks, and volumes backed by a real-time Docker event bus; each cache is invalidated on the relevant Docker event type, with a `WatchEvents` reconnect loop and a `Close()` lifecycle method.
- **Compose file cache** (`project_service.go`): mtime-validated `KeyedCache` avoids re-parsing compose files on every request; invalidated on project create/update/destroy/include-file write and via the filesystem watcher.
- **Split project-details API** (`projects.go`, `project-service.ts`): `GET /projects/{id}` now returns only base DB fields; four new endpoints (`/compose`, `/files`, `/runtime`, `/updates`) return the expensive parts, called in parallel by the frontend.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The caching and parallelisation logic is correct, but the GET /projects/{id} endpoint now returns only base DB fields instead of the full project payload, which is a breaking change for any API consumer outside the bundled frontend.

The GetProject handler now passes DetailsOptions{} (all feature flags false), stripping compose content, runtime services, env state, directory files, and update info from the response. Existing API clients will silently receive a partial object with no deprecation notice or version bump.

backend/api/handlers/projects.go — the GetProject handler's use of DetailsOptions{} is the primary concern; review whether the existing endpoint contract needs to be preserved or a migration path provided for non-frontend consumers.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22perf%2Fprojects-loading%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fprojects-loading%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fapi%2Fhandlers%2Fprojects.go%3A694%0A**%60GET%20%2Fprojects%2F%7Bid%7D%60%20now%20returns%20only%20the%20base%20DB%20fields**%0A%0A%60GetProject%60%20now%20passes%20%60project.DetailsOptions%7B%7D%60%20%E2%80%94%20all%20feature%20flags%20false.%20This%20omits%20compose%20content%2C%20env%20state%2C%20include%20files%2C%20service%20configs%2C%20directory%20files%2C%20runtime%20services%2C%20and%20update%20info%20from%20the%20response.%20Any%20API%20consumer%20%28API-key-authenticated%20client%2C%20external%20integration%2C%20SDK%20usage%29%20that%20previously%20called%20%60GET%20%2Fenvironments%2F%7Bid%7D%2Fprojects%2F%7BprojectId%7D%60%20and%20expected%20the%20full%20project%20payload%20will%20now%20receive%20a%20partial%20object%20with%20no%20indication%20that%20data%20is%20missing.%20The%20four%20new%20sub-resource%20endpoints%20only%20exist%20via%20the%20updated%20frontend%3B%20HTTP%20clients%20not%20using%20that%20frontend%20have%20no%20automated%20fallback.%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Fprojects%2Fenv.go%3A65-70%0A**Package-level%20%60processEnvOnce%60%20captures%20process%20env%20at%20first%20call%20and%20never%20resets**%0A%0A%60processEnvOnce%60%20fires%20exactly%20once%20per%20process%20lifetime.%20In%20the%20test%20binary%20this%20means%20whichever%20test%20case%20first%20calls%20%60LoadEnvironment%60%20freezes%20%60processEnvSnapshot%60.%20Any%20later%20test%20that%20sets%20process%20env%20vars%20via%20%60t.Setenv%60%20%28expecting%20them%20to%20appear%20in%20compose%20variable%20interpolation%29%20will%20silently%20see%20the%20stale%20snapshot%20instead.%20Similarly%2C%20%60globalEnvFileCache%60%20and%20%60projectEnvFileCache%60%20are%20package-level%20globals%20that%20accumulate%20entries%20across%20test%20cases%20%E2%80%94%20a%20test%20that%20creates%20a%20%60.env.global%60%20file%20and%20then%20removes%20it%20may%20find%20a%20cached%20%22exists%22%20entry%20used%20by%20a%20later%20test.%0A%0AProduction%20is%20unaffected%20%28env%20vars%20don't%20change%20at%20runtime%29%2C%20but%20the%20pattern%20can%20cause%20order-dependent%2C%20hard-to-diagnose%20test%20failures.%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Finternal%2Fbootstrap%2Frouter_bootstrap.go%3A307-316%0A**Gzip%20skipper%20uses%20broad%20substring%20match%20on%20%60%2Flogs%60%20and%20%60%2Fterminal%60**%0A%0A%60strings.Contains%28path%2C%20%22%2Flogs%22%29%60%20skips%20gzip%20for%20any%20URL%20path%20that%20contains%20the%20substring%20%60%2Flogs%60%2C%20not%20just%20dedicated%20streaming%20routes.%20Any%20future%20REST%20endpoint%20whose%20path%20contains%20%60%2Flogs%60%20would%20silently%20skip%20response%20compression.%20Anchoring%20to%20the%20full%20segment%20or%20using%20an%20explicit%20route%20list%20would%20make%20the%20intent%20clearer.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Abackend%2Fapi%2Fhandlers%2Fprojects.go%3A694%0A**%60GET%20%2Fprojects%2F%7Bid%7D%60%20now%20returns%20only%20the%20base%20DB%20fields**%0A%0A%60GetProject%60%20now%20passes%20%60project.DetailsOptions%7B%7D%60%20%E2%80%94%20all%20feature%20flags%20false.%20This%20omits%20compose%20content%2C%20env%20state%2C%20include%20files%2C%20service%20configs%2C%20directory%20files%2C%20runtime%20services%2C%20and%20update%20info%20from%20the%20response.%20Any%20API%20consumer%20%28API-key-authenticated%20client%2C%20external%20integration%2C%20SDK%20usage%29%20that%20previously%20called%20%60GET%20%2Fenvironments%2F%7Bid%7D%2Fprojects%2F%7BprojectId%7D%60%20and%20expected%20the%20full%20project%20payload%20will%20now%20receive%20a%20partial%20object%20with%20no%20indication%20that%20data%20is%20missing.%20The%20four%20new%20sub-resource%20endpoints%20only%20exist%20via%20the%20updated%20frontend%3B%20HTTP%20clients%20not%20using%20that%20frontend%20have%20no%20automated%20fallback.%0A%0A%23%23%23%20Issue%202%20of%203%0Abackend%2Fpkg%2Fprojects%2Fenv.go%3A65-70%0A**Package-level%20%60processEnvOnce%60%20captures%20process%20env%20at%20first%20call%20and%20never%20resets**%0A%0A%60processEnvOnce%60%20fires%20exactly%20once%20per%20process%20lifetime.%20In%20the%20test%20binary%20this%20means%20whichever%20test%20case%20first%20calls%20%60LoadEnvironment%60%20freezes%20%60processEnvSnapshot%60.%20Any%20later%20test%20that%20sets%20process%20env%20vars%20via%20%60t.Setenv%60%20%28expecting%20them%20to%20appear%20in%20compose%20variable%20interpolation%29%20will%20silently%20see%20the%20stale%20snapshot%20instead.%20Similarly%2C%20%60globalEnvFileCache%60%20and%20%60projectEnvFileCache%60%20are%20package-level%20globals%20that%20accumulate%20entries%20across%20test%20cases%20%E2%80%94%20a%20test%20that%20creates%20a%20%60.env.global%60%20file%20and%20then%20removes%20it%20may%20find%20a%20cached%20%22exists%22%20entry%20used%20by%20a%20later%20test.%0A%0AProduction%20is%20unaffected%20%28env%20vars%20don't%20change%20at%20runtime%29%2C%20but%20the%20pattern%20can%20cause%20order-dependent%2C%20hard-to-diagnose%20test%20failures.%0A%0A%23%23%23%20Issue%203%20of%203%0Abackend%2Finternal%2Fbootstrap%2Frouter_bootstrap.go%3A307-316%0A**Gzip%20skipper%20uses%20broad%20substring%20match%20on%20%60%2Flogs%60%20and%20%60%2Fterminal%60**%0A%0A%60strings.Contains%28path%2C%20%22%2Flogs%22%29%60%20skips%20gzip%20for%20any%20URL%20path%20that%20contains%20the%20substring%20%60%2Flogs%60%2C%20not%20just%20dedicated%20streaming%20routes.%20Any%20future%20REST%20endpoint%20whose%20path%20contains%20%60%2Flogs%60%20would%20silently%20skip%20response%20compression.%20Anchoring%20to%20the%20full%20segment%20or%20using%20an%20explicit%20route%20list%20would%20make%20the%20intent%20clearer.%0A%0A&repo=getarcaneapp%2Farcane&pr=2596&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
backend/api/handlers/projects.go:694
**`GET /projects/{id}` now returns only the base DB fields**

`GetProject` now passes `project.DetailsOptions{}` — all feature flags false. This omits compose content, env state, include files, service configs, directory files, runtime services, and update info from the response. Any API consumer (API-key-authenticated client, external integration, SDK usage) that previously called `GET /environments/{id}/projects/{projectId}` and expected the full project payload will now receive a partial object with no indication that data is missing. The four new sub-resource endpoints only exist via the updated frontend; HTTP clients not using that frontend have no automated fallback.

### Issue 2 of 3
backend/pkg/projects/env.go:65-70
**Package-level `processEnvOnce` captures process env at first call and never resets**

`processEnvOnce` fires exactly once per process lifetime. In the test binary this means whichever test case first calls `LoadEnvironment` freezes `processEnvSnapshot`. Any later test that sets process env vars via `t.Setenv` (expecting them to appear in compose variable interpolation) will silently see the stale snapshot instead. Similarly, `globalEnvFileCache` and `projectEnvFileCache` are package-level globals that accumulate entries across test cases — a test that creates a `.env.global` file and then removes it may find a cached "exists" entry used by a later test.

Production is unaffected (env vars don't change at runtime), but the pattern can cause order-dependent, hard-to-diagnose test failures.

### Issue 3 of 3
backend/internal/bootstrap/router_bootstrap.go:307-316
**Gzip skipper uses broad substring match on `/logs` and `/terminal`**

`strings.Contains(path, "/logs")` skips gzip for any URL path that contains the substring `/logs`, not just dedicated streaming routes. Any future REST endpoint whose path contains `/logs` would silently skip response compression. Anchoring to the full segment or using an explicit route list would make the intent clearer.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["perf: increase loading times of project ..."](https://github.com/getarcaneapp/arcane/commit/d4b6c1a352dbf2da0ef1362e883ae057aa82fddc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32085345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->