### PR TITLE
fix: system upgrade doesnt support non unix socket docker hosts

### DIFF
--- a/backend/api/handlers/system.go
+++ b/backend/api/handlers/system.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -544,7 +543,7 @@ func (h *SystemHandler) TriggerUpgrade(ctx context.Context, input *TriggerUpgrad
 	if err != nil {
 		slog.Error("System upgrade failed", "error", err, "user", user.Username)
 
-		if errors.Is(err, services.ErrUpgradeInProgress) {
+		if common.IsUpgradeInProgressError(err) {
 			return nil, huma.Error409Conflict((&common.UpgradeTriggerError{Err: err}).Error())
 		}
 

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1070,6 +1070,34 @@ func (e *UpgradeTriggerError) Error() string {
 	return fmt.Sprintf("Failed to initiate upgrade: %v", e.Err)
 }
 
+type NotRunningInDockerError struct{}
+
+func (e *NotRunningInDockerError) Error() string {
+	return "arcane is not running in a Docker container"
+}
+
+type ArcaneContainerNotFoundError struct{}
+
+func (e *ArcaneContainerNotFoundError) Error() string {
+	return "could not find Arcane container"
+}
+
+type UpgradeInProgressError struct{}
+
+func (e *UpgradeInProgressError) Error() string {
+	return "an upgrade is already in progress"
+}
+
+func IsUpgradeInProgressError(err error) bool {
+	return isErrorTypeInternal[*UpgradeInProgressError](err)
+}
+
+type DockerSocketAccessError struct{}
+
+func (e *DockerSocketAccessError) Error() string {
+	return "docker socket is not accessible"
+}
+
 type TemplateListError struct {
 	Err error
 }

--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	dockerutils "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane"
@@ -20,13 +21,7 @@ import (
 	"github.com/moby/moby/client"
 )
 
-var (
-	ErrNotRunningInDocker = errors.New("arcane is not running in a Docker container")
-	ErrContainerNotFound  = errors.New("could not find Arcane container")
-	ErrUpgradeInProgress  = errors.New("an upgrade is already in progress")
-	ErrDockerSocketAccess = errors.New("docker socket is not accessible")
-	ArcaneUpgraderImage   = "ghcr.io/getarcaneapp/arcane:latest"
-)
+var ArcaneUpgraderImage = "ghcr.io/getarcaneapp/arcane:latest"
 
 type SystemUpgradeService struct {
 	upgrading       atomic.Bool
@@ -34,6 +29,12 @@ type SystemUpgradeService struct {
 	versionService  *VersionService
 	eventService    *EventService
 	settingsService *SettingsService
+}
+
+type upgraderRuntimeOptionsInternal struct {
+	ContainerEnv []string
+	Mounts       []mounttypes.Mount
+	NetworkMode  containertypes.NetworkMode
 }
 
 func NewSystemUpgradeService(
@@ -53,19 +54,19 @@ func NewSystemUpgradeService(
 // CanUpgrade checks if self-upgrade is possible
 func (s *SystemUpgradeService) CanUpgrade(ctx context.Context) (bool, error) {
 	// Check if running in Docker
-	containerId, err := s.getCurrentContainerID()
+	containerId, err := s.getCurrentContainerIDInternal()
 	if err != nil {
-		return false, ErrNotRunningInDocker
+		return false, err
 	}
 
 	// Verify we can access Docker
 	_, err = s.dockerService.GetClient(ctx)
 	if err != nil {
-		return false, ErrDockerSocketAccess
+		return false, &common.DockerSocketAccessError{}
 	}
 
 	// Verify we can find our container
-	_, err = s.findArcaneContainer(ctx, containerId)
+	_, err = s.findArcaneContainerInternal(ctx, containerId)
 	if err != nil {
 		return false, err
 	}
@@ -77,17 +78,17 @@ func (s *SystemUpgradeService) CanUpgrade(ctx context.Context) (bool, error) {
 // This avoids self-termination issues by running the upgrade from outside
 func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user models.User) error {
 	if !s.upgrading.CompareAndSwap(false, true) {
-		return ErrUpgradeInProgress
+		return &common.UpgradeInProgressError{}
 	}
 	defer s.upgrading.Store(false)
 
 	// Get current container name
-	containerId, err := s.getCurrentContainerID()
+	containerId, err := s.getCurrentContainerIDInternal()
 	if err != nil {
 		return fmt.Errorf("get current container: %w", err)
 	}
 
-	currentContainer, err := s.findArcaneContainer(ctx, containerId)
+	currentContainer, err := s.findArcaneContainerInternal(ctx, containerId)
 	if err != nil {
 		return fmt.Errorf("inspect container: %w", err)
 	}
@@ -162,18 +163,33 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	}
 
 	// Create the upgrader container config
+	runtimeOptions, err := resolveSystemUpgraderRuntimeOptionsInternal(
+		ctx,
+		s.dockerService.DockerHost(),
+		&currentContainer,
+		func(ctx context.Context, containerPath string) (string, error) {
+			return dockerutils.GetHostPathForContainerPath(ctx, dockerClient, containerPath)
+		},
+		func() bool {
+			_, err := dockerutils.GetCurrentContainerID()
+			return err == nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("resolve upgrader docker runtime: %w", err)
+	}
+
 	config := &containertypes.Config{
 		Image: ArcaneUpgraderImage,
 		Cmd:   []string{binaryPath, "upgrade", "--container", containerName},
+		Env:   runtimeOptions.ContainerEnv,
 		Labels: map[string]string{
 			"com.getarcaneapp.arcane.upgrader": "true",
 			"com.getarcaneapp.arcane":          "true",
 		},
 	}
 
-	mounts := []mounttypes.Mount{
-		{Type: mounttypes.TypeBind, Source: "/var/run/docker.sock", Target: "/var/run/docker.sock"},
-	}
+	mounts := append([]mounttypes.Mount{}, runtimeOptions.Mounts...)
 	if appDataMount != nil {
 		mounts = append(mounts, *appDataMount)
 	}
@@ -184,8 +200,9 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	}
 
 	hostConfig := &containertypes.HostConfig{
-		AutoRemove: !keepUpgraderContainer, // default: clean up after completion
-		Mounts:     mounts,
+		AutoRemove:  !keepUpgraderContainer, // default: clean up after completion
+		Mounts:      mounts,
+		NetworkMode: runtimeOptions.NetworkMode,
 	}
 
 	containerName = fmt.Sprintf("%s-upgrader-%d", containerName, time.Now().Unix())
@@ -218,17 +235,57 @@ func determineUpgradeBinaryPathInternal(labels map[string]string) string {
 	return "/app/arcane"
 }
 
+func resolveSystemUpgraderRuntimeOptionsInternal(
+	ctx context.Context,
+	dockerHost string,
+	currentContainer *containertypes.InspectResponse,
+	discoverHostPath func(context.Context, string) (string, error),
+	isRunningInDocker func() bool,
+) (upgraderRuntimeOptionsInternal, error) {
+	options := upgraderRuntimeOptionsInternal{
+		ContainerEnv: buildTrivyDockerHostEnvInternal(dockerHost),
+	}
+
+	scheme, socketPath, err := parseTrivyDockerHostInternal(dockerHost)
+	if err != nil {
+		return upgraderRuntimeOptionsInternal{}, fmt.Errorf("resolve docker host %q: %w", dockerHost, err)
+	}
+
+	if scheme != "unix" {
+		options.NetworkMode = containertypes.NetworkMode(selectTrivyAutoNetworkModeInternal(currentContainer))
+		return options, nil
+	}
+
+	socketSource, err := resolveTrivyUnixSocketSourceInternal(
+		ctx,
+		socketPath,
+		discoverHostPath,
+		isRunningInDocker,
+	)
+	if err != nil {
+		return upgraderRuntimeOptionsInternal{}, fmt.Errorf("resolve unix socket source: %w", err)
+	}
+
+	options.Mounts = append(options.Mounts, mounttypes.Mount{
+		Type:   mounttypes.TypeBind,
+		Source: socketSource,
+		Target: socketPath,
+	})
+
+	return options, nil
+}
+
 // getCurrentContainerID detects if we're running in Docker and returns container ID
-func (s *SystemUpgradeService) getCurrentContainerID() (string, error) {
+func (s *SystemUpgradeService) getCurrentContainerIDInternal() (string, error) {
 	id, err := dockerutils.GetCurrentContainerID()
 	if err != nil {
-		return "", ErrNotRunningInDocker
+		return "", &common.NotRunningInDockerError{}
 	}
 	return id, nil
 }
 
 // findArcaneContainer finds the container using the ID
-func (s *SystemUpgradeService) findArcaneContainer(ctx context.Context, containerId string) (containertypes.InspectResponse, error) {
+func (s *SystemUpgradeService) findArcaneContainerInternal(ctx context.Context, containerId string) (containertypes.InspectResponse, error) {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		return containertypes.InspectResponse{}, err
@@ -278,5 +335,5 @@ func (s *SystemUpgradeService) findArcaneContainer(ctx context.Context, containe
 		}
 	}
 
-	return containertypes.InspectResponse{}, ErrContainerNotFound
+	return containertypes.InspectResponse{}, &common.ArcaneContainerNotFoundError{}
 }

--- a/backend/internal/services/system_upgrade_service_test.go
+++ b/backend/internal/services/system_upgrade_service_test.go
@@ -1,9 +1,15 @@
 package services
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/imageupdate"
+	containertypes "github.com/moby/moby/api/types/container"
+	mounttypes "github.com/moby/moby/api/types/mount"
+	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,16 +41,16 @@ func TestSystemUpgradeService_Initialization(t *testing.T) {
 // TestSystemUpgradeService_ErrorVariables tests that error variables are properly defined
 func TestSystemUpgradeService_ErrorVariables(t *testing.T) {
 	// Test that all expected errors exist and are not nil
-	require.Error(t, ErrNotRunningInDocker)
-	require.Error(t, ErrContainerNotFound)
-	require.Error(t, ErrUpgradeInProgress)
-	require.Error(t, ErrDockerSocketAccess)
+	require.Error(t, &common.NotRunningInDockerError{})
+	require.Error(t, &common.ArcaneContainerNotFoundError{})
+	require.Error(t, &common.UpgradeInProgressError{})
+	require.Error(t, &common.DockerSocketAccessError{})
 
 	// Test error messages
-	require.Equal(t, "arcane is not running in a Docker container", ErrNotRunningInDocker.Error())
-	require.Equal(t, "could not find Arcane container", ErrContainerNotFound.Error())
-	require.Equal(t, "an upgrade is already in progress", ErrUpgradeInProgress.Error())
-	require.Equal(t, "docker socket is not accessible", ErrDockerSocketAccess.Error())
+	require.Equal(t, "arcane is not running in a Docker container", (&common.NotRunningInDockerError{}).Error())
+	require.Equal(t, "could not find Arcane container", (&common.ArcaneContainerNotFoundError{}).Error())
+	require.Equal(t, "an upgrade is already in progress", (&common.UpgradeInProgressError{}).Error())
+	require.Equal(t, "docker socket is not accessible", (&common.DockerSocketAccessError{}).Error())
 }
 
 // TestSystemUpgradeService_UpgradingFlag_ConcurrentAccess tests upgrading flag
@@ -116,12 +122,12 @@ func TestSystemUpgradeService_ConcurrentUpgradeAttempts(t *testing.T) {
 // TestSystemUpgradeService_UpgradeInProgressError tests the upgrade in progress sentinel error
 func TestSystemUpgradeService_UpgradeInProgressError(t *testing.T) {
 	// This tests the specific error that the handler checks for
-	// The handler uses: if errors.Is(err, services.ErrUpgradeInProgress)
+	// The handler uses common.IsUpgradeInProgressError for conflict detection.
 
-	require.Equal(t, "an upgrade is already in progress", ErrUpgradeInProgress.Error())
+	err := &common.UpgradeInProgressError{}
+	require.Equal(t, "an upgrade is already in progress", err.Error())
 
-	// Test that the error is not nil
-	require.Error(t, ErrUpgradeInProgress)
+	require.True(t, common.IsUpgradeInProgressError(err))
 }
 
 // TestSystemUpgradeService_AtomicOperations tests atomic.Bool operations
@@ -183,4 +189,85 @@ func TestDetermineUpgradeBinaryPath(t *testing.T) {
 			require.Equal(t, tt.want, determineUpgradeBinaryPathInternal(tt.labels))
 		})
 	}
+}
+
+func TestResolveSystemUpgraderRuntimeOptionsInternal_TCPDockerHost(t *testing.T) {
+	currentContainer := &containertypes.InspectResponse{
+		HostConfig: &containertypes.HostConfig{NetworkMode: "bridge"},
+		NetworkSettings: &containertypes.NetworkSettings{
+			Networks: map[string]*networktypes.EndpointSettings{
+				"bridge":      {},
+				"arcane-test": {},
+			},
+		},
+	}
+
+	options, err := resolveSystemUpgraderRuntimeOptionsInternal(
+		context.Background(),
+		"tcp://docker-socket-proxy:2375",
+		currentContainer,
+		nil,
+		func() bool { return true },
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"}, options.ContainerEnv)
+	require.Empty(t, options.Mounts)
+	require.Equal(t, containertypes.NetworkMode("arcane-test"), options.NetworkMode)
+}
+
+func TestResolveSystemUpgraderRuntimeOptionsInternal_UnixDockerHost(t *testing.T) {
+	options, err := resolveSystemUpgraderRuntimeOptionsInternal(
+		context.Background(),
+		"unix:///var/run/docker.sock",
+		nil,
+		func(context.Context, string) (string, error) {
+			return "/host/run/docker.sock", nil
+		},
+		func() bool { return true },
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"DOCKER_HOST=unix:///var/run/docker.sock"}, options.ContainerEnv)
+	require.Equal(t, containertypes.NetworkMode(""), options.NetworkMode)
+	require.Equal(t, []mounttypes.Mount{
+		{
+			Type:   mounttypes.TypeBind,
+			Source: "/host/run/docker.sock",
+			Target: "/var/run/docker.sock",
+		},
+	}, options.Mounts)
+}
+
+func TestResolveSystemUpgraderRuntimeOptionsInternal_DefaultDockerHost(t *testing.T) {
+	options, err := resolveSystemUpgraderRuntimeOptionsInternal(
+		context.Background(),
+		"",
+		nil,
+		func(context.Context, string) (string, error) {
+			return "/var/run/docker.sock", nil
+		},
+		func() bool { return true },
+	)
+	require.NoError(t, err)
+	require.Nil(t, options.ContainerEnv)
+	require.Equal(t, []mounttypes.Mount{
+		{
+			Type:   mounttypes.TypeBind,
+			Source: "/var/run/docker.sock",
+			Target: "/var/run/docker.sock",
+		},
+	}, options.Mounts)
+}
+
+func TestResolveSystemUpgraderRuntimeOptionsInternal_UnixDockerHostResolutionError(t *testing.T) {
+	_, err := resolveSystemUpgraderRuntimeOptionsInternal(
+		context.Background(),
+		"unix:///var/run/docker.sock",
+		nil,
+		func(context.Context, string) (string, error) {
+			return "", errors.New("inspect failed")
+		},
+		func() bool { return true },
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "resolve unix socket source")
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2644

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes system upgrades when Docker is accessed via a non-unix socket (e.g. a TCP socket proxy). The old code unconditionally bind-mounted `/var/run/docker.sock`, which is meaningless for TCP/HTTP Docker hosts.

- Error variables previously living as package-level sentinels in the `services` package are moved to typed error structs in `common`, with an `IsUpgradeInProgressError` helper using `errors.As` for unwrap-safe detection.
- A new `resolveSystemUpgraderRuntimeOptionsInternal` function (reusing the existing Trivy socket helpers from `vulnerability_service.go`) determines at runtime whether the upgrader container needs a socket bind-mount (unix) or a matching network mode + `DOCKER_HOST` env var (TCP/HTTP).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the core upgrade path for non-unix Docker hosts is now handled correctly, and the unix path is functionally unchanged.

The functional logic is well-structured and reuses battle-tested helpers already used by the vulnerability scanner. The only finding is a pre-existing naming convention that two modified methods don't follow — a style gap, not a correctness problem.

system_upgrade_service.go — the two modified unexported methods could use a naming pass for consistency with the rest of the file.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fupgrade-avc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupgrade-avc%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fsystem_upgrade_service.go%3A279-285%0A**Naming%20convention%20not%20followed%20for%20modified%20unexported%20methods**%0A%0AThe%20unexported%20methods%20%60getCurrentContainerID%60%20%28line%20279%29%20and%20%60findArcaneContainer%60%20%28line%20288%29%20are%20both%20modified%20in%20this%20PR%20but%20don't%20carry%20the%20required%20%60Internal%60%20suffix%20that%20the%20codebase%20convention%20mandates%20for%20all%20unexported%20functions.%20Every%20other%20unexported%20function%20added%20or%20modified%20in%20this%20changeset%20%E2%80%94%20%60resolveSystemUpgraderRuntimeOptionsInternal%60%2C%20%60determineUpgradeBinaryPathInternal%60%2C%20etc.%20%E2%80%94%20already%20follows%20the%20convention.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fsystem_upgrade_service.go%3A279-285%0A**Naming%20convention%20not%20followed%20for%20modified%20unexported%20methods**%0A%0AThe%20unexported%20methods%20%60getCurrentContainerID%60%20%28line%20279%29%20and%20%60findArcaneContainer%60%20%28line%20288%29%20are%20both%20modified%20in%20this%20PR%20but%20don't%20carry%20the%20required%20%60Internal%60%20suffix%20that%20the%20codebase%20convention%20mandates%20for%20all%20unexported%20functions.%20Every%20other%20unexported%20function%20added%20or%20modified%20in%20this%20changeset%20%E2%80%94%20%60resolveSystemUpgraderRuntimeOptionsInternal%60%2C%20%60determineUpgradeBinaryPathInternal%60%2C%20etc.%20%E2%80%94%20already%20follows%20the%20convention.%0A%0A&repo=getarcaneapp%2Farcane&pr=2651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/system_upgrade_service.go:279-285
**Naming convention not followed for modified unexported methods**

The unexported methods `getCurrentContainerID` (line 279) and `findArcaneContainer` (line 288) are both modified in this PR but don't carry the required `Internal` suffix that the codebase convention mandates for all unexported functions. Every other unexported function added or modified in this changeset — `resolveSystemUpgraderRuntimeOptionsInternal`, `determineUpgradeBinaryPathInternal`, etc. — already follows the convention.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: system upgrade doesnt support non u..."](https://github.com/getarcaneapp/arcane/commit/5bd548dde7aa41ba4ead7f94d4fabf10de216caa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32731354)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/review/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->