### PR TITLE
fix: improve environment proxy error handling

### DIFF
--- a/backend/api/handlers/environments.go
+++ b/backend/api/handlers/environments.go
@@ -23,6 +23,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/base"
 	"github.com/getarcaneapp/arcane/types/environment"
@@ -1127,8 +1128,15 @@ func (h *EnvironmentHandler) GetEnvironmentVersion(ctx context.Context, input *G
 		}
 	} else {
 		// Direct HTTP request for non-edge environments
-		url := strings.TrimRight(env.ApiUrl, "/") + "/api/app-version"
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+		validatedURL, validateErr := httputils.ValidateOutboundHTTPURL(env.ApiUrl)
+		if validateErr != nil {
+			return nil, huma.Error400BadRequest("Invalid environment API URL")
+		}
+		validatedURL.RawQuery = ""
+		validatedURL.Fragment = ""
+		validatedURL.Path = strings.TrimRight(validatedURL.Path, "/") + "/api/app-version"
+
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, validatedURL.String(), nil)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("Failed to create request")
 		}

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -371,6 +371,50 @@ func (e *EnvironmentNotFoundError) Error() string {
 	return "Environment not found"
 }
 
+type EnvironmentDisabledError struct{}
+
+func (e *EnvironmentDisabledError) Error() string {
+	return "Environment is disabled"
+}
+
+type EnvironmentUnauthorizedError struct{}
+
+func (e *EnvironmentUnauthorizedError) Error() string {
+	return "Authentication required to access remote environments"
+}
+
+type EnvironmentInvalidProxyTargetError struct {
+	Err error
+}
+
+func (e *EnvironmentInvalidProxyTargetError) Error() string {
+	return fmt.Sprintf("Invalid proxy target URL: %v", e.Err)
+}
+
+func (e *EnvironmentInvalidProxyTargetError) Unwrap() error { return e.Err }
+
+type EnvironmentProxyRequestCreationError struct {
+	Err error
+}
+
+func (e *EnvironmentProxyRequestCreationError) Error() string {
+	return fmt.Sprintf("Failed to create proxy request: %v", e.Err)
+}
+
+type EnvironmentProxyRequestFailedError struct {
+	Err error
+}
+
+func (e *EnvironmentProxyRequestFailedError) Error() string {
+	return fmt.Sprintf("Proxy request failed: %v", e.Err)
+}
+
+type EdgeAgentNotConnectedError struct{}
+
+func (e *EdgeAgentNotConnectedError) Error() string {
+	return "Edge agent is not connected"
+}
+
 type AgentTokenPersistenceError struct {
 	Err error
 }

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,8 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	wsutil "github.com/getarcaneapp/arcane/backend/pkg/libarcane/ws"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 )
@@ -20,12 +23,6 @@ import (
 const (
 	apiEnvironmentsPrefix  = "/api/environments/"
 	environmentsPathMarker = "/environments/"
-
-	errEnvironmentNotFound      = "Environment not found"
-	errEnvironmentDisabled      = "Environment is disabled"
-	errFailedCreateProxyRequest = "Failed to create proxy request"
-	errProxyRequestFailedPrefix = "Proxy request failed:"
-	errUnauthorized             = "Authentication required to access remote environments"
 
 	// proxyTimeout is intentionally generous because some proxied operations
 	// (e.g., image pulls with progress streaming) can take multiple minutes.
@@ -112,7 +109,7 @@ func (m *EnvironmentMiddleware) Handle(c echo.Context, next echo.HandlerFunc) er
 	if m.authValidator != nil && !m.authValidator(c.Request().Context(), c) {
 		return c.JSON(http.StatusUnauthorized, map[string]any{
 			"success": false,
-			"data":    map[string]any{"error": errUnauthorized},
+			"data":    map[string]any{"error": (&common.EnvironmentUnauthorizedError{}).Error()},
 		})
 	}
 
@@ -120,14 +117,14 @@ func (m *EnvironmentMiddleware) Handle(c echo.Context, next echo.HandlerFunc) er
 	if err != nil || apiURL == "" {
 		return c.JSON(http.StatusNotFound, map[string]any{
 			"success": false,
-			"data":    map[string]any{"error": errEnvironmentNotFound},
+			"data":    map[string]any{"error": (&common.EnvironmentNotFoundError{}).Error()},
 		})
 	}
 
 	if !enabled {
 		return c.JSON(http.StatusBadRequest, map[string]any{
 			"success": false,
-			"data":    map[string]any{"error": errEnvironmentDisabled},
+			"data":    map[string]any{"error": (&common.EnvironmentDisabledError{}).Error()},
 		})
 	}
 
@@ -314,7 +311,7 @@ func (m *EnvironmentMiddleware) abortEdgeTunnelUnavailable(c echo.Context) error
 	return c.JSON(http.StatusBadGateway, map[string]any{
 		"success": false,
 		"data": map[string]any{
-			"error": "Edge agent is not connected",
+			"error": (&common.EdgeAgentNotConnectedError{}).Error(),
 		},
 	})
 }
@@ -344,9 +341,14 @@ func (m *EnvironmentMiddleware) proxyHTTP(c echo.Context, target string, accessT
 
 	req, err := m.createProxyRequest(c, target, accessToken)
 	if err != nil {
+		errMessage := (&common.EnvironmentProxyRequestCreationError{Err: err}).Error()
+		var invalidTargetErr *common.EnvironmentInvalidProxyTargetError
+		if errors.As(err, &invalidTargetErr) {
+			errMessage = invalidTargetErr.Error()
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]any{
 			"success": false,
-			"data":    map[string]any{"error": errFailedCreateProxyRequest},
+			"data":    map[string]any{"error": errMessage},
 		})
 	}
 
@@ -354,7 +356,7 @@ func (m *EnvironmentMiddleware) proxyHTTP(c echo.Context, target string, accessT
 	if err != nil {
 		return c.JSON(http.StatusBadGateway, map[string]any{
 			"success": false,
-			"data":    map[string]any{"error": fmt.Sprintf("%s %v", errProxyRequestFailedPrefix, err)},
+			"data":    map[string]any{"error": (&common.EnvironmentProxyRequestFailedError{Err: err}).Error()},
 		})
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -366,6 +368,11 @@ func (m *EnvironmentMiddleware) proxyHTTP(c echo.Context, target string, accessT
 // createProxyRequest builds the HTTP request to forward to the remote environment.
 func (m *EnvironmentMiddleware) createProxyRequest(c echo.Context, target string, accessToken *string) (*http.Request, error) {
 	srcReq := c.Request()
+	validatedTarget, err := httputils.ValidateOutboundHTTPURL(target)
+	if err != nil {
+		return nil, &common.EnvironmentInvalidProxyTargetError{Err: err}
+	}
+
 	var bodyBytes []byte
 	if srcReq.Body != nil {
 		var err error
@@ -378,14 +385,23 @@ func (m *EnvironmentMiddleware) createProxyRequest(c echo.Context, target string
 
 	slog.DebugContext(srcReq.Context(), "Creating proxy request", "method", srcReq.Method, "target", target, "contentLength", srcReq.ContentLength, "contentType", srcReq.Header.Get("Content-Type"), "bodyLength", len(bodyBytes), "body", string(bodyBytes))
 
-	var body io.Reader
+	var requestBody io.ReadCloser
+	var getBody func() (io.ReadCloser, error)
 	if len(bodyBytes) > 0 {
-		body = bytes.NewReader(bodyBytes)
+		requestBody = io.NopCloser(bytes.NewReader(bodyBytes))
+		getBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
 	}
-	req, err := http.NewRequestWithContext(srcReq.Context(), srcReq.Method, target, body)
-	if err != nil {
-		return nil, err
-	}
+	requestURL := *validatedTarget
+	req := (&http.Request{
+		Method:  srcReq.Method,
+		URL:     &requestURL,
+		Host:    requestURL.Host,
+		Header:  make(http.Header),
+		Body:    requestBody,
+		GetBody: getBody,
+	}).WithContext(srcReq.Context())
 
 	skip := edge.GetSkipHeaders()
 	edge.CopyRequestHeaders(srcReq.Header, req.Header, skip)

--- a/backend/internal/middleware/environment_middleware_test.go
+++ b/backend/internal/middleware/environment_middleware_test.go
@@ -230,3 +230,15 @@ func TestIsWebSocketUpgrade(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentMiddleware_CreateProxyRequest_RejectsInvalidProxyTarget(t *testing.T) {
+	middleware := newTestEnvironmentMiddleware()
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/environments/env-edge/containers", nil)
+	c := e.NewContext(req, recorder)
+
+	_, err := middleware.createProxyRequest(c, "ftp://example.com/containers", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid proxy target URL")
+}

--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/remenv"
+	httputils "github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/containerregistry"
 	"github.com/getarcaneapp/arcane/types/environment"
@@ -743,10 +744,17 @@ func (s *EnvironmentService) TestConnection(ctx context.Context, id string, cust
 		apiUrl = *customApiUrl
 	}
 
+	healthURL, err := buildEnvironmentEndpointURLInternal(apiUrl, "/api/health")
+	if err != nil {
+		if customApiUrl == nil {
+			_ = s.updateEnvironmentStatusInternal(ctx, id, string(models.EnvironmentStatusOffline))
+		}
+		return "offline", fmt.Errorf("invalid environment API URL: %w", err)
+	}
+
 	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	url := strings.TrimRight(apiUrl, "/") + "/api/health"
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, healthURL, nil)
 	if err != nil {
 		if customApiUrl == nil {
 			_ = s.updateEnvironmentStatusInternal(ctx, id, string(models.EnvironmentStatusOffline))
@@ -965,9 +973,14 @@ func (s *EnvironmentService) RegenerateEnvironmentApiKey(ctx context.Context, en
 
 // Deprecated - Use the Api Key flow
 func (s *EnvironmentService) PairAgentWithBootstrap(ctx context.Context, apiUrl, bootstrapToken string) (string, error) {
+	pairURL, err := buildEnvironmentEndpointURLInternal(apiUrl, "/api/environments/0/agent/pair")
+	if err != nil {
+		return "", fmt.Errorf("invalid agent API URL: %w", err)
+	}
+
 	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, strings.TrimRight(apiUrl, "/")+"/api/environments/0/agent/pair", nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, pairURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}
@@ -1319,13 +1332,43 @@ func (s *EnvironmentService) resolveRemoteEnvironmentTargetInternal(ctx context.
 		return nil, fmt.Errorf("cannot proxy request to local environment")
 	}
 
+	targetURL := strings.TrimRight(environment.ApiUrl, "/")
+	if !environment.IsEdge {
+		validatedTargetURL, err := normalizeEnvironmentBaseURLInternal(environment.ApiUrl)
+		if err != nil {
+			return nil, fmt.Errorf("invalid environment API URL: %w", err)
+		}
+		targetURL = validatedTargetURL
+	}
+
 	return &remoteEnvironmentTargetInternal{
 		ID:          environment.ID,
 		Name:        environment.Name,
 		IsEdge:      environment.IsEdge,
 		AccessToken: environment.AccessToken,
-		TargetURL:   strings.TrimRight(environment.ApiUrl, "/"),
+		TargetURL:   targetURL,
 	}, nil
+}
+
+func normalizeEnvironmentBaseURLInternal(apiURL string) (string, error) {
+	parsed, err := httputils.ValidateOutboundHTTPURL(apiURL)
+	if err != nil {
+		return "", err
+	}
+
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return parsed.String(), nil
+}
+
+func buildEnvironmentEndpointURLInternal(apiURL, endpointPath string) (string, error) {
+	baseURL, err := normalizeEnvironmentBaseURLInternal(apiURL)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(baseURL, "/") + endpointPath, nil
 }
 
 func (s *EnvironmentService) getProxyRequestContextInternal(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/backend/internal/services/environment_service_test.go
+++ b/backend/internal/services/environment_service_test.go
@@ -928,3 +928,37 @@ func TestEnvironmentService_GenerateEdgeDeploymentSnippets_ReturnsBasicSnippetsW
 	require.Contains(t, snippets.DockerRun, "EDGE_TRANSPORT=poll")
 	require.Contains(t, snippets.DockerCompose, "MANAGER_API_URL=https://manager.example.com")
 }
+
+func TestEnvironmentService_PairAgentWithBootstrap_RejectsInvalidURL(t *testing.T) {
+	svc := NewEnvironmentService(nil, nil, nil, nil, nil, nil)
+
+	_, err := svc.PairAgentWithBootstrap(context.Background(), "ftp://example.com", "bootstrap-token")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid agent API URL")
+}
+
+func TestEnvironmentService_TestConnection_RejectsInvalidCustomURL(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	svc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
+
+	createTestEnvironment(t, db, "env-1", "http://example.com", nil)
+	customURL := "ftp://example.com"
+
+	status, err := svc.TestConnection(ctx, "env-1", &customURL)
+	require.Error(t, err)
+	require.Equal(t, "offline", status)
+	require.Contains(t, err.Error(), "invalid environment API URL")
+}
+
+func TestEnvironmentService_ExecuteRemoteRequest_RejectsInvalidEnvironmentURL(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	svc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
+
+	createTestEnvironment(t, db, "env-invalid-url", "http://user:pass@example.com", nil)
+
+	_, err := svc.ExecuteRemoteRequest(ctx, "env-invalid-url", http.MethodGet, "/api/health", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid environment API URL")
+}

--- a/backend/pkg/utils/httpx/outbound_url.go
+++ b/backend/pkg/utils/httpx/outbound_url.go
@@ -1,0 +1,38 @@
+package httpx
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateOutboundHTTPURL parses and validates an outbound HTTP(S) target URL.
+// It intentionally performs syntactic hardening (scheme/host/credentials)
+// without restricting private network ranges, because environment agents may be
+// deployed on trusted private subnets.
+func ValidateOutboundHTTPURL(rawURL string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return nil, fmt.Errorf("URL is required")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q", parsed.Scheme)
+	}
+
+	if parsed.User != nil {
+		return nil, fmt.Errorf("embedded credentials are not allowed")
+	}
+
+	if parsed.Host == "" || parsed.Hostname() == "" {
+		return nil, fmt.Errorf("URL host is required")
+	}
+
+	return parsed, nil
+}

--- a/backend/pkg/utils/httpx/outbound_url_test.go
+++ b/backend/pkg/utils/httpx/outbound_url_test.go
@@ -1,0 +1,36 @@
+package httpx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOutboundHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{name: "allow https URL", rawURL: "https://example.com/api/health"},
+		{name: "allow private network URL", rawURL: "http://10.0.0.5:3553/api/health"},
+		{name: "reject empty URL", rawURL: "", wantErr: true},
+		{name: "reject unsupported scheme", rawURL: "ftp://example.com", wantErr: true},
+		{name: "reject missing host", rawURL: "https:///api/health", wantErr: true},
+		{name: "reject embedded credentials", rawURL: "https://user:pass@example.com/api/health", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ValidateOutboundHTTPURL(tt.rawURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, parsed)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+		})
+	}
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens outbound HTTP request handling by introducing a `ValidateOutboundHTTPURL` utility that rejects non-HTTP/S schemes and embedded credentials, then wires that validation into every proxy/health-check/pair call site in the middleware and environment service.

- Adds `backend/pkg/utils/httpx.ValidateOutboundHTTPURL` for reusable scheme + host + credential validation, and three new helper functions (`normalizeEnvironmentBaseURLInternal`, `buildEnvironmentEndpointURLInternal`) to replace ad-hoc `strings.TrimRight` URL construction throughout the service layer.
- Converts five previously hardcoded error-string constants in the middleware into typed `common.*Error` structs in `errors.go`, each implementing `Unwrap()` for proper error-chain traversal; the manual `http.Request` construction in `createProxyRequest` now also explicitly sets both `GetBody` (for redirect replay) and `ContentLength` (to preserve explicit `Content-Length` headers on proxied requests with bodies).
- Adds unit tests for the new URL validator, the middleware's rejection of invalid proxy targets, and service-level rejection of invalid environment URLs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — URL validation is additive and the manual proxy request construction correctly sets both GetBody and ContentLength.

The change is well-scoped: it adds a validated URL parser, replaces loose string trimming with it throughout the service, introduces typed error wrappers with Unwrap(), and covers the new paths with targeted tests. The one area of concern from a prior review cycle (GetBody not set in manual request construction) is addressed, and ContentLength is explicitly set after the struct literal on line 412-414. No data-path regressions were found.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/middleware/environment_middleware.go`, line 392-412 ([link](https://github.com/getarcaneapp/arcane/blob/d28a436d31a6934156e46f8340d117f7d914664b/backend/internal/middleware/environment_middleware.go#L392-L412)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> The manual `http.Request` construction does not set `GetBody`, unlike `http.NewRequestWithContext` which snapshots a `*bytes.Reader` and sets `GetBody` automatically. Go's HTTP client uses `GetBody` to replay the body on 307/308 redirects — without it, the body is already consumed from the first send, so any redirect to a body-bearing POST/PUT/PATCH silently sends an empty body to the redirect destination. Simplifying back to `http.NewRequestWithContext(srcReq.Context(), srcReq.Method, validatedTarget.String(), body)` with the subsequent header copies avoids this regression while still benefiting from URL validation.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/middleware/environment_middleware.go
   Line: 392-412

   Comment:
   The manual `http.Request` construction does not set `GetBody`, unlike `http.NewRequestWithContext` which snapshots a `*bytes.Reader` and sets `GetBody` automatically. Go's HTTP client uses `GetBody` to replay the body on 307/308 redirects — without it, the body is already consumed from the first send, so any redirect to a body-bearing POST/PUT/PATCH silently sends an empty body to the redirect destination. Simplifying back to `http.NewRequestWithContext(srcReq.Context(), srcReq.Method, validatedTarget.String(), body)` with the subsequent header copies avoids this regression while still benefiting from URL validation.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fenv-middleware%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fenv-middleware%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%0ALine%3A%20392-412%0A%0AComment%3A%0AThe%20manual%20%60http.Request%60%20construction%20does%20not%20set%20%60GetBody%60%2C%20unlike%20%60http.NewRequestWithContext%60%20which%20snapshots%20a%20%60*bytes.Reader%60%20and%20sets%20%60GetBody%60%20automatically.%20Go's%20HTTP%20client%20uses%20%60GetBody%60%20to%20replay%20the%20body%20on%20307%2F308%20redirects%20%E2%80%94%20without%20it%2C%20the%20body%20is%20already%20consumed%20from%20the%20first%20send%2C%20so%20any%20redirect%20to%20a%20body-bearing%20POST%2FPUT%2FPATCH%20silently%20sends%20an%20empty%20body%20to%20the%20redirect%20destination.%20Simplifying%20back%20to%20%60http.NewRequestWithContext%28srcReq.Context%28%29%2C%20srcReq.Method%2C%20validatedTarget.String%28%29%2C%20body%29%60%20with%20the%20subsequent%20header%20copies%20avoids%20this%20regression%20while%20still%20benefiting%20from%20URL%20validation.%0A%0A%60%60%60suggestion%0A%09req%2C%20err%20%3A%3D%20http.NewRequestWithContext%28srcReq.Context%28%29%2C%20srcReq.Method%2C%20validatedTarget.String%28%29%2C%20body%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20nil%2C%20fmt.Errorf%28%22failed%20to%20build%20proxy%20request%3A%20%25w%22%2C%20err%29%0A%09%7D%0A%0A%09skip%20%3A%3D%20edge.GetSkipHeaders%28%29%0A%09edge.CopyRequestHeaders%28srcReq.Header%2C%20req.Header%2C%20skip%29%0A%09edge.SetAuthHeader%28req%2C%20c%29%0A%09edge.SetAgentToken%28req%2C%20accessToken%29%0A%09edge.SetForwardedHeaders%28req%2C%20c.RealIP%28%29%2C%20srcReq.Host%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%0ALine%3A%20392-412%0A%0AComment%3A%0AThe%20manual%20%60http.Request%60%20construction%20does%20not%20set%20%60GetBody%60%2C%20unlike%20%60http.NewRequestWithContext%60%20which%20snapshots%20a%20%60*bytes.Reader%60%20and%20sets%20%60GetBody%60%20automatically.%20Go's%20HTTP%20client%20uses%20%60GetBody%60%20to%20replay%20the%20body%20on%20307%2F308%20redirects%20%E2%80%94%20without%20it%2C%20the%20body%20is%20already%20consumed%20from%20the%20first%20send%2C%20so%20any%20redirect%20to%20a%20body-bearing%20POST%2FPUT%2FPATCH%20silently%20sends%20an%20empty%20body%20to%20the%20redirect%20destination.%20Simplifying%20back%20to%20%60http.NewRequestWithContext%28srcReq.Context%28%29%2C%20srcReq.Method%2C%20validatedTarget.String%28%29%2C%20body%29%60%20with%20the%20subsequent%20header%20copies%20avoids%20this%20regression%20while%20still%20benefiting%20from%20URL%20validation.%0A%0A%60%60%60suggestion%0A%09req%2C%20err%20%3A%3D%20http.NewRequestWithContext%28srcReq.Context%28%29%2C%20srcReq.Method%2C%20validatedTarget.String%28%29%2C%20body%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09return%20nil%2C%20fmt.Errorf%28%22failed%20to%20build%20proxy%20request%3A%20%25w%22%2C%20err%29%0A%09%7D%0A%0A%09skip%20%3A%3D%20edge.GetSkipHeaders%28%29%0A%09edge.CopyRequestHeaders%28srcReq.Header%2C%20req.Header%2C%20skip%29%0A%09edge.SetAuthHeader%28req%2C%20c%29%0A%09edge.SetAgentToken%28req%2C%20accessToken%29%0A%09edge.SetForwardedHeaders%28req%2C%20c.RealIP%28%29%2C%20srcReq.Host%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: improve environment proxy error han..."](https://github.com/getarcaneapp/arcane/commit/173d171083bc80cac2f1e5b7f938c179dd8a9c61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32679773)</sub>

<!-- /greptile_comment -->