### PR TITLE
fix: block unsafe compose include file reads

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1039,16 +1039,16 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 		envLoader := projects.NewEnvLoader(projectsDirectory, filepath.Dir(composeFile), utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false))
 		envMap, _, _ := envLoader.LoadEnvironment(ctx)
 
-		includes, parseErr := projects.ParseIncludes(composeFile, envMap, true)
+		includes, parseErr := projects.ParseIncludes(composeFile, envMap, false)
 		if parseErr == nil {
 			for _, inc := range includes {
-				if inc.RelativePath == relativePath {
-					return project.IncludeFile{
-						Path:         inc.Path,
-						RelativePath: inc.RelativePath,
-						Content:      inc.Content,
-					}, nil
+				if inc.RelativePath != relativePath {
+					continue
 				}
+				if !projects.IsSafeSubdirectory(proj.Path, inc.Path) {
+					return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+				}
+				return readProjectIncludeFileContentInternal(proj.Path, inc)
 			}
 		}
 	}
@@ -1094,6 +1094,60 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 	return project.IncludeFile{
 		Path:         absFilePath,
 		RelativePath: relativePath,
+		Content:      string(content),
+	}, nil
+}
+
+func readProjectIncludeFileContentInternal(projectPath string, inc projects.IncludeFile) (project.IncludeFile, error) {
+	validatedPath, err := projects.ValidateIncludePathForWrite(projectPath, inc.Path)
+	if err != nil {
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+	}
+
+	resolvedProjectPath, err := filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		return project.IncludeFile{}, fmt.Errorf("failed to resolve project path: %w", err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(validatedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return project.IncludeFile{
+				Path:         validatedPath,
+				RelativePath: inc.RelativePath,
+				Content:      "# This file will be created when you save changes\nservices:\n",
+			}, nil
+		}
+		return project.IncludeFile{}, fmt.Errorf("failed to resolve include file: %w", err)
+	}
+	if !projects.IsSafeSubdirectory(resolvedProjectPath, resolvedPath) {
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+	}
+
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return project.IncludeFile{}, &common.ProjectFileNotFoundError{}
+		}
+		return project.IncludeFile{}, fmt.Errorf("failed to stat include file: %w", err)
+	}
+	if info.IsDir() {
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("path refers to a directory")}
+	}
+
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return project.IncludeFile{}, &common.ProjectFileNotFoundError{}
+		}
+		return project.IncludeFile{}, fmt.Errorf("failed to read include file: %w", err)
+	}
+	if projects.IsBinaryProjectFileContent(content) {
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("binary files are not supported")}
+	}
+
+	return project.IncludeFile{
+		Path:         resolvedPath,
+		RelativePath: inc.RelativePath,
 		Content:      string(content),
 	}, nil
 }
@@ -1920,6 +1974,12 @@ func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent
 
 	if err := s.db.WithContext(ctx).Create(proj).Error; err != nil {
 		return nil, fmt.Errorf("failed to create project: %w", err)
+	}
+
+	if err := s.validateComposeContentForUpdate(ctx, projectsDirectory, projectPath, name, composeContent, envContent); err != nil {
+		_ = s.db.WithContext(ctx).Delete(proj).Error
+		_ = os.RemoveAll(projectPath)
+		return nil, fmt.Errorf("invalid compose file: %w", err)
 	}
 
 	if err := projects.SaveOrUpdateProjectFiles(projectsDirectory, projectPath, composeContent, envContent); err != nil {
@@ -2926,6 +2986,10 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 		return envErr
 	}
 
+	if err := validateComposeIncludePathsForProjectInternal(projectPath, composeContent, fullEnvMap); err != nil {
+		return err
+	}
+
 	validationProjectName := normalizeComposeProjectName(projectName)
 	cfg := composetypes.ConfigDetails{
 		Version:    api.ComposeVersion,
@@ -2950,6 +3014,19 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 	})
 
 	return err
