### PR TITLE
fix: tolerate undefined typed env vars in GitOps sync

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/depot/depot-go v0.5.2
 	github.com/docker/cli v29.5.2+incompatible
 	github.com/docker/compose/v5 v5.1.4
+	github.com/docker/go-units v0.5.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getarcaneapp/arcane/cli v1.19.1
 	github.com/getarcaneapp/arcane/types v1.19.4
@@ -104,7 +105,6 @@ require (
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.7 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/eclipse/paho.golang v0.23.0 // indirect

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -1132,6 +1132,9 @@ func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync
 			_ = os.RemoveAll(stagePath)
 			return nil, fmt.Errorf("failed to stage current project files: %w", err)
 		}
+	} else if err := s.seedStageEnvFromCandidateDirInternal(ctx, sync, projectsDir, stagePath); err != nil {
+		_ = os.RemoveAll(stagePath)
+		return nil, err
 	}
 
 	syncedFiles := make([]string, len(syncFiles))
@@ -1183,6 +1186,88 @@ func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync
 		serviceCount:    serviceCount,
 		contentsChanged: contentsChanged,
 	}, nil
+}
+
+// seedStageEnvFromCandidateDirInternal copies env files from a pre-existing project
+// directory at the conventional path (projectsDir/<sanitized-sync-name>/) into the
+// staging directory before initial-sync validation. This lets users pre-seed
+// ${VAR} substitutions via a server-side .env when the compose file in git
+// expects values that the git repo intentionally does not provide. Only env
+// files are touched — other files would conflict with what WriteSyncedDirectory
+// is about to lay down from git.
+func (s *GitOpsSyncService) seedStageEnvFromCandidateDirInternal(ctx context.Context, sync *models.GitOpsSync, projectsDir, stagePath string) error {
+	candidatePath := filepath.Join(projectsDir, projects.SanitizeProjectName(sync.ProjectName))
+	info, err := os.Stat(candidatePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("inspect pre-existing project directory %s: %w", candidatePath, err)
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	readOptional := func(name string) (string, bool, error) {
+		content, readErr := os.ReadFile(filepath.Join(candidatePath, name))
+		if readErr == nil {
+			return string(content), true, nil
+		}
+		if errors.Is(readErr, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("read %s from %s: %w", name, candidatePath, readErr)
+	}
+
+	effective, hasEffective, err := readOptional(projects.EffectiveEnvFileName)
+	if err != nil {
+		return err
+	}
+	gitSource, hasGit, err := readOptional(projects.GitSourceEnvFileName)
+	if err != nil {
+		return err
+	}
+	override, hasOverride, err := readOptional(projects.OverrideEnvFileName)
+	if err != nil {
+		return err
+	}
+	if !hasEffective && !hasGit && !hasOverride {
+		return nil
+	}
+
+	if hasGit {
+		if err := projects.WriteProjectFile(projectsDir, stagePath, projects.GitSourceEnvFileName, gitSource); err != nil {
+			return fmt.Errorf("seed stage .env.git: %w", err)
+		}
+	}
+	if hasOverride {
+		if err := projects.WriteProjectFile(projectsDir, stagePath, projects.OverrideEnvFileName, override); err != nil {
+			return fmt.Errorf("seed stage project.env: %w", err)
+		}
+	}
+
+	switch {
+	case hasEffective:
+		if err := projects.WriteEnvFile(projectsDir, stagePath, effective); err != nil {
+			return fmt.Errorf("seed stage .env: %w", err)
+		}
+	case hasGit || hasOverride:
+		merged, mergeErr := projects.BuildEffectiveEnvContent(gitSource, override)
+		if mergeErr != nil {
+			return fmt.Errorf("build effective env from pre-existing project: %w", mergeErr)
+		}
+		if err := projects.WriteEnvFile(projectsDir, stagePath, merged); err != nil {
+			return fmt.Errorf("seed stage .env: %w", err)
+		}
+	}
+
+	slog.DebugContext(ctx, "Seeded GitOps stage with pre-existing project env files",
+		"candidatePath", candidatePath,
+		"hasEffective", hasEffective,
+		"hasGit", hasGit,
+		"hasOverride", hasOverride,
+	)
+	return nil
 }
 
 func (s *GitOpsSyncService) lookupProjectByIDInternal(ctx context.Context, projectID string) (*models.Project, bool, error) {

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -6,16 +6,20 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	interp "github.com/compose-spec/compose-go/v2/interpolation"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/template"
+	"github.com/compose-spec/compose-go/v2/tree"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
+	units "github.com/docker/go-units"
 )
 
 var errComposeFileNotFoundInternal = errors.New("no compose file found")
@@ -153,6 +157,64 @@ func LoadComposeProjectLenient(ctx context.Context, composeFile, projectName, pr
 	return loadComposeProjectInternal(ctx, composeFile, projectName, projectsDirectory, autoInjectEnv, pathMapper, nil, nil, true)
 }
 
+// wrapTypeCastMappingLenientInternal prepares the interp type-cast mapping for lenient
+// loading: every existing cast falls back to "0" when it fails (so the lenient
+// placeholder for an undefined variable doesn't abort interpolation), and casts
+// are added for typed struct fields that compose-go would otherwise decode at
+// the mapstructure stage (NanoCPUs, UnitBytes under deploy.resources). Without
+// the added casts, the placeholder string reaches mapstructure and fails to
+// parse — handling it at interp time lets us hand mapstructure a typed value
+// it accepts directly.
+func wrapTypeCastMappingLenientInternal(mapping map[tree.Path]interp.Cast) map[tree.Path]interp.Cast {
+	wrapped := make(map[tree.Path]interp.Cast, len(mapping)+4)
+	for path, original := range mapping {
+		wrapped[path] = wrapCastWithLenientFallbackInternal(original)
+	}
+	addIfAbsent := func(path tree.Path, cast interp.Cast) {
+		if _, exists := wrapped[path]; exists {
+			return
+		}
+		wrapped[path] = wrapCastWithLenientFallbackInternal(cast)
+	}
+	for _, section := range []string{"limits", "reservations"} {
+		addIfAbsent(tree.NewPath("services", tree.PathMatchAll, "deploy", "resources", section, "cpus"), lenientCastFloatInternal)
+		addIfAbsent(tree.NewPath("services", tree.PathMatchAll, "deploy", "resources", section, "memory"), lenientCastSizeInternal)
+	}
+	return wrapped
+}
+
+func wrapCastWithLenientFallbackInternal(original interp.Cast) interp.Cast {
+	return func(value string) (interface{}, error) {
+		result, err := original(value)
+		if err == nil {
+			return result, nil
+		}
+		if fallback, fallbackErr := original("0"); fallbackErr == nil {
+			return fallback, nil
+		}
+		return result, err
+	}
+}
+
+func lenientCastFloatInternal(value string) (interface{}, error) {
+	return strconv.ParseFloat(value, 64)
+}
+
+func lenientCastSizeInternal(value string) (interface{}, error) {
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		b, parseErr := units.RAMInBytes(value)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		n = b
+	}
+	if n > math.MaxInt || n < math.MinInt {
+		return nil, fmt.Errorf("size %d out of range for platform int", n)
+	}
+	return int(n), nil
+}
+
 func loadComposeProjectInternal(
 	ctx context.Context,
 	composeFile string,
@@ -210,13 +272,15 @@ func loadComposeProjectInternal(
 			opts.SetProjectName(projectName, true)
 		}
 		if lenient {
+			opts.SkipValidation = true
+			opts.SkipConsistencyCheck = true
 			if opts.Interpolate == nil {
 				slog.WarnContext(ctx, "compose loader did not initialize Interpolate options; lenient variable substitution will not apply", "compose_file", composeFile)
 			} else {
 				realLookup := opts.Interpolate.LookupValue
 				opts.Interpolate = &interp.Options{
 					Substitute:      template.Substitute,
-					TypeCastMapping: opts.Interpolate.TypeCastMapping,
+					TypeCastMapping: wrapTypeCastMappingLenientInternal(opts.Interpolate.TypeCastMapping),
 					LookupValue: func(key string) (string, bool) {
 						if val, ok := realLookup(key); ok {
 							return val, true

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -188,6 +188,32 @@ func TestLoadComposeProjectLenient_ToleratesUndefinedVariables(t *testing.T) {
 	assert.Len(t, project.Services, 1)
 }
 
+func TestLoadComposeProjectLenient_ToleratesUndefinedTypedFieldVariables(t *testing.T) {
+	t.Parallel()
+
+	// Same chicken-and-egg problem for typed fields: deploy.resources.limits.cpus
+	// is parsed as a float and memory as a size. With no .env the strict loader
+	// fails with `strconv.ParseFloat: parsing "": invalid syntax` and
+	// `invalid size: ''`. Lenient mode must succeed so the GitOps sync can
+	// create the project and let the user supply real values afterward.
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte(`services:
+  chrony:
+    image: ${DOCKER_IMAGE}
+    deploy:
+      resources:
+        limits:
+          cpus: ${CPU}
+          memory: ${MEMORY}
+`), 0o600))
+
+	project, err := LoadComposeProjectLenient(context.Background(), composePath, "demo", dir, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	assert.Len(t, project.Services, 1)
+}
+
 func TestLoadComposeProject_UsesProjectLevelComposeLabelsForIncludedServices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2566

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash during GitOps sync validation when a compose file references typed fields (e.g. `deploy.resources.limits.cpus`, `memory`) through undefined environment variables. It also adds an env-file seeding step so a pre-existing project directory can supply `.env` values before the first sync.

- **`load.go`**: Adds `wrapTypeCastMappingLenientInternal` which wraps every compose-go type-cast with a `\"0\"` fallback and injects new casts for `cpus` (float) and `memory` (size) paths that compose-go would otherwise push through to mapstructure as a raw placeholder string; also enables `SkipValidation` and `SkipConsistencyCheck` in lenient mode.
- **`gitops_sync_service.go`**: Adds `seedStageEnvFromCandidateDirInternal` which, on a first-time sync (no managed project yet), copies env files from the conventional project directory into the staging area so variable substitution can succeed before `WriteSyncedDirectory` is called.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the lenient-load path and first-sync env seeding, with no impact on normal compose loading or running projects.

Both code paths added here are defensive: the type-cast wrapping only activates when compose-go's interpolation engine processes a typed field with an undefined variable, and the env seeding is a best-effort no-op when the candidate directory does not exist. The new test directly exercises the failing scenario from the issue. Error paths consistently clean up the temp stage directory.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: tolerate undefined typed env vars i..."](https://github.com/getarcaneapp/arcane/commit/3cf1c9d4bf62ad7ff3b385254050529e538ddd5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33621778)</sub>

<!-- /greptile_comment -->