### PR TITLE
fix: prevent projects from disappearing when projects folder is unreadable

### DIFF
--- a/backend/api/handlers/settings.go
+++ b/backend/api/handlers/settings.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -355,6 +357,21 @@ func (h *SettingsHandler) updateSettingsForRemoteEnvironment(ctx context.Context
 }
 
 func (h *SettingsHandler) updateSettingsForLocalEnvironment(ctx context.Context, input settings.Update) (*UpdateSettingsOutput, error) {
+	if input.ProjectsDirectory != nil && *input.ProjectsDirectory != "" {
+		currentDir := h.settingsService.GetSettingsConfig().ProjectsDirectory.Value
+		if *input.ProjectsDirectory != currentDir {
+			resolved, err := projects.GetProjectsDirectory(ctx, strings.TrimSpace(*input.ProjectsDirectory))
+			if err != nil {
+				return nil, huma.Error400BadRequest(fmt.Sprintf("cannot use projects directory %q: %v", *input.ProjectsDirectory, err))
+			}
+			f, err := os.Open(resolved)
+			if err != nil {
+				return nil, huma.Error400BadRequest(fmt.Sprintf("cannot read projects directory %q: %v", resolved, err))
+			}
+			f.Close()
+		}
+	}
+
 	updatedSettings, err := h.settingsService.UpdateSettings(ctx, input)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.SettingsUpdateError{Err: err}).Error())

--- a/backend/api/handlers/settings_test.go
+++ b/backend/api/handlers/settings_test.go
@@ -1,13 +1,23 @@
 package handlers
 
 import (
+	"context"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	apitypes "github.com/getarcaneapp/arcane/types/settings"
+	glsqlite "github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestSettingsHandler_AppendRuntimeSettings(t *testing.T) {
@@ -50,6 +60,43 @@ func TestSettingsHandler_AppendRuntimeSettings_DoesNotGenerateEdgeMTLSCA(t *test
 	require.Equal(t, "false", authenticatedKeys["edgeMTLSManagerCAAvailable"])
 	require.NoFileExists(t, filepath.Join(assetsDir, "ca.crt"))
 	require.NoFileExists(t, filepath.Join(assetsDir, "ca.key"))
+}
+
+func TestSettingsHandler_UpdateLocalEnvironment_RejectsUnreadableProjectsDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission-denied behavior is not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root UID to trigger permission-denied on ReadDir")
+	}
+
+	ctx := context.Background()
+
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SettingVariable{}))
+
+	settingsSvc, err := services.NewSettingsService(ctx, &database.DB{DB: db})
+	require.NoError(t, err)
+
+	originalDir := settingsSvc.GetSettingsConfig().ProjectsDirectory.Value
+
+	unreadable := t.TempDir()
+	require.NoError(t, os.Chmod(unreadable, 0))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+
+	handler := &SettingsHandler{settingsService: settingsSvc, cfg: &config.Config{}}
+
+	dirPtr := unreadable
+	_, err = handler.updateSettingsForLocalEnvironment(ctx, apitypes.Update{ProjectsDirectory: &dirPtr})
+	require.Error(t, err)
+
+	var statusErr huma.StatusError
+	require.ErrorAs(t, err, &statusErr, "expected a huma status error")
+	require.Equal(t, 400, statusErr.GetStatus())
+	require.True(t, strings.Contains(err.Error(), "cannot read projects directory"), "error message should explain the failure: %s", err.Error())
+
+	require.Equal(t, originalDir, settingsSvc.GetSettingsConfig().ProjectsDirectory.Value, "projectsDirectory must not be persisted on validation failure")
 }
 
 func runtimeSettingKeysInternal(settings []apitypes.PublicSetting) map[string]string {

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -827,6 +827,19 @@ func (e *ProjectComposeFileNotFoundError) Error() string {
 	return fmt.Sprintf("Project compose file not found: %v", e.Err)
 }
 
+type ProjectDiscoveryError struct {
+	Dir string
+	Err error
+}
+
+func (e *ProjectDiscoveryError) Error() string {
+	return fmt.Sprintf("Failed to discover projects in %q: %v", e.Dir, e.Err)
+}
+
+func (e *ProjectDiscoveryError) Unwrap() error {
+	return e.Err
+}
+
 type ProjectRedeploymentError struct {
 	Err error
 }

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1489,8 +1489,7 @@ func (s *ProjectService) SyncProjectsFromFileSystem(ctx context.Context) error {
 		if os.IsNotExist(discoveryErr) {
 			return nil
 		}
-		slog.WarnContext(ctx, "failed to discover projects directory contents", "dir", projectsDir, "error", discoveryErr)
-		return nil
+		return &common.ProjectDiscoveryError{Dir: projectsDir, Err: discoveryErr}
 	}
 
 	seen := map[string]struct{}{}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -3425,6 +3426,47 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesDeletedNestedProject(t
 	items, err = svc.ListAllProjects(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, items)
+}
+
+func TestProjectService_SyncProjectsFromFileSystem_PreservesDBRecordsWhenDirectoryUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission-denied behavior is not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root UID to trigger permission-denied on ReadDir")
+	}
+
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	createComposeProjectDir(t, projectsRoot, "project1")
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	before, err := svc.ListAllProjects(ctx)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	unreadable := t.TempDir()
+	require.NoError(t, os.Chmod(unreadable, 0))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", unreadable))
+
+	syncErr := svc.SyncProjectsFromFileSystem(ctx)
+	require.Error(t, syncErr, "sync should propagate the permission-denied error")
+
+	after, err := svc.ListAllProjects(ctx)
+	require.NoError(t, err)
+	assert.Len(t, after, 1, "DB records must not be wiped when discovery fails")
+	assert.Equal(t, before[0].Path, after[0].Path)
 }
 
 func TestProjectService_SyncProjectsFromFileSystem_AllowsDuplicateLeafDirectoriesInDifferentParents(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2576

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where all projects would disappear from the UI when the configured projects directory became temporarily unreadable (e.g. a permission-denied error). The root cause was that `SyncProjectsFromFileSystem` swallowed non-ENOENT discovery errors and returned nil, allowing the subsequent DB cleanup pass to wipe all project records.

- `project_service.go`: propagates `ProjectDiscoveryError` on non-ENOENT discovery failures so the cleanup code is never reached, preserving existing DB records.
- `settings.go`: adds upfront readability validation (open + close the resolved path) when the projects directory setting is changed, returning HTTP 400 before persisting an unreadable path.
- Tests cover both paths: the new service-level test confirms DB records survive an unreadable-directory sync, and the handler test confirms the 400 is returned and the setting is not persisted.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped: it stops swallowing a permission-denied error so DB records are preserved, and all scheduler callers already handle a non-nil return by logging and continuing.

The logic change is small and well-tested. Both the service-layer fix and the settings-handler guard are independently correct, and the new tests exercise the exact failure paths being addressed.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: prevent projects from disappearing ..."](https://github.com/getarcaneapp/arcane/commit/b2b27cd6583d924ca0852b4309dd458b783d069f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32535378)</sub>

<!-- /greptile_comment -->