### PR TITLE
fix: retry rate limited update checks

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	backoff "github.com/cenkalti/backoff/v5"
 	"golang.org/x/sync/singleflight"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -733,28 +734,73 @@ func (s *ContainerRegistryService) inspectImageDigestInternal(ctx context.Contex
 		return nil, err
 	}
 
-	result, err := s.inspectImageDigestViaDaemonInternal(ctx, parts.NormalizedRef, parts.RegistryHost, externalCreds)
-	if err == nil {
-		return result, nil
-	}
-	if !isDistributionFallbackEligibleInternal(err) {
-		return result, err
+	var lastResult *registryDigestResult
+	var lastErr error
+	fallbackWarningLogged := false
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 500 * time.Millisecond
+	bo.MaxInterval = 10 * time.Second
+	bo.RandomizationFactor = 0.3
+
+	_, retryErr := backoff.Retry(ctx, func() (*registryDigestResult, error) {
+		result, err := s.inspectImageDigestViaDaemonInternal(ctx, parts.NormalizedRef, parts.RegistryHost, externalCreds)
+		if err == nil {
+			lastResult = result
+			return result, nil
+		}
+
+		if isRateLimitErrorInternal(err) {
+			lastResult = result
+			lastErr = err
+			slog.DebugContext(ctx, "rate limited by registry, will retry",
+				"registry", parts.RegistryHost,
+				"imageRef", parts.NormalizedRef)
+			return nil, err
+		}
+
+		if !isDistributionFallbackEligibleInternal(err) {
+			lastResult = result
+			lastErr = err
+			return nil, backoff.Permanent(err)
+		}
+
+		if !fallbackWarningLogged {
+			fallbackWarningLogged = true
+			slog.WarnContext(ctx, "distribution inspect unavailable, falling back to direct registry digest lookup",
+				"imageRef", parts.NormalizedRef,
+				"registry", parts.RegistryHost,
+				"error", err.Error())
+		}
+
+		fallbackResult, fallbackErr := s.inspectImageDigestViaRegistryInternal(ctx, parts.RegistryHost, parts.Repository, parts.Tag, externalCreds)
+		if fallbackErr == nil {
+			lastResult = fallbackResult
+			return fallbackResult, nil
+		}
+
+		if isRateLimitErrorInternal(fallbackErr) {
+			lastResult = fallbackResult
+			lastErr = fallbackErr
+			slog.DebugContext(ctx, "rate limited by registry on fallback, will retry",
+				"registry", parts.RegistryHost,
+				"imageRef", parts.NormalizedRef)
+			return nil, fallbackErr
+		}
+
+		lastResult = fallbackResult
+		lastErr = fmt.Errorf("daemon digest lookup failed; registry fallback failed: %w", errors.Join(err, fallbackErr))
+		return nil, backoff.Permanent(lastErr)
+	}, backoff.WithBackOff(bo), backoff.WithMaxTries(5))
+
+	if retryErr != nil {
+		if errors.Is(retryErr, context.Canceled) || errors.Is(retryErr, context.DeadlineExceeded) {
+			return lastResult, retryErr
+		}
+		return lastResult, lastErr
 	}
 
-	slog.WarnContext(ctx, "distribution inspect unavailable, falling back to direct registry digest lookup",
-		"imageRef", parts.NormalizedRef,
-		"registry", parts.RegistryHost,
-		"error", err.Error())
-
-	fallbackResult, fallbackErr := s.inspectImageDigestViaRegistryInternal(ctx, parts.RegistryHost, parts.Repository, parts.Tag, externalCreds)
-	if fallbackErr == nil {
-		return fallbackResult, nil
-	}
-
-	return fallbackResult, fmt.Errorf(
-		"daemon digest lookup failed; registry fallback failed: %w",
-		errors.Join(err, fallbackErr),
-	)
+	return lastResult, nil
 }
 
 func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx context.Context, normalizedRef, registryHost string, externalCreds []containerregistry.Credential) (*registryDigestResult, error) {
@@ -1220,8 +1266,6 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 		"no basic auth credentials",
 		"access denied",
 		"incorrect username or password",
-		"toomanyrequests",
-		"unauthenticated pull rate limit",
 		"status: 401",
 		"status 401",
 		"status: 403",
@@ -1234,6 +1278,27 @@ func isUnauthorizedRegistryErrorInternal(err error) bool {
 		}
 	}
 
