### PR TITLE
refactor: use trivy-db mirrors from arcane-tools

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -45,22 +45,25 @@ const (
 	DefaultArcaneToolsImage = "ghcr.io/getarcaneapp/tools:latest"
 	// DefaultTrivyImage preserves the existing setting name, but now points at
 	// the shared Arcane tools image that includes the Trivy binary.
-	DefaultTrivyImage                  = DefaultArcaneToolsImage
-	DefaultTrivyNetworkMode            = "bridge"
-	trivyCacheVolumeName               = "arcane-trivy-cache"
-	trivyCacheMountTarget              = "/root/.cache"
-	trivyCacheSlotRootDir              = trivyCacheMountTarget + "/arcane-scan-slots"
-	scanStaleTimeout                   = 30 * time.Minute
-	defaultTrivyCPULimitCores          = 1.0
-	defaultTrivyMemoryLimitMB    int64 = 0
-	trivyNanoCPUsPerCore               = int64(1_000_000_000)
-	trivyBytesPerMB                    = int64(1024 * 1024)
-	trivyErrorExcerptSize              = int64(32 * 1024)
-	defaultScanSaveRetryAttempts       = 3
-	defaultScanSaveRetryDelay          = 200 * time.Millisecond
-	defaultScanSaveRetryMaxDelay       = 2 * time.Second
-	trivyOutputPathPrefix              = "/tmp/arcane-trivy-result-"
-	defaultDockerHostURI               = "unix:///var/run/docker.sock"
+	DefaultTrivyImage                        = DefaultArcaneToolsImage
+	DefaultTrivyNetworkMode                  = "bridge"
+	trivyCacheVolumeName                     = "arcane-trivy-cache"
+	trivyCacheMountTarget                    = "/root/.cache"
+	trivyCacheSlotRootDir                    = trivyCacheMountTarget + "/arcane-scan-slots"
+	scanStaleTimeout                         = 30 * time.Minute
+	defaultTrivyCPULimitCores                = 1.0
+	defaultTrivyMemoryLimitMB          int64 = 0
+	trivyNanoCPUsPerCore                     = int64(1_000_000_000)
+	trivyBytesPerMB                          = int64(1024 * 1024)
+	trivyErrorExcerptSize                    = int64(32 * 1024)
+	defaultScanSaveRetryAttempts             = 3
+	defaultScanSaveRetryDelay                = 200 * time.Millisecond
+	defaultScanSaveRetryMaxDelay             = 2 * time.Second
+	trivyOutputPathPrefix                    = "/tmp/arcane-trivy-result-"
+	defaultDockerHostURI                     = "unix:///var/run/docker.sock"
+	DefaultTrivyDBRepository                 = "ghcr.io/getarcaneapp/trivy-db:2"
+	DefaultTrivyJavaDBRepository             = "ghcr.io/getarcaneapp/trivy-java-db:1"
+	DefaultTrivyChecksBundleRepository       = "ghcr.io/getarcaneapp/trivy-checks:1"
 )
 
 type trivyRuntimeOptions struct {
@@ -1400,6 +1403,7 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 
 	execCmd := []string{"trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout}
 	execCmd = append(execCmd, trivyScanCacheBackendArgsInternal()...)
+	execCmd = append(execCmd, trivyDefaultRepositoryArgsInternal()...)
 	execCmd = append(execCmd, imageName)
 
 	execCfg := client.ExecCreateOptions{
@@ -2135,6 +2139,14 @@ func trivyScanCacheBackendArgsInternal() []string {
 	return trivyScanCacheBackendArgsForArchInternal(runtime.GOARCH)
 }
 
+func trivyDefaultRepositoryArgsInternal() []string {
+	return []string{
+		"--db-repository", DefaultTrivyDBRepository,
+		"--java-db-repository", DefaultTrivyJavaDBRepository,
+		"--checks-bundle-repository", DefaultTrivyChecksBundleRepository,
+	}
+}
+
 func (s *VulnerabilityService) buildTrivyCommandArgs(
 	ctx context.Context,
 	imageName string,
@@ -2145,6 +2157,7 @@ func (s *VulnerabilityService) buildTrivyCommandArgs(
 ) ([]string, []string) {
 	cmdArgs := []string{"image", "--format", "json", "--quiet", "--timeout", s.getTrivyScanTimeoutArg()}
 	cmdArgs = append(cmdArgs, trivyScanCacheBackendArgsInternal()...)
+	cmdArgs = append(cmdArgs, trivyDefaultRepositoryArgsInternal()...)
 	var tempFiles []string
 
 	if strings.TrimSpace(configContent) != "" {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -290,6 +290,18 @@ func TestBuildTrivyCommandArgs_WithoutCacheDir(t *testing.T) {
 	require.Equal(t, "alpine:3.20", cmdArgs[len(cmdArgs)-1])
 }
 
+func TestBuildTrivyCommandArgs_IncludesDefaultRepositories(t *testing.T) {
+	svc := &VulnerabilityService{}
+	cmdArgs, _ := svc.buildTrivyCommandArgs(context.Background(), "alpine:3.20", "", "", "", "/tmp/out.json")
+
+	require.Contains(t, cmdArgs, "--db-repository")
+	require.Contains(t, cmdArgs, DefaultTrivyDBRepository)
+	require.Contains(t, cmdArgs, "--java-db-repository")
+	require.Contains(t, cmdArgs, DefaultTrivyJavaDBRepository)
+	require.Contains(t, cmdArgs, "--checks-bundle-repository")
+	require.Contains(t, cmdArgs, DefaultTrivyChecksBundleRepository)
+}
+
 func TestTrivyScanCacheBackendArgsForArch(t *testing.T) {
 	memoryBackend := []string{"--cache-backend", "memory"}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces three new exported constants (`DefaultTrivyDBRepository`, `DefaultTrivyJavaDBRepository`, `DefaultTrivyChecksBundleRepository`) pointing to `ghcr.io/getarcaneapp` mirror images, and injects them into both Trivy invocation paths via a new helper function `trivyDefaultRepositoryArgsInternal()`.

- Both code paths that build Trivy commands (`execTrivyScanInContainer` and `buildTrivyCommandArgs`) are updated consistently, and the image name positional argument remains correctly placed as the last element in both.
- A focused test verifies that `buildTrivyCommandArgs` now includes all three repository flags; the existing `TestBuildTrivyCommandArgs_WithoutCacheDir` positional assertion (`cmdArgs[len(cmdArgs)-1] == "alpine:3.20"`) continues to hold since `imageName` is still appended last.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow, both Trivy command-building paths are updated symmetrically, and the new repository args are inserted before the positional image argument in both paths.

The logic is straightforward: a new helper returns a fixed slice of three flag-value pairs and is appended at the same point in both scan paths. The existing tests still pass (image name remains last), a new test covers the added flags, and no edge cases are introduced.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use trivy-db mirrors from arca..."](https://github.com/getarcaneapp/arcane/commit/9e7b924c2148dadfe9648c279721a5ae16eb981c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32543122)</sub>

<!-- /greptile_comment -->