+}
+
+func validateComposeIncludePathsForProjectInternal(projectPath, composeContent string, envMap projects.EnvMap) error {
+	includes, err := projects.ParseIncludesFromContent(filepath.Join(projectPath, "compose.yaml"), []byte(composeContent), envMap, false)
+	if err != nil {
+		return err
+	}
+	for _, inc := range includes {
+		if _, err := projects.ValidateIncludePathForWrite(projectPath, inc.Path); err != nil {
+			return fmt.Errorf("include path %q is outside project directory: %w", inc.RelativePath, err)
+		}
+	}
+	return nil
 }
 
 type missingIncludeStubResourceLoaderInternal struct {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -1213,6 +1213,215 @@ services:
 	assert.NoFileExists(t, filepath.Join(projectPath, "compose.yaml"))
 }
 
+func TestProjectService_CreateProject_RejectsExternalInclude(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "metadata.yaml"), []byte("services: {}\n"), 0o644))
+
+	compose := `include:
+  - ../metadata.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+
+	project, err := svc.CreateProject(ctx, "evil", compose, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Nil(t, project)
+	assert.Contains(t, err.Error(), "invalid compose file")
+	assert.NoDirExists(t, filepath.Join(projectsDir, "evil"))
+	assert.FileExists(t, filepath.Join(projectsDir, "metadata.yaml"))
+
+	var count int64
+	require.NoError(t, db.Model(&models.Project{}).Where("name = ?", "evil").Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+func TestProjectService_CreateProject_RejectsArrayPathInclude(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "metadata.yaml"), []byte("services: {}\n"), 0o644))
+
+	compose := `include:
+  - path:
+      - ./local.yaml
+      - ../metadata.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+
+	project, err := svc.CreateProject(ctx, "evil-array", compose, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Nil(t, project)
+	assert.Contains(t, err.Error(), "invalid compose file")
+	assert.NoDirExists(t, filepath.Join(projectsDir, "evil-array"))
+	assert.FileExists(t, filepath.Join(projectsDir, "metadata.yaml"))
+
+	var count int64
+	require.NoError(t, db.Model(&models.Project{}).Where("name = ?", "evil-array").Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+func TestProjectService_GetProjectFileContent_RejectsExternalInclude(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "include-read"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "metadata.yaml"), []byte("services: {}\n"), 0o644))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-external-include-read"},
+		Name:      "include-read",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `include:
+  - ../metadata.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(compose), 0o644))
+
+	includeFile, err := svc.GetProjectFileContent(ctx, project.ID, "../metadata.yaml")
+	require.Error(t, err)
+	assert.Empty(t, includeFile)
+
+	var forbiddenErr *common.ProjectFileForbiddenError
+	assert.ErrorAs(t, err, &forbiddenErr)
+}
+
+func TestProjectService_GetProjectFileContent_RejectsSymlinkInclude(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "include-symlink"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	outsidePath := filepath.Join(t.TempDir(), "outside.yaml")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("services: {}\n"), 0o644))
+	require.NoError(t, os.Symlink(outsidePath, filepath.Join(projectPath, "evil-link")))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-symlink-include-read"},
+		Name:      "include-symlink",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `include:
+  - ./evil-link
+services:
+  app:
+    image: nginx:alpine
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(compose), 0o644))
+
+	includeFile, err := svc.GetProjectFileContent(ctx, project.ID, "evil-link")
+	require.Error(t, err)
+	assert.Empty(t, includeFile)
+
+	var forbiddenErr *common.ProjectFileForbiddenError
+	assert.ErrorAs(t, err, &forbiddenErr)
+}
+
+func TestProjectService_GetProjectFileContent_RejectsIntermediateSymlinkInclude(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
+
+	dirName := "include-intermediate-symlink"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	outsideDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.yaml"), []byte("services: {}\n"), 0o644))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(projectPath, "subdir")))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-intermediate-symlink-include-read"},
+		Name:      "include-intermediate-symlink",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `include:
+  - ./subdir/secret.yaml
+services:
+  app:
+    image: nginx:alpine
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(compose), 0o644))
+
+	includeFile, err := svc.GetProjectFileContent(ctx, project.ID, "subdir/secret.yaml")
+	require.Error(t, err)
+	assert.Empty(t, includeFile)
+
+	var forbiddenErr *common.ProjectFileForbiddenError
+	assert.ErrorAs(t, err, &forbiddenErr)
+}
+
 func TestProjectService_UpdateProject_UsesExistingEnvFileDuringComposeValidation(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/pkg/projects/includes.go
+++ b/backend/pkg/projects/includes.go
@@ -22,10 +22,12 @@ func expandEnvVarsInternal(s string, envMap EnvMap) string {
 }
 
 // Security Model for Include Files:
-// - READ: Docker Compose allows include files from anywhere (parent dirs, absolute paths, etc.)
-//         We allow reading from any path to maintain compatibility with standard Docker Compose behavior
-// - WRITE/DELETE: Restricted to files within the project directory only for security
-//         This prevents malicious users from modifying files outside the project scope
+// - READ: Docker Compose's spec allows include files from anywhere (parent dirs,
+//   absolute paths). ParseIncludes does NOT enforce containment; it returns whatever
+//   the compose file points at. Callers must validate containment and symlinks before
+//   reading include content or returning inc.Content to users.
+// - WRITE/DELETE: Restricted to files within the project directory only for security.
+//   Always go through ValidateIncludePathForWrite or WriteIncludeFile.
 
 type IncludeFile struct {
 	Path         string `json:"path"`
@@ -41,6 +43,11 @@ func ParseIncludes(composeFilePath string, envMap EnvMap, includeContent bool) (
 		return nil, fmt.Errorf("failed to read compose file: %w", err)
 	}
 
+	return ParseIncludesFromContent(composeFilePath, content, envMap, includeContent)
+}
+
+// ParseIncludesFromContent extracts include directives from compose content using composeFilePath as the base path.
+func ParseIncludesFromContent(composeFilePath string, content []byte, envMap EnvMap, includeContent bool) ([]IncludeFile, error) {
 	var composeData map[string]any
 	if err := yaml.Unmarshal(content, &composeData); err != nil {
 		return nil, fmt.Errorf("failed to parse compose file: %w", err)
@@ -58,33 +65,77 @@ func ParseIncludes(composeFilePath string, envMap EnvMap, includeContent bool) (
 	switch v := includes.(type) {
 	case []any:
 		for _, item := range v {
-			if include, err := parseIncludeItemInternal(item, composeDir, envMap, includeContent); err == nil {
-				includeFiles = append(includeFiles, include)
+			incs, err := parseIncludeItemInternal(item, composeDir, envMap, includeContent)
+			if err != nil {
+				return nil, err
 			}
+			includeFiles = append(includeFiles, incs...)
 		}
 	case string:
-		if include, err := parseIncludeItemInternal(v, composeDir, envMap, includeContent); err == nil {
-			includeFiles = append(includeFiles, include)
+		incs, err := parseIncludeItemInternal(v, composeDir, envMap, includeContent)
+		if err != nil {
+			return nil, err
 		}
+		includeFiles = append(includeFiles, incs...)
+	case nil:
+		// `include:` key present but null (e.g. `include: ~`) — treat as empty.
+		return []IncludeFile{}, nil
+	default:
+		return nil, fmt.Errorf("invalid include type")
 	}
 
 	return includeFiles, nil
 }
 
-func parseIncludeItemInternal(item any, baseDir string, envMap EnvMap, includeContent bool) (IncludeFile, error) {
-	var includePath string
-
-	switch v := item.(type) {
-	case string:
-		includePath = v
-	case map[string]any:
-		if path, ok := v["path"].(string); ok {
-			includePath = path
-		}
-	default:
-		return IncludeFile{}, fmt.Errorf("invalid include item type")
+func parseIncludeItemInternal(item any, baseDir string, envMap EnvMap, includeContent bool) ([]IncludeFile, error) {
+	includePaths, err := extractIncludePathsInternal(item)
+	if err != nil {
+		return nil, err
 	}
 
+	results := make([]IncludeFile, 0, len(includePaths))
+	for _, includePath := range includePaths {
+		inc, err := resolveIncludeFileInternal(includePath, baseDir, envMap, includeContent)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, inc)
+	}
+	return results, nil
+}
+
+func extractIncludePathsInternal(item any) ([]string, error) {
+	switch v := item.(type) {
+	case string:
+		return []string{v}, nil
+	case map[string]any:
+		return extractIncludePathsFromMapInternal(v)
+	default:
+		return nil, fmt.Errorf("invalid include item type")
+	}
+}
+
+func extractIncludePathsFromMapInternal(v map[string]any) ([]string, error) {
+	switch p := v["path"].(type) {
+	case string:
+		return []string{p}, nil
+	case []any:
+		// Docker Compose allows `path: [./base.yaml, ./override.yaml]` for multi-file overrides.
+		paths := make([]string, 0, len(p))
+		for _, entry := range p {
+			s, ok := entry.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid include path entry: expected string, got %T", entry)
+			}
+			paths = append(paths, s)
+		}
+		return paths, nil
+	default:
+		return nil, fmt.Errorf("invalid include path type: %T", v["path"])
+	}
+}
+
+func resolveIncludeFileInternal(includePath, baseDir string, envMap EnvMap, includeContent bool) (IncludeFile, error) {
 	if includePath == "" {
 		return IncludeFile{}, fmt.Errorf("empty include path")
 	}
@@ -100,19 +151,9 @@ func parseIncludeItemInternal(item any, baseDir string, envMap EnvMap, includeCo
 	}
 	fullPath = filepath.Clean(fullPath)
 
-	var content string
-	if includeContent {
-		fileContent, err := os.ReadFile(fullPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				// File doesn't exist yet - return empty content so it can be created
-				content = "# This file will be created when you save changes\nservices:\n"
-			} else {
-				return IncludeFile{}, fmt.Errorf("failed to read include file %s: %w", includePath, err)
-			}
-		} else {
-			content = string(fileContent)
-		}
+	content, err := readIncludeContentInternal(fullPath, includePath, includeContent)
+	if err != nil {
+		return IncludeFile{}, err
 	}
 
 	relativePath := includePath
@@ -131,6 +172,21 @@ func parseIncludeItemInternal(item any, baseDir string, envMap EnvMap, includeCo
 		RelativePath: relativePath,
 		Content:      content,
 	}, nil
+}
+
+func readIncludeContentInternal(fullPath, includePath string, includeContent bool) (string, error) {
+	if !includeContent {
+		return "", nil
+	}
+	fileContent, err := os.ReadFile(fullPath)
+	if err == nil {
+		return string(fileContent), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		// File doesn't exist yet - return empty content so it can be created
+		return "# This file will be created when you save changes\nservices:\n", nil
+	}
+	return "", fmt.Errorf("failed to read include file %s: %w", includePath, err)
 }
 
 // ValidateIncludePathForWrite ensures the include path is safe for write operations

--- a/backend/pkg/projects/includes_test.go
+++ b/backend/pkg/projects/includes_test.go
@@ -39,6 +39,32 @@ func TestParseIncludes_NormalizesRelativePaths(t *testing.T) {
 	}
 }
 
+func TestParseIncludes_ExpandsArrayPathForm(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	composePath := filepath.Join(projectDir, "compose.yaml")
+
+	requireNoError := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	requireNoError(os.WriteFile(composePath, []byte("include:\n  - path:\n      - ./base.yaml\n      - ./override.yaml\n"), 0o600))
+
+	includes, err := ParseIncludes(composePath, nil, false)
+	requireNoError(err)
+
+	if len(includes) != 2 {
+		t.Fatalf("expected 2 includes, got %d", len(includes))
+	}
+	if includes[0].RelativePath != "base.yaml" || includes[1].RelativePath != "override.yaml" {
+		t.Fatalf("unexpected relative paths: %q, %q", includes[0].RelativePath, includes[1].RelativePath)
+	}
+}
+
 func TestWriteIncludeFilePermissions(t *testing.T) {
 	// Save original perms
 	origFilePerm := pkgutils.FilePerm


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds security enforcement for Docker Compose include file reads, preventing path traversal and symlink attacks that allowed reading files outside a project's directory. Previously, include content was read without containment checks; now every read path goes through symlink-resolved boundary validation.

- **Read path secured** (`GetProjectFileContent`): include files are now routed through `readProjectIncludeFileContentInternal`, which calls `ValidateIncludePathForWrite` (symlink-resolving) and then independently calls `filepath.EvalSymlinks` + `IsSafeSubdirectory` on both the project root and the resolved include path for defense-in-depth.
- **Write/create path secured** (`validateComposeContentForUpdate`): `validateComposeIncludePathsForProjectInternal` is now called before files are persisted on both `CreateProject` and `UpdateProject`, blocking external paths before the compose loader ever sees them.
- **Parser hardened**: `ParseIncludesFromContent` is extracted as a new public function; errors from individual include items are now propagated (no silent drops); the array-path form (`path: [./a.yaml, ./b.yaml]`) is properly expanded and validated; a `nil` top-level `include:` key is treated as an empty list rather than an error.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change tightens security on all include-file code paths without regressing valid functionality, and every new restriction is covered by a corresponding test.

All three code paths that previously allowed reads without containment checks (simple includes, array-path includes, and the GetProjectFileContent include branch) are now routed through symlink-resolved boundary validation. The previous thread concerns — test guarding absence rather than enforcement, array-path form bypass, and null include — are each addressed in this revision. No new defects are introduced in the changed code.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/pkg/projects/includes.go`, line 65-76 ([link](https://github.com/getarcaneapp/arcane/blob/bb9cdc71d4516d7b9ab4d5ba88ed6ea61591d272/backend/pkg/projects/includes.go#L65-L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Array-path include format silently bypasses containment validation**

   Docker Compose supports specifying multiple paths per include entry using the map form (`path: [./a.yaml, ../b.yaml]`). When `v["path"]` is a `[]any` instead of a `string`, the type-assertion on line 89 (`v["path"].(string)`) fails, `includePath` stays empty, and `parseIncludeItemInternal` returns an error. That error is silently swallowed here — the item is simply omitted from the returned slice.

   `validateComposeIncludePathsForProjectInternal` iterates only over the returned slice, so an array-path include entry is never passed to `ValidateIncludePathForWrite`. The compose content is then fed to `loader.LoadWithContext`, which does understand the array syntax and will call the default resource loader for any path that `missingIncludeStubResourceLoaderInternal.Accept` rejects. If a file at the out-of-project path exists, the Docker Compose loader resolves it successfully, project creation succeeds, and the compose file is persisted referencing a path outside the project directory.

   A safe fix is to return an error (rather than silently drop) whenever `parseIncludeItemInternal` cannot parse an item, so that callers of `ParseIncludesFromContent` who care about security can propagate the error instead of treating it as "no includes".

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/includes.go
   Line: 65-76

   Comment:
   **Array-path include format silently bypasses containment validation**

   Docker Compose supports specifying multiple paths per include entry using the map form (`path: [./a.yaml, ../b.yaml]`). When `v["path"]` is a `[]any` instead of a `string`, the type-assertion on line 89 (`v["path"].(string)`) fails, `includePath` stays empty, and `parseIncludeItemInternal` returns an error. That error is silently swallowed here — the item is simply omitted from the returned slice.

   `validateComposeIncludePathsForProjectInternal` iterates only over the returned slice, so an array-path include entry is never passed to `ValidateIncludePathForWrite`. The compose content is then fed to `loader.LoadWithContext`, which does understand the array syntax and will call the default resource loader for any path that `missingIncludeStubResourceLoaderInternal.Accept` rejects. If a file at the out-of-project path exists, the Docker Compose loader resolves it successfully, project creation succeeds, and the compose file is persisted referencing a path outside the project directory.

   A safe fix is to return an error (rather than silently drop) whenever `parseIncludeItemInternal` cannot parse an item, so that callers of `ParseIncludesFromContent` who care about security can propagate the error instead of treating it as "no includes".

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Funsafe-projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Funsafe-projects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fincludes.go%0ALine%3A%2065-76%0A%0AComment%3A%0A**Array-path%20include%20format%20silently%20bypasses%20containment%20validation**%0A%0ADocker%20Compose%20supports%20specifying%20multiple%20paths%20per%20include%20entry%20using%20the%20map%20form%20%28%60path%3A%20%5B.%2Fa.yaml%2C%20..%2Fb.yaml%5D%60%29.%20When%20%60v%5B%22path%22%5D%60%20is%20a%20%60%5B%5Dany%60%20instead%20of%20a%20%60string%60%2C%20the%20type-assertion%20on%20line%2089%20%28%60v%5B%22path%22%5D.%28string%29%60%29%20fails%2C%20%60includePath%60%20stays%20empty%2C%20and%20%60parseIncludeItemInternal%60%20returns%20an%20error.%20That%20error%20is%20silently%20swallowed%20here%20%E2%80%94%20the%20item%20is%20simply%20omitted%20from%20the%20returned%20slice.%0A%0A%60validateComposeIncludePathsForProjectInternal%60%20iterates%20only%20over%20the%20returned%20slice%2C%20so%20an%20array-path%20include%20entry%20is%20never%20passed%20to%20%60ValidateIncludePathForWrite%60.%20The%20compose%20content%20is%20then%20fed%20to%20%60loader.LoadWithContext%60%2C%20which%20does%20understand%20the%20array%20syntax%20and%20will%20call%20the%20default%20resource%20loader%20for%20any%20path%20that%20%60missingIncludeStubResourceLoaderInternal.Accept%60%20rejects.%20If%20a%20file%20at%20the%20out-of-project%20path%20exists%2C%20the%20Docker%20Compose%20loader%20resolves%20it%20successfully%2C%20project%20creation%20succeeds%2C%20and%20the%20compose%20file%20is%20persisted%20referencing%20a%20path%20outside%20the%20project%20directory.%0A%0AA%20safe%20fix%20is%20to%20return%20an%20error%20%28rather%20than%20silently%20drop%29%20whenever%20%60parseIncludeItemInternal%60%20cannot%20parse%20an%20item%2C%20so%20that%20callers%20of%20%60ParseIncludesFromContent%60%20who%20care%20about%20security%20can%20propagate%20the%20error%20instead%20of%20treating%20it%20as%20%22no%20includes%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fincludes.go%0ALine%3A%2065-76%0A%0AComment%3A%0A**Array-path%20include%20format%20silently%20bypasses%20containment%20validation**%0A%0ADocker%20Compose%20supports%20specifying%20multiple%20paths%20per%20include%20entry%20using%20the%20map%20form%20%28%60path%3A%20%5B.%2Fa.yaml%2C%20..%2Fb.yaml%5D%60%29.%20When%20%60v%5B%22path%22%5D%60%20is%20a%20%60%5B%5Dany%60%20instead%20of%20a%20%60string%60%2C%20the%20type-assertion%20on%20line%2089%20%28%60v%5B%22path%22%5D.%28string%29%60%29%20fails%2C%20%60includePath%60%20stays%20empty%2C%20and%20%60parseIncludeItemInternal%60%20returns%20an%20error.%20That%20error%20is%20silently%20swallowed%20here%20%E2%80%94%20the%20item%20is%20simply%20omitted%20from%20the%20returned%20slice.%0A%0A%60validateComposeIncludePathsForProjectInternal%60%20iterates%20only%20over%20the%20returned%20slice%2C%20so%20an%20array-path%20include%20entry%20is%20never%20passed%20to%20%60ValidateIncludePathForWrite%60.%20The%20compose%20content%20is%20then%20fed%20to%20%60loader.LoadWithContext%60%2C%20which%20does%20understand%20the%20array%20syntax%20and%20will%20call%20the%20default%20resource%20loader%20for%20any%20path%20that%20%60missingIncludeStubResourceLoaderInternal.Accept%60%20rejects.%20If%20a%20file%20at%20the%20out-of-project%20path%20exists%2C%20the%20Docker%20Compose%20loader%20resolves%20it%20successfully%2C%20project%20creation%20succeeds%2C%20and%20the%20compose%20file%20is%20persisted%20referencing%20a%20path%20outside%20the%20project%20directory.%0A%0AA%20safe%20fix%20is%20to%20return%20an%20error%20%28rather%20than%20silently%20drop%29%20whenever%20%60parseIncludeItemInternal%60%20cannot%20parse%20an%20item%2C%20so%20that%20callers%20of%20%60ParseIncludesFromContent%60%20who%20care%20about%20security%20can%20propagate%20the%20error%20instead%20of%20treating%20it%20as%20%22no%20includes%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2630&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `backend/pkg/projects/includes.go`, line 93-103 ([link](https://github.com/getarcaneapp/arcane/blob/2fabc9ffc7a976b4206c0ad39ba5c272370d82e3/backend/pkg/projects/includes.go#L93-L103)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Array-path includes break valid projects — paths not validated, just rejected**

   `parseIncludeItemInternal` handles the `map[string]any` case only when `v["path"]` is a `string`. When the Docker Compose `path` field is a `[]any` (the multi-override form — `path: [./base.yaml, ./override.yaml]`), the type assertion on line 94 fails silently, `includePath` stays empty, and the function returns `fmt.Errorf("empty include path")`. Because error propagation was changed in this PR from "silently drop" to "propagate", `ParseIncludesFromContent` now returns that error to `validateComposeIncludePathsForProjectInternal`, causing project creation and updates to fail with `"invalid compose file: empty include path"` — even when every path in the array is safely inside the project directory.

   A project that was previously created successfully with `path: [./base.yaml, ./override.yaml]` would now be impossible to update through Arcane. Validating each path in the array individually (instead of treating the unhandled case as empty) would block external paths while keeping in-project multi-path entries working.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/includes.go
   Line: 93-103

   Comment:
   **Array-path includes break valid projects — paths not validated, just rejected**

   `parseIncludeItemInternal` handles the `map[string]any` case only when `v["path"]` is a `string`. When the Docker Compose `path` field is a `[]any` (the multi-override form — `path: [./base.yaml, ./override.yaml]`), the type assertion on line 94 fails silently, `includePath` stays empty, and the function returns `fmt.Errorf("empty include path")`. Because error propagation was changed in this PR from "silently drop" to "propagate", `ParseIncludesFromContent` now returns that error to `validateComposeIncludePathsForProjectInternal`, causing project creation and updates to fail with `"invalid compose file: empty include path"` — even when every path in the array is safely inside the project directory.

   A project that was previously created successfully with `path: [./base.yaml, ./override.yaml]` would now be impossible to update through Arcane. Validating each path in the array individually (instead of treating the unhandled case as empty) would block external paths while keeping in-project multi-path entries working.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Funsafe-projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Funsafe-projects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fincludes.go%0ALine%3A%2093-103%0A%0AComment%3A%0A**Array-path%20includes%20break%20valid%20projects%20%E2%80%94%20paths%20not%20validated%2C%20just%20rejected**%0A%0A%60parseIncludeItemInternal%60%20handles%20the%20%60map%5Bstring%5Dany%60%20case%20only%20when%20%60v%5B%22path%22%5D%60%20is%20a%20%60string%60.%20When%20the%20Docker%20Compose%20%60path%60%20field%20is%20a%20%60%5B%5Dany%60%20%28the%20multi-override%20form%20%E2%80%94%20%60path%3A%20%5B.%2Fbase.yaml%2C%20.%2Foverride.yaml%5D%60%29%2C%20the%20type%20assertion%20on%20line%2094%20fails%20silently%2C%20%60includePath%60%20stays%20empty%2C%20and%20the%20function%20returns%20%60fmt.Errorf%28%22empty%20include%20path%22%29%60.%20Because%20error%20propagation%20was%20changed%20in%20this%20PR%20from%20%22silently%20drop%22%20to%20%22propagate%22%2C%20%60ParseIncludesFromContent%60%20now%20returns%20that%20error%20to%20%60validateComposeIncludePathsForProjectInternal%60%2C%20causing%20project%20creation%20and%20updates%20to%20fail%20with%20%60%22invalid%20compose%20file%3A%20empty%20include%20path%22%60%20%E2%80%94%20even%20when%20every%20path%20in%20the%20array%20is%20safely%20inside%20the%20project%20directory.%0A%0AA%20project%20that%20was%20previously%20created%20successfully%20with%20%60path%3A%20%5B.%2Fbase.yaml%2C%20.%2Foverride.yaml%5D%60%20would%20now%20be%20impossible%20to%20update%20through%20Arcane.%20Validating%20each%20path%20in%20the%20array%20individually%20%28instead%20of%20treating%20the%20unhandled%20case%20as%20empty%29%20would%20block%20external%20paths%20while%20keeping%20in-project%20multi-path%20entries%20working.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fincludes.go%0ALine%3A%2093-103%0A%0AComment%3A%0A**Array-path%20includes%20break%20valid%20projects%20%E2%80%94%20paths%20not%20validated%2C%20just%20rejected**%0A%0A%60parseIncludeItemInternal%60%20handles%20the%20%60map%5Bstring%5Dany%60%20case%20only%20when%20%60v%5B%22path%22%5D%60%20is%20a%20%60string%60.%20When%20the%20Docker%20Compose%20%60path%60%20field%20is%20a%20%60%5B%5Dany%60%20%28the%20multi-override%20form%20%E2%80%94%20%60path%3A%20%5B.%2Fbase.yaml%2C%20.%2Foverride.yaml%5D%60%29%2C%20the%20type%20assertion%20on%20line%2094%20fails%20silently%2C%20%60includePath%60%20stays%20empty%2C%20and%20the%20function%20returns%20%60fmt.Errorf%28%22empty%20include%20path%22%29%60.%20Because%20error%20propagation%20was%20changed%20in%20this%20PR%20from%20%22silently%20drop%22%20to%20%22propagate%22%2C%20%60ParseIncludesFromContent%60%20now%20returns%20that%20error%20to%20%60validateComposeIncludePathsForProjectInternal%60%2C%20causing%20project%20creation%20and%20updates%20to%20fail%20with%20%60%22invalid%20compose%20file%3A%20empty%20include%20path%22%60%20%E2%80%94%20even%20when%20every%20path%20in%20the%20array%20is%20safely%20inside%20the%20project%20directory.%0A%0AA%20project%20that%20was%20previously%20created%20successfully%20with%20%60path%3A%20%5B.%2Fbase.yaml%2C%20.%2Foverride.yaml%5D%60%20would%20now%20be%20impossible%20to%20update%20through%20Arcane.%20Validating%20each%20path%20in%20the%20array%20individually%20%28instead%20of%20treating%20the%20unhandled%20case%20as%20empty%29%20would%20block%20external%20paths%20while%20keeping%20in-project%20multi-path%20entries%20working.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2630&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix: block unsafe compose include file r..."](https://github.com/getarcaneapp/arcane/commit/d2d474a86d3c60440eecf95f5913921117534c71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32515833)</sub>

<!-- /greptile_comment -->