### PR TITLE
fix: show all container ip's in list view

### DIFF
--- a/frontend/src/routes/(app)/containers/container-table.helpers.ts
+++ b/frontend/src/routes/(app)/containers/container-table.helpers.ts
@@ -47,14 +47,21 @@ export function getStateBadgeVariant(state: string): StateBadgeVariant {
 	return 'amber';
 }
 
-export function getContainerIpAddress(container: ContainerSummaryDto): string | null {
+export function getContainerIpAddresses(container: ContainerSummaryDto): string[] {
 	const networks = container.networkSettings?.networks;
-	if (!networks) return null;
-	for (const networkName in networks) {
-		const network = networks[networkName];
-		if (network?.ipAddress) return network.ipAddress;
+	if (!networks) return [];
+
+	const seen = new Set<string>();
+	const ipAddresses: string[] = [];
+	for (const networkName of Object.keys(networks).sort((a, b) => a.localeCompare(b))) {
+		const ipAddress = networks[networkName]?.ipAddress?.trim();
+		if (!ipAddress || seen.has(ipAddress)) continue;
+
+		seen.add(ipAddress);
+		ipAddresses.push(ipAddress);
 	}
-	return null;
+
+	return ipAddresses;
 }
 
 export function getProjectName(container: ContainerSummaryDto): string {

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -34,7 +34,7 @@
 	import {
 		getActionStatusMessage,
 		getContainerDisplayName,
-		getContainerIpAddress,
+		getContainerIpAddresses,
 		getProjectName,
 		getStateBadgeVariant,
 		parseImageRef,
@@ -334,8 +334,28 @@
 <ContainerStatsSync {statsManager} envId={currentEnvId} targetIds={shouldConnect} />
 
 {#snippet IPAddressCell({ item }: { item: ContainerSummaryDto })}
-	{@const ip = getContainerIpAddress(item)}
-	<span class="font-mono text-sm">{ip ?? m.common_na()}</span>
+	{@const ipAddresses = getContainerIpAddresses(item)}
+	{#if ipAddresses.length > 0}
+		<div class="space-y-0.5">
+			{#each ipAddresses as ipAddress (ipAddress)}
+				<div class="font-mono text-sm leading-tight">{ipAddress}</div>
+			{/each}
+		</div>
+	{:else}
+		<span class="font-mono text-sm">{m.common_na()}</span>
+	{/if}
+{/snippet}
+
+{#snippet IPAddressesField(ipAddresses: string[])}
+	{#if ipAddresses.length > 0}
+		<span class="flex flex-col gap-0.5">
+			{#each ipAddresses as ipAddress (ipAddress)}
+				<span class="font-mono text-xs leading-tight">{ipAddress}</span>
+			{/each}
+		</span>
+	{:else}
+		<span class="font-mono text-xs">{m.common_na()}</span>
+	{/if}
 {/snippet}
 
 {#snippet CPUCell({ item }: { item: ContainerSummaryDto })}
@@ -500,10 +520,11 @@
 			},
 			{
 				label: m.containers_ip_address(),
-				getValue: (item: ContainerSummaryDto) => getContainerIpAddress(item) ?? m.common_na(),
+				getValue: (item: ContainerSummaryDto) => getContainerIpAddresses(item),
 				icon: NetworksIcon,
 				iconVariant: 'sky' as const,
-				type: 'mono' as const,
+				type: 'component' as const,
+				component: IPAddressesField,
 				show: mobileFieldVisibility['ipAddress'] ?? false
 			},
 			{

--- a/tests/spec/containers.spec.ts
+++ b/tests/spec/containers.spec.ts
@@ -11,12 +11,12 @@ async function navigateToContainers(page: Page) {
 
 let containersData: Paginated<ContainerSummary> = { data: [], pagination: { totalItems: 0 } };
 
-test.beforeEach(async ({ page }) => {
-	await navigateToContainers(page);
-	containersData = await fetchContainersWithRetry(page);
-});
-
 test.describe('Containers Page', () => {
+	test.beforeEach(async ({ page }) => {
+		await navigateToContainers(page);
+		containersData = await fetchContainersWithRetry(page);
+	});
+
 	test('should display the containers page title and description', async ({ page }) => {
 		await navigateToContainers(page);
 		await expect(page.getByRole('heading', { name: 'Containers', level: 1 })).toBeVisible();
@@ -148,5 +148,80 @@ test.describe('Containers Page', () => {
 
 		await page.getByRole('button', { name: 'Cancel' }).click();
 		await expect(dialog).toBeHidden();
+	});
+});
+
+test.describe('Containers Page network IP addresses', () => {
+	test('should show every network IP address for a multi-network container', async ({
+		page,
+		context
+	}) => {
+		await page.addInitScript(() => {
+			localStorage.removeItem('arcane-container-table');
+		});
+
+		await context.route('**/api/environments/*/containers**', async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.continue();
+				return;
+			}
+
+			const url = new URL(route.request().url());
+			if (!/^\/api\/environments\/[^/]+\/containers$/.test(url.pathname)) {
+				await route.continue();
+				return;
+			}
+
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: true,
+					data: [
+						{
+							id: 'wordpress-multi-network',
+							names: ['/wordpress'],
+							image: 'wordpress:latest',
+							imageId: 'sha256:wordpress',
+							command: 'apache2-foreground',
+							created: 1_700_000_000,
+							labels: {},
+							state: 'running',
+							status: 'Up 5 minutes',
+							ports: [],
+							hostConfig: { networkMode: 'default' },
+							networkSettings: {
+								networks: {
+									proxy: { ipAddress: '172.20.0.10' },
+									private: { ipAddress: '10.10.0.5' }
+								}
+							},
+							mounts: []
+						}
+					],
+					counts: {
+						runningContainers: 1,
+						stoppedContainers: 0,
+						totalContainers: 1
+					},
+					pagination: {
+						totalPages: 1,
+						totalItems: 1,
+						currentPage: 1,
+						itemsPerPage: 20,
+						grandTotalItems: 1
+					}
+				})
+			});
+		});
+
+		await navigateToContainers(page);
+
+		const row = page.locator('tbody tr').filter({
+			has: page.getByRole('link', { name: 'wordpress', exact: true })
+		});
+
+		await expect(row).toContainText('10.10.0.5');
+		await expect(row).toContainText('172.20.0.10');
 	});
 });


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2725

## Changes Made

<!-- List specific changes with brief explanations -->

- 
- 
- 

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an issue where containers connected to multiple Docker networks only showed the first network's IP address in the containers list view. It replaces the single-IP helper with a multi-IP variant and updates both the table cell and mobile card renderers to display all IPs.

- `getContainerIpAddresses` now collects all non-empty, deduplicated IPs across networks, sorted deterministically by network name — replacing the old first-match-wins approach.
- New `IPAddressCell` and `IPAddressesField` snippets render a stacked list of IPs (or "N/A") in the table and mobile card views respectively; the mobile field config is updated to `type: 'component'` with the new snippet passed as `component`.
- A new Playwright test covers the multi-network IP display case; the existing `beforeEach` is correctly scoped inside its own `describe` block to avoid conflicting with the new test's route mock.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive and well-tested, with no regressions to existing behavior.

The helper function is straightforward and handles all edge cases (no networks, empty IPs, duplicates). The Svelte snippets render correctly in both table and mobile card contexts, and the IPAddressesField snippet already uses a span as its root to stay valid inside the inline span wrapper the mobile card provides in compact mode. The new Playwright test is well-constructed with proper route mocking and verifies both IPs appear in the table row.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: show all container ip&#39;s in list vie..."](https://github.com/getarcaneapp/arcane/commit/b30d8716b85262e29328bcfac8deea8609405681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33776702)</sub>

<!-- /greptile_comment -->