### PR TITLE
fix: only validate project name if it has changed

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -75,14 +75,22 @@
 		refetchOnMount: false
 	}));
 
-	const formSchema = z.object({
-		name: z
-			.string()
-			.min(1, m.compose_project_name_required())
-			.regex(/^[a-z0-9_-]+$/i, m.compose_project_name_invalid_with_underscores()),
-		composeContent: z.string().min(1, m.compose_compose_content_required()),
-		envContent: z.string().optional().default('')
-	});
+	const formSchema = z
+		.object({
+			name: z.string().min(1, m.compose_project_name_required()),
+			composeContent: z.string().min(1, m.compose_compose_content_required()),
+			envContent: z.string().optional().default('')
+		})
+		.superRefine((data, ctx) => {
+			const currentServerName = project?.name ?? '';
+			if (data.name !== currentServerName && !/^[a-z0-9_-]+$/i.test(data.name)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ['name'],
+					message: m.compose_project_name_invalid_with_underscores()
+				});
+			}
+		});
 
 	const initialFormData = untrack(() => ({
 		name: data.editorState.originalName,

--- a/frontend/src/routes/(app)/projects/components/EditableName.svelte
+++ b/frontend/src/routes/(app)/projects/components/EditableName.svelte
@@ -97,7 +97,9 @@
 		<h1 class="m-0 w-full">
 			<button
 				type="button"
-				class="hover:bg-muted/50 focus:ring-ring min-h-[32px] w-full rounded bg-transparent px-1 py-1 text-center text-base font-semibold transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+				class="hover:bg-muted/50 focus:ring-ring min-h-[32px] w-full rounded bg-transparent px-1 py-1 text-center text-base font-semibold transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 {error
+					? 'border border-destructive'
+					: ''}"
 				title={canEdit ? `${value || placeholder} (tap to edit)` : value || placeholder}
 				onclick={beginEdit}
 				disabled={!canEdit}
@@ -126,9 +128,11 @@
 			<h1 class="m-0 max-w-[360px]">
 				<button
 					type="button"
-					class="w-full truncate bg-transparent px-0 py-0 text-left text-lg leading-none font-semibold {!value && placeholder
-						? 'text-muted-foreground'
-						: ''}"
+					class={cn(
+						'w-full truncate bg-transparent px-0 py-0 text-left text-lg leading-none font-semibold',
+						!value && placeholder && 'text-muted-foreground',
+						error && 'rounded border border-destructive px-1'
+					)}
 					title={value || placeholder}
 					onclick={beginEdit}
 					disabled={!canEdit}
@@ -163,6 +167,6 @@
 	{/if}
 </div>
 
-{#if isEditing && error}
+{#if error}
 	<p class="text-destructive mt-1 text-xs">{error}</p>
 {/if}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2659

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an issue where opening a project whose name contains characters valid on the server (but rejected by the UI regex) would immediately show a validation error on an unchanged field. The regex check is moved into a `superRefine` closure that skips validation when the name matches the server's current name.

- **`+page.svelte`**: The flat `name` field regex is replaced by a `superRefine` on the schema object that reads `project?.name` at validation time; because `project` is a Svelte 5 `$derived` signal the closure always sees the current server name, not a stale snapshot.
- **`EditableName.svelte`**: The error paragraph and the display-button border indicator are now rendered whenever `error` is set, not only while `isEditing` is true, so users see the error message after committing an invalid name even in view mode.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the logic change is narrow and correct, and the UI improvements match the intended fix.

The `superRefine` closure reads the reactive `project` signal at validation time, so it correctly reflects the current server name rather than a stale snapshot. The conditional skip only bypasses the regex when the name is identical to what the server already holds, leaving all other validation intact. The UI changes to `EditableName.svelte` are straightforward: making the error message and border visible outside edit mode is the intended improvement. The only findable issue is a Tailwind padding-class conflict in the inline button's error state, which is a cosmetic edge case unlikely to cause visible problems in practice.

No files require special attention.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fvalidate-name%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvalidate-name%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2Fcomponents%2FEditableName.svelte%3A131-133%0A**Conflicting%20Tailwind%20padding%20utilities%20in%20error%20state**%0A%0AWhen%20%60error%60%20is%20truthy%20the%20class%20list%20contains%20both%20%60px-0%60%20%28base%29%20and%20%60px-1%60%20%28error%20suffix%29%20simultaneously.%20Both%20compile%20to%20%60padding-inline%60%20at%20equal%20specificity%2C%20so%20the%20winner%20depends%20on%20stylesheet%20generation%20order%20%E2%80%94%20which%20can%20differ%20between%20Tailwind%20versions%20or%20purge%20configurations.%20Since%20%60cn%28%29%60%20is%20already%20imported%20in%20this%20component%2C%20prefer%20using%20it%20here%20to%20merge%20conflicting%20utilities%20unambiguously%2C%20keeping%20%60px-0%60%20for%20the%20non-error%20case%20and%20%60px-1%60%20for%20the%20error%20case.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2Fcomponents%2FEditableName.svelte%3A131-133%0A**Conflicting%20Tailwind%20padding%20utilities%20in%20error%20state**%0A%0AWhen%20%60error%60%20is%20truthy%20the%20class%20list%20contains%20both%20%60px-0%60%20%28base%29%20and%20%60px-1%60%20%28error%20suffix%29%20simultaneously.%20Both%20compile%20to%20%60padding-inline%60%20at%20equal%20specificity%2C%20so%20the%20winner%20depends%20on%20stylesheet%20generation%20order%20%E2%80%94%20which%20can%20differ%20between%20Tailwind%20versions%20or%20purge%20configurations.%20Since%20%60cn%28%29%60%20is%20already%20imported%20in%20this%20component%2C%20prefer%20using%20it%20here%20to%20merge%20conflicting%20utilities%20unambiguously%2C%20keeping%20%60px-0%60%20for%20the%20non-error%20case%20and%20%60px-1%60%20for%20the%20error%20case.%0A%0A&repo=getarcaneapp%2Farcane&pr=2720&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/routes/(app)/projects/components/EditableName.svelte:131-133
**Conflicting Tailwind padding utilities in error state**

When `error` is truthy the class list contains both `px-0` (base) and `px-1` (error suffix) simultaneously. Both compile to `padding-inline` at equal specificity, so the winner depends on stylesheet generation order — which can differ between Tailwind versions or purge configurations. Since `cn()` is already imported in this component, prefer using it here to merge conflicting utilities unambiguously, keeping `px-0` for the non-error case and `px-1` for the error case.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: only validate project name if it ha..."](https://github.com/getarcaneapp/arcane/commit/baae040b63d81614b2a833c7f98d174f4b161c3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33617166)</sub>

<!-- /greptile_comment -->