### PR TITLE
fix: remove gzip middleware from agent endpoints

### DIFF
--- a/backend/internal/bootstrap/bootstrap_test.go
+++ b/backend/internal/bootstrap/bootstrap_test.go
@@ -2,15 +2,21 @@ package bootstrap
 
 import (
 	"context"
+	"crypto/tls"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	libcrypto "github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
 	tunnelpb "github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge/proto/tunnel/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 )
 
 func TestNormalizeTunnelGRPCRequestPathInternal(t *testing.T) {
@@ -141,6 +147,65 @@ func TestConfigureHTTPProtocolsInternal(t *testing.T) {
 		assert.False(t, protocols.HTTP2())
 		assert.True(t, protocols.UnencryptedHTTP2())
 	})
+}
+
+func TestHTTP2APIResponsesDoNotUseAPIGzipInternal(t *testing.T) {
+	router, _ := setupRouter(context.Background(), &config.Config{
+		AppUrl:      "http://localhost:3552",
+		Environment: config.AppEnvironmentTest,
+	}, &Services{})
+	handler, protocols := configureHTTPProtocolsInternal(false, router)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &http.Server{
+		Handler:           handler,
+		Protocols:         protocols,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, server.Shutdown(context.Background()))
+		require.ErrorIs(t, <-errCh, http.ErrServerClosed)
+	})
+
+	transport := &http2.Transport{
+		AllowHTTP:          true,
+		DisableCompression: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}
+	client := &http.Client{Transport: transport}
+
+	for _, path := range []string{"/api/health", "/api/openapi.json"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://"+listener.Addr().String()+path, nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept-Encoding", "gzip")
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			require.Equal(t, "HTTP/2.0", resp.Proto)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Empty(t, resp.Header.Get("Content-Encoding"))
+
+			if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+				parsedLength, parseErr := strconv.Atoi(contentLength)
+				require.NoError(t, parseErr)
+				require.Equal(t, len(body), parsedLength)
+			}
+		})
+	}
 }
 
 func TestPrepareServerTLSInternal_AgentModeSkipsManagerMTLSValidation(t *testing.T) {

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -153,16 +153,6 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *Services)
 	e.Use(middleware.NewCORSMiddleware(cfg).Add())
 
 	apiGroup := e.Group("/api")
-	apiGroup.Use(echomiddleware.GzipWithConfig(echomiddleware.GzipConfig{
-		Level: 5,
-		Skipper: func(c echo.Context) bool {
-			if strings.EqualFold(c.Request().Header.Get(echo.HeaderUpgrade), "websocket") {
-				return true
-			}
-			path := c.Request().URL.Path
-			return strings.Contains(path, "/ws/") || strings.Contains(path, "/logs") || strings.Contains(path, "/terminal")
-		},
-	}))
 
 	apiGroup.Use(middleware.PerIPRateLimitForPaths(
 		[]string{

--- a/backend/pkg/libarcane/edge/remenv.go
+++ b/backend/pkg/libarcane/edge/remenv.go
@@ -164,7 +164,7 @@ func GetSkipHeaders() map[string]struct{} {
 	return map[string]struct{}{
 		"Host": {}, "Connection": {}, "Keep-Alive": {}, "Proxy-Authenticate": {},
 		"Proxy-Authorization": {}, "Te": {}, "Trailer": {}, "Transfer-Encoding": {},
-		"Upgrade": {}, "Content-Length": {}, "Origin": {}, "Referer": {},
+		"Upgrade": {}, "Content-Length": {}, "Accept-Encoding": {}, "Origin": {}, "Referer": {},
 		"Access-Control-Request-Method": {}, "Access-Control-Request-Headers": {}, "Cookie": {},
 	}
 }

--- a/backend/pkg/libarcane/edge/remenv_test.go
+++ b/backend/pkg/libarcane/edge/remenv_test.go
@@ -185,6 +185,7 @@ func TestGetSkipHeaders_ContainsExpectedEntries(t *testing.T) {
 	require.Contains(t, skip, "Transfer-Encoding")
 	require.Contains(t, skip, "Upgrade")
 	require.Contains(t, skip, "Content-Length")
+	require.Contains(t, skip, "Accept-Encoding")
 	require.Contains(t, skip, "Cookie")
 	require.Contains(t, skip, "Origin")
 	require.Contains(t, skip, "Referer")


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2626

Fixes: https://github.com/getarcaneapp/arcane/issues/2625

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes gzip-related issues with agent/proxy endpoints by removing the Echo gzip middleware from the `/api` route group entirely and suppressing the `Accept-Encoding` header when the manager proxies requests to remote agents.

- **`router_bootstrap.go`**: Drops the `echomiddleware.GzipWithConfig` call that applied level-5 compression to all `/api` responses. The previous skipper only excluded WebSocket/streaming paths; removing the middleware globally eliminates gzip interference on HTTP/2 and agent tunnels.
- **`remenv.go`**: Adds `Accept-Encoding` to `GetSkipHeaders()` so the proxy never asks remote agents to compress their responses, preventing the manager from receiving opaque compressed payloads it cannot decode.
- **Tests**: A new H2C integration test (`TestHTTP2APIResponsesDoNotUseAPIGzipInternal`) validates the fix end-to-end against a live server; `remenv_test.go` adds a corresponding assertion for the new skip entry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are minimal, well-scoped, and backed by a real H2C integration test.

Both changes are small and targeted: the gzip middleware removal is a single apiGroup.Use(...) deletion, and the Accept-Encoding skip is a one-line map entry addition. The new integration test exercises the actual fix against a real server, and the existing test suite gains a matching assertion. No logic paths, auth flows, or data models are touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove gzip middleware from agent e..."](https://github.com/getarcaneapp/arcane/commit/8c6a111dd989ab34e663cf3841f928eb9c1a8bc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32512207)</sub>

<!-- /greptile_comment -->