### PR TITLE
refactor: publish manager and agent image tags

### DIFF
--- a/.depot/workflows/build-next-images.yml
+++ b/.depot/workflows/build-next-images.yml
@@ -20,7 +20,9 @@ jobs:
 
     env:
       MANAGER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane
+      MANAGER_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/manager
       AGENT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane-headless
+      AGENT_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/agent
 
     steps:
       - name: Checkout code
@@ -112,7 +114,9 @@ jobs:
         id: manager-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.MANAGER_IMAGE_NAME }}
+          images: |
+            ${{ env.MANAGER_IMAGE_NAME }}
+            ${{ env.MANAGER_IMAGE_ALIAS }}
           tags: |
             type=raw,value=next
             type=raw,value=next-${{ steps.vars.outputs.sha_short }}
@@ -146,7 +150,7 @@ jobs:
           provenance: true
 
       - name: Sign manager image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}" "${MANAGER_IMAGE_ALIAS}@${{ steps.manager-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -155,7 +159,9 @@ jobs:
         id: agent-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.AGENT_IMAGE_NAME }}
+          images: |
+            ${{ env.AGENT_IMAGE_NAME }}
+            ${{ env.AGENT_IMAGE_ALIAS }}
           tags: |
             type=raw,value=next
             type=raw,value=next-${{ steps.vars.outputs.sha_short }}
@@ -190,7 +196,7 @@ jobs:
           provenance: true
 
       - name: Sign agent image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}" "${AGENT_IMAGE_ALIAS}@${{ steps.agent-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/build-next-images.yml
+++ b/.github/workflows/build-next-images.yml
@@ -19,7 +19,9 @@ jobs:
 
     env:
       MANAGER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane
+      MANAGER_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/manager
       AGENT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane-headless
+      AGENT_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/agent
 
     steps:
       - name: Checkout code
@@ -103,7 +105,9 @@ jobs:
         id: manager-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.MANAGER_IMAGE_NAME }}
+          images: |
+            ${{ env.MANAGER_IMAGE_NAME }}
+            ${{ env.MANAGER_IMAGE_ALIAS }}
           tags: |
             type=raw,value=next
             type=raw,value=next-${{ steps.vars.outputs.sha_short }}
@@ -137,7 +141,7 @@ jobs:
           provenance: true
 
       - name: Sign manager image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}" "${MANAGER_IMAGE_ALIAS}@${{ steps.manager-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -146,7 +150,9 @@ jobs:
         id: agent-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.AGENT_IMAGE_NAME }}
+          images: |
+            ${{ env.AGENT_IMAGE_NAME }}
+            ${{ env.AGENT_IMAGE_ALIAS }}
           tags: |
             type=raw,value=next
             type=raw,value=next-${{ steps.vars.outputs.sha_short }}
@@ -181,7 +187,7 @@ jobs:
           provenance: true
 
       - name: Sign agent image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}" "${AGENT_IMAGE_ALIAS}@${{ steps.agent-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.github/workflows/build-pr-images.yml
+++ b/.github/workflows/build-pr-images.yml
@@ -21,8 +21,8 @@ jobs:
         runs-on: depot-ubuntu-latest
 
         env:
-            MANAGER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane
-            AGENT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane-headless
+            MANAGER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/manager
+            AGENT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/agent
 
         steps:
             - name: Checkout code
@@ -48,7 +48,8 @@ jobs:
               id: manager-meta
               uses: docker/metadata-action@v6
               with:
-                  images: ${{ env.MANAGER_IMAGE_NAME }}
+                  images: |
+                      ${{ env.MANAGER_IMAGE_NAME }}
                   tags: |
                       type=raw,value=pr-${{ github.event.pull_request.number }}
                   labels: |
@@ -68,7 +69,8 @@ jobs:
               id: agent-meta
               uses: docker/metadata-action@v6
               with:
-                  images: ${{ env.AGENT_IMAGE_NAME }}
+                  images: |
+                      ${{ env.AGENT_IMAGE_NAME }}
                   tags: |
                       type=raw,value=pr-${{ github.event.pull_request.number }}
                   labels: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
 
     env:
       MANAGER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane
+      MANAGER_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/manager
       AGENT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/arcane-headless
+      AGENT_IMAGE_ALIAS: ghcr.io/${{ github.repository_owner }}/agent
 
     steps:
       - name: Checkout
@@ -75,7 +77,9 @@ jobs:
         id: manager-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.MANAGER_IMAGE_NAME }}
+          images: |
+            ${{ env.MANAGER_IMAGE_NAME }}
+            ${{ env.MANAGER_IMAGE_ALIAS }}
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -111,7 +115,7 @@ jobs:
           provenance: true
 
       - name: Sign manager image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${MANAGER_IMAGE_NAME}@${{ steps.manager-build.outputs.digest }}" "${MANAGER_IMAGE_ALIAS}@${{ steps.manager-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -120,7 +124,9 @@ jobs:
         id: agent-meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.AGENT_IMAGE_NAME }}
+          images: |
+            ${{ env.AGENT_IMAGE_NAME }}
+            ${{ env.AGENT_IMAGE_ALIAS }}
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -157,7 +163,7 @@ jobs:
           provenance: true
 
       - name: Sign agent image
