### PR TITLE
fix: release notes not populated for manager instance

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2445,7 +2445,7 @@
 	"upgrade_checking": "Checking...",
 	"upgrade_reload_auto": "Page will reload automatically in {countdown} seconds",
 	"upgrade_reload_now": "Reload Now",
-	"upgrade_remote_description": "You are about to upgrade {targetDescription} to v{version}.",
+	"upgrade_remote_description": "You are about to upgrade {targetDescription} to {version}.",
 	"update_center_remote_title": "Update {target}",
 	"update_center_tag_label": "Tag",
 	"update_center_current_label": "Current",

--- a/frontend/src/lib/services/version-service.ts
+++ b/frontend/src/lib/services/version-service.ts
@@ -26,6 +26,8 @@ async function getVersionInformation(): Promise<AppVersionInformation> {
 			newestDigest?: string;
 			updateAvailable?: boolean;
 			releaseUrl?: string;
+			releaseNotes?: string;
+			releasedAt?: string;
 		};
 
 		return {
@@ -42,7 +44,9 @@ async function getVersionInformation(): Promise<AppVersionInformation> {
 			newestVersion: data.newestVersion,
 			newestDigest: data.newestDigest,
 			updateAvailable: data.updateAvailable || false,
-			releaseUrl: data.releaseUrl
+			releaseUrl: data.releaseUrl,
+			releaseNotes: data.releaseNotes,
+			releasedAt: data.releasedAt
 		};
 	} catch (error) {
 		// Fallback to basic version info if app-version endpoint fails

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -131,7 +131,9 @@ export const load = async () => {
 			newestVersion: info.newestVersion,
 			newestDigest: info.newestDigest,
 			updateAvailable: info.updateAvailable,
-			releaseUrl: info.releaseUrl
+			releaseUrl: info.releaseUrl,
+			releaseNotes: info.releaseNotes,
+			releasedAt: info.releasedAt
 		};
 	} catch {}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2638

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `releaseNotes` and `releasedAt` fields not being populated when version info is fetched for a manager instance. Both fields were already declared in the `AppVersionInformation` interface but were missing from the API response mapping in the version service and the layout loader.

- `version-service.ts` and `+layout.ts` now forward `releaseNotes` and `releasedAt` from the `/app-version` API response through to the `AppVersionInformation` object.
- `en.json` removes the hardcoded `v` prefix from the `upgrade_remote_description` string, consistent with how `upgrade_to_version` formats version strings (where `newestVersion` already carries the prefix, e.g. `v1.2.3`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only adds two previously-ignored fields to an existing data-mapping path, with no logic or control-flow changes.

All three modified files make additive, mechanical changes: two API response fields are forwarded that were silently dropped before, and an i18n string removes a double-v prefix that would have appeared for manager instances. No new error paths, no changed defaults, no structural refactoring.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: release notes not populated for man..."](https://github.com/getarcaneapp/arcane/commit/9d7d9535beb40a11584abd7e3ebeb93f0b91e111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32538956)</sub>

<!-- /greptile_comment -->