### PR TITLE
fix: trivy scans not using arcane registries credentials

### DIFF
--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -79,7 +79,7 @@ func initializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	svcs.Environment = services.NewEnvironmentService(db, httpClient, svcs.Docker, svcs.Event, svcs.Settings, svcs.ApiKey)
 	svcs.Version = services.NewVersionService(httpClient, cfg.UpdateCheckDisabled, config.Version, config.Revision, svcs.ContainerRegistry, svcs.Docker)
 	svcs.Notification = services.NewNotificationService(db, cfg, svcs.Environment)
-	svcs.Vulnerability = services.NewVulnerabilityService(db, svcs.Docker, svcs.Event, svcs.Settings, svcs.Notification, svcs.Activity)
+	svcs.Vulnerability = services.NewVulnerabilityService(db, svcs.Docker, svcs.Event, svcs.Settings, svcs.Notification, svcs.Activity, svcs.ContainerRegistry)
 	svcs.ImageUpdate = services.NewImageUpdateService(db, svcs.Settings, svcs.ContainerRegistry, svcs.Docker, svcs.Event, svcs.Notification, svcs.Activity)
 	svcs.Image = services.NewImageService(db, svcs.Docker, svcs.ContainerRegistry, svcs.ImageUpdate, svcs.Vulnerability, svcs.Event)
 	svcs.GitRepository = services.NewGitRepositoryService(db, cfg.GitWorkDir, svcs.Event, svcs.Settings)

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	imagetypes "github.com/moby/moby/api/types/image"
 	mounttypes "github.com/moby/moby/api/types/mount"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -66,6 +68,9 @@ const (
 	DefaultTrivyDBRepository                 = "ghcr.io/getarcaneapp/trivy-db:2"
 	DefaultTrivyJavaDBRepository             = "ghcr.io/getarcaneapp/trivy-java-db:1"
 	DefaultTrivyChecksBundleRepository       = "ghcr.io/getarcaneapp/trivy-checks:1"
+	trivyRegistryConfigDir                   = "/tmp/arcane-registry-auth"
+	trivyRegistryConfigCopyDest              = "/tmp"
+	trivyRegistryConfigTarName               = "arcane-registry-auth/config.json"
 )
 
 type trivyRuntimeOptions struct {
@@ -82,6 +87,7 @@ type VulnerabilityService struct {
 	settingsService     *SettingsService
 	notificationService *NotificationService
 	activityService     *ActivityService
+	registryService     *ContainerRegistryService
 	// scanLocks provides per-image locking to allow concurrent scans of different images
 	// while preventing duplicate scans of the same image
 	scanLocks sync.Map // map[string]*sync.Mutex
@@ -233,7 +239,7 @@ func (s *VulnerabilityService) getTrivyScanSlotChannelInternal(limit int) chan i
 }
 
 // NewVulnerabilityService creates a new VulnerabilityService instance
-func NewVulnerabilityService(db *database.DB, dockerService *DockerClientService, eventService *EventService, settingsService *SettingsService, notificationService *NotificationService, activityService *ActivityService) *VulnerabilityService {
+func NewVulnerabilityService(db *database.DB, dockerService *DockerClientService, eventService *EventService, settingsService *SettingsService, notificationService *NotificationService, activityService *ActivityService, registryService *ContainerRegistryService) *VulnerabilityService {
 	return &VulnerabilityService{
 		db:                  db,
 		dockerService:       dockerService,
@@ -241,8 +247,59 @@ func NewVulnerabilityService(db *database.DB, dockerService *DockerClientService
 		settingsService:     settingsService,
 		notificationService: notificationService,
 		activityService:     activityService,
+		registryService:     registryService,
 		trivyScanSlots:      nil,
 	}
+}
+
+func buildDockerConfigJSONInternal(authConfigs map[string]dockerregistry.AuthConfig) ([]byte, error) {
+	if len(authConfigs) == 0 {
+		return nil, nil
+	}
+
+	type authEntry struct {
+		Auth string `json:"auth"`
+	}
+
+	auths := make(map[string]authEntry, len(authConfigs))
+	for host, cfg := range authConfigs {
+		host = strings.TrimSpace(host)
+		if host == "" || cfg.Username == "" || cfg.Password == "" {
+			continue
+		}
+
+		auths[host] = authEntry{
+			Auth: base64.StdEncoding.EncodeToString([]byte(cfg.Username + ":" + cfg.Password)),
+		}
+	}
+
+	if len(auths) == 0 {
+		return nil, nil
+	}
+
+	return json.Marshal(struct {
+		Auths map[string]authEntry `json:"auths"`
+	}{Auths: auths})
+}
+
+func (s *VulnerabilityService) buildTrivyRegistryConfigInternal(ctx context.Context) []byte {
+	if s.registryService == nil {
+		return nil
+	}
+
+	authConfigs, err := s.registryService.GetAllRegistryAuthConfigs(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to load registry credentials for trivy scan; continuing anonymously", "error", err)
+		return nil
+	}
+
+	configJSON, err := buildDockerConfigJSONInternal(authConfigs)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to build trivy registry config; continuing anonymously", "error", err)
+		return nil
+	}
+
+	return configJSON
 }
 
 // ScanImage scans an image for vulnerabilities using Trivy
@@ -1438,10 +1495,18 @@ func (s *VulnerabilityService) createBatchTrivyContainer(ctx context.Context, tr
 		return "", err
 	}
 
+	registryConfigJSON := s.buildTrivyRegistryConfigInternal(ctx)
+	env := append([]string(nil), runtimeOptions.ContainerEnv...)
+	if len(registryConfigJSON) > 0 {
+		env = append(env, "DOCKER_CONFIG="+trivyRegistryConfigDir)
+		// ECR tokens are refreshed when the batch container is created; a multi-hour
+		// batch could outlive the token and fall back to anonymous pulls.
+	}
+
 	config := &containertypes.Config{
 		Image:      trivyImage,
 		Entrypoint: []string{"sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"},
-		Env:        append([]string(nil), runtimeOptions.ContainerEnv...),
+		Env:        env,
 		Labels: map[string]string{
 			libarcane.InternalResourceLabel: "true",
 		},
@@ -1453,7 +1518,7 @@ func (s *VulnerabilityService) createBatchTrivyContainer(ctx context.Context, tr
 	resources, cpuSet, applyLimits := s.getTrivyContainerResourceOptionsInternal(ctx, dockerClient)
 	applyTrivyContainerResourcesInternal(hostConfig, resources, cpuSet, applyLimits)
 
-	containerID, err := s.createAndStartTrivyContainerInternal(ctx, dockerClient, "batch", config, hostConfig)
+	containerID, err := s.createAndStartTrivyContainerInternal(ctx, dockerClient, "batch", config, hostConfig, registryConfigJSON)
 	if err != nil {
 		return "", err
 	}
@@ -2570,12 +2635,46 @@ func removeDockerContainerInternal(ctx context.Context, dockerClient *client.Cli
 	}
 }
 
+func copyRegistryConfigToContainerInternal(ctx context.Context, dockerClient *client.Client, containerID string, configJSON []byte) error {
+	if dockerClient == nil || containerID == "" || len(configJSON) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	if err := tw.WriteHeader(&tar.Header{Name: "arcane-registry-auth/", Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+		return err
+	}
+	if err := tw.WriteHeader(&tar.Header{Name: trivyRegistryConfigTarName, Mode: 0o644, Size: int64(len(configJSON))}); err != nil {
+		_ = tw.Close()
+		return err
+	}
+	if _, err := tw.Write(configJSON); err != nil {
+		_ = tw.Close()
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+
+	copyCtx, copyCancel := timeouts.WithTimeout(ctx, 0, timeouts.DefaultDockerAPI)
+	defer copyCancel()
+
+	_, err := dockerClient.CopyToContainer(copyCtx, containerID, client.CopyToContainerOptions{
+		DestinationPath: trivyRegistryConfigCopyDest,
+		Content:         &buf,
+	})
+	return err
+}
+
 func (s *VulnerabilityService) createAndStartTrivyContainerInternal(
 	ctx context.Context,
 	dockerClient *client.Client,
 	scope string,
 	config *containertypes.Config,
 	hostConfig *containertypes.HostConfig,
+	registryConfigJSON []byte,
 ) (string, error) {
 	logTrivyContainerStartupRequestInternal(ctx, scope, config, hostConfig)
 
@@ -2589,6 +2688,19 @@ func (s *VulnerabilityService) createAndStartTrivyContainerInternal(
 	if err != nil {
 		slog.WarnContext(ctx, "failed to create trivy container", "scope", scope, "error", err)
 		return "", fmt.Errorf("failed to create container: %w", err)
+	}
+
+	if len(registryConfigJSON) > 0 {
+		if err := copyRegistryConfigToContainerInternal(ctx, dockerClient, resp.ID, registryConfigJSON); err != nil {
+			// DOCKER_CONFIG may still point at the target directory. When the
+			// config file is absent, Trivy falls back to anonymous registry access.
+			slog.WarnContext(ctx,
+				"failed to inject registry credentials into trivy container; continuing anonymously",
+				"scope", scope,
+				"containerId", resp.ID,
+				"error", err,
+			)
+		}
 	}
 
 	startCtx, startCancel := timeouts.WithTimeout(ctx, 0, timeouts.DefaultDockerAPI)
@@ -3129,6 +3241,7 @@ func (s *VulnerabilityService) runTrivyContainer(
 	imageID string,
 	config *containertypes.Config,
 	hostConfig *containertypes.HostConfig,
+	registryConfigJSON []byte,
 ) (*os.File, *os.File, int64, int64, string, error) {
 	stdoutFile, err := createTrivyLogTempFileInternal("trivy-stdout-*")
 	if err != nil {
@@ -3150,7 +3263,7 @@ func (s *VulnerabilityService) runTrivyContainer(
 		}
 	}()
 
-	containerID, err = s.createAndStartTrivyContainerInternal(ctx, dockerClient, "single-scan", config, hostConfig)
+	containerID, err = s.createAndStartTrivyContainerInternal(ctx, dockerClient, "single-scan", config, hostConfig, registryConfigJSON)
 	if err != nil {
 		return nil, nil, 0, 0, "", fmt.Errorf("failed to prepare trivy scan container: %w", err)
 	}
@@ -3334,7 +3447,13 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 		return nil, err
 	}
 
-	config := buildTrivyContainerConfig(trivyImage, cmdArgs, runtimeOptions.ContainerEnv)
+	registryConfigJSON := s.buildTrivyRegistryConfigInternal(ctx)
+	env := append([]string(nil), runtimeOptions.ContainerEnv...)
+	if len(registryConfigJSON) > 0 {
+		env = append(env, "DOCKER_CONFIG="+trivyRegistryConfigDir)
+	}
+
+	config := buildTrivyContainerConfig(trivyImage, cmdArgs, env)
 	resources, cpuSet, applyLimits := s.getTrivyContainerResourceOptionsInternal(ctx, dockerClient)
 	securityOpts, privileged := s.getTrivyRuntimeSecurityInternal()
 	hostConfig := buildTrivyHostConfig(
@@ -3349,7 +3468,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	)
 	s.setScanPhaseInternal(imageID, vulnerability.ScanPhaseCreatingContainer)
 
-	stdoutFile, stderrFile, duration, statusCode, containerID, err := s.runTrivyContainer(ctx, dockerClient, imageID, config, hostConfig)
+	stdoutFile, stderrFile, duration, statusCode, containerID, err := s.runTrivyContainer(ctx, dockerClient, imageID, config, hostConfig, registryConfigJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,9 +22,80 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
+
+func TestBuildDockerConfigJSONInternal(t *testing.T) {
+	tests := []struct {
+		name      string
+		auths     map[string]dockerregistry.AuthConfig
+		wantAuths map[string]string
+	}{
+		{
+			name: "nil map",
+		},
+		{
+			name:  "empty map",
+			auths: map[string]dockerregistry.AuthConfig{},
+		},
+		{
+			name: "one registry",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry.example.com": {Username: "user", Password: "pass"},
+			},
+			wantAuths: map[string]string{
+				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			},
+		},
+		{
+			name: "skips blank credentials",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry.example.com": {Username: "user", Password: "pass"},
+				"blank-user.example":   {Username: "", Password: "pass"},
+				"blank-pass.example":   {Username: "user", Password: ""},
+				"   ":                  {Username: "user", Password: "pass"},
+			},
+			wantAuths: map[string]string{
+				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			},
+		},
+		{
+			name: "two registries",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry-a.example.com": {Username: "user-a", Password: "pass-a"},
+				"registry-b.example.com": {Username: "user-b", Password: "pass-b"},
+			},
+			wantAuths: map[string]string{
+				"registry-a.example.com": base64.StdEncoding.EncodeToString([]byte("user-a:pass-a")),
+				"registry-b.example.com": base64.StdEncoding.EncodeToString([]byte("user-b:pass-b")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildDockerConfigJSONInternal(tt.auths)
+			require.NoError(t, err)
+			if len(tt.wantAuths) == 0 {
+				require.Nil(t, got)
+				return
+			}
+
+			var parsed struct {
+				Auths map[string]struct {
+					Auth string `json:"auth"`
+				} `json:"auths"`
+			}
+			require.NoError(t, json.Unmarshal(got, &parsed))
+			require.Len(t, parsed.Auths, len(tt.wantAuths))
+			for host, want := range tt.wantAuths {
+				require.Equal(t, want, parsed.Auths[host].Auth)
+			}
+		})
+	}
+}
 
 func TestIsExpectedDockerStreamEndErrorInternal(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR injects Arcane registry credentials into Trivy scan containers so that private-registry images can be scanned without falling back to anonymous access. The `ContainerRegistryService` is wired into `VulnerabilityService`, credentials are assembled into a Docker `config.json`, packed into a tar archive, and copied into both single-scan and batch Trivy containers before scans run.

- `buildDockerConfigJSONInternal` assembles a standard Docker `config.json` from all enabled registry `AuthConfig` entries, filtering out blank hosts/credentials; the function is covered by a well-structured table-driven test.
- `copyRegistryConfigToContainerInternal` tars the config file and pushes it to `/tmp/arcane-registry-auth/config.json` inside the container; `DOCKER_CONFIG` is set to that directory so Trivy picks it up automatically.
- The batch container path and the single-scan (`runTrivyScan`) path both receive the credential injection, and failures are degraded gracefully (logged as warnings, scan continues anonymously).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the credential injection is additive and degraded gracefully on failure, so existing anonymous-scan behavior is preserved as a fallback.

The change follows the established CopyToContainer/tar pattern already used in volume_service.go, all new unexported helpers carry the required Internal suffix, error paths degrade to anonymous access rather than aborting scans, and the core encoding logic is covered by table-driven tests. No logic paths that could break existing scans were introduced.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: trivy scans not using arcane regist..."](https://github.com/getarcaneapp/arcane/commit/f9563f13091d47de20861623fc4923cf3454087a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34749084)</sub>

<!-- /greptile_comment -->