+	return false
+}
+
+func isRateLimitErrorInternal(err error) bool {
+	if err == nil {
+		return false
+	}
+	errLower := strings.ToLower(err.Error())
+	indicators := []string{
+		"toomanyrequests",
+		"rate limit",
+		"too many requests",
+		"status: 429",
+		"status 429",
+		"retry-after",
+	}
+	for _, indicator := range indicators {
+		if strings.Contains(errLower, indicator) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
 	imageupdatecore "github.com/getarcaneapp/arcane/backend/pkg/libarcane/imageupdate"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/ratelimit"
 	registry "github.com/getarcaneapp/arcane/backend/pkg/libarcane/registryauth"
 	"github.com/getarcaneapp/arcane/types/containerregistry"
 	"github.com/getarcaneapp/arcane/types/imageupdate"
@@ -30,6 +31,7 @@ type ImageUpdateService struct {
 	dockerService       *DockerClientService
 	eventService        *EventService
 	notificationService *NotificationService
+	registryLimiter     *ratelimit.RegistryRateLimiter
 }
 
 type ImageParts struct {
@@ -54,6 +56,7 @@ func NewImageUpdateService(db *database.DB, settingsService *SettingsService, re
 		dockerService:       dockerService,
 		eventService:        eventService,
 		notificationService: notificationService,
+		registryLimiter:     ratelimit.NewRegistryRateLimiter(),
 	}
 }
 
@@ -904,6 +907,17 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	for _, img := range images {
 		g.Go(func() error {
+			registry := img.parts.Registry
+
+			if err := s.registryLimiter.Acquire(groupCtx, registry); err != nil {
+				slog.DebugContext(groupCtx, "skipping image check: registry limiter acquire failed",
+					"imageRef", img.canonicalRef,
+					"registry", registry,
+					"error", err.Error())
+				return err
+			}
+			defer s.registryLimiter.Release(registry)
+
 			res, snapshot := s.checkSingleImageInBatchInternal(groupCtx, resolvedCreds, img.parts)
 
 			mu.Lock()
@@ -921,6 +935,7 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	if err := g.Wait(); err != nil {
 		slog.ErrorContext(ctx, "Batch check error", "error", err)
+		return results, err
 	}
 
 	successCount, errorCount := countBatchResultOutcomesInternal(imageRefs, results)

--- a/backend/pkg/libarcane/ratelimit/registry_rate_limiter.go
+++ b/backend/pkg/libarcane/ratelimit/registry_rate_limiter.go
@@ -1,0 +1,89 @@
+package ratelimit
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type RegistryRateLimiter struct {
+	mu           sync.RWMutex
+	semaphores   map[string]*semaphore.Weighted
+	limits       map[string]int64
+	defaultLimit int64
+}
+
+var defaultRegistryLimits = map[string]int64{
+	"ghcr.io":   3,
+	"docker.io": 5,
+	"quay.io":   4,
+	"gcr.io":    4,
+}
+
+const defaultRegistryConcurrencyLimit int64 = 3
+
+func NewRegistryRateLimiter() *RegistryRateLimiter {
+	return &RegistryRateLimiter{
+		semaphores:   make(map[string]*semaphore.Weighted),
+		limits:       defaultRegistryLimits,
+		defaultLimit: defaultRegistryConcurrencyLimit,
+	}
+}
+
+func (r *RegistryRateLimiter) Acquire(ctx context.Context, registry string) error {
+	sem := r.getSemaphoreInternal(registry)
+	return sem.Acquire(ctx, 1)
+}
+
+func (r *RegistryRateLimiter) Release(registry string) {
+	normalized := normalizeRegistryKeyInternal(registry)
+	r.mu.RLock()
+	sem, ok := r.semaphores[normalized]
+	r.mu.RUnlock()
+	if ok {
+		sem.Release(1)
+	}
+}
+
+func (r *RegistryRateLimiter) getSemaphoreInternal(registry string) *semaphore.Weighted {
+	normalized := normalizeRegistryKeyInternal(registry)
+
+	r.mu.RLock()
+	sem, ok := r.semaphores[normalized]
+	r.mu.RUnlock()
+	if ok {
+		return sem
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if sem, ok = r.semaphores[normalized]; ok {
+		return sem
+	}
+
+	limit := r.limitForRegistryInternal(normalized)
+	sem = semaphore.NewWeighted(limit)
+	r.semaphores[normalized] = sem
+	return sem
+}
+
+func (r *RegistryRateLimiter) limitForRegistryInternal(registry string) int64 {
+	if limit, ok := r.limits[registry]; ok {
+		return limit
+	}
+	if strings.Contains(registry, ".ecr.") && strings.Contains(registry, ".amazonaws.com") {
+		return 4
+	}
+	return r.defaultLimit
+}
+
+func normalizeRegistryKeyInternal(registry string) string {
+	normalized := strings.ToLower(strings.TrimSpace(registry))
+	if normalized == "registry-1.docker.io" || normalized == "index.docker.io" {
+		return "docker.io"
+	}
+	return normalized
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2635

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes retry handling for rate-limited container registry update checks by adding exponential-backoff retry logic (`cenkalti/backoff/v5`) in `inspectImageDigestInternal` and introducing a new `RegistryRateLimiter` that caps per-registry concurrency using weighted semaphores.

- Retry logic wraps both the Docker daemon inspect path and its direct-registry fallback; `\"toomanyrequests\"` and related strings are moved out of `isUnauthorizedRegistryErrorInternal` into a dedicated `isRateLimitErrorInternal`, and up to 5 retries with exponential back-off are attempted before surfacing the error.
- `CheckMultipleImages` now acquires a per-registry permit before each goroutine does its work and correctly propagates `Acquire` and `g.Wait()` errors to callers instead of swallowing them.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the retry and semaphore logic is correct and the known context-propagation edge case is a pre-existing concern already captured in an open thread.

All three changed files implement mechanically straightforward additions — exponential back-off retry with a clearly bounded attempt count, a per-registry weighted semaphore, and correct error propagation through the errgroup. The only new observation is that blocked goroutines can hold errgroup concurrency slots and reduce throughput in mixed-registry batches, which is a performance trade-off rather than a correctness defect.

No files require special attention; image_update_service.go has the noted throughput consideration but is otherwise correct.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fretry-rate-limts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fretry-rate-limts%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fimage_update_service.go%3A906-919%0A**Blocked%20goroutines%20hold%20errgroup%20slots%2C%20starving%20other%20registries**%0A%0A%60g.SetLimit%2810%29%60%20controls%20how%20many%20goroutines%20run%20at%20once%2C%20but%20goroutines%20are%20counted%20as%20started%20the%20moment%20they%20enter%20the%20closure%20%E2%80%94%20before%20%60Acquire%60%20returns.%20If%2010%20docker.io%20images%20are%20queued%2C%20all%2010%20errgroup%20slots%20can%20fill%20up%3A%205%20hold%20semaphore%20permits%20and%20work%2C%20while%205%20sit%20blocked%20on%20%60Acquire%28groupCtx%2C%20%22docker.io%22%29%60.%20During%20that%20window%2C%20ghcr.io%2Fgcr.io%20goroutines%20never%20start%20even%20though%20their%20registries%20have%20headroom.%20In%20large%20mixed-registry%20batches%20this%20can%20serialize%20work%20that%20should%20be%20parallel.%0A%0AConsider%20either%20raising%20%60g.SetLimit%60%20above%20the%20worst-case%20sum%20of%20all%20per-registry%20limits%20%28e.g.%20%E2%89%A5%20sum%20of%20all%20%60defaultRegistryLimits%60%29%2C%20or%20acquiring%20the%20semaphore%20before%20launching%20the%20goroutine%20so%20that%20the%20errgroup%20slot%20is%20not%20consumed%20until%20the%20permit%20is%20ready.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fimage_update_service.go%3A906-919%0A**Blocked%20goroutines%20hold%20errgroup%20slots%2C%20starving%20other%20registries**%0A%0A%60g.SetLimit%2810%29%60%20controls%20how%20many%20goroutines%20run%20at%20once%2C%20but%20goroutines%20are%20counted%20as%20started%20the%20moment%20they%20enter%20the%20closure%20%E2%80%94%20before%20%60Acquire%60%20returns.%20If%2010%20docker.io%20images%20are%20queued%2C%20all%2010%20errgroup%20slots%20can%20fill%20up%3A%205%20hold%20semaphore%20permits%20and%20work%2C%20while%205%20sit%20blocked%20on%20%60Acquire%28groupCtx%2C%20%22docker.io%22%29%60.%20During%20that%20window%2C%20ghcr.io%2Fgcr.io%20goroutines%20never%20start%20even%20though%20their%20registries%20have%20headroom.%20In%20large%20mixed-registry%20batches%20this%20can%20serialize%20work%20that%20should%20be%20parallel.%0A%0AConsider%20either%20raising%20%60g.SetLimit%60%20above%20the%20worst-case%20sum%20of%20all%20per-registry%20limits%20%28e.g.%20%E2%89%A5%20sum%20of%20all%20%60defaultRegistryLimits%60%29%2C%20or%20acquiring%20the%20semaphore%20before%20launching%20the%20goroutine%20so%20that%20the%20errgroup%20slot%20is%20not%20consumed%20until%20the%20permit%20is%20ready.%0A%0A&repo=getarcaneapp%2Farcane&pr=2639&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/image_update_service.go:906-919
**Blocked goroutines hold errgroup slots, starving other registries**

`g.SetLimit(10)` controls how many goroutines run at once, but goroutines are counted as started the moment they enter the closure — before `Acquire` returns. If 10 docker.io images are queued, all 10 errgroup slots can fill up: 5 hold semaphore permits and work, while 5 sit blocked on `Acquire(groupCtx, "docker.io")`. During that window, ghcr.io/gcr.io goroutines never start even though their registries have headroom. In large mixed-registry batches this can serialize work that should be parallel.

Consider either raising `g.SetLimit` above the worst-case sum of all per-registry limits (e.g. ≥ sum of all `defaultRegistryLimits`), or acquiring the semaphore before launching the goroutine so that the errgroup slot is not consumed until the permit is ready.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: retry rate limited update checks"](https://github.com/getarcaneapp/arcane/commit/5bab236126a3d4f03cddab14d40a95b5b2b90fd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32529118)</sub>

<!-- /greptile_comment -->