### PR TITLE
fix: container cache leak from docker subscription

### DIFF
--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -85,7 +85,7 @@ func initializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	svcs.Build = services.NewBuildService(db, svcs.Settings, svcs.Docker, svcs.ContainerRegistry, svcs.GitRepository, svcs.Event)
 	svcs.BuildWorkspace = services.NewBuildWorkspaceService(svcs.Settings)
 	svcs.Project = services.NewProjectService(db, svcs.Settings, svcs.Event, svcs.Image, svcs.Docker, svcs.Build, cfg)
-	svcs.Container = services.NewContainerService(db, svcs.Event, svcs.Docker, svcs.Image, svcs.Settings, svcs.Project)
+	svcs.Container = services.NewContainerService(ctx, db, svcs.Event, svcs.Docker, svcs.Image, svcs.Settings, svcs.Project)
 	svcs.Dashboard = services.NewDashboardService(
 		db,
 		svcs.Docker,

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -57,7 +57,7 @@ type ContainerListResult struct {
 	Counts     containertypes.StatusCounts
 }
 
-func NewContainerService(db *database.DB, eventService *EventService, dockerService *DockerClientService, imageService *ImageService, settingsService *SettingsService, projectService *ProjectService) *ContainerService {
+func NewContainerService(ctx context.Context, db *database.DB, eventService *EventService, dockerService *DockerClientService, imageService *ImageService, settingsService *SettingsService, projectService *ProjectService) *ContainerService {
 	svc := &ContainerService{
 		db:              db,
 		eventService:    eventService,
@@ -67,19 +67,28 @@ func NewContainerService(db *database.DB, eventService *EventService, dockerServ
 		projectService:  projectService,
 		updateInfoCache: cache.NewKeyed[string, *imagetypes.UpdateInfo](),
 	}
-	svc.subscribeUpdateInfoCacheInvalidationInternal()
+	svc.subscribeUpdateInfoCacheInvalidationInternal(ctx)
 	return svc
 }
 
-func (s *ContainerService) subscribeUpdateInfoCacheInvalidationInternal() {
+func (s *ContainerService) subscribeUpdateInfoCacheInvalidationInternal(ctx context.Context) {
 	if s.dockerService == nil || s.updateInfoCache == nil || s.dockerService.EventBus() == nil {
 		return
 	}
 	ch := make(chan events.Message, 16)
-	s.dockerService.EventBus().Subscribe(events.ImageEventType, ch)
+	unsubscribe := s.dockerService.EventBus().Subscribe(events.ImageEventType, ch)
 	go func() {
-		for range ch {
-			s.updateInfoCache.InvalidateAll()
+		defer unsubscribe()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				s.updateInfoCache.InvalidateAll()
+			}
 		}
 	}()
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a goroutine and subscription leak in `ContainerService` where a Docker image event subscription was never unsubscribed, causing the subscribed channel to stay registered in `DockerEventBus` indefinitely.

- The constructor now accepts a `context.Context` and passes it into `subscribeUpdateInfoCacheInvalidationInternal`, which uses a `select` loop to exit on `ctx.Done()` and calls `defer unsubscribe()` so the channel is removed from the event bus when the goroutine exits.
- The call site in `services_bootstrap.go` is updated to pass the application-level `appCtx`, so the goroutine is properly cleaned up at server shutdown.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal and correctly plugs the subscription leak by tying the goroutine lifecycle to the application context.

The goroutine now exits cleanly when the application context is cancelled, and `defer unsubscribe()` ensures the channel is deregistered from the event bus on every exit path (context cancellation and channel close). There is only one subscription in `ContainerService`, so the fix is complete. The application context passed from `bootstrap.go` has the correct lifetime.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: container cache leak from docker su..."](https://github.com/getarcaneapp/arcane/commit/cd7041e4e963c46470c62f5b955b9a531c966b40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32482165)</sub>

<!-- /greptile_comment -->