### PR TITLE
fix: keep session across backend version bumps

### DIFF
--- a/backend/api/ws/handler_test.go
+++ b/backend/api/ws/handler_test.go
@@ -29,7 +29,7 @@ func TestBroadcastContainerLogStreamErrorInternal_JSON(t *testing.T) {
 	clientConn, serverConn, cleanup := newTestWSPairInternal(t)
 	t.Cleanup(cleanup)
 
-	wshub.ServeClient(ctx, hub, serverConn)
+	wshub.ServeClientWithOnRemove(ctx, hub, serverConn, nil)
 
 	stream := &wsLogStream{
 		hub:    hub,
@@ -59,7 +59,7 @@ func TestBroadcastContainerLogStreamErrorInternal_Text(t *testing.T) {
 	clientConn, serverConn, cleanup := newTestWSPairInternal(t)
 	t.Cleanup(cleanup)
 
-	wshub.ServeClient(ctx, hub, serverConn)
+	wshub.ServeClientWithOnRemove(ctx, hub, serverConn, nil)
 
 	stream := &wsLogStream{
 		hub:    hub,

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -613,8 +613,7 @@ func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string, met
 	}
 
 	if claims.AppVersion != "" && claims.AppVersion != config.Version {
-		slog.InfoContext(ctx, "Refresh token version mismatch detected", "tokenVersion", claims.AppVersion, "currentVersion", config.Version)
-		return nil, ErrTokenVersionMismatch
+		slog.InfoContext(ctx, "Refresh token version mismatch — rotating to current version", "tokenVersion", claims.AppVersion, "currentVersion", config.Version)
 	}
 
 	if claims.UserID == "" {

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -341,6 +341,59 @@ func TestRefreshToken_Valid(t *testing.T) {
 	require.NotEmpty(t, tokenPair.RefreshToken)
 }
 
+// A refresh token minted under an older config.Version must still refresh successfully
+// and the newly issued tokens must carry the current config.Version. This is what keeps
+// users logged in across backend releases — see plans/how-can-we-make-compiled-quilt.md.
+func TestRefreshToken_VersionMismatchRotates(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	userSvc := NewUserService(db)
+	settingsSvc, err := NewSettingsService(context.Background(), db)
+	require.NoError(t, err)
+	s := newTestAuthService("")
+	s.userService = userSvc
+	s.settingsService = settingsSvc
+	s.sessionService = NewSessionService(db)
+
+	user := &models.User{
+		BaseModel: models.BaseModel{ID: "u-versionmismatch"},
+		Username:  "versionmismatch-user",
+		Roles:     models.StringSlice{"user"},
+	}
+	_, err = userSvc.CreateUser(context.Background(), user)
+	require.NoError(t, err)
+
+	exp := time.Now().Add(5 * time.Minute)
+	session, refreshJTI := createTestSession(t, db, user.ID, exp)
+
+	oldVersion := config.Version
+	t.Cleanup(func() { config.Version = oldVersion })
+	config.Version = "1.0.0"
+	token := makeRefreshToken(t, s.jwtSecret, "refresh", refreshJTI, exp, user.ID, session.ID)
+	config.Version = "2.0.0"
+
+	tokenPair, err := s.RefreshToken(context.Background(), token, auth.SessionMeta{})
+	require.NoError(t, err)
+	require.NotNil(t, tokenPair)
+	require.NotEmpty(t, tokenPair.AccessToken)
+	require.NotEmpty(t, tokenPair.RefreshToken)
+
+	parsedAccess, err := jwt.ParseWithClaims(tokenPair.AccessToken, &userClaims{}, func(*jwt.Token) (any, error) {
+		return s.jwtSecret, nil
+	})
+	require.NoError(t, err)
+	accessClaims, ok := parsedAccess.Claims.(*userClaims)
+	require.True(t, ok)
+	require.Equal(t, "2.0.0", accessClaims.AppVersion)
+
+	parsedRefresh, err := jwt.ParseWithClaims(tokenPair.RefreshToken, &refreshClaims{}, func(*jwt.Token) (any, error) {
+		return s.jwtSecret, nil
+	})
+	require.NoError(t, err)
+	rClaims, ok := parsedRefresh.Claims.(*refreshClaims)
+	require.True(t, ok)
+	require.Equal(t, "2.0.0", rClaims.AppVersion)
+}
+
 func TestVerifyToken_RejectsRevokedSession(t *testing.T) {
 	db := setupAuthServiceTestDB(t)
 	userSvc := NewUserService(db)

--- a/backend/pkg/libarcane/ws/client.go
+++ b/backend/pkg/libarcane/ws/client.go
@@ -37,12 +37,9 @@ func NewClient(conn *websocket.Conn, sendBuffer int) *Client {
 	}
 }
 
-// ServeClient registers the client with the hub and starts read/write pumps.
+// ServeClientWithOnRemove registers the client with the hub and starts read/write pumps.
 // Caller is responsible for creating/closing the websocket.Conn.
-func ServeClient(ctx context.Context, hub *Hub, conn *websocket.Conn) {
-	ServeClientWithOnRemove(ctx, hub, conn, nil)
-}
-
+// If onRemove is non-nil, it is invoked when the client is removed from the hub.
 func ServeClientWithOnRemove(ctx context.Context, hub *Hub, conn *websocket.Conn, onRemove func()) {
 	c := NewClient(conn, clientSendBuffer)
 	c.onRemove = onRemove

--- a/backend/pkg/libarcane/ws/client_test.go
+++ b/backend/pkg/libarcane/ws/client_test.go
@@ -39,7 +39,7 @@ func TestServeClient_ReceivesBroadcast(t *testing.T) {
 			return
 		}
 		close(serverReady)
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 
@@ -79,7 +79,7 @@ func TestServeClient_ClientDisconnect(t *testing.T) {
 		if err != nil {
 			return
 		}
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 
@@ -116,7 +116,7 @@ func TestServeClient_ContextCancellation(t *testing.T) {
 		if err != nil {
 			return
 		}
-		ServeClient(clientCtx, h, conn)
+		ServeClientWithOnRemove(clientCtx, h, conn, nil)
 	}))
 	defer server.Close()
 
@@ -215,7 +215,7 @@ func TestServeClient_MultipleMessages(t *testing.T) {
 			return
 		}
 		close(serverReady)
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 

--- a/backend/pkg/libarcane/ws/cpu_regression_test.go
+++ b/backend/pkg/libarcane/ws/cpu_regression_test.go
@@ -91,7 +91,7 @@ func BenchmarkCPU_PageReloadSimulation(b *testing.B) {
 		hub.SetOnEmpty(func() { cancel() })
 		go hub.Run(ctx)
 		startStatsHubPipeline(ctx, hub)
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 
@@ -184,7 +184,7 @@ func BenchmarkCPU_ContainerLogReloadSimulation(b *testing.B) {
 
 		go ForwardLogJSONBatched(ctx, hub, msgs, 50, 400*time.Millisecond)
 
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 
@@ -240,7 +240,7 @@ func BenchmarkCPU_GoroutineScaling(b *testing.B) {
 				hub.SetOnEmpty(func() { cancel() })
 				go hub.Run(ctx)
 				startStatsHubPipeline(ctx, hub)
-				ServeClient(ctx, hub, conn)
+				ServeClientWithOnRemove(ctx, hub, conn, nil)
 			}))
 			defer server.Close()
 
@@ -305,7 +305,7 @@ func BenchmarkCPU_SustainedStreaming(b *testing.B) {
 		hub.SetOnEmpty(func() { cancel() })
 		go hub.Run(ctx)
 		startStatsHubPipeline(ctx, hub)
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 	url := "ws" + strings.TrimPrefix(server.URL, "http")
@@ -349,7 +349,7 @@ func TestCPU_GoroutineCountReport(t *testing.T) {
 		hub.SetOnEmpty(func() { cancel() })
 		go hub.Run(ctx)
 		startStatsHubPipeline(ctx, hub)
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 	url := "ws" + strings.TrimPrefix(server.URL, "http")

--- a/backend/pkg/libarcane/ws/goroutine_leak_test.go
+++ b/backend/pkg/libarcane/ws/goroutine_leak_test.go
@@ -137,7 +137,7 @@ func TestLeak_ServeClientFullLifecycle(t *testing.T) {
 		if err != nil {
 			return
 		}
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 
@@ -193,7 +193,7 @@ func TestLeak_OnEmptyCallbackCancelsContext(t *testing.T) {
 		if err != nil {
 			return
 		}
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 
@@ -235,7 +235,7 @@ func TestLeak_RepeatedConnectDisconnect(t *testing.T) {
 		hub := NewHub(64)
 		hub.SetOnEmpty(func() { cancel() })
 		go hub.Run(ctx)
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 
@@ -313,7 +313,7 @@ func TestLeak_HubWithForwardLinesLifecycle(t *testing.T) {
 
 		go ForwardLines(ctx, hub, lines) //nolint:contextcheck // intentional: context must outlive the HTTP request
 
-		ServeClient(ctx, hub, conn) //nolint:contextcheck // intentional: context must outlive the HTTP request
+		ServeClientWithOnRemove(ctx, hub, conn, nil) //nolint:contextcheck // intentional: context must outlive the HTTP request
 	}))
 	defer server.Close()
 
@@ -393,7 +393,7 @@ func TestLeak_HubWithForwardLogJSONBatchedLifecycle(t *testing.T) {
 
 		go ForwardLogJSONBatched(ctx, hub, msgs, 50, 400*time.Millisecond) //nolint:contextcheck // intentional: context must outlive the HTTP request
 
-		ServeClient(ctx, hub, conn) //nolint:contextcheck // intentional: context must outlive the HTTP request
+		ServeClientWithOnRemove(ctx, hub, conn, nil) //nolint:contextcheck // intentional: context must outlive the HTTP request
 	}))
 	defer server.Close()
 
@@ -423,7 +423,7 @@ func TestLeak_HubWithForwardLogJSONBatchedLifecycle(t *testing.T) {
 }
 
 // startStatsHubForTest starts Hub.Run plus stats producer and JSON broadcaster;
-// caller must call ServeClient(ctx, hub, conn). Used by container-stats leak tests.
+// caller must call ServeClientWithOnRemove(ctx, hub, conn, nil). Used by container-stats leak tests.
 func startStatsHubForTest(ctx context.Context, hub *Hub) {
 	statsChan := make(chan any, 64)
 	go func() {
@@ -513,9 +513,9 @@ func TestLeak_ContainerStatsHubPattern(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		hub := NewHub(64)
 		hub.SetOnEmpty(func() { cancel() })
-		go hub.Run(ctx)                //nolint:contextcheck // intentional: context must outlive the HTTP request
-		startStatsHubForTest(ctx, hub) //nolint:contextcheck // intentional: context must outlive the HTTP request
-		ServeClient(ctx, hub, conn)    //nolint:contextcheck // intentional: context must outlive the HTTP request
+		go hub.Run(ctx)                              //nolint:contextcheck // intentional: context must outlive the HTTP request
+		startStatsHubForTest(ctx, hub)               //nolint:contextcheck // intentional: context must outlive the HTTP request
+		ServeClientWithOnRemove(ctx, hub, conn, nil) //nolint:contextcheck // intentional: context must outlive the HTTP request
 	}))
 	defer server.Close()
 
@@ -553,7 +553,7 @@ func TestLeak_RepeatedStatsHubCycles(t *testing.T) {
 		hub.SetOnEmpty(func() { cancel() })
 		go hub.Run(ctx)
 		startStatsHubRepeatedTest(ctx, hub)
-		ServeClient(ctx, hub, conn)
+		ServeClientWithOnRemove(ctx, hub, conn, nil)
 	}))
 	defer server.Close()
 
@@ -610,7 +610,7 @@ func TestLeak_MultipleClientsOnSameHub(t *testing.T) {
 		if err != nil {
 			return
 		}
-		ServeClient(ctx, h, conn)
+		ServeClientWithOnRemove(ctx, h, conn, nil)
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes session behavior across backend version bumps: refresh tokens with a version mismatch now silently rotate (issuing new tokens at the current version) rather than forcing re-login. It also collapses the `ServeClient` wrapper into a single `ServeClientWithOnRemove` entry point, updating all call sites.

- `auth_service.go`: The version-mismatch branch in `RefreshToken` now only logs and continues instead of returning `ErrTokenVersionMismatch`; `VerifyToken` still rejects mismatched access tokens, forcing clients to refresh.
- `client.go`: `ServeClient` is removed; all test and production callers (including `handler.go` at lines 414 and 825) are updated to call `ServeClientWithOnRemove(..., nil)` directly.
- `auth_service_test.go`: New `TestRefreshToken_VersionMismatchRotates` test mints a token under `"1.0.0"`, refreshes under `"2.0.0"`, and asserts the returned tokens carry the current version; `t.Cleanup` is correctly used for version restoration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The behavioral change is narrowly scoped: only refresh-token rotation is relaxed; access-token verification still rejects stale versions. JWT signature and DB session validation remain in place.

The auth change is deliberately designed — version mismatch on refresh now rotates tokens rather than logging users out, while access tokens still enforce version matching. The new test covers the happy path end-to-end, and t.Cleanup is used correctly for global-state restoration. The ServeClient removal is fully propagated across all production and test callers.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep session across backend version..."](https://github.com/getarcaneapp/arcane/commit/9a20dd252a2a50a480a90889961bcb3da57f0f9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32381047)</sub>

<!-- /greptile_comment -->