### PR TITLE
fix: align local BuildKit load/push exporter

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1654,3 +1654,25 @@ type SwarmInspectError struct {
 func (e *SwarmInspectError) Error() string {
 	return fmt.Sprintf("Failed to inspect swarm: %v", e.Err)
 }
+
+type BuildKitImageExporterError struct {
+	ProviderName string
+	Err          error
+}
+
+func (e *BuildKitImageExporterError) Error() string {
+	return fmt.Sprintf("depot and remote BuildKit providers require the image exporter for provider %s: %v", e.ProviderName, e.Err)
+}
+
+func (e *BuildKitImageExporterError) Unwrap() error { return e.Err }
+
+type BuildKitDockerExporterError struct {
+	ProviderName string
+	Err          error
+}
+
+func (e *BuildKitDockerExporterError) Error() string {
+	return fmt.Sprintf("the Docker Engine embedded BuildKit requires the docker image-store exporter (used for load) for provider %s: %v", e.ProviderName, e.Err)
+}
+
+func (e *BuildKitDockerExporterError) Unwrap() error { return e.Err }

--- a/backend/internal/services/build_service_test.go
+++ b/backend/internal/services/build_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	buildgit "github.com/getarcaneapp/arcane/backend/pkg/gitutil"
@@ -375,6 +377,66 @@ func TestBuildService_BuildImage_FailureRecordsHistoryAndEvent(t *testing.T) {
 	assert.Equal(t, record.ID, event.Metadata["buildRecordId"])
 }
 
+func TestBuildService_BuildImage_FailureExporterErrorsAppearInOutputHistoryAndEvent(t *testing.T) {
+	db, err := setupBuildHistoryTestDB()
+	require.NoError(t, err)
+
+	buildErr := &common.BuildKitImageExporterError{
+		ProviderName: "depot",
+		Err:          errors.New(`failed to solve: failed to solve: exporter "image" could not be found`),
+	}
+	progress := &bytes.Buffer{}
+
+	svc := &BuildService{
+		db:           db,
+		eventService: NewEventService(db, nil, nil),
+		builder: testBuildRecorder{
+			err: buildErr,
+			onProgress: func(_ image.BuildRequest, w io.Writer) {
+				_, _ = w.Write([]byte(buildErr.Error()))
+			},
+		},
+	}
+
+	user := &models.User{
+		BaseModel: models.BaseModel{ID: "user-2"},
+		Username:  "registry-test",
+	}
+
+	req := image.BuildRequest{
+		ContextDir: "/builds/demo",
+		Dockerfile: "Dockerfile",
+		Tags:       []string{"ghcr.io/getarcaneapp/arcane:test"},
+		Provider:   "depot",
+		Load:       true,
+	}
+
+	_, err = svc.BuildImage(context.Background(), "0", req, progress, "web", user)
+	require.ErrorIs(t, err, buildErr)
+
+	var record models.ImageBuild
+	require.NoError(t, db.WithContext(context.Background()).First(&record).Error)
+	assert.Equal(t, models.ImageBuildStatusFailed, record.Status)
+	require.NotNil(t, record.Output)
+	assert.Contains(t, *record.Output, buildErr.Error())
+	require.NotNil(t, record.ErrorMessage)
+	assert.Contains(t, *record.ErrorMessage, "exporter \"image\"")
+
+	var event models.Event
+	require.NoError(t, db.WithContext(context.Background()).First(&event, "type = ?", models.EventTypeImageError).Error)
+	assert.Equal(t, models.EventSeverityError, event.Severity)
+	require.NotNil(t, event.ResourceName)
+	assert.Equal(t, "ghcr.io/getarcaneapp/arcane:test", *event.ResourceName)
+	assert.Equal(t, "build", event.Metadata["action"])
+	assert.Equal(t, "depot", event.Metadata["provider"])
+	assert.Equal(t, "/builds/demo", event.Metadata["contextDir"])
+	assert.Equal(t, buildErr.Error(), event.Metadata["error"])
+	assert.Equal(t, buildErr.Error(), progress.String())
+	assert.Equal(t, buildErr.Error(), *record.ErrorMessage)
+	assert.NotEmpty(t, event.Metadata["buildRecordId"])
+	assert.Equal(t, record.ID, event.Metadata["buildRecordId"])
+}
+
 func TestSanitizeBuildContextForEventInternal_RedactsURLCredentials(t *testing.T) {
 	assert.Equal(
 		t,
@@ -390,15 +452,19 @@ func TestSanitizeBuildContextForEventInternal_RedactsURLCredentials(t *testing.T
 }
 
 type testBuildRecorder struct {
-	onBuild func(image.BuildRequest)
-	err     error
+	onBuild    func(image.BuildRequest)
+	onProgress func(image.BuildRequest, io.Writer)
+	err        error
 }
 
-func (b testBuildRecorder) BuildImage(_ context.Context, req image.BuildRequest, _ io.Writer, _ string) (*image.BuildResult, error) {
+func (b testBuildRecorder) BuildImage(_ context.Context, req image.BuildRequest, writer io.Writer, _ string) (*image.BuildResult, error) {
 	if b.onBuild != nil {
 		b.onBuild(req)
 	}
 	if b.err != nil {
+		if b.onProgress != nil {
+			b.onProgress(req, writer)
+		}
 		return nil, b.err
 	}
 	return &image.BuildResult{Provider: "local"}, nil

--- a/backend/pkg/libarcane/libbuild/builder_buildkit.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit.go
@@ -169,16 +169,9 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 	}
 
 	if providerName == "local" && (req.Load || req.Push) {
-		attrs := map[string]string{
-			"name":           strings.Join(req.Tags, ","),
-			"oci-mediatypes": "true",
-		}
-		if req.Push {
-			attrs["push"] = "true"
-		}
 		exports = append(exports, buildkit.ExportEntry{
-			Type:  "image",
-			Attrs: attrs,
+			Type:  "moby",
+			Attrs: map[string]string{"name": strings.Join(req.Tags, ",")},
 		})
 	} else if req.Load {
 		exportEntry, errCh, err := b.buildLoadExportInternal(ctx, req.Tags)

--- a/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit_test.go
@@ -48,7 +48,7 @@ func TestBuildSolveOptInternal_StagesInlineDockerfile(t *testing.T) {
 	assert.Equal(t, "hello\n", string(appContents))
 }
 
-func TestBuildSolveOptInternal_LocalLoadUsesImageExporter(t *testing.T) {
+func TestBuildSolveOptInternal_LocalLoadUsesMobyExporter(t *testing.T) {
 	contextDir := createBuildkitTestContext(t)
 	b := &builder{}
 
@@ -63,13 +63,13 @@ func TestBuildSolveOptInternal_LocalLoadUsesImageExporter(t *testing.T) {
 
 	require.Nil(t, loadErrCh)
 	require.Len(t, solveOpt.Exports, 1)
-	assert.Equal(t, "image", solveOpt.Exports[0].Type)
+	assert.Equal(t, "moby", solveOpt.Exports[0].Type)
 	assert.Equal(t, "arcane.local/app:test", solveOpt.Exports[0].Attrs["name"])
 	assert.NotContains(t, solveOpt.Exports[0].Attrs, "push")
 	assert.Nil(t, solveOpt.Exports[0].Output)
 }
 
-func TestBuildSolveOptInternal_LocalPushAndLoadUsesSingleImageExporter(t *testing.T) {
+func TestBuildSolveOptInternal_LocalPushAndLoadUsesSingleMobyExporter(t *testing.T) {
 	contextDir := createBuildkitTestContext(t)
 	b := &builder{}
 
@@ -85,9 +85,9 @@ func TestBuildSolveOptInternal_LocalPushAndLoadUsesSingleImageExporter(t *testin
 
 	require.Nil(t, loadErrCh)
 	require.Len(t, solveOpt.Exports, 1)
-	assert.Equal(t, "image", solveOpt.Exports[0].Type)
+	assert.Equal(t, "moby", solveOpt.Exports[0].Type)
 	assert.Equal(t, "registry.example.com/app:test", solveOpt.Exports[0].Attrs["name"])
-	assert.Equal(t, "true", solveOpt.Exports[0].Attrs["push"])
+	assert.NotContains(t, solveOpt.Exports[0].Attrs, "push")
 }
 
 func TestBuildSolveOptInternal_NonLocalLoadKeepsDockerExporter(t *testing.T) {

--- a/backend/pkg/libarcane/libbuild/builder_core.go
+++ b/backend/pkg/libarcane/libbuild/builder_core.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/cli/cli/config"
 	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	utilsregistry "github.com/getarcaneapp/arcane/backend/pkg/libarcane/registryauth"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	buildtypes "github.com/getarcaneapp/arcane/types/builds"
@@ -164,6 +165,39 @@ func (b *builder) buildWithBuildkitSessionInternal(
 		}
 	}
 
+	if providerName == "local" && req.Push {
+		if b.dockerClientProvider == nil {
+			missingClientErr := errors.New("docker service not available")
+			buildErr = missingClientErr
+			writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
+				Type:    "build",
+				Service: serviceName,
+				Error:   missingClientErr.Error(),
+			})
+			return nil, missingClientErr
+		}
+
+		dockerClient, dockerClientErr := b.dockerClientProvider.GetClient(ctx)
+		if dockerClientErr != nil {
+			buildErr = dockerClientErr
+			writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
+				Type:    "build",
+				Service: serviceName,
+				Error:   dockerClientErr.Error(),
+			})
+			return nil, dockerClientErr
+		}
+		if pushErr := b.pushDockerImagesInternal(ctx, dockerClient, req.Tags, progressWriter, serviceName); pushErr != nil {
+			buildErr = pushErr
+			writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
+				Type:    "build",
+				Service: serviceName,
+				Error:   pushErr.Error(),
+			})
+			return nil, pushErr
+		}
+	}
+
 	writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
 		Type:    "build",
 		Phase:   "complete",
@@ -191,7 +225,11 @@ func wrapBuildkitSolveErrorInternal(err error, providerName string) error {
 	}
 
 	if strings.Contains(err.Error(), `exporter "docker" could not be found`) {
-		return fmt.Errorf("BuildKit could not load the image with the docker exporter for provider %s; the builder does not expose that exporter: %w", providerName, err)
+		return &common.BuildKitDockerExporterError{ProviderName: providerName, Err: err}
+	}
+
+	if strings.Contains(err.Error(), `exporter "image" could not be found`) {
+		return &common.BuildKitImageExporterError{ProviderName: providerName, Err: err}
 	}
 
 	return err

--- a/backend/pkg/libarcane/libbuild/builder_core_test.go
+++ b/backend/pkg/libarcane/libbuild/builder_core_test.go
@@ -107,3 +107,21 @@ func TestWrapBuildkitSolveErrorInternal_LeavesGenericErrorsUnchanged(t *testing.
 	require.ErrorIs(t, wrapped, err)
 	assert.Equal(t, err.Error(), wrapped.Error())
 }
+
+func TestWrapBuildkitSolveErrorInternal_WrapsDockerAndImageExporterErrors(t *testing.T) {
+	t.Run("docker exporter", func(t *testing.T) {
+		rawErr := errors.New(`failed to solve: exporter "docker" could not be found`)
+		wrapped := wrapBuildkitSolveErrorInternal(rawErr, "local")
+
+		require.ErrorIs(t, wrapped, rawErr)
+		assert.Contains(t, wrapped.Error(), "the Docker Engine embedded BuildKit requires the docker image-store exporter")
+	})
+
+	t.Run("image exporter", func(t *testing.T) {
+		rawErr := errors.New(`failed to solve: exporter "image" could not be found`)
+		wrapped := wrapBuildkitSolveErrorInternal(rawErr, "depot")
+
+		require.ErrorIs(t, wrapped, rawErr)
+		assert.Contains(t, wrapped.Error(), "depot and remote BuildKit providers require the image exporter")
+	})
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2465

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an exporter mismatch for local BuildKit builds by switching from the `"image"` exporter (which the embedded Docker Engine BuildKit doesn't expose) to the `"moby"` exporter, which writes directly into the local Docker image store. For local `Push` operations, a separate explicit push step via `pushDockerImagesInternal` is added after the solve completes.

- **`builder_buildkit.go`**: Local load/push now uses `Type: "moby"` exporter instead of `Type: "image"`, removing the `push` and `oci-mediatypes` attributes since push is no longer done inline by BuildKit.
- **`builder_core.go`**: After a successful local solve, a dedicated push block calls `pushDockerImagesInternal` when `req.Push` is set; `wrapBuildkitSolveErrorInternal` gains a new case for `exporter "image" could not be found` that wraps into `BuildKitImageExporterError`.
- **`errors.go`**: Two new structured error types (`BuildKitImageExporterError`, `BuildKitDockerExporterError`) replace inline `fmt.Errorf` strings, both implementing `Unwrap` so callers can use `errors.Is`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to local BuildKit exporter selection and adds a well-guarded explicit push step.

All code paths for local load, local push, local load+push, and non-local variants are covered by updated tests. The two-step moby export then explicit Docker push is the correct approach for the embedded BuildKit, error types implement Unwrap for errors.Is compatibility, and no unguarded nil dereferences or goroutine leaks were introduced.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: align local BuildKit load/push expo..."](https://github.com/getarcaneapp/arcane/commit/84528220a26b8d56e7e5d0dd8b857f81800a1929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32728708)</sub>

<!-- /greptile_comment -->