-        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}"
+        run: cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${AGENT_IMAGE_NAME}@${{ steps.agent-build.outputs.digest }}" "${AGENT_IMAGE_ALIAS}@${{ steps.agent-build.outputs.digest }}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -169,10 +175,24 @@ jobs:
           subject-digest: ${{ steps.manager-build.outputs.digest }}
           push-to-registry: true
 
+      - name: Container image attestation (manager alias)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.MANAGER_IMAGE_ALIAS }}
+          subject-digest: ${{ steps.manager-build.outputs.digest }}
+          push-to-registry: true
+
       - name: Container image attestation (agent)
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.AGENT_IMAGE_NAME }}
+          subject-digest: ${{ steps.agent-build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Container image attestation (agent alias)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.AGENT_IMAGE_ALIAS }}
           subject-digest: ${{ steps.agent-build.outputs.digest }}
           push-to-registry: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -288,6 +288,7 @@ dockers_v2:
     dockerfile: docker/next-builds/Dockerfile-static
     images:
       - "ghcr.io/getarcaneapp/arcane"
+      - "ghcr.io/getarcaneapp/manager"
     tags:
       - "next-static"
       - "{{ .Version }}"
@@ -315,6 +316,7 @@ dockers_v2:
     dockerfile: docker/next-builds/Dockerfile-agent-static
     images:
       - "ghcr.io/getarcaneapp/arcane-headless"
+      - "ghcr.io/getarcaneapp/agent"
     tags:
       - "next-static"
       - "{{ .Version }}"
@@ -342,6 +344,7 @@ dockers_v2:
     dockerfile: docker/next-builds/Dockerfile-next-distroless
     images:
       - "ghcr.io/getarcaneapp/arcane"
+      - "ghcr.io/getarcaneapp/manager"
     tags:
       - "next-distroless"
       - "{{ .Version }}-distroless"
@@ -369,6 +372,7 @@ dockers_v2:
     dockerfile: docker/next-builds/Dockerfile-agent-distroless
     images:
       - "ghcr.io/getarcaneapp/arcane-headless"
+      - "ghcr.io/getarcaneapp/agent"
     tags:
       - "next-distroless"
       - "{{ .Version }}-distroless"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-> [!IMPORTANT]
-> All Arcane repos have moved to the [@getarcaneapp](https://github.com/getarcaneapp) org on GitHub.
->
-> This means the images used for Arcane for all future releases (past 1.7.2) will use the following repositories:
->
-> Arcane: `ghcr.io/getarcaneapp/arcane`
->
-> Arcane Agent: `ghcr.io/getarcaneapp/arcane-headless`
-
 <div align="center">
 
   <img src=".github/assets/img/PNG-3.png" alt="Arcane Logo" width="500" />

--- a/docker/examples/compose.agent-edge.yaml
+++ b/docker/examples/compose.agent-edge.yaml
@@ -1,6 +1,6 @@
 services:
   arcane-edge-agent:
-    image: ghcr.io/getarcaneapp/arcane-headless:latest
+    image: ghcr.io/getarcaneapp/agent:latest
     container_name: arcane-edge-agent
     # No ports exposed - agent connects outbound to manager tunnel transport
     environment:

--- a/docker/examples/compose.agent.yaml
+++ b/docker/examples/compose.agent.yaml
@@ -1,6 +1,6 @@
 services:
   arcane-agent:
-    image: ghcr.io/getarcaneapp/arcane-headless:latest
+    image: ghcr.io/getarcaneapp/agent:latest
     container_name: arcane-agent
     ports:
       - "3553:3553"

--- a/docker/examples/compose.basic.yaml
+++ b/docker/examples/compose.basic.yaml
@@ -1,6 +1,6 @@
 services:
   arcane:
-    image: ghcr.io/getarcaneapp/arcane:latest
+    image: ghcr.io/getarcaneapp/manager:latest
     container_name: arcane
     ports:
       - "3552:3552"


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces shorter, cleaner alias image names — `ghcr.io/getarcaneapp/manager` and `ghcr.io/getarcaneapp/agent` — alongside the existing `arcane` and `arcane-headless` repositories. All four CI workflows (GitHub Actions release, next-image, PR, and the Depot equivalent) as well as `.goreleaser.yaml` are updated consistently to build, push, sign, and attest both the canonical and alias image names from the same manifest digest.

- All workflow files add `MANAGER_IMAGE_ALIAS` / `AGENT_IMAGE_ALIAS` env vars and extend every relevant step (metadata, push, cosign sign, attest-build-provenance) to cover both image names.
- `.goreleaser.yaml` appends the alias repos to the appropriate `dockers_v2` image lists so GoReleaser publishes both on release.
- Example compose files and the README notice are updated to reference the new canonical names; the old names continue to be published as aliases for backward compatibility.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive alias registrations with no removal of existing image names or breaking pipeline logic.

Every workflow and goreleaser block is updated symmetrically: the same manifest digest is used to push, sign, and attest both the original and alias image names. The old arcane and arcane-headless repositories continue to receive all tags, so existing deployments are unaffected. No logic is altered; this is purely a publishing-configuration expansion.

No files require special attention. The release.yml attestation steps for the aliases are new but follow exactly the same pattern as the existing attestation steps.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: publish manager and agent imag..."](https://github.com/getarcaneapp/arcane/commit/94cc5d9df39cf82821292aefd4fa677d594163a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32542178)</sub>

<!-- /greptile_comment -->