### PR TITLE
fix: PUID and PGID being set on project subfolder on every startup

### DIFF
--- a/backend/api/handlers/swarm.go
+++ b/backend/api/handlers/swarm.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -443,7 +442,7 @@ type UpdateSwarmConfigInput struct {
 }
 
 type UpdateSwarmConfigOutput struct {
-	Body base.ApiResponse[swarmtypes.ConfigSummary]
+	Status int `status:"204"`
 }
 
 type DeleteSwarmConfigInput struct {
@@ -488,7 +487,7 @@ type UpdateSwarmSecretInput struct {
 }
 
 type UpdateSwarmSecretOutput struct {
-	Body base.ApiResponse[swarmtypes.SecretSummary]
+	Status int `status:"204"`
 }
 
 type DeleteSwarmSecretInput struct {
@@ -1741,15 +1740,16 @@ func (h *SwarmHandler) CreateConfig(ctx context.Context, input *CreateSwarmConfi
 	return &CreateSwarmConfigOutput{Body: base.ApiResponse[swarmtypes.ConfigSummary]{Success: true, Data: *cfg}}, nil
 }
 
-// UpdateConfig updates an existing swarm config.
+// UpdateConfig rejects updates to an existing swarm config.
 //
-// It requires admin privileges, delegates the update to the swarm service, and
-// records an audit event containing the config ID and updated name.
+// It requires admin privileges and delegates the update request to the swarm
+// service. Docker swarm configs are immutable, so the current service behavior
+// returns a mapped validation error instead of a replacement config.
 //
 // ctx carries request-scoped cancellation, auth, and audit context.
 // input identifies the config to update and contains the replacement specification.
 //
-// Returns the updated config summary.
+// Returns no content if a future service implementation completes the update.
 // Returns an authorization error for non-admin callers or mapped HTTP errors
 // when the update fails.
 func (h *SwarmHandler) UpdateConfig(ctx context.Context, input *UpdateSwarmConfigInput) (*UpdateSwarmConfigOutput, error) {
@@ -1760,14 +1760,10 @@ func (h *SwarmHandler) UpdateConfig(ctx context.Context, input *UpdateSwarmConfi
 		return nil, err
 	}
 
-	cfg, err := h.swarmService.UpdateConfig(ctx, input.ConfigID, input.Body)
-	if err != nil {
+	if err := h.swarmService.UpdateConfig(ctx, input.ConfigID, input.Body); err != nil {
 		return nil, mapSwarmServiceError(err, "Failed to update swarm config")
 	}
-
-	h.auditSwarmMutation(ctx, input.EnvironmentID, "config.update", "swarm_config", input.ConfigID, cfg.Spec.Name, map[string]any{"configId": input.ConfigID, "name": cfg.Spec.Name})
-
-	return &UpdateSwarmConfigOutput{Body: base.ApiResponse[swarmtypes.ConfigSummary]{Success: true, Data: *cfg}}, nil
+	return &UpdateSwarmConfigOutput{}, nil
 }
 
 // DeleteConfig removes a swarm config.
@@ -1883,15 +1879,16 @@ func (h *SwarmHandler) CreateSecret(ctx context.Context, input *CreateSwarmSecre
 	return &CreateSwarmSecretOutput{Body: base.ApiResponse[swarmtypes.SecretSummary]{Success: true, Data: *secret}}, nil
 }
 
-// UpdateSecret updates an existing swarm secret.
+// UpdateSecret rejects updates to an existing swarm secret.
 //
-// It requires admin privileges, delegates the update to the swarm service, and
-// records an audit event containing the secret ID and updated name.
+// It requires admin privileges and delegates the update request to the swarm
+// service. Docker swarm secrets are immutable, so the current service behavior
+// returns a mapped validation error instead of a replacement secret.
 //
 // ctx carries request-scoped cancellation, auth, and audit context.
 // input identifies the secret to update and contains the replacement specification.
 //
-// Returns the updated secret summary.
+// Returns no content if a future service implementation completes the update.
 // Returns an authorization error for non-admin callers or mapped HTTP errors
 // when the update fails.
 func (h *SwarmHandler) UpdateSecret(ctx context.Context, input *UpdateSwarmSecretInput) (*UpdateSwarmSecretOutput, error) {
@@ -1902,14 +1899,10 @@ func (h *SwarmHandler) UpdateSecret(ctx context.Context, input *UpdateSwarmSecre
 		return nil, err
 	}
 
-	secret, err := h.swarmService.UpdateSecret(ctx, input.SecretID, input.Body)
-	if err != nil {
+	if err := h.swarmService.UpdateSecret(ctx, input.SecretID, input.Body); err != nil {
 		return nil, mapSwarmServiceError(err, "Failed to update swarm secret")
 	}
-
-	h.auditSwarmMutation(ctx, input.EnvironmentID, "secret.update", "swarm_secret", input.SecretID, secret.Spec.Name, map[string]any{"secretId": input.SecretID, "name": secret.Spec.Name})
-
-	return &UpdateSwarmSecretOutput{Body: base.ApiResponse[swarmtypes.SecretSummary]{Success: true, Data: *secret}}, nil
+	return &UpdateSwarmSecretOutput{}, nil
 }
 
 // DeleteSecret removes a swarm secret.
@@ -2071,11 +2064,17 @@ func buildSwarmQueryParams(search, sort, order string, start, limit int) paginat
 //
 // Returns an HTTP-shaped error suitable for returning from a Huma handler.
 func mapSwarmServiceError(err error, fallback string) error {
-	if errors.Is(err, services.ErrSwarmNotEnabled) {
+	if err == nil {
+		return nil
+	}
+	if common.IsSwarmNotEnabledError(err) {
 		return huma.Error409Conflict((&common.SwarmNotEnabledError{}).Error())
 	}
-	if errors.Is(err, services.ErrSwarmManagerRequired) {
+	if common.IsSwarmManagerRequiredError(err) {
 		return huma.Error403Forbidden((&common.SwarmManagerRequiredError{}).Error())
+	}
+	if common.IsSwarmConfigImmutableError(err) || common.IsSwarmSecretImmutableError(err) {
+		return huma.Error400BadRequest(err.Error())
 	}
 	if errdefs.IsNotFound(err) {
 		return huma.Error404NotFound(err.Error())

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -31,11 +31,12 @@ func Bootstrap(ctx context.Context) error {
 	_ = godotenv.Load()
 	cfg := config.Load()
 	runtimeIdentityCfg := &startup.RuntimeIdentityConfig{
-		PUID:         cfg.PUID,
-		PGID:         cfg.PGID,
-		DockerHost:   cfg.DockerHost,
-		DockerConfig: cfg.DockerConfig,
-		DatabaseURL:  cfg.DatabaseURL,
+		PUID:              cfg.PUID,
+		PGID:              cfg.PGID,
+		DockerHost:        cfg.DockerHost,
+		DockerConfig:      cfg.DockerConfig,
+		DatabaseURL:       cfg.DatabaseURL,
+		ProjectsDirectory: cfg.ProjectsDirectory,
 	}
 	if err := startup.ApplyRequestedRuntimeIdentity(ctx, runtimeIdentityCfg); err != nil {
 		return fmt.Errorf("apply runtime identity: %w", err)

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1567,6 +1567,34 @@ func (e *SwarmManagerRequiredError) Error() string {
 	return "Swarm manager access required"
 }
 
+func IsSwarmNotEnabledError(err error) bool {
+	return isErrorTypeInternal[*SwarmNotEnabledError](err)
+}
+
+func IsSwarmManagerRequiredError(err error) bool {
+	return isErrorTypeInternal[*SwarmManagerRequiredError](err)
+}
+
+type SwarmConfigImmutableError struct{}
+
+func (e *SwarmConfigImmutableError) Error() string {
+	return "Swarm configs are immutable; create a new config and update services to use it"
+}
+
+type SwarmSecretImmutableError struct{}
+
+func (e *SwarmSecretImmutableError) Error() string {
+	return "Swarm secrets are immutable; create a new secret and update services to use it"
+}
+
+func IsSwarmConfigImmutableError(err error) bool {
+	return isErrorTypeInternal[*SwarmConfigImmutableError](err)
+}
+
+func IsSwarmSecretImmutableError(err error) bool {
+	return isErrorTypeInternal[*SwarmSecretImmutableError](err)
+}
+
 type SwarmServiceListError struct {
 	Err error
 }

--- a/backend/internal/services/swarm_service.go
+++ b/backend/internal/services/swarm_service.go
@@ -34,9 +34,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var ErrSwarmNotEnabled = errors.New("swarm mode is not enabled")
-var ErrSwarmManagerRequired = errors.New("swarm manager access required")
-
 const swarmNodeIdentityProbeConcurrency = 5
 const KVKeySwarmEnabled = "swarm.enabled"
 const defaultSwarmListenAddr = "0.0.0.0:2377"
@@ -1744,10 +1741,10 @@ func (s *SwarmService) CreateConfig(ctx context.Context, req swarmtypes.ConfigCr
 	return s.GetConfig(ctx, createResult.ID)
 }
 
-func (s *SwarmService) UpdateConfig(ctx context.Context, configID string, req swarmtypes.ConfigUpdateRequest) (*swarmtypes.ConfigSummary, error) {
+func (s *SwarmService) UpdateConfig(ctx context.Context, configID string, req swarmtypes.ConfigUpdateRequest) error {
 	_ = configID
 	_ = req
-	return nil, errors.New("swarm configs are immutable; create a new config and update services to use it")
+	return &common.SwarmConfigImmutableError{}
 }
 
 func (s *SwarmService) RemoveConfig(ctx context.Context, configID string) error {
@@ -1830,10 +1827,10 @@ func (s *SwarmService) CreateSecret(ctx context.Context, req swarmtypes.SecretCr
 	return s.GetSecret(ctx, createResult.ID)
 }
 
-func (s *SwarmService) UpdateSecret(ctx context.Context, secretID string, req swarmtypes.SecretUpdateRequest) (*swarmtypes.SecretSummary, error) {
+func (s *SwarmService) UpdateSecret(ctx context.Context, secretID string, req swarmtypes.SecretUpdateRequest) error {
 	_ = secretID
 	_ = req
-	return nil, errors.New("swarm secrets are immutable; create a new secret and update services to use it")
+	return &common.SwarmSecretImmutableError{}
 }
 
 func (s *SwarmService) RemoveSecret(ctx context.Context, secretID string) error {
@@ -2300,10 +2297,10 @@ func (s *SwarmService) ensureSwarmManagerInternal(ctx context.Context) error {
 	}
 
 	if info.Swarm.LocalNodeState != swarm.LocalNodeStateActive {
-		return ErrSwarmNotEnabled
+		return &common.SwarmNotEnabledError{}
 	}
 	if !info.Swarm.ControlAvailable {
-		return ErrSwarmManagerRequired
+		return &common.SwarmManagerRequiredError{}
 	}
 
 	return nil
@@ -2316,7 +2313,7 @@ func (s *SwarmService) ensureSwarmActiveInternal(ctx context.Context) error {
 	}
 
 	if info.Swarm.LocalNodeState != swarm.LocalNodeStateActive {
-		return ErrSwarmNotEnabled
+		return &common.SwarmNotEnabledError{}
 	}
 
 	return nil

--- a/backend/pkg/libarcane/startup/runtime_identity.go
+++ b/backend/pkg/libarcane/startup/runtime_identity.go
@@ -20,6 +20,8 @@ const (
 	mountInfoPath           = "/proc/self/mountinfo"
 )
 
+var lchownFn = os.Lchown
+
 type runtimeIdentityRequest struct {
 	Enabled       bool
 	UID           int
@@ -32,11 +34,12 @@ type runtimeIdentityRequest struct {
 // RuntimeIdentityConfig contains the config-backed environment values used to
 // switch the process runtime identity before the application initializes.
 type RuntimeIdentityConfig struct {
-	PUID         string
-	PGID         string
-	DockerHost   string
-	DockerConfig string
-	DatabaseURL  string
+	PUID              string
+	PGID              string
+	DockerHost        string
+	DockerConfig      string
+	DatabaseURL       string
+	ProjectsDirectory string
 }
 
 // ApplyRequestedRuntimeIdentity switches the current process to the configured
@@ -44,6 +47,11 @@ type RuntimeIdentityConfig struct {
 func ApplyRequestedRuntimeIdentity(ctx context.Context, cfg *RuntimeIdentityConfig) error {
 	if cfg == nil {
 		cfg = &RuntimeIdentityConfig{}
+	}
+
+	projectsDir := ""
+	if strings.TrimSpace(cfg.ProjectsDirectory) != "" {
+		projectsDir = filepath.Clean(strings.TrimSpace(cfg.ProjectsDirectory))
 	}
 
 	req, warning, err := loadRuntimeIdentityRequestInternal(cfg)
@@ -84,7 +92,7 @@ func ApplyRequestedRuntimeIdentity(ctx context.Context, cfg *RuntimeIdentityConf
 		return err
 	}
 
-	if err := prepareWritablePathsInternal(runtimeUID, runtimeGID, mountpoints); err != nil {
+	if err := prepareWritablePathsInternal(runtimeUID, runtimeGID, mountpoints, projectsDir); err != nil {
 		return err
 	}
 
@@ -228,42 +236,52 @@ func dockerSocketPathInternal(raw string) (string, bool) {
 	return filepath.Clean(socketPath), true
 }
 
-func prepareWritablePathsInternal(uid int, gid int, mountpoints map[string]struct{}) error {
-	if err := os.MkdirAll(defaultDataDirectory, pkgutils.DirPerm); err != nil {
+func prepareWritablePathsInternal(uid int, gid int, mountpoints map[string]struct{}, projectsDir string) error {
+	return prepareWritablePathsWithRootsInternal(uid, gid, mountpoints, projectsDir, defaultDataDirectory, defaultBuildsDirectory)
+}
+
+func prepareWritablePathsWithRootsInternal(uid int, gid int, mountpoints map[string]struct{}, projectsDir string, dataDirectory string, buildsDirectory string) error {
+	if err := os.MkdirAll(dataDirectory, pkgutils.DirPerm); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
 	}
 
-	if err := os.Chown(defaultDataDirectory, uid, gid); err != nil {
+	if err := os.Chown(dataDirectory, uid, gid); err != nil {
 		return fmt.Errorf("chown data directory: %w", err)
 	}
 
-	entries, err := os.ReadDir(defaultDataDirectory)
+	entries, err := os.ReadDir(dataDirectory)
 	if err != nil {
 		return fmt.Errorf("read data directory: %w", err)
 	}
 
 	for _, entry := range entries {
-		entryPath := filepath.Join(defaultDataDirectory, entry.Name())
+		entryPath := filepath.Join(dataDirectory, entry.Name())
 		if _, mounted := mountpoints[entryPath]; mounted {
 			continue
 		}
-		if err := chownRecursiveInternal(entryPath, uid, gid, mountpoints); err != nil {
+		if projectsDir != "" && filepath.Clean(entryPath) == projectsDir {
+			if err := lchownFn(entryPath, uid, gid); err != nil {
+				return fmt.Errorf("chown %s: %w", entryPath, err)
+			}
+			continue
+		}
+		if err := chownRecursiveInternal(entryPath, uid, gid, mountpoints, projectsDir); err != nil {
 			return fmt.Errorf("chown %s: %w", entryPath, err)
 		}
 	}
 
-	if _, mounted := mountpoints[defaultBuildsDirectory]; mounted {
+	if _, mounted := mountpoints[buildsDirectory]; mounted {
 		return nil
 	}
 
-	if _, err := os.Stat(defaultBuildsDirectory); err != nil {
+	if _, err := os.Stat(buildsDirectory); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return fmt.Errorf("stat builds directory: %w", err)
 	}
 
-	if err := chownRecursiveInternal(defaultBuildsDirectory, uid, gid, mountpoints); err != nil {
+	if err := chownRecursiveInternal(buildsDirectory, uid, gid, mountpoints, projectsDir); err != nil {
 		return fmt.Errorf("chown builds directory: %w", err)
 	}
 
@@ -332,7 +350,7 @@ func sqliteDatabasePathInternal(databaseURL string) (string, bool, error) {
 	return filepath.Clean(pathPart), true, nil
 }
 
-func chownRecursiveInternal(path string, uid int, gid int, mountpoints map[string]struct{}) error {
+func chownRecursiveInternal(path string, uid int, gid int, mountpoints map[string]struct{}, projectsDir string) error {
 	return filepath.Walk(path, func(currentPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -343,8 +361,14 @@ func chownRecursiveInternal(path string, uid int, gid int, mountpoints map[strin
 				return filepath.SkipDir
 			}
 		}
+		if projectsDir != "" && filepath.Clean(currentPath) == projectsDir {
+			if err := lchownFn(currentPath, uid, gid); err != nil {
+				return err
+			}
+			return filepath.SkipDir
+		}
 		//nolint:gosec // currentPath comes from fixed container paths under /app/data or /builds
-		return os.Lchown(currentPath, uid, gid)
+		return lchownFn(currentPath, uid, gid)
 	})
 }
 

--- a/backend/pkg/libarcane/startup/runtime_identity_test.go
+++ b/backend/pkg/libarcane/startup/runtime_identity_test.go
@@ -324,3 +324,86 @@ func TestUnescapeMountInfoPath(t *testing.T) {
 		})
 	}
 }
+
+func TestChownRecursiveInternalSkipsProjects(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Setup directory structure:
+	// tempDir/
+	//   database/
+	//   projects/ (this is the protected projects directory)
+	//     demo/
+	//       keep.txt (should not be touched)
+	projectsDir := filepath.Join(tempDir, "projects")
+	demoDir := filepath.Join(projectsDir, "demo")
+	keepFile := filepath.Join(demoDir, "keep.txt")
+	databaseDir := filepath.Join(tempDir, "database")
+
+	require.NoError(t, os.MkdirAll(demoDir, 0755))
+	require.NoError(t, os.WriteFile(keepFile, []byte("keep"), 0644))
+	require.NoError(t, os.MkdirAll(databaseDir, 0755))
+
+	// Track visited paths using mocked lchownFn
+	visited := make(map[string]bool)
+	oldLchownFn := lchownFn
+	lchownFn = func(path string, uid int, gid int) error {
+		visited[filepath.Clean(path)] = true
+		return nil
+	}
+	t.Cleanup(func() {
+		lchownFn = oldLchownFn
+	})
+
+	mountpoints := make(map[string]struct{})
+	err := chownRecursiveInternal(tempDir, 1000, 1000, mountpoints, filepath.Clean(projectsDir))
+	require.NoError(t, err)
+
+	cleanedTempDir := filepath.Clean(tempDir)
+	cleanedDatabaseDir := filepath.Clean(databaseDir)
+	cleanedProjectsDir := filepath.Clean(projectsDir)
+	cleanedDemoDir := filepath.Clean(demoDir)
+	cleanedKeepFile := filepath.Clean(keepFile)
+
+	// Assert base directories / other directories under the path were visited
+	require.True(t, visited[cleanedTempDir], "temp root dir must be visited")
+	require.True(t, visited[cleanedDatabaseDir], "non-protected database dir must be visited")
+
+	// Assert projects directory itself was visited (top level chown)
+	require.True(t, visited[cleanedProjectsDir], "protected projects dir must be visited at top-level")
+
+	// Assert contents inside elements of projects directory were NOT visited
+	require.False(t, visited[cleanedDemoDir], "subdir inside projects dir must NOT be visited")
+	require.False(t, visited[cleanedKeepFile], "file inside projects dir must NOT be visited")
+}
+
+func TestPrepareWritablePathsInternalChownsTopLevelProjectsShallowly(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	buildsDir := filepath.Join(tempDir, "builds")
+	projectsDir := filepath.Join(dataDir, "projects")
+	demoDir := filepath.Join(projectsDir, "demo")
+	keepFile := filepath.Join(demoDir, "keep.txt")
+	databaseDir := filepath.Join(dataDir, "database")
+
+	require.NoError(t, os.MkdirAll(demoDir, 0755))
+	require.NoError(t, os.WriteFile(keepFile, []byte("keep"), 0644))
+	require.NoError(t, os.MkdirAll(databaseDir, 0755))
+
+	visited := make(map[string]bool)
+	oldLchownFn := lchownFn
+	lchownFn = func(path string, uid int, gid int) error {
+		visited[filepath.Clean(path)] = true
+		return nil
+	}
+	t.Cleanup(func() {
+		lchownFn = oldLchownFn
+	})
+
+	err := prepareWritablePathsWithRootsInternal(os.Getuid(), os.Getgid(), map[string]struct{}{}, filepath.Clean(projectsDir), dataDir, buildsDir)
+	require.NoError(t, err)
+
+	require.True(t, visited[filepath.Clean(projectsDir)], "top-level projects dir must be chowned")
+	require.True(t, visited[filepath.Clean(databaseDir)], "non-protected data child must be chowned")
+	require.False(t, visited[filepath.Clean(demoDir)], "subdir inside projects dir must NOT be chowned")
+	require.False(t, visited[filepath.Clean(keepFile)], "file inside projects dir must NOT be chowned")
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2655

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup regression where PUID/PGID ownership was being applied recursively into the projects subdirectory on every container boot. It also refactors swarm error handling from package-level sentinel `errors.New` values to typed error structs with `Is*` helpers, and changes `UpdateConfig`/`UpdateSecret` to return `error` since Docker swarm configs and secrets are immutable.

- `runtime_identity.go` now accepts a `ProjectsDirectory` field; when a projects dir is identified inside the data directory, only the directory itself is chowned (via `lchownFn`) rather than its entire subtree, preventing user-owned project files from being re-owned on every startup.
- `swarm_service.go` replaces `ErrSwarmNotEnabled`/`ErrSwarmManagerRequired` sentinel errors and the always-failing `UpdateConfig`/`UpdateSecret` return values with properly typed errors in `common`, surfaced through new `Is*` helpers and mapped to HTTP 400 in the handler.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it only applies a shallow chown to the configured projects directory instead of recursing into it, and the swarm refactoring is a mechanical rename of sentinel errors to typed structs.

Both the core fix and the swarm refactoring are straightforward. The new tests cover the shallow-chown path and verify that files inside the projects directory are not visited. The `lchownFn` indirection — which was flagged in a prior round — is now used consistently in both the early-exit branch and the walk callback. No correctness or data-loss concerns were found.

No files require special attention.
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: PUID and PGID being set on project ..."](https://github.com/getarcaneapp/arcane/commit/a210a09fa57222877f817a025efe70d2f8731601) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32905306)</sub>

<!-- /greptile_comment -->