### PR TITLE
refactor: modernize backend code

### DIFF
--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -17,7 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/authz"
 	activitylib "github.com/getarcaneapp/arcane/backend/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
-	projects "github.com/getarcaneapp/arcane/backend/pkg/projects"
+	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"

--- a/backend/api/handlers/swarm.go
+++ b/backend/api/handlers/swarm.go
@@ -1165,7 +1165,7 @@ func (h *SwarmHandler) GetStack(ctx context.Context, input *GetSwarmStackInput) 
 	stack, err := h.swarmService.GetStack(ctx, input.EnvironmentID, input.Name)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			return nil, huma.Error404NotFound(("Swarm stack not found"))
+			return nil, huma.Error404NotFound("Swarm stack not found")
 		}
 		return nil, mapSwarmServiceError(err, "Failed to inspect swarm stack")
 	}

--- a/backend/cli/generate/generate.go
+++ b/backend/cli/generate/generate.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	cligenerate "github.com/getarcaneapp/arcane/cli/pkg/generate"
-	"github.com/spf13/cobra"
 )
 
-var GenerateCmd *cobra.Command = cligenerate.GenerateCmd
+var GenerateCmd = cligenerate.GenerateCmd

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -262,7 +262,7 @@ func parseTrustedProxyCIDRsInternal(raw string) []*net.IPNet {
 		return nil
 	}
 	var nets []*net.IPNet
-	for _, cidr := range strings.Split(raw, ",") {
+	for cidr := range strings.SplitSeq(raw, ",") {
 		cidr = strings.TrimSpace(cidr)
 		if cidr == "" {
 			continue

--- a/backend/internal/middleware/rate_limit_middleware_test.go
+++ b/backend/internal/middleware/rate_limit_middleware_test.go
@@ -91,7 +91,7 @@ func TestPerIPRateLimitForPaths_AppliesOnlyToConfiguredPaths(t *testing.T) {
 	require.Equal(t, http.StatusOK, doReq("/limited"))
 	require.Equal(t, http.StatusTooManyRequests, doReq("/limited"))
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		require.Equal(t, http.StatusOK, doReq("/unlimited"))
 	}
 }

--- a/backend/internal/services/activity_service.go
+++ b/backend/internal/services/activity_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -768,10 +769,7 @@ func clampProgressPtrInternal(value *int) *int {
 	if value == nil {
 		return nil
 	}
-	clamped := *value
-	if clamped < 0 {
-		clamped = 0
-	}
+	clamped := max(*value, 0)
 	if clamped > 100 {
 		clamped = 100
 	}
@@ -783,9 +781,7 @@ func cloneJSONInternal(input models.JSON) models.JSON {
 		return nil
 	}
 	out := make(models.JSON, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 
@@ -794,9 +790,7 @@ func jsonToMapInternal(input models.JSON) map[string]any {
 		return nil
 	}
 	out := make(map[string]any, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 
@@ -847,10 +841,7 @@ func deleteActivitiesByIDInternal(tx *gorm.DB, activityIDs []string) (int64, err
 
 	var totalDeleted int64
 	for i := 0; i < len(activityIDs); i += deleteActivitiesBatchSize {
-		end := i + deleteActivitiesBatchSize
-		if end > len(activityIDs) {
-			end = len(activityIDs)
-		}
+		end := min(i+deleteActivitiesBatchSize, len(activityIDs))
 		batch := activityIDs[i:end]
 
 		if err := tx.Where("activity_id IN ?", batch).Delete(&models.ActivityMessage{}).Error; err != nil {

--- a/backend/internal/services/build_service.go
+++ b/backend/internal/services/build_service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	buildgit "github.com/getarcaneapp/arcane/backend/pkg/gitutil"
-	libbuild "github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	buildtypes "github.com/getarcaneapp/arcane/types/builds"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"

--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	backoff "github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v5"
 	"golang.org/x/sync/singleflight"
 
 	cerrdefs "github.com/containerd/errdefs"

--- a/backend/internal/services/docker_client_service.go
+++ b/backend/internal/services/docker_client_service.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	backoff "github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	docker "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -10,7 +10,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	git "github.com/getarcaneapp/arcane/backend/pkg/gitutil"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
-	libbuild "github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -21,7 +21,7 @@ import (
 	dockertypesimage "github.com/moby/moby/api/types/image"
 	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -25,7 +25,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	dockerutil "github.com/getarcaneapp/arcane/backend/pkg/dockerutil"
 	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/imageupdate"
-	libbuild "github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/libbuild"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -31,7 +31,7 @@ import (
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"

--- a/backend/pkg/authz/permission_set.go
+++ b/backend/pkg/authz/permission_set.go
@@ -113,14 +113,14 @@ func EnvIDFromPath(path string) string {
 		return ""
 	}
 	rest := path[len("/environments/"):]
-	slash := strings.Index(rest, "/")
-	if slash == -1 {
+	before, _, ok := strings.Cut(rest, "/")
+	if !ok {
 		// Path is just /environments/<id> (no trailing segment) — this is
 		// not an env-scoped operation, it's the env detail endpoint itself,
 		// which is org-level.
 		return ""
 	}
-	id := rest[:slash]
+	id := before
 	if id == "" {
 		return ""
 	}

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -522,13 +523,7 @@ func TestWalkDirectory_ComposeInSubdirectory(t *testing.T) {
 		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
 	}
 	for _, want := range expected {
-		found := false
-		for _, got := range paths {
-			if got == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(paths, want)
 		if !found {
 			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
 		}
@@ -556,13 +551,7 @@ func TestWalkDirectory_NestedSiblingFile(t *testing.T) {
 		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
 	}
 	for _, want := range expected {
-		found := false
-		for _, got := range paths {
-			if got == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(paths, want)
 		if !found {
 			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
 		}
@@ -590,13 +579,7 @@ func TestWalkDirectory_SpecialCharsInPath(t *testing.T) {
 		t.Fatalf("expected %d files, got %d (%v)", len(expected), len(paths), paths)
 	}
 	for _, want := range expected {
-		found := false
-		for _, got := range paths {
-			if got == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(paths, want)
 		if !found {
 			t.Fatalf("expected walked paths to include %q, got %v", want, paths)
 		}

--- a/backend/pkg/libarcane/activity/writer.go
+++ b/backend/pkg/libarcane/activity/writer.go
@@ -224,10 +224,7 @@ func (w *Writer) updateLayerProgressInternal(id, status string, rawDetail any) *
 		}
 	}
 
-	progress := int((weighted / float64(len(w.layers))) * 100)
-	if progress > 100 {
-		progress = 100
-	}
+	progress := min(int((weighted/float64(len(w.layers)))*100), 100)
 	if progress < 0 {
 		progress = 0
 	}

--- a/backend/pkg/libarcane/edge/tls_test.go
+++ b/backend/pkg/libarcane/edge/tls_test.go
@@ -215,7 +215,7 @@ func TestEnsureAgentMTLSAssets_UsesDownloadedCAPathWhenPresent(t *testing.T) {
 
 func TestRemoveStaleEdgeMTLSLockInternal_PreservesLivePID(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), ".ca.lock")
-	require.NoError(t, os.WriteFile(lockPath, []byte(fmt.Sprintf("%d %s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))), 0o600))
+	require.NoError(t, os.WriteFile(lockPath, fmt.Appendf(nil, "%d %s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano)), 0o600))
 
 	require.False(t, removeStaleEdgeMTLSLockInternal(lockPath))
 	require.FileExists(t, lockPath)
@@ -224,7 +224,7 @@ func TestRemoveStaleEdgeMTLSLockInternal_PreservesLivePID(t *testing.T) {
 func TestRemoveStaleEdgeMTLSLockInternal_RemovesOldLockDespiteLivePID(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), ".ca.lock")
 	oldTimestamp := time.Now().Add(-(2*managerCALockTimeout + time.Second)).UTC().Format(time.RFC3339Nano)
-	require.NoError(t, os.WriteFile(lockPath, []byte(fmt.Sprintf("%d %s\n", os.Getpid(), oldTimestamp)), 0o600))
+	require.NoError(t, os.WriteFile(lockPath, fmt.Appendf(nil, "%d %s\n", os.Getpid(), oldTimestamp), 0o600))
 
 	require.True(t, removeStaleEdgeMTLSLockInternal(lockPath))
 	require.NoFileExists(t, lockPath)

--- a/backend/pkg/libarcane/imageupdate/digest.go
+++ b/backend/pkg/libarcane/imageupdate/digest.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/moby/moby/client"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 )
 
 type remoteDigestResolver interface {

--- a/backend/pkg/libarcane/imageupdate/digest_test.go
+++ b/backend/pkg/libarcane/imageupdate/digest_test.go
@@ -3,7 +3,7 @@ package imageupdate
 import (
 	"testing"
 
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/backend/pkg/libarcane/imageupdate/registry_http_test.go
+++ b/backend/pkg/libarcane/imageupdate/registry_http_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -19,7 +19,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
-	units "github.com/docker/go-units"
+	"github.com/docker/go-units"
 )
 
 var errComposeFileNotFoundInternal = errors.New("no compose file found")
@@ -184,7 +184,7 @@ func wrapTypeCastMappingLenientInternal(mapping map[tree.Path]interp.Cast) map[t
 }
 
 func wrapCastWithLenientFallbackInternal(original interp.Cast) interp.Cast {
-	return func(value string) (interface{}, error) {
+	return func(value string) (any, error) {
 		result, err := original(value)
 		if err == nil {
 			return result, nil
@@ -196,11 +196,11 @@ func wrapCastWithLenientFallbackInternal(original interp.Cast) interp.Cast {
 	}
 }
 
-func lenientCastFloatInternal(value string) (interface{}, error) {
+func lenientCastFloatInternal(value string) (any, error) {
 	return strconv.ParseFloat(value, 64)
 }
 
-func lenientCastSizeInternal(value string) (interface{}, error) {
+func lenientCastSizeInternal(value string) (any, error) {
 	n, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		b, parseErr := units.RAMInBytes(value)

--- a/backend/pkg/remenv/client.go
+++ b/backend/pkg/remenv/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -297,8 +298,6 @@ func cloneHeaders(headers map[string]string) map[string]string {
 	}
 
 	out := make(map[string]string, len(headers))
-	for key, value := range headers {
-		out[key] = value
-	}
+	maps.Copy(out, headers)
 	return out
 }

--- a/backend/pkg/scheduler/analytics_job.go
+++ b/backend/pkg/scheduler/analytics_job.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	backoff "github.com/cenkalti/backoff/v5"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
 )

--- a/types/container/container.go
+++ b/types/container/container.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	containerregistry "github.com/getarcaneapp/arcane/types/containerregistry"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	containerregistry "github.com/getarcaneapp/arcane/types/containerregistry"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
 	"github.com/moby/moby/api/types/image"
 )

--- a/types/imageupdate/image_update.go
+++ b/types/imageupdate/image_update.go
@@ -3,7 +3,7 @@ package imageupdate
 import (
 	"time"
 
-	containerregistry "github.com/getarcaneapp/arcane/types/containerregistry"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
 )
 
 type Response struct {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR modernizes Go backend code by replacing manual idioms with newer standard library functions and language features throughout the codebase. No behavioral changes are intended.

- **Import aliases removed** where the package's declared name already matches (e.g., `backoff`, `digest`, `units`, `libbuild`), and redundant explicit type annotations dropped (e.g., `var GenerateCmd *cobra.Command = ...` → `var GenerateCmd = ...`).
- **Modern built-ins adopted**: `min`/`max` replace manual clamping, `maps.Copy` replaces manual map copy loops, `slices.Contains` replaces nested linear search loops, `strings.Cut` replaces `strings.Index`+slice, `strings.SplitSeq` replaces `strings.Split` in a range loop, `fmt.Appendf` replaces `[]byte(fmt.Sprintf(...))`, and `any` replaces `interface{}`.
- **Range syntax modernized**: `for range 10` replaces `for i := 0; i < 10; i++` where the loop variable is unused, and `for cidr := range strings.SplitSeq(...)` replaces the old `Split`-based range.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are mechanical refactors with no behavioral difference; the Go module targets 1.26.3, which provides every API and language feature used here.

Every change is a direct, semantically equivalent substitution: min/max built-ins for explicit comparisons, maps.Copy for manual copy loops, strings.SplitSeq for strings.Split in a range, strings.Cut for strings.Index+slice, fmt.Appendf(nil, ...) for []byte(fmt.Sprintf(...)), and any for interface{}. All new APIs are present in Go 1.26.3 (declared in backend/go.mod). No logic paths are altered, no error handling is touched, and no types change their runtime representation.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: modernize backend code"](https://github.com/getarcaneapp/arcane/commit/3e21eae39091b9795aab24a061ce0d464651c6f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34613848)</sub>

<!-- /greptile_comment -->