### PR TITLE
fix: refresh project detail runtime status

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -976,34 +976,24 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 	}
 	s.enrichWithGitOpsInfo(ctx, proj, &resp)
 
-	// Get runtime services and update status/counts
-	if opts.IncludeRuntimeServices {
-		services, serr := s.GetProjectServices(ctx, projectID)
-		if serr == nil && services != nil {
-			resp.ServiceCount = len(services)
-			_, runningCount := s.getServiceCounts(services)
-			resp.RunningCount = runningCount
-			resp.Status = string(s.calculateProjectStatus(services))
+	// Refresh runtime status/counts even when callers do not request the full
+	// runtime service array. DB values are only a fallback when Docker lookup
+	// or compose loading fails.
+	services, serr := s.GetProjectServices(ctx, projectID)
+	if serr == nil && services != nil {
+		resp.ServiceCount = len(services)
+		_, runningCount := s.getServiceCounts(services)
+		resp.RunningCount = runningCount
+		resp.Status = string(s.calculateProjectStatus(services))
 
-			runtimeServices := make([]project.RuntimeService, len(services))
-			for i, svc := range services {
-				runtimeServices[i] = project.RuntimeService{
-					Name:             svc.Name,
-					Image:            svc.Image,
-					Status:           svc.Status,
-					ContainerID:      svc.ContainerID,
-					ContainerName:    svc.ContainerName,
-					Ports:            svc.Ports,
-					Health:           svc.Health,
-					IconURL:          svc.IconURL,
-					ServiceConfig:    svc.ServiceConfig,
-					RedeployDisabled: svc.RedeployDisabled,
-				}
+		if opts.IncludeRuntimeServices {
+			resp.RuntimeServices = buildProjectRuntimeServicesInternal(services)
+			for _, svc := range services {
 				if svc.RedeployDisabled {
 					resp.RedeployDisabled = true
+					break
 				}
 			}
-			resp.RuntimeServices = runtimeServices
 		}
 	}
 
@@ -1012,6 +1002,25 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 	}
 
 	return resp, nil
+}
+
+func buildProjectRuntimeServicesInternal(services []ProjectServiceInfo) []project.RuntimeService {
+	runtimeServices := make([]project.RuntimeService, len(services))
+	for i, svc := range services {
+		runtimeServices[i] = project.RuntimeService{
+			Name:             svc.Name,
+			Image:            svc.Image,
+			Status:           svc.Status,
+			ContainerID:      svc.ContainerID,
+			ContainerName:    svc.ContainerName,
+			Ports:            svc.Ports,
+			Health:           svc.Health,
+			IconURL:          svc.IconURL,
+			ServiceConfig:    svc.ServiceConfig,
+			RedeployDisabled: svc.RedeployDisabled,
+		}
+	}
+	return runtimeServices
 }
 
 func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, relativePath string) (project.IncludeFile, error) {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	composeapi "github.com/docker/compose/v5/pkg/api"
 	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/updater"
@@ -1984,6 +1986,133 @@ func TestProjectService_GetProjectDetails_IncludesUpdateInfo(t *testing.T) {
 	assert.Equal(t, []string{"nginx:latest"}, details.UpdateInfo.UpdatedImageRefs)
 }
 
+func TestProjectService_GetProjectDetails_RefreshesRuntimeStatusWithoutRuntimeServices(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	projectPath := createComposeProjectDir(t, projectsDir, "projectA")
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  server:\n    image: nginx:alpine\n  worker:\n    image: busybox:latest\n"), 0o644))
+
+	server := newProjectRuntimeDockerServerInternal(t, []container.Summary{
+		{
+			ID:     "server-container",
+			Names:  []string{"/projecta-server-1"},
+			Image:  "nginx:alpine",
+			State:  container.StateRunning,
+			Status: "Up 30 seconds (healthy)",
+			Ports: []container.PortSummary{
+				{
+					IP:          netip.MustParseAddr("0.0.0.0"),
+					PrivatePort: 80,
+					PublicPort:  8080,
+					Type:        "tcp",
+				},
+			},
+			Labels: map[string]string{
+				composeapi.ProjectLabel:    "projecta",
+				composeapi.ServiceLabel:    "server",
+				composeapi.ConfigHashLabel: "server-hash",
+				composeapi.WorkingDirLabel: "/host/path/projects/projectA",
+			},
+		},
+		{
+			ID:     "worker-container",
+			Names:  []string{"/projecta-worker-1"},
+			Image:  "busybox:latest",
+			State:  container.StateRunning,
+			Status: "Up 30 seconds",
+			Labels: map[string]string{
+				composeapi.ProjectLabel:    "projecta",
+				composeapi.ServiceLabel:    "worker",
+				composeapi.ConfigHashLabel: "worker-hash",
+				composeapi.WorkingDirLabel: "/host/path/projects/projectA",
+			},
+		},
+	})
+	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, server.URL))
+
+	projectRecord := &models.Project{
+		BaseModel:    models.BaseModel{ID: "proj-runtime-refresh"},
+		Name:         "projectA",
+		DirName:      ptr("projectA"),
+		Path:         projectPath,
+		Status:       models.ProjectStatusStopped,
+		ServiceCount: 2,
+		RunningCount: 0,
+	}
+	require.NoError(t, db.Create(projectRecord).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+
+	details, err := svc.GetProjectDetails(ctx, projectRecord.ID, projecttypes.DetailsOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(models.ProjectStatusRunning), details.Status)
+	assert.Equal(t, 2, details.ServiceCount)
+	assert.Equal(t, 2, details.RunningCount)
+	assert.Empty(t, details.RuntimeServices)
+}
+
+func TestProjectService_GetProjectDetails_PopulatesRuntimeServicesFromComposePs(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	projectPath := createComposeProjectDir(t, projectsDir, "projectA")
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  server:\n    image: nginx:alpine\n"), 0o644))
+
+	server := newProjectRuntimeDockerServerInternal(t, []container.Summary{
+		{
+			ID:     "server-container",
+			Names:  []string{"/projecta-server-1"},
+			Image:  "nginx:alpine",
+			State:  container.StateRunning,
+			Status: "Up 30 seconds",
+			Labels: map[string]string{
+				composeapi.ProjectLabel:    "projecta",
+				composeapi.ServiceLabel:    "server",
+				composeapi.ConfigHashLabel: "server-hash",
+				composeapi.WorkingDirLabel: "/host/path/projects/projectA",
+			},
+		},
+	})
+	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, server.URL))
+
+	projectRecord := &models.Project{
+		BaseModel:    models.BaseModel{ID: "proj-runtime-services"},
+		Name:         "projectA",
+		DirName:      ptr("projectA"),
+		Path:         projectPath,
+		Status:       models.ProjectStatusStopped,
+		ServiceCount: 1,
+		RunningCount: 0,
+	}
+	require.NoError(t, db.Create(projectRecord).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+
+	details, err := svc.GetProjectDetails(ctx, projectRecord.ID, projecttypes.DetailsOptions{IncludeRuntimeServices: true})
+	require.NoError(t, err)
+	require.Len(t, details.RuntimeServices, 1)
+	assert.Equal(t, string(models.ProjectStatusRunning), details.Status)
+	assert.Equal(t, "server", details.RuntimeServices[0].Name)
+	assert.Equal(t, "running", details.RuntimeServices[0].Status)
+	assert.Equal(t, "server-container", details.RuntimeServices[0].ContainerID)
+	assert.Equal(t, "projecta-server-1", details.RuntimeServices[0].ContainerName)
+}
+
 func TestProjectService_ListProjects_FiltersByUpdateStatus(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -3369,6 +3498,56 @@ func createComposeProjectDir(t *testing.T, root, name string) string {
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o644))
 
 	return projectPath
+}
+
+func newProjectRuntimeDockerServerInternal(t *testing.T, containers []container.Summary) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/_ping"):
+			_, _ = io.WriteString(w, "OK")
+		case strings.HasSuffix(r.URL.Path, "/version"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"ApiVersion":    "1.41",
+				"MinAPIVersion": "1.24",
+				"Version":       "24.0.0",
+			})
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(containers)
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			containerID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path[strings.LastIndex(r.URL.Path, "/containers/"):], "/containers/"), "/json")
+			for _, c := range containers {
+				if c.ID != containerID {
+					continue
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(container.InspectResponse{
+					ID: c.ID,
+					State: &container.State{
+						Status:  c.State,
+						Running: c.State == container.StateRunning,
+					},
+				})
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func dockerHostFromProjectRuntimeServerURLInternal(t *testing.T, serverURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(serverURL)
+	require.NoError(t, err)
+	return "tcp://" + parsed.Host
 }
 
 //go:fix inline

--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -252,7 +252,7 @@ func ComposePs(ctx context.Context, proj *types.Project, services []string, all 
 	}
 	defer func() { _ = c.Close() }()
 
-	return c.svc.Ps(ctx, proj.Name, api.PsOptions{All: all})
+	return c.svc.Ps(ctx, proj.Name, api.PsOptions{All: all, Services: services})
 }
 
 func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) error {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2597

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale-status bug on the project detail page by moving the `GetProjectServices` call outside the `IncludeRuntimeServices` guard, so `Status`, `ServiceCount`, and `RunningCount` are always refreshed from live Docker state rather than from cached DB values. It also fixes a silent bug in `ComposePs` where the `services` filter argument was accepted but never forwarded to the Docker Compose API.

- **`project_service.go`**: runtime status refresh is now unconditional; `buildProjectRuntimeServicesInternal` is extracted as a helper; `RedeployDisabled` scan gets an early `break`.
- **`cmds.go`**: `ComposePs` now correctly passes `Services: services` to `api.PsOptions`, fixing service-scoped `ps` calls in `container_service.go`.
- **`project_service_test.go`**: two new integration tests cover the no-`IncludeRuntimeServices` refresh path and the full runtime-services population path, backed by a lightweight fake Docker HTTP server.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic change is well-contained and backed by new integration tests covering both affected code paths.

The runtime-status refresh and ComposePs filter fix are both correct. The only notable trade-off is that GetProjectDetails now always makes a Docker API call, even for callers that only need static metadata — worth a quick check that no high-frequency path is negatively affected, but not a blocker.

No files require special attention; project_service.go is the most impactful change and is well-tested.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fproject-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fproject-refresh%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A982-998%0A**Unconditional%20Docker%20call%20on%20every%20%60GetProjectDetails%60%20invocation**%0A%0A%60GetProjectServices%60%20now%20fires%20for%20every%20%60GetProjectDetails%60%20call%20regardless%20of%20%60IncludeRuntimeServices%60%2C%20which%20includes%20a%20full%20%60ComposePs%60%20%28Docker%20API%20round-trip%29%20plus%20compose-file%20loading.%20Callers%20that%20only%20need%20static%20project%20metadata%20%28e.g.%20those%20that%20fetch%20compose%20content%20or%20directory%20files%20without%20runtime%20state%29%20will%20now%20pay%20this%20cost%20on%20every%20request.%20The%20fix%20is%20correct%20for%20the%20reported%20issue%2C%20but%20it's%20worth%20confirming%20no%20high-frequency%20call%20site%20fetches%20project%20details%20without%20needing%20live%20status%2C%20since%20this%20will%20add%20latency%20there.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A982-998%0A**Unconditional%20Docker%20call%20on%20every%20%60GetProjectDetails%60%20invocation**%0A%0A%60GetProjectServices%60%20now%20fires%20for%20every%20%60GetProjectDetails%60%20call%20regardless%20of%20%60IncludeRuntimeServices%60%2C%20which%20includes%20a%20full%20%60ComposePs%60%20%28Docker%20API%20round-trip%29%20plus%20compose-file%20loading.%20Callers%20that%20only%20need%20static%20project%20metadata%20%28e.g.%20those%20that%20fetch%20compose%20content%20or%20directory%20files%20without%20runtime%20state%29%20will%20now%20pay%20this%20cost%20on%20every%20request.%20The%20fix%20is%20correct%20for%20the%20reported%20issue%2C%20but%20it's%20worth%20confirming%20no%20high-frequency%20call%20site%20fetches%20project%20details%20without%20needing%20live%20status%2C%20since%20this%20will%20add%20latency%20there.%0A%0A&repo=getarcaneapp%2Farcane&pr=2602&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/project_service.go:982-998
**Unconditional Docker call on every `GetProjectDetails` invocation**

`GetProjectServices` now fires for every `GetProjectDetails` call regardless of `IncludeRuntimeServices`, which includes a full `ComposePs` (Docker API round-trip) plus compose-file loading. Callers that only need static project metadata (e.g. those that fetch compose content or directory files without runtime state) will now pay this cost on every request. The fix is correct for the reported issue, but it's worth confirming no high-frequency call site fetches project details without needing live status, since this will add latency there.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: refresh project detail runtime stat..."](https://github.com/getarcaneapp/arcane/commit/2b85d552cf123e84e53e2942147d38ff47c29bdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32252690)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->