### PR TITLE
refactor: add new go linters and refactor functions

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -5,46 +5,92 @@ run:
 linters:
   default: none
   enable:
+    - arangolint
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
+    - clickhouselint
     - contextcheck
     - copyloopvar
+    - decorder
     - dupl
+    - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errchkjson
+    - errname
     - errorlint
     - exhaustive
+    - exptostd
+    - fatcontext
+    - forbidigo
+    - forcetypeassert
+    - ginkgolinter
     - gocheckcompilerdirectives
     - gochecksumtype
     - gocognit
     - gocritic
+    - gocyclo
+    - godoclint
+    - goheader
+    - gomoddirectives
+    - gomodguard_v2
+    - goprintffuncname
     - gosec
     - gosmopolitan
     - govet
+    - grouper
+    - iface
+    - importas
+    - inamedparam
     - ineffassign
+    - interfacebloat
+    - intrange
+    - iotamixing
     - loggercheck
+    - maintidx
     - makezero
-    - misspell
     - mirror
+    - misspell
+    - modernize
     - musttag
     - nakedret
     - nilerr
     - nilnesserr
     - noctx
+    - nolintlint
+    - nosprintfhostport
+    - perfsprint
+    - prealloc
+    - predeclared
+    - promlinter
     - protogetter
     - reassign
     - recvcheck
+    - revive
     - rowserrcheck
+    - sloglint
     - spancheck
     - sqlclosecheck
     - staticcheck
+    - testableexamples
     - testifylint
+    - unconvert
+    - unparam
+    - unqueryvet
     - unused
     - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
     - zerologlint
+  settings:
+    gomoddirectives:
+      # replace directives (=> ../cli, => ../types). Allow them.
+      replace-local: true
   exclusions:
     generated: lax
     presets:
@@ -52,6 +98,25 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # Initialism naming (ApiKey -> APIKey, AppUrl -> AppURL, etc.) is intentional,
+      # widespread, and API-surface; track separately rather than churn it here.
+      - linters:
+          - revive
+        text: "var-naming:"
+      # Unused params are required by interface/callback/gorm-hook signatures.
+      - linters:
+          - revive
+        text: "unused-parameter:"
+      # Package-prefixed exported names (swarm.SwarmInfo, port.PortMapping, etc.) are
+      # an intentional, monorepo-wide convention; renaming is a large public-API change.
+      - linters:
+          - revive
+        text: "exported:"
+      # The cli command package is a CLI entrypoint; printing to stdout is correct.
+      - linters:
+          - forbidigo
+        path: cli/
     paths:
       - '.*\.pb\.go$'
       - third_party$

--- a/backend/api/handlers/activities.go
+++ b/backend/api/handlers/activities.go
@@ -256,7 +256,7 @@ func (h *ActivityHandler) streamLocalActivitiesInternal(
 ) {
 	sendSnapshot := func() bool {
 		activities, _, err := h.activityService.ListActivitiesPaginated(ctx, input.EnvironmentID, pagination.QueryParams{
-			PaginationParams: pagination.PaginationParams{Limit: resolveActivityStreamLimitInternal(input.Limit)},
+			Params: pagination.Params{Limit: resolveActivityStreamLimitInternal(input.Limit)},
 		})
 		if err != nil {
 			return false

--- a/backend/api/handlers/apikeys.go
+++ b/backend/api/handlers/apikeys.go
@@ -210,7 +210,7 @@ func (h *ApiKeyHandler) ListApiKeys(ctx context.Context, input *ListApiKeysInput
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/handlers/container_registries.go
+++ b/backend/api/handlers/container_registries.go
@@ -452,7 +452,7 @@ func (h *ContainerRegistryHandler) SyncRegistries(ctx context.Context, input *Sy
 // Helper Methods
 // ============================================================================
 
-func (h *ContainerRegistryHandler) triggerRemoteRegistrySync(ctx context.Context, reason string) { //nolint:contextcheck // intentionally spawns background sync
+func (h *ContainerRegistryHandler) triggerRemoteRegistrySync(ctx context.Context, reason string) {
 	if h.environmentService == nil {
 		return
 	}

--- a/backend/api/handlers/containers.go
+++ b/backend/api/handlers/containers.go
@@ -33,7 +33,7 @@ type ContainerHandler struct {
 	appCtx           context.Context
 }
 
-// Paginated response
+// ContainerPaginatedResponse is the paginated list response for containers.
 type ContainerPaginatedResponse struct {
 	Success    bool                          `json:"success"`
 	Data       []containertypes.Summary      `json:"data"`
@@ -130,7 +130,7 @@ type DeleteContainerOutput struct {
 	Body ContainerActionResponse
 }
 
-// RegisterContainers registers container endpoints.
+// SetAutoUpdateInput is the request input for toggling container auto-update.
 type SetAutoUpdateInput struct {
 	EnvironmentID string `path:"id" doc:"Environment ID"`
 	ContainerID   string `path:"containerId" doc:"Container ID"`
@@ -275,7 +275,7 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},
@@ -339,9 +339,9 @@ func (h *ContainerHandler) GetContainerStatusCounts(ctx context.Context, input *
 		Body: ContainerStatusCountsResponse{
 			Success: true,
 			Data: containertypes.StatusCounts{
-				RunningContainers: int(running),
-				StoppedContainers: int(stopped),
-				TotalContainers:   int(total),
+				RunningContainers: running,
+				StoppedContainers: stopped,
+				TotalContainers:   total,
 			},
 		},
 	}, nil

--- a/backend/api/handlers/edge_mtls_ca.go
+++ b/backend/api/handlers/edge_mtls_ca.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -18,10 +19,10 @@ const edgeMTLSCertificateExpiryWarningWindow = 30 * 24 * time.Hour
 
 func generatedEdgeMTLSCAPathInternal(cfg *config.Config) (string, error) {
 	if cfg == nil {
-		return "", fmt.Errorf("config not available")
+		return "", errors.New("config not available")
 	}
 	if edge.NormalizeEdgeMTLSMode(cfg.EdgeMTLSMode) == edge.EdgeMTLSModeDisabled {
-		return "", fmt.Errorf("edge mTLS is disabled")
+		return "", errors.New("edge mTLS is disabled")
 	}
 
 	edgeCfg := &edge.Config{
@@ -48,10 +49,10 @@ func hasGeneratedEdgeMTLSCAInternal(cfg *config.Config) bool {
 
 func generatedEdgeMTLSClientCertPathInternal(cfg *config.Config, envID string) (string, error) {
 	if cfg == nil {
-		return "", fmt.Errorf("config not available")
+		return "", errors.New("config not available")
 	}
 	if edge.NormalizeEdgeMTLSMode(cfg.EdgeMTLSMode) == edge.EdgeMTLSModeDisabled {
-		return "", fmt.Errorf("edge mTLS is disabled")
+		return "", errors.New("edge mTLS is disabled")
 	}
 
 	edgeCfg := &edge.Config{
@@ -82,7 +83,7 @@ func readGeneratedEdgeMTLSCertificateInfoInternal(cfg *config.Config, envID stri
 
 	block, _ := pem.Decode(certPEM)
 	if block == nil {
-		return nil, fmt.Errorf("decode generated edge mTLS client certificate PEM")
+		return nil, errors.New("decode generated edge mTLS client certificate PEM")
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)

--- a/backend/api/handlers/environments.go
+++ b/backend/api/handlers/environments.go
@@ -72,7 +72,8 @@ type CreateEnvironmentInput struct {
 
 type EnvironmentWithApiKey struct {
 	environment.Environment
-	ApiKey *string `json:"apiKey,omitempty" doc:"API key for pairing (only shown once during creation)"` //nolint:gosec // response schema requires apiKey naming
+
+	ApiKey *string `json:"apiKey,omitempty" doc:"API key for pairing (only shown once during creation)"`
 }
 
 type CreateEnvironmentOutput struct {
@@ -435,7 +436,7 @@ func (h *EnvironmentHandler) ListEnvironments(ctx context.Context, input *ListEn
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},
@@ -450,7 +451,7 @@ func (h *EnvironmentHandler) ListEnvironments(ctx context.Context, input *ListEn
 		return nil, huma.Error500InternalServerError((&common.EnvironmentListError{Err: err}).Error())
 	}
 	for i := range envs {
-		h.applyEdgeRuntimeState(&envs[i])
+		h.applyEdgeRuntimeStateInternal(&envs[i])
 	}
 
 	return &ListEnvironmentsOutput{
@@ -497,13 +498,13 @@ func (h *EnvironmentHandler) CreateEnvironment(ctx context.Context, input *Creat
 	useApiKey := input.Body.UseApiKey != nil && *input.Body.UseApiKey
 
 	if useApiKey {
-		return h.createEnvironmentWithApiKey(ctx, env, user)
+		return h.createEnvironmentWithApiKeyInternal(ctx, env, user)
 	}
 
-	return h.createEnvironmentLegacy(ctx, env, user, input.Body)
+	return h.createEnvironmentLegacyInternal(ctx, env, user, input.Body)
 }
 
-func (h *EnvironmentHandler) createEnvironmentWithApiKey(ctx context.Context, env *models.Environment, user *models.User) (*CreateEnvironmentOutput, error) {
+func (h *EnvironmentHandler) createEnvironmentWithApiKeyInternal(ctx context.Context, env *models.Environment, user *models.User) (*CreateEnvironmentOutput, error) {
 	// New API key-based pairing flow
 	env.Status = string(models.EnvironmentStatusPending)
 
@@ -537,7 +538,7 @@ func (h *EnvironmentHandler) createEnvironmentWithApiKey(ctx context.Context, en
 	if mapErr != nil {
 		return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 	}
-	h.applyEdgeRuntimeState(&out)
+	h.applyEdgeRuntimeStateInternal(&out)
 
 	return &CreateEnvironmentOutput{
 		Body: base.ApiResponse[EnvironmentWithApiKey]{
@@ -550,7 +551,7 @@ func (h *EnvironmentHandler) createEnvironmentWithApiKey(ctx context.Context, en
 	}, nil
 }
 
-func (h *EnvironmentHandler) createEnvironmentLegacy(ctx context.Context, env *models.Environment, user *models.User, body environment.Create) (*CreateEnvironmentOutput, error) {
+func (h *EnvironmentHandler) createEnvironmentLegacyInternal(ctx context.Context, env *models.Environment, user *models.User, body environment.Create) (*CreateEnvironmentOutput, error) {
 	if body.AccessToken != nil && *body.AccessToken != "" {
 		env.AccessToken = body.AccessToken
 	}
@@ -562,14 +563,14 @@ func (h *EnvironmentHandler) createEnvironmentLegacy(ctx context.Context, env *m
 
 	// Sync registries and git repositories in background (intentionally detached from request context)
 	if created.AccessToken != nil && *created.AccessToken != "" {
-		h.triggerEnvironmentResourceSync(ctx, created.ID, created.Name, "environment creation")
+		h.triggerEnvironmentResourceSyncInternal(ctx, created.ID, created.Name, "environment creation")
 	}
 
 	out, mapErr := mapper.MapOne[*models.Environment, environment.Environment](created)
 	if mapErr != nil {
 		return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 	}
-	h.applyEdgeRuntimeState(&out)
+	h.applyEdgeRuntimeStateInternal(&out)
 
 	return &CreateEnvironmentOutput{
 		Body: base.ApiResponse[EnvironmentWithApiKey]{
@@ -596,7 +597,7 @@ func (h *EnvironmentHandler) GetEnvironment(ctx context.Context, input *GetEnvir
 	if mapErr != nil {
 		return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 	}
-	h.applyEdgeRuntimeState(&out)
+	h.applyEdgeRuntimeStateInternal(&out)
 	if env.IsEdge {
 		if certInfo, certErr := readGeneratedEdgeMTLSCertificateInfoInternal(h.cfg, env.ID); certErr == nil {
 			out.EdgeMTLSCertificate = certInfo
@@ -618,12 +619,9 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 	}
 
 	isLocalEnv := input.ID == localDockerEnvironmentID
-	updates := h.buildUpdateMap(&input.Body, isLocalEnv)
+	updates := h.buildUpdateMapInternal(&input.Body, isLocalEnv)
 
-	pairingSucceeded, err := h.handleEnvironmentPairing(ctx, input.ID, &input.Body, updates, isLocalEnv)
-	if err != nil {
-		return nil, err
-	}
+	h.handleEnvironmentPairingInternal(ctx, input.ID, &input.Body, updates, isLocalEnv)
 
 	user, _ := humamw.GetCurrentUserFromContext(ctx)
 	var userID, username *string
@@ -636,13 +634,13 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 		return nil, huma.Error500InternalServerError((&common.EnvironmentUpdateError{Err: updateErr}).Error())
 	}
 
-	h.triggerPostUpdateTasks(ctx, input.ID, updated, pairingSucceeded, &input.Body) //nolint:contextcheck // intentionally detached background tasks
+	h.triggerPostUpdateTasksInternal(ctx, input.ID, updated, &input.Body)
 
 	out, mapErr := mapper.MapOne[*models.Environment, environment.Environment](updated)
 	if mapErr != nil {
 		return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 	}
-	h.applyEdgeRuntimeState(&out)
+	h.applyEdgeRuntimeStateInternal(&out)
 
 	// If regenerating API key, return the new key
 	var newApiKey *string
@@ -684,7 +682,7 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 		if mapErr != nil {
 			return nil, huma.Error500InternalServerError((&common.EnvironmentMappingError{Err: mapErr}).Error())
 		}
-		h.applyEdgeRuntimeState(&out)
+		h.applyEdgeRuntimeStateInternal(&out)
 
 		newApiKey = new(apiKeyDto.Key)
 	}
@@ -700,7 +698,7 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 	}, nil
 }
 
-func (h *EnvironmentHandler) applyEdgeRuntimeState(env *environment.Environment) {
+func (h *EnvironmentHandler) applyEdgeRuntimeStateInternal(env *environment.Environment) {
 	services.ApplyEnvironmentRuntimeState(env)
 }
 
@@ -844,7 +842,7 @@ func (h *EnvironmentHandler) SyncEnvironment(ctx context.Context, input *SyncEnv
 // Helper Methods
 // ============================================================================
 
-func (h *EnvironmentHandler) buildUpdateMap(req *environment.Update, isLocalEnv bool) map[string]any {
+func (h *EnvironmentHandler) buildUpdateMapInternal(req *environment.Update, isLocalEnv bool) map[string]any {
 	updates := map[string]any{}
 
 	if !isLocalEnv {
@@ -863,21 +861,19 @@ func (h *EnvironmentHandler) buildUpdateMap(req *environment.Update, isLocalEnv 
 	return updates
 }
 
-func (h *EnvironmentHandler) handleEnvironmentPairing(ctx context.Context, environmentID string, req *environment.Update, updates map[string]any, isLocalEnv bool) (bool, error) {
+func (h *EnvironmentHandler) handleEnvironmentPairingInternal(ctx context.Context, environmentID string, req *environment.Update, updates map[string]any, isLocalEnv bool) {
 	_ = ctx
 	_ = environmentID
 	if isLocalEnv {
-		return false, nil
+		return
 	}
 
 	if req.AccessToken != nil {
 		updates["access_token"] = *req.AccessToken
 	}
-
-	return false, nil
 }
 
-func (h *EnvironmentHandler) triggerPostUpdateTasks(ctx context.Context, environmentID string, updated *models.Environment, pairingSucceeded bool, req *environment.Update) { //nolint:contextcheck // intentionally spawns background tasks
+func (h *EnvironmentHandler) triggerPostUpdateTasksInternal(ctx context.Context, environmentID string, updated *models.Environment, req *environment.Update) {
 	if updated.Enabled {
 		detachedCtx := context.WithoutCancel(ctx)
 		go func(syncCtx context.Context, envID string, envName string) {
@@ -889,12 +885,12 @@ func (h *EnvironmentHandler) triggerPostUpdateTasks(ctx context.Context, environ
 		}(detachedCtx, environmentID, updated.Name)
 	}
 
-	if updated.AccessToken != nil && *updated.AccessToken != "" && (pairingSucceeded || (req.AccessToken != nil && *req.AccessToken != "") || req.Name != nil) {
-		h.triggerEnvironmentResourceSync(ctx, environmentID, updated.Name, "environment update")
+	if updated.AccessToken != nil && *updated.AccessToken != "" && ((req.AccessToken != nil && *req.AccessToken != "") || req.Name != nil) {
+		h.triggerEnvironmentResourceSyncInternal(ctx, environmentID, updated.Name, "environment update")
 	}
 }
 
-func (h *EnvironmentHandler) triggerEnvironmentResourceSync(ctx context.Context, environmentID string, environmentName string, reason string) { //nolint:contextcheck // intentionally spawns background tasks
+func (h *EnvironmentHandler) triggerEnvironmentResourceSyncInternal(ctx context.Context, environmentID string, environmentName string, reason string) {
 	detachedCtx := context.WithoutCancel(ctx)
 
 	go func(syncCtx context.Context, envID string, envName string, syncReason string) {
@@ -958,7 +954,7 @@ func (h *EnvironmentHandler) PairEnvironment(ctx context.Context, input *PairEnv
 	}
 
 	slog.InfoContext(ctx, "Environment pairing completed", "environmentID", *envID, "environmentName", env.Name)
-	h.triggerEnvironmentResourceSync(ctx, *envID, env.Name, "environment pairing")
+	h.triggerEnvironmentResourceSyncInternal(ctx, *envID, env.Name, "environment pairing")
 
 	return &PairEnvironmentOutput{
 		Body: base.ApiResponse[base.MessageResponse]{
@@ -1096,7 +1092,7 @@ func (h *EnvironmentHandler) GetEnvironmentVersion(ctx context.Context, input *G
 		}
 
 		client := &http.Client{Timeout: 15 * time.Second}
-		resp, err := client.Do(req) //nolint:gosec // intentional request to configured remote environment API URL
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("Request failed: " + err.Error())
 		}
@@ -1153,7 +1149,7 @@ func (h *EnvironmentHandler) DownloadEdgeMTLSCA(ctx context.Context, _ *Download
 				slog.WarnContext(humaCtx.Context(), "Failed to stream edge mTLS CA download", "fileName", fileName, "bytesWritten", written, "bytesExpected", len(caPEM), "error", writeErr)
 				return
 			}
-			h.logMTLSAuditEvent(humaCtx.Context(), nil, models.EventTypeEnvironmentMTLSDownload,
+			h.logMTLSAuditEventInternal(humaCtx.Context(), nil, models.EventTypeEnvironmentMTLSDownload,
 				"mTLS CA downloaded",
 				fmt.Sprintf("Administrator downloaded edge mTLS CA %q", fileName),
 				models.JSON{
@@ -1165,7 +1161,7 @@ func (h *EnvironmentHandler) DownloadEdgeMTLSCA(ctx context.Context, _ *Download
 }
 
 func (h *EnvironmentHandler) DownloadEnvironmentMTLSBundle(ctx context.Context, input *DownloadEnvironmentMTLSBundleInput) (*huma.StreamResponse, error) {
-	env, files, err := h.loadEnvironmentMTLSFiles(ctx, input.ID)
+	env, files, err := h.loadEnvironmentMTLSFilesInternal(ctx, input.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -1210,7 +1206,7 @@ func (h *EnvironmentHandler) DownloadEnvironmentMTLSBundle(ctx context.Context, 
 				slog.WarnContext(humaCtx.Context(), "Failed to stream edge mTLS bundle download", "environmentID", input.ID, "fileName", fileName, "bytesWritten", written, "bytesExpected", archive.Len(), "error", writeErr)
 				return
 			}
-			h.logMTLSAuditEvent(humaCtx.Context(), env, models.EventTypeEnvironmentMTLSDownload,
+			h.logMTLSAuditEventInternal(humaCtx.Context(), env, models.EventTypeEnvironmentMTLSDownload,
 				"mTLS bundle downloaded",
 				fmt.Sprintf("Administrator downloaded edge mTLS bundle %q (%d files)", fileName, len(files)),
 				models.JSON{
@@ -1223,7 +1219,7 @@ func (h *EnvironmentHandler) DownloadEnvironmentMTLSBundle(ctx context.Context, 
 }
 
 func (h *EnvironmentHandler) DownloadEnvironmentMTLSFile(ctx context.Context, input *DownloadEnvironmentMTLSFileInput) (*huma.StreamResponse, error) {
-	env, file, err := h.loadEnvironmentMTLSFile(ctx, input.ID, input.FileName)
+	env, file, err := h.loadEnvironmentMTLSFileInternal(ctx, input.ID, input.FileName)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1237,7 @@ func (h *EnvironmentHandler) DownloadEnvironmentMTLSFile(ctx context.Context, in
 				slog.WarnContext(humaCtx.Context(), "Failed to stream edge mTLS asset download", "environmentID", input.ID, "fileName", file.Name, "bytesWritten", written, "bytesExpected", len(fileContent), "error", writeErr)
 				return
 			}
-			h.logMTLSAuditEvent(humaCtx.Context(), env, models.EventTypeEnvironmentMTLSDownload,
+			h.logMTLSAuditEventInternal(humaCtx.Context(), env, models.EventTypeEnvironmentMTLSDownload,
 				"mTLS asset downloaded",
 				fmt.Sprintf("Administrator downloaded edge mTLS asset %q", file.Name),
 				models.JSON{
@@ -1278,7 +1274,7 @@ func (h *EnvironmentHandler) loadEnvironmentMTLSEnvironmentInternal(ctx context.
 	return env, nil
 }
 
-func (h *EnvironmentHandler) loadEnvironmentMTLSFiles(ctx context.Context, environmentID string) (*models.Environment, []services.DeploymentSnippetFile, error) {
+func (h *EnvironmentHandler) loadEnvironmentMTLSFilesInternal(ctx context.Context, environmentID string) (*models.Environment, []services.DeploymentSnippetFile, error) {
 	env, err := h.loadEnvironmentMTLSEnvironmentInternal(ctx, environmentID)
 	if err != nil {
 		return nil, nil, err
@@ -1302,8 +1298,8 @@ func (h *EnvironmentHandler) loadEnvironmentMTLSFiles(ctx context.Context, envir
 	return env, snippets.MTLS.Files, nil
 }
 
-func (h *EnvironmentHandler) loadEnvironmentMTLSFile(ctx context.Context, environmentID string, fileName string) (*models.Environment, services.DeploymentSnippetFile, error) {
-	env, files, err := h.loadEnvironmentMTLSFiles(ctx, environmentID)
+func (h *EnvironmentHandler) loadEnvironmentMTLSFileInternal(ctx context.Context, environmentID string, fileName string) (*models.Environment, services.DeploymentSnippetFile, error) {
+	env, files, err := h.loadEnvironmentMTLSFilesInternal(ctx, environmentID)
 	if err != nil {
 		return nil, services.DeploymentSnippetFile{}, err
 	}
@@ -1376,10 +1372,10 @@ func environmentMTLSAssetFileModeInternal(file services.DeploymentSnippetFile) o
 	return 0o644
 }
 
-// logMTLSAuditEvent records an audit event for administrator-triggered
+// logMTLSAuditEventInternal records an audit event for administrator-triggered
 // edge mTLS actions (downloads, bundle exports). Must never include raw
 // certificate content or private key material.
-func (h *EnvironmentHandler) logMTLSAuditEvent(ctx context.Context, env *models.Environment, eventType models.EventType, title, description string, extra models.JSON) {
+func (h *EnvironmentHandler) logMTLSAuditEventInternal(ctx context.Context, env *models.Environment, eventType models.EventType, title, description string, extra models.JSON) {
 	if h == nil || h.eventService == nil {
 		return
 	}

--- a/backend/api/handlers/environments_test.go
+++ b/backend/api/handlers/environments_test.go
@@ -43,7 +43,7 @@ func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
 			IsEdge: false,
 		}
 
-		handler.applyEdgeRuntimeState(&env)
+		handler.applyEdgeRuntimeStateInternal(&env)
 
 		assert.Equal(t, string(models.EnvironmentStatusOnline), env.Status)
 		assert.Nil(t, env.EdgeTransport)
@@ -68,7 +68,7 @@ func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
 			IsEdge: true,
 		}
 
-		handler.applyEdgeRuntimeState(&env)
+		handler.applyEdgeRuntimeStateInternal(&env)
 
 		assert.Equal(t, string(models.EnvironmentStatusOffline), env.Status)
 		assert.Nil(t, env.EdgeTransport)
@@ -95,7 +95,7 @@ func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
 			IsEdge: true,
 		}
 
-		handler.applyEdgeRuntimeState(&env)
+		handler.applyEdgeRuntimeStateInternal(&env)
 
 		assert.Equal(t, string(models.EnvironmentStatusPending), env.Status)
 		assert.Nil(t, env.EdgeTransport)
@@ -129,7 +129,7 @@ func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
 			IsEdge: true,
 		}
 
-		handler.applyEdgeRuntimeState(&env)
+		handler.applyEdgeRuntimeStateInternal(&env)
 
 		assert.Equal(t, string(models.EnvironmentStatusOnline), env.Status)
 		if assert.NotNil(t, env.EdgeTransport) {
@@ -166,7 +166,7 @@ func TestEnvironmentHandlerApplyEdgeRuntimeState(t *testing.T) {
 			IsEdge: true,
 		}
 
-		handler.applyEdgeRuntimeState(&env)
+		handler.applyEdgeRuntimeStateInternal(&env)
 
 		assert.Equal(t, string(models.EnvironmentStatusStandby), env.Status)
 		if assert.NotNil(t, env.Connected) {

--- a/backend/api/handlers/federated.go
+++ b/backend/api/handlers/federated.go
@@ -193,7 +193,7 @@ func (h *FederatedCredentialHandler) ListFederatedCredentials(ctx context.Contex
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/handlers/helpers.go
+++ b/backend/api/handlers/helpers.go
@@ -50,7 +50,7 @@ func buildPaginationParamsInternal(start, limit int, sortCol, sortDir, search st
 			Sort:  sortCol,
 			Order: pagination.SortOrder(sortDir),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: start,
 			Limit: limit,
 		},

--- a/backend/api/handlers/images.go
+++ b/backend/api/handlers/images.go
@@ -347,7 +347,7 @@ func (h *ImageHandler) ListImages(ctx context.Context, input *ListImagesInput) (
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/handlers/networks.go
+++ b/backend/api/handlers/networks.go
@@ -231,7 +231,7 @@ func (h *NetworkHandler) ListNetworks(ctx context.Context, input *ListNetworksIn
 			Sort:  strings.TrimSpace(input.Sort),
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/handlers/oidc.go
+++ b/backend/api/handlers/oidc.go
@@ -48,6 +48,7 @@ type GetOidcStatusOutput struct {
 
 type GetOidcAuthUrlInput struct {
 	OidcHeaders
+
 	Body auth.OidcAuthUrlRequest
 }
 
@@ -58,6 +59,7 @@ type GetOidcAuthUrlOutput struct {
 
 type HandleOidcCallbackInput struct {
 	OidcHeaders
+
 	OidcStateCookie string `cookie:"oidc_state" doc:"OIDC state cookie from auth URL request"`
 	Body            auth.OidcCallbackRequest
 }

--- a/backend/api/handlers/ports.go
+++ b/backend/api/handlers/ports.go
@@ -64,7 +64,7 @@ func (h *PortHandler) ListPorts(ctx context.Context, input *ListPortsInput) (*Li
 			Sort:  strings.TrimSpace(input.Sort),
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -208,6 +208,8 @@ type PullProgressEvent struct {
 
 // RegisterProjects registers project management routes using Huma.
 // Note: WebSocket and streaming endpoints remain as Gin handlers.
+//
+//nolint:maintidx // long but flat Huma route-registration function; complexity is sequential, not branching
 func RegisterProjects(api huma.API, projectService *services.ProjectService, activityService *services.ActivityService, appCtx ActivityAppContext) {
 	h := &ProjectHandler{
 		projectService:  projectService,
@@ -521,7 +523,7 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, input *ListProjectsIn
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},
@@ -570,10 +572,10 @@ func (h *ProjectHandler) GetProjectStatusCounts(ctx context.Context, input *GetP
 		Body: base.ApiResponse[project.StatusCounts]{
 			Success: true,
 			Data: project.StatusCounts{
-				RunningProjects:  int(running),
-				StoppedProjects:  int(stopped),
-				TotalProjects:    int(total),
-				ArchivedProjects: int(archived),
+				RunningProjects:  running,
+				StoppedProjects:  stopped,
+				TotalProjects:    total,
+				ArchivedProjects: archived,
 			},
 		},
 	}, nil
@@ -1199,7 +1201,7 @@ func (h *ProjectHandler) PullProjectImages(ctx context.Context, input *PullProje
 		Body: func(humaCtx huma.Context) { //nolint:contextcheck // context is obtained from humaCtx.Context()
 			httpx.SetJSONStreamHeaders(humaCtx)
 
-			runtimeCtx := utils.ActivityRuntimeContext(humaCtx.Context(), h.appCtx) //nolint:contextcheck // activity context intentionally outlives the HTTP stream (uses app lifecycle context)
+			runtimeCtx := utils.ActivityRuntimeContext(humaCtx.Context(), h.appCtx)
 			rawWriter := humaCtx.BodyWriter()
 			activityID, runtimeCtx := activitylib.StartHandlerActivityForUser(
 				runtimeCtx,
@@ -1268,7 +1270,7 @@ func (h *ProjectHandler) BuildProjectImages(ctx context.Context, input *BuildPro
 		Body: func(humaCtx huma.Context) { //nolint:contextcheck // context is obtained from humaCtx.Context()
 			httpx.SetJSONStreamHeaders(humaCtx)
 
-			runtimeCtx := utils.ActivityRuntimeContext(humaCtx.Context(), h.appCtx) //nolint:contextcheck // activity context intentionally outlives the HTTP stream (uses app lifecycle context)
+			runtimeCtx := utils.ActivityRuntimeContext(humaCtx.Context(), h.appCtx)
 			rawWriter := humaCtx.BodyWriter()
 			activityID, runtimeCtx := activitylib.StartHandlerActivityForUser(
 				runtimeCtx,

--- a/backend/api/handlers/settings.go
+++ b/backend/api/handlers/settings.go
@@ -312,7 +312,6 @@ func (h *SettingsHandler) UpdateSettings(ctx context.Context, input *UpdateSetti
 }
 
 func (h *SettingsHandler) validateSettingsUpdateInput(input settings.Update) error {
-
 	// Validate projects directory if provided and changed from current value.
 	// Skip validation when the value matches the current (possibly env-overridden) setting
 	// so that saving unrelated settings doesn't fail due to env-provided directory formats.

--- a/backend/api/handlers/swarm.go
+++ b/backend/api/handlers/swarm.go
@@ -149,6 +149,7 @@ type GetSwarmNodeAgentDeploymentInput struct {
 
 type SwarmNodeAgentDeployment struct {
 	DeploymentSnippet
+
 	EnvironmentID string                     `json:"environmentId"`
 	Agent         swarmtypes.NodeAgentStatus `json:"agent"`
 }
@@ -1331,7 +1332,7 @@ func (h *SwarmHandler) RenderStackConfig(ctx context.Context, input *RenderSwarm
 	return &RenderSwarmStackConfigOutput{Body: base.ApiResponse[swarmtypes.StackRenderConfigResponse]{Success: true, Data: *resp}}, nil
 }
 
-// GetSwarmInfo returns the current swarm cluster metadata for an environment.
+// GetSwarmStatus returns the current swarm cluster metadata for an environment.
 //
 // It delegates to the swarm service to inspect the local swarm state and maps
 // service-layer failures to the API's HTTP error model.
@@ -1935,7 +1936,7 @@ func buildSwarmQueryParams(search, sort, order string, start, limit int) paginat
 			Sort:  strings.TrimSpace(sort),
 			Order: pagination.SortOrder(order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: start,
 			Limit: limit,
 		},

--- a/backend/api/handlers/system.go
+++ b/backend/api/handlers/system.go
@@ -309,7 +309,7 @@ func (h *SystemHandler) GetDockerInfo(ctx context.Context, input *GetDockerInfoI
 	if !docker.IsDockerContainer() {
 		if cgroupLimits, err := docker.DetectCgroupLimits(); err == nil {
 			if limit := cgroupLimits.MemoryLimit; limit > 0 {
-				limitInt := int64(limit)
+				limitInt := limit
 				if memTotal == 0 || limitInt < memTotal {
 					memTotal = limitInt
 				}

--- a/backend/api/handlers/volumes.go
+++ b/backend/api/handlers/volumes.go
@@ -300,6 +300,8 @@ type UploadAndRestoreOutput struct {
 }
 
 // RegisterVolumes registers volume management routes using Huma.
+//
+//nolint:maintidx // long but flat Huma route-registration function; complexity is sequential, not branching
 func RegisterVolumes(api huma.API, dockerService *services.DockerClientService, volumeService *services.VolumeService, activityService *services.ActivityService, appCtx ActivityAppContext) {
 	h := &VolumeHandler{
 		volumeService:   volumeService,
@@ -673,7 +675,7 @@ func (h *VolumeHandler) ListVolumes(ctx context.Context, input *ListVolumesInput
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},
@@ -1123,7 +1125,7 @@ func (h *VolumeHandler) ListBackups(ctx context.Context, input *ListBackupsInput
 			Sort:  input.Sort,
 			Order: pagination.SortOrder(input.Order),
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: input.Start,
 			Limit: input.Limit,
 		},

--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -157,6 +157,7 @@ type WebSocketHandler struct {
 	logStreams        map[string]*wsLogStream
 	cpuCache          struct {
 		sync.RWMutex
+
 		value     float64
 		timestamp time.Time
 	}
@@ -181,6 +182,7 @@ type WebSocketHandler struct {
 
 	diskUsagePathCache struct {
 		sync.RWMutex
+
 		value     string
 		timestamp time.Time
 	}
@@ -813,7 +815,7 @@ func (h *WebSocketHandler) ContainerStats(c echo.Context) error {
 	conn, err := h.wsUpgrader.Upgrade(c.Response().Writer, c.Request(), nil)
 	if err != nil {
 		slog.DebugContext(c.Request().Context(), "Failed to upgrade WebSocket for container stats", "containerID", containerID, "error", err)
-		return nil //nolint:nilerr // Upgrade has already written an HTTP error response to the client.
+		return nil
 	}
 
 	connID := h.wsMetrics.RegisterConnection(buildWSConnectionInfoInternal(c, systemtypes.WSKindContainerStats, containerID))
@@ -829,13 +831,20 @@ func (h *WebSocketHandler) ContainerStats(c echo.Context) error {
 
 func (h *WebSocketHandler) getOrCreateContainerStatsHubInternal(containerID string) *wshub.Hub {
 	if existing, ok := h.containerStatsHubs.Load(containerID); ok {
-		return existing.(*wshub.Hub)
+		if hub, ok := existing.(*wshub.Hub); ok {
+			return hub
+		}
 	}
 
 	hub := wshub.NewHub(64)
 	actual, loaded := h.containerStatsHubs.LoadOrStore(containerID, hub)
 	if loaded {
-		return actual.(*wshub.Hub)
+		if existingHub, ok := actual.(*wshub.Hub); ok {
+			return existingHub
+		}
+		// type assertion failure is impossible in practice, but avoid running
+		// an unregistered hub if it somehow occurs
+		return hub
 	}
 
 	h.runContainerStatsHubInternal(containerID, hub)
@@ -843,7 +852,7 @@ func (h *WebSocketHandler) getOrCreateContainerStatsHubInternal(containerID stri
 }
 
 func (h *WebSocketHandler) runContainerStatsHubInternal(containerID string, hub *wshub.Hub) {
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is intentionally retained and invoked by the hub OnEmpty callback.
+	ctx, cancel := context.WithCancel(context.Background())
 	var cleanupTimer *time.Timer
 	var cleanupTimerMu sync.Mutex
 
@@ -972,7 +981,7 @@ func (h *WebSocketHandler) execCleanupFuncInternal(ctx context.Context, execSess
 	return func() {
 		slog.Debug("Cleaning up exec session", "execID", execID, "containerID", containerID, "contextErr", ctx.Err())
 		// Cleanup must proceed even if parent ctx is canceled.
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:contextcheck
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
 		if err := execSession.Close(cleanupCtx); err != nil { //nolint:contextcheck
 			slog.Warn("Failed to clean up exec session", "execID", execID, "error", err)
@@ -1037,11 +1046,14 @@ func (h *WebSocketHandler) pipeExecInputInternal(ctx context.Context, cancel con
 // System WebSocket Endpoints
 // ============================================================================
 
-// checkRateLimit checks and applies rate limiting for WebSocket connections.
+// checkRateLimitInternal checks and applies rate limiting for WebSocket connections.
 // Returns the counter and whether the connection should be allowed.
-func (h *WebSocketHandler) checkRateLimit(clientIP string) (*int32, bool) {
+func (h *WebSocketHandler) checkRateLimitInternal(clientIP string) (*int32, bool) {
 	connCount, _ := h.activeConnections.LoadOrStore(clientIP, new(int32))
-	count := connCount.(*int32)
+	count, ok := connCount.(*int32)
+	if !ok {
+		return nil, false
+	}
 
 	currentCount := atomic.AddInt32(count, 1)
 	if currentCount > 5 {
@@ -1051,8 +1063,8 @@ func (h *WebSocketHandler) checkRateLimit(clientIP string) (*int32, bool) {
 	return count, true
 }
 
-// releaseRateLimit decrements the connection counter and cleans up if needed.
-func (h *WebSocketHandler) releaseRateLimit(clientIP string, count *int32) {
+// releaseRateLimitInternal decrements the connection counter and cleans up if needed.
+func (h *WebSocketHandler) releaseRateLimitInternal(clientIP string, count *int32) {
 	newCount := atomic.AddInt32(count, -1)
 	if newCount <= 0 {
 		h.activeConnections.Delete(clientIP)
@@ -1069,7 +1081,7 @@ func (h *WebSocketHandler) acquireSystemStatsSamplerInternal(ctx context.Context
 		return waitForSystemStatsSamplerReadyInternal(ctx, ready)
 	}
 
-	samplerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx)) //nolint:gosec // cancel is intentionally retained in sampler state and invoked when the last subscriber disconnects.
+	samplerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	ready := make(chan struct{})
 	h.systemStatsSampler.cancel = cancel
 	h.systemStatsSampler.ready = ready
@@ -1371,14 +1383,14 @@ func (h *WebSocketHandler) getCachedCgroupLimitsInternal() *docker.CgroupLimits 
 func (h *WebSocketHandler) SystemStats(c echo.Context) error {
 	clientIP := c.RealIP()
 
-	count, allowed := h.checkRateLimit(clientIP)
+	count, allowed := h.checkRateLimitInternal(clientIP)
 	if !allowed {
 		return c.JSON(http.StatusTooManyRequests, map[string]any{
 			"success": false,
 			"error":   "Too many concurrent stats connections from this IP",
 		})
 	}
-	defer h.releaseRateLimit(clientIP, count)
+	defer h.releaseRateLimitInternal(clientIP, count)
 
 	conn, err := h.wsUpgrader.Upgrade(c.Response().Writer, c.Request(), nil)
 	if err != nil {

--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -170,7 +171,7 @@ func findArcaneContainer(ctx context.Context, dockerClient *client.Client) (cont
 		}
 	}
 
-	return container.InspectResponse{}, fmt.Errorf("no running Arcane container found")
+	return container.InspectResponse{}, errors.New("no running Arcane container found")
 }
 
 func isLegacyServerLabel(labels map[string]string) bool {

--- a/backend/frontend/frontend.go
+++ b/backend/frontend/frontend.go
@@ -47,7 +47,7 @@ func RegisterFrontend(e *echo.Echo) error {
 		if strings.HasPrefix(path, "/api/") {
 			_ = c.JSON(http.StatusNotFound, map[string]any{
 				"success": false,
-				"error":   fmt.Sprintf("API endpoint not found: %s", path),
+				"error":   "API endpoint not found: " + path,
 			})
 			return
 		}

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -58,11 +58,13 @@ func Bootstrap(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize database: %w", err)
 	}
 	defer func(ctx context.Context) {
-		// Use background context for shutdown as appCtx is already canceled
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second) //nolint:contextcheck
+		// appCtx is already canceled here, so derive the shutdown deadline from a
+		// non-canceled copy of it.
+		baseCtx := context.WithoutCancel(ctx)
+		shutdownCtx, shutdownCancel := context.WithTimeout(baseCtx, 10*time.Second)
 		defer shutdownCancel()
 		if err := db.Close(); err != nil {
-			slog.ErrorContext(shutdownCtx, "Error closing database", "error", err) //nolint:contextcheck
+			slog.ErrorContext(shutdownCtx, "Error closing database", "error", err)
 		}
 	}(appCtx)
 
@@ -93,7 +95,7 @@ func Bootstrap(ctx context.Context) error {
 
 	startEdgeTunnelClientIfConfigured(appCtx, cfg, router)
 
-	err = runServices(appCtx, cfg, router, tunnelServer, scheduler)
+	err = runServicesInternal(appCtx, cfg, router, tunnelServer, scheduler)
 	if err != nil {
 		return fmt.Errorf("failed to run services: %w", err)
 	}
@@ -294,7 +296,7 @@ func handleAgentBootstrapPairing(ctx context.Context, cfg *config.Config, httpCl
 		return fmt.Errorf("failed to create pairing request: %w", err)
 	}
 
-	req.Header.Set("X-API-Key", cfg.AgentToken)
+	req.Header.Set("X-Api-Key", cfg.AgentToken)
 
 	if cfg.EdgeAgent && strings.TrimSpace(cfg.ManagerApiUrl) != "" {
 		edgeClient, edgeErr := edge.NewManagerHTTPClient(&edge.Config{
@@ -312,7 +314,7 @@ func handleAgentBootstrapPairing(ctx context.Context, cfg *config.Config, httpCl
 		httpClient = edgeClient
 	}
 
-	resp, err := httpClient.Do(req) //nolint:gosec // intentional request to configured manager pairing endpoint
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("pairing request failed: %w", err)
 	}
@@ -341,7 +343,9 @@ func handleAgentBootstrapPairing(ctx context.Context, cfg *config.Config, httpCl
 	}
 }
 
-func runServices(appCtx context.Context, cfg *config.Config, router http.Handler, tunnelServer *edge.TunnelServer, schedulers ...interface{ Run(context.Context) error }) error {
+func runServicesInternal(appCtx context.Context, cfg *config.Config, router http.Handler, tunnelServer *edge.TunnelServer, schedulers ...interface {
+	Run(ctx context.Context) error
+}) error {
 	for _, s := range schedulers {
 		scheduler := s
 		go func() {
@@ -398,7 +402,7 @@ func runServices(appCtx context.Context, cfg *config.Config, router http.Handler
 	}
 
 	// Use background context for shutdown as appCtx is already canceled
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second) //nolint:contextcheck
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
 	if err := srv.Shutdown(shutdownCtx); err != nil { //nolint:contextcheck
@@ -425,7 +429,7 @@ func prepareServerTLSInternal(ctx context.Context, cfg *config.Config) (bool, st
 	tlsKeyFile := strings.TrimSpace(cfg.TLSKeyFile)
 	edgeCfg := buildEdgeRuntimeConfigInternal(cfg)
 	if useTLS && (tlsCertFile == "" || tlsKeyFile == "") {
-		return false, "", "", nil, fmt.Errorf("TLS_ENABLED requires both TLS_CERT_FILE and TLS_KEY_FILE")
+		return false, "", "", nil, errors.New("TLS_ENABLED requires both TLS_CERT_FILE and TLS_KEY_FILE")
 	}
 
 	if cfg.AgentMode {

--- a/backend/internal/bootstrap/edge_bootstrap.go
+++ b/backend/internal/bootstrap/edge_bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -51,7 +52,7 @@ func registerEdgeTunnelRoutes(
 
 	eventCallback := func(ctx context.Context, envID string, evt *edge.TunnelEvent) error {
 		if evt == nil {
-			return fmt.Errorf("event payload is required")
+			return errors.New("event payload is required")
 		}
 
 		var metadata models.JSON
@@ -118,7 +119,7 @@ func registerEdgeTunnelRoutes(
 			Type:          models.EventTypeEnvironmentMTLSEnroll,
 			Severity:      edgeMTLSEnrollmentSeverityInternal(reenrolled),
 			Title:         "Edge mTLS enrollment",
-			Description:   fmt.Sprintf("Edge agent completed mTLS enrollment from %s", remoteAddr),
+			Description:   "Edge agent completed mTLS enrollment from " + remoteAddr,
 			ResourceType:  new("environment"),
 			ResourceID:    &envIDCopy,
 			ResourceName:  &envNameCopy,

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -87,7 +87,7 @@ func createAuthValidatorInternal(appServices *Services) middleware.AuthValidator
 	return func(ctx context.Context, c echo.Context) bool {
 		req := c.Request()
 		// Check for API key authentication
-		if apiKey := req.Header.Get("X-API-Key"); apiKey != "" {
+		if apiKey := req.Header.Get("X-Api-Key"); apiKey != "" {
 			// User-owned API key
 			if user, err := appServices.ApiKey.ValidateApiKey(ctx, apiKey); err == nil && user != nil {
 				return true

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1732,7 +1732,7 @@ type UnknownPermissionError struct {
 }
 
 func (e *UnknownPermissionError) Error() string {
-	return fmt.Sprintf("Unknown permission: %s", e.Perm)
+	return "Unknown permission: " + e.Perm
 }
 
 func IsUnknownPermissionError(err error) bool {
@@ -1748,7 +1748,7 @@ type RolePermissionEscalationError struct {
 }
 
 func (e *RolePermissionEscalationError) Error() string {
-	return fmt.Sprintf("cannot grant a permission you do not hold: %s", e.Perm)
+	return "cannot grant a permission you do not hold: " + e.Perm
 }
 
 func IsRolePermissionEscalationError(err error) bool {
@@ -1796,6 +1796,38 @@ func (e *FederatedCredentialInvalidError) Error() string {
 
 func IsErrorFederatedCredentialInvalid(err error) bool {
 	return isErrorTypeInternal[*FederatedCredentialInvalidError](err)
+}
+
+// DefaultTransportTypeError is returned when http.DefaultTransport is not the
+// expected *http.Transport concrete type and therefore cannot be cloned.
+type DefaultTransportTypeError struct{}
+
+func (e *DefaultTransportTypeError) Error() string {
+	return "http.DefaultTransport is not *http.Transport"
+}
+
+// ManagerCALockTypeError is returned when a cached manager CA lock value is not
+// the expected *sync.Mutex.
+type ManagerCALockTypeError struct{}
+
+func (e *ManagerCALockTypeError) Error() string {
+	return "manager CA lock value is not *sync.Mutex"
+}
+
+// ECRTokenResultTypeError is returned when a deduplicated ECR token refresh
+// yields a value that is not the expected *ecrTokenResult.
+type ECRTokenResultTypeError struct{}
+
+func (e *ECRTokenResultTypeError) Error() string {
+	return "unexpected ECR token result type"
+}
+
+// OidcProviderCacheTypeError is returned when a cached OIDC provider value is
+// not the expected *oidc.Provider.
+type OidcProviderCacheTypeError struct{}
+
+func (e *OidcProviderCacheTypeError) Error() string {
+	return "unexpected provider type from cache"
 }
 
 type FederatedCredentialInvalidRequestError struct{}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -28,6 +28,9 @@ const (
 // Fields with `options:"file"` support Docker secrets via the _FILE suffix.
 // Available options: file, toLower, trimTrailingSlash
 type Config struct {
+	// BuildablesConfig contains feature-specific configuration that can be conditionally compiled
+	BuildablesConfig
+
 	AppUrl            string         `env:"APP_URL" default:"http://localhost:3552"`
 	DatabaseURL       string         `env:"DATABASE_URL" default:"file:data/arcane.db?_pragma=journal_mode(WAL)&_pragma=busy_timeout(2500)&_txlock=immediate" options:"file"`
 	AllowDowngrade    bool           `env:"ALLOW_DOWNGRADE" default:"false"`
@@ -37,7 +40,7 @@ type Config struct {
 	TLSCertFile       string         `env:"TLS_CERT_FILE" default:""`
 	TLSKeyFile        string         `env:"TLS_KEY_FILE" default:""`
 	Environment       AppEnvironment `env:"ENVIRONMENT" default:"production"`
-	JWTSecret         string         `env:"JWT_SECRET" default:"default-jwt-secret-change-me" options:"file"` //nolint:gosec // configuration field name is part of stable config API
+	JWTSecret         string         `env:"JWT_SECRET" default:"default-jwt-secret-change-me" options:"file"`
 	JWTRefreshExpiry  time.Duration  `env:"JWT_REFRESH_EXPIRY" default:"168h"`
 	EncryptionKey     string         `env:"ENCRYPTION_KEY" default:"arcane-dev-key-32-characters!!!" options:"file"`
 	AdminStaticAPIKey string         `env:"ADMIN_STATIC_API_KEY" default:"" options:"file"`
@@ -105,9 +108,6 @@ type Config struct {
 	// Timezone for cron job scheduling. Uses IANA timezone names (e.g., "America/New_York", "Europe/London").
 	// "Local" uses the system's local timezone, "UTC" for Coordinated Universal Time.
 	Timezone string `env:"TZ" default:"Local"`
-
-	// BuildablesConfig contains feature-specific configuration that can be conditionally compiled
-	BuildablesConfig
 }
 
 func Load() *Config {
@@ -218,7 +218,7 @@ func visitConfigFields(v reflect.Value, fn func(reflect.Value, reflect.StructFie
 	}
 
 	t := v.Type()
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := v.Field(i)
 		fieldType := t.Field(i)
 
@@ -332,14 +332,14 @@ func setFieldValueInternal(field reflect.Value, fieldType reflect.StructField, v
 			defaultValue := fieldType.Tag.Get("default")
 
 			if fallback, fallbackErr := time.ParseDuration(defaultValue); fallbackErr == nil {
-				slog.Warn("Invalid duration for config field, using tagged default", //nolint:gosec // logging invalid config input for diagnostics is intentional here.
+				slog.Warn("Invalid duration for config field, using tagged default",
 					"reason", reason,
 					"field", envTag,
 					"value", value,
 					"default", defaultValue)
 				field.SetInt(int64(fallback))
 			} else {
-				slog.Warn("Invalid duration for config field and invalid tagged default", //nolint:gosec // logging invalid config input for diagnostics is intentional here.
+				slog.Warn("Invalid duration for config field and invalid tagged default",
 					"reason", reason,
 					"field", envTag,
 					"value", value,
@@ -476,7 +476,7 @@ func (c *Config) MaskSensitive() map[string]any {
 	v := reflect.ValueOf(c).Elem()
 	t := v.Type()
 
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		field := v.Field(i)
 		fieldType := t.Field(i)
 

--- a/backend/internal/configschema/schema.go
+++ b/backend/internal/configschema/schema.go
@@ -3,6 +3,7 @@ package configschema
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/format"
@@ -443,7 +444,7 @@ func resolveSourceRootInternal(sourceRoot string) (string, error) {
 		return "", fmt.Errorf("resolve source root from %q: expected backend/internal/config/config.go", sourceRoot)
 	}
 
-	return "", fmt.Errorf("resolve source root: run from the repository root/backend directory or pass --source-root")
+	return "", errors.New("resolve source root: run from the repository root/backend directory or pass --source-root")
 }
 
 func resolveSourceRootCandidateInternal(candidate string) (string, error) {

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -19,6 +19,8 @@ import (
 	postgresMigrate "github.com/golang-migrate/migrate/v4/database/postgres"
 	sqliteMigrate "github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source"
+
+	// Registers the "github" source driver for golang-migrate (remote migration sources).
 	_ "github.com/golang-migrate/migrate/v4/source/github"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"gorm.io/driver/postgres"
@@ -532,5 +534,5 @@ func ensureSQLiteDirectory(connString string) error {
 	if dir == "" || dir == "." {
 		return nil
 	}
-	return os.MkdirAll(dir, 0o755) //nolint:gosec // directory path is intentionally derived from configured SQLite DSN
+	return os.MkdirAll(dir, 0o755)
 }

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -351,7 +351,7 @@ func (m *EnvironmentMiddleware) proxyHTTP(c echo.Context, target string, accessT
 		})
 	}
 
-	resp, err := m.httpClient.Do(req) //nolint:gosec // intentional proxy request to resolved remote environment URL
+	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		return c.JSON(http.StatusBadGateway, map[string]any{
 			"success": false,

--- a/backend/internal/middleware/rate_limit_middleware.go
+++ b/backend/internal/middleware/rate_limit_middleware.go
@@ -146,7 +146,7 @@ func PerAgentTokenRateLimit(perMinute int, burst int) echo.MiddlewareFunc {
 			req := c.Request()
 			key := strings.TrimSpace(req.Header.Get("X-Arcane-Agent-Token"))
 			if key == "" {
-				key = strings.TrimSpace(req.Header.Get("X-API-Key"))
+				key = strings.TrimSpace(req.Header.Get("X-Api-Key"))
 			}
 			if key == "" {
 				return next(c)

--- a/backend/internal/models/activity.go
+++ b/backend/internal/models/activity.go
@@ -46,6 +46,8 @@ const (
 )
 
 type Activity struct {
+	BaseModel
+
 	EnvironmentID        string         `json:"environmentId" gorm:"column:environment_id;not null;index" sortable:"true"`
 	Type                 ActivityType   `json:"type" gorm:"column:type;not null;index" sortable:"true"`
 	Status               ActivityStatus `json:"status" gorm:"column:status;not null;index" sortable:"true"`
@@ -63,7 +65,6 @@ type Activity struct {
 	DurationMs           *int64         `json:"durationMs,omitempty" gorm:"column:duration_ms" sortable:"true"`
 	Error                *string        `json:"error,omitempty" gorm:"column:error"`
 	Metadata             JSON           `json:"metadata,omitempty" gorm:"type:text"`
-	BaseModel
 }
 
 func (Activity) TableName() string {
@@ -71,12 +72,13 @@ func (Activity) TableName() string {
 }
 
 type ActivityMessage struct {
+	BaseModel
+
 	ActivityID string               `json:"activityId" gorm:"column:activity_id;not null;index"`
 	Level      ActivityMessageLevel `json:"level" gorm:"column:level;not null"`
 	Message    string               `json:"message" gorm:"column:message;not null"`
 	Payload    JSON                 `json:"payload,omitempty" gorm:"type:text"`
 	Activity   *Activity            `json:"-" gorm:"foreignKey:ActivityID;constraint:OnDelete:CASCADE"`
-	BaseModel
 }
 
 func (ActivityMessage) TableName() string {

--- a/backend/internal/models/api_key.go
+++ b/backend/internal/models/api_key.go
@@ -5,6 +5,8 @@ import (
 )
 
 type ApiKey struct {
+	BaseModel
+
 	Name          string     `json:"name" gorm:"column:name;not null" sortable:"true"`
 	Description   *string    `json:"description,omitempty" gorm:"column:description"`
 	KeyHash       string     `json:"-" gorm:"column:key_hash;not null"`
@@ -14,7 +16,6 @@ type ApiKey struct {
 	EnvironmentID *string    `json:"environmentId,omitempty" gorm:"column:environment_id"`
 	ExpiresAt     *time.Time `json:"expiresAt,omitempty" gorm:"column:expires_at" sortable:"true"`
 	LastUsedAt    *time.Time `json:"lastUsedAt,omitempty" gorm:"column:last_used_at" sortable:"true"`
-	BaseModel
 }
 
 func (ApiKey) TableName() string {

--- a/backend/internal/models/auto_update.go
+++ b/backend/internal/models/auto_update.go
@@ -16,6 +16,8 @@ const (
 )
 
 type AutoUpdateRecord struct {
+	BaseModel
+
 	ResourceID       string           `json:"resourceId"`
 	ResourceType     string           `json:"resourceType"`
 	ResourceName     string           `json:"resourceName"`
@@ -28,7 +30,6 @@ type AutoUpdateRecord struct {
 	NewImageVersions JSON             `json:"newImageVersions,omitempty" gorm:"type:text"`
 	Error            *string          `json:"error,omitempty"`
 	Details          JSON             `json:"details,omitempty" gorm:"type:text"`
-	BaseModel
 }
 
 func (AutoUpdateRecord) TableName() string {

--- a/backend/internal/models/base.go
+++ b/backend/internal/models/base.go
@@ -30,7 +30,7 @@ func (m *BaseModel) BeforeUpdate(_ *gorm.DB) (err error) {
 	return nil
 }
 
-// nolint:recvcheck
+//nolint:recvcheck
 type JSON map[string]any
 
 func (j JSON) Value() (driver.Value, error) {
@@ -55,7 +55,7 @@ func (j *JSON) Scan(value any) error {
 	}
 }
 
-// nolint:recvcheck
+//nolint:recvcheck
 type StringSlice []string
 
 func (s StringSlice) Value() (driver.Value, error) {

--- a/backend/internal/models/container_registry.go
+++ b/backend/internal/models/container_registry.go
@@ -5,6 +5,8 @@ import (
 )
 
 type ContainerRegistry struct {
+	BaseModel
+
 	URL                 string     `json:"url" sortable:"true"`
 	Username            string     `json:"username" sortable:"true"`
 	Token               string     `json:"token"`
@@ -19,7 +21,6 @@ type ContainerRegistry struct {
 	ECRTokenGeneratedAt *time.Time `json:"ecrTokenGeneratedAt"`
 	CreatedAt           time.Time  `json:"createdAt" sortable:"true"`
 	UpdatedAt           time.Time  `json:"updatedAt" sortable:"true"`
-	BaseModel
 }
 
 func (ContainerRegistry) TableName() string {

--- a/backend/internal/models/environment.go
+++ b/backend/internal/models/environment.go
@@ -3,6 +3,8 @@ package models
 import "time"
 
 type Environment struct {
+	BaseModel
+
 	Name                string     `json:"name" sortable:"true"`
 	ApiUrl              string     `json:"apiUrl" gorm:"column:api_url" sortable:"true"`
 	Status              string     `json:"status" sortable:"true"`
@@ -14,8 +16,6 @@ type Environment struct {
 	ApiKeyID            *string    `json:"-" gorm:"column:api_key_id"`
 	ParentEnvironmentID *string    `json:"-" gorm:"column:parent_environment_id"`
 	SwarmNodeID         *string    `json:"-" gorm:"column:swarm_node_id"`
-
-	BaseModel
 }
 
 func (Environment) TableName() string { return "environments" }

--- a/backend/internal/models/event.go
+++ b/backend/internal/models/event.go
@@ -10,7 +10,7 @@ type (
 )
 
 const (
-	// Event types
+	// EventTypeContainerStart and the constants below enumerate Arcane event types.
 	EventTypeContainerStart   EventType = "container.start"
 	EventTypeContainerStop    EventType = "container.stop"
 	EventTypeContainerRestart EventType = "container.restart"
@@ -89,7 +89,7 @@ const (
 	EventTypeWebhookDelete  EventType = "webhook.delete"
 	EventTypeWebhookTrigger EventType = "webhook.trigger"
 
-	// Event severities
+	// EventSeverityInfo and the constants below enumerate event severities.
 	EventSeverityInfo    EventSeverity = "info"
 	EventSeverityWarning EventSeverity = "warning"
 	EventSeverityError   EventSeverity = "error"
@@ -97,6 +97,8 @@ const (
 )
 
 type Event struct {
+	BaseModel
+
 	Type          EventType     `json:"type" sortable:"true"`
 	Severity      EventSeverity `json:"severity" sortable:"true"`
 	Title         string        `json:"title" sortable:"true"`
@@ -109,7 +111,6 @@ type Event struct {
 	EnvironmentID *string       `json:"environmentId,omitempty"`
 	Metadata      JSON          `json:"metadata,omitempty" gorm:"type:text"`
 	Timestamp     time.Time     `json:"timestamp" sortable:"true"`
-	BaseModel
 }
 
 func (Event) TableName() string {

--- a/backend/internal/models/federated_credential.go
+++ b/backend/internal/models/federated_credential.go
@@ -8,6 +8,8 @@ const (
 )
 
 type FederatedCredential struct {
+	BaseModel
+
 	Name            string       `json:"name" gorm:"column:name;not null" sortable:"true"`
 	Description     *string      `json:"description,omitempty" gorm:"column:description"`
 	Enabled         bool         `json:"enabled" gorm:"column:enabled;not null;default:false;index" sortable:"true"`
@@ -25,7 +27,6 @@ type FederatedCredential struct {
 	IdentityUser    *User        `json:"identityUser,omitempty" gorm:"foreignKey:IdentityUserID;constraint:OnDelete:CASCADE"`
 	Role            *Role        `json:"role,omitempty" gorm:"foreignKey:RoleID;constraint:OnDelete:RESTRICT"`
 	Environment     *Environment `json:"environment,omitempty" gorm:"foreignKey:EnvironmentID;constraint:OnDelete:SET NULL"`
-	BaseModel
 }
 
 func (FederatedCredential) TableName() string {

--- a/backend/internal/models/federated_token_replay.go
+++ b/backend/internal/models/federated_token_replay.go
@@ -3,10 +3,11 @@ package models
 import "time"
 
 type FederatedTokenReplay struct {
+	BaseModel
+
 	TokenHash string    `json:"-" gorm:"column:token_hash;not null;uniqueIndex"`
 	IssuerURL string    `json:"issuerUrl" gorm:"column:issuer_url;not null;index"`
 	ExpiresAt time.Time `json:"expiresAt" gorm:"column:expires_at;not null;index"`
-	BaseModel
 }
 
 func (FederatedTokenReplay) TableName() string {

--- a/backend/internal/models/git_repository.go
+++ b/backend/internal/models/git_repository.go
@@ -1,6 +1,8 @@
 package models
 
 type GitRepository struct {
+	BaseModel
+
 	Name                   string  `json:"name" sortable:"true" search:"git,repository,repo,source,version,control,github,gitlab,bitbucket"`
 	URL                    string  `json:"url" sortable:"true" search:"url,git,clone,remote,https,ssh"`
 	AuthType               string  `json:"authType" sortable:"true" search:"auth,authentication,credentials,token,ssh,http"` // none, http, ssh
@@ -10,7 +12,6 @@ type GitRepository struct {
 	SSHHostKeyVerification string  `json:"sshHostKeyVerification" gorm:"default:accept_new"`      // strict, accept_new, skip
 	Description            *string `json:"description,omitempty" sortable:"true"`
 	Enabled                bool    `json:"enabled" sortable:"true" search:"enabled,active,disabled"`
-	BaseModel
 }
 
 func (GitRepository) TableName() string {

--- a/backend/internal/models/gitops_sync.go
+++ b/backend/internal/models/gitops_sync.go
@@ -5,6 +5,8 @@ import (
 )
 
 type GitOpsSync struct {
+	BaseModel
+
 	Name              string         `json:"name" sortable:"true" search:"sync,gitops,automation,deploy,deployment,continuous"`
 	EnvironmentID     string         `json:"environmentId" sortable:"true"`
 	Environment       *Environment   `json:"environment,omitempty" gorm:"foreignKey:EnvironmentID"`
@@ -27,7 +29,6 @@ type GitOpsSync struct {
 	LastSyncStatus    *string        `json:"lastSyncStatus,omitempty" search:"status,success,failed,pending,error"`
 	LastSyncError     *string        `json:"lastSyncError,omitempty"`
 	LastSyncCommit    *string        `json:"lastSyncCommit,omitempty" search:"commit,hash,sha,revision"`
-	BaseModel
 }
 
 func (GitOpsSync) TableName() string {

--- a/backend/internal/models/image_build.go
+++ b/backend/internal/models/image_build.go
@@ -11,6 +11,8 @@ const (
 )
 
 type ImageBuild struct {
+	BaseModel
+
 	EnvironmentID   string           `json:"environmentId" gorm:"column:environment_id;index"`
 	UserID          *string          `json:"userId,omitempty" gorm:"column:user_id"`
 	Username        *string          `json:"username,omitempty" gorm:"column:username"`
@@ -42,7 +44,6 @@ type ImageBuild struct {
 	OutputTruncated bool             `json:"outputTruncated" gorm:"column:output_truncated;default:false"`
 	CompletedAt     *time.Time       `json:"completedAt,omitempty" gorm:"column:completed_at" sortable:"true"`
 	DurationMs      *int64           `json:"durationMs,omitempty" gorm:"column:duration_ms"`
-	BaseModel
 }
 
 func (ImageBuild) TableName() string {

--- a/backend/internal/models/image_update.go
+++ b/backend/internal/models/image_update.go
@@ -5,6 +5,8 @@ import (
 )
 
 type ImageUpdateRecord struct {
+	BaseModel
+
 	ID             string    `json:"id" gorm:"primaryKey;type:text"`
 	Repository     string    `json:"repository"`
 	Tag            string    `json:"tag"`
@@ -24,8 +26,6 @@ type ImageUpdateRecord struct {
 	UsedCredential bool    `json:"usedCredential,omitempty" gorm:"column:used_credential"`
 
 	NotificationSent bool `json:"notificationSent" gorm:"column:notification_sent;default:false"`
-
-	BaseModel
 }
 
 func (i *ImageUpdateRecord) TableName() string {

--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -127,7 +127,7 @@ type SignalConfig struct {
 	Host       string                         `json:"host"`
 	Port       int                            `json:"port"`
 	User       string                         `json:"user,omitempty"`
-	Password   string                         `json:"password,omitempty"` //nolint:gosec // JSON schema compatibility with external provider config
+	Password   string                         `json:"password,omitempty"`
 	Token      string                         `json:"token,omitempty"`
 	Source     string                         `json:"source"`
 	Recipients []string                       `json:"recipients"`
@@ -151,7 +151,7 @@ type NtfyConfig struct {
 	Port                   int                            `json:"port"`
 	Topic                  string                         `json:"topic"`
 	Username               string                         `json:"username,omitempty"`
-	Password               string                         `json:"password,omitempty"` //nolint:gosec // JSON schema compatibility with external provider config
+	Password               string                         `json:"password,omitempty"`
 	Title                  string                         `json:"title,omitempty"`
 	Priority               string                         `json:"priority,omitempty"`
 	Tags                   []string                       `json:"tags,omitempty"`
@@ -187,7 +187,7 @@ type MatrixConfig struct {
 	Port                   int                            `json:"port,omitempty"`
 	Rooms                  string                         `json:"rooms"`
 	Username               string                         `json:"username,omitempty"`
-	Password               string                         `json:"password,omitempty"` //nolint:gosec // JSON schema compatibility with external provider config
+	Password               string                         `json:"password,omitempty"`
 	DisableTLSVerification bool                           `json:"disableTlsVerification"`
 	Events                 map[NotificationEventType]bool `json:"events,omitempty"`
 }

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -15,6 +15,8 @@ const (
 )
 
 type Project struct {
+	BaseModel
+
 	Name               string        `json:"name" sortable:"true" gorm:"index:idx_projects_name"`
 	DirName            *string       `json:"dir_name"`
 	Path               string        `json:"path" sortable:"true" gorm:"uniqueIndex"`
@@ -27,8 +29,6 @@ type Project struct {
 	ImageRefsJSON      string        `json:"image_refs_json,omitempty" gorm:"column:image_refs_json"`
 	IsArchived         bool          `json:"is_archived" gorm:"column:is_archived;default:false;index"`
 	ArchivedAt         *time.Time    `json:"archived_at,omitempty" gorm:"column:archived_at"`
-
-	BaseModel
 }
 
 func (Project) TableName() string {

--- a/backend/internal/models/rbac.go
+++ b/backend/internal/models/rbac.go
@@ -3,11 +3,12 @@ package models
 // Role is a named permission set. Built-in roles (Admin, Editor, Deployer,
 // Viewer) are seeded by migration 054 and cannot be edited or deleted.
 type Role struct {
+	BaseModel
+
 	Name        string      `json:"name" gorm:"column:name;not null;uniqueIndex" sortable:"true"`
 	Description *string     `json:"description,omitempty" gorm:"column:description"`
 	Permissions StringSlice `json:"permissions" gorm:"column:permissions;type:text;not null"`
 	BuiltIn     bool        `json:"builtIn" gorm:"column:built_in;not null;default:false" sortable:"true"`
-	BaseModel
 }
 
 func (Role) TableName() string { return "roles" }
@@ -19,11 +20,12 @@ func (Role) TableName() string { return "roles" }
 // Source distinguishes manual assignments (managed by admins via the UI) from
 // assignments synthesized from OIDC group mappings on every login.
 type UserRoleAssignment struct {
+	BaseModel
+
 	UserID        string  `json:"userId" gorm:"column:user_id;not null;index"`
 	RoleID        string  `json:"roleId" gorm:"column:role_id;not null;index"`
 	EnvironmentID *string `json:"environmentId,omitempty" gorm:"column:environment_id;index"`
 	Source        string  `json:"source" gorm:"column:source;not null;default:'manual'"`
-	BaseModel
 }
 
 func (UserRoleAssignment) TableName() string { return "user_role_assignments" }
@@ -39,10 +41,11 @@ const (
 // column on api_keys) so we can index by (api_key_id, permission) for fast
 // lookups in the auth bridge.
 type ApiKeyPermission struct {
+	BaseModel
+
 	ApiKeyID      string  `json:"apiKeyId" gorm:"column:api_key_id;not null;index"`
 	Permission    string  `json:"permission" gorm:"column:permission;not null"`
 	EnvironmentID *string `json:"environmentId,omitempty" gorm:"column:environment_id"`
-	BaseModel
 }
 
 func (ApiKeyPermission) TableName() string { return "api_key_permissions" }
@@ -57,11 +60,12 @@ func (ApiKeyPermission) TableName() string { return "api_key_permissions" }
 // read-only via the API — they can only be changed by editing the env var
 // and restarting.
 type OidcRoleMapping struct {
+	BaseModel
+
 	ClaimValue    string  `json:"claimValue" gorm:"column:claim_value;not null;index"`
 	RoleID        string  `json:"roleId" gorm:"column:role_id;not null;index"`
 	EnvironmentID *string `json:"environmentId,omitempty" gorm:"column:environment_id"`
 	Source        string  `json:"source" gorm:"column:source;not null;default:'manual'"`
-	BaseModel
 }
 
 func (OidcRoleMapping) TableName() string { return "oidc_role_mappings" }

--- a/backend/internal/models/settings.go
+++ b/backend/internal/models/settings.go
@@ -198,7 +198,7 @@ func buildSettingsFieldCacheInternal() {
 	ordered := make([]settingFieldMeta, 0, rt.NumField())
 	byKey := make(map[string]settingFieldMeta, rt.NumField())
 
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		field := rt.Field(i)
 		key, attrs, _ := strings.Cut(field.Tag.Get("key"), ",")
 		if key == "" {
@@ -363,7 +363,7 @@ func (e SettingSensitiveForbiddenError) Is(target error) bool {
 
 type OidcConfig struct {
 	ClientID     string `json:"clientId"`
-	ClientSecret string `json:"clientSecret"` //nolint:gosec // OIDC schema compatibility requires this field name
+	ClientSecret string `json:"clientSecret"`
 	IssuerURL    string `json:"issuerUrl"`
 	Scopes       string `json:"scopes"`
 

--- a/backend/internal/models/template.go
+++ b/backend/internal/models/template.go
@@ -2,6 +2,7 @@ package models
 
 type TemplateRegistry struct {
 	BaseModel
+
 	Name        string `json:"name"`
 	URL         string `json:"url"`
 	Enabled     bool   `json:"enabled"`
@@ -10,6 +11,7 @@ type TemplateRegistry struct {
 
 type ComposeTemplate struct {
 	BaseModel
+
 	Name        string                   `json:"name"`
 	Description string                   `json:"description"`
 	Content     string                   `json:"content" gorm:"type:text"`

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -5,6 +5,8 @@ import (
 )
 
 type User struct {
+	BaseModel
+
 	Username               string     `json:"username" sortable:"true"`
 	PasswordHash           string     `json:"-" gorm:"column:password_hash"`
 	DisplayName            *string    `json:"displayName,omitempty" gorm:"column:display_name" sortable:"true"`
@@ -19,7 +21,6 @@ type User struct {
 	OidcAccessToken          *string    `json:"-" gorm:"type:text"`
 	OidcRefreshToken         *string    `json:"-" gorm:"type:text"`
 	OidcAccessTokenExpiresAt *time.Time `json:"-"`
-	BaseModel
 }
 
 func (User) TableName() string {

--- a/backend/internal/models/user_session.go
+++ b/backend/internal/models/user_session.go
@@ -10,6 +10,7 @@ const (
 
 type UserSession struct {
 	BaseModel
+
 	UserID                string               `json:"userId" gorm:"column:user_id;not null;index"`
 	User                  *User                `json:"user,omitempty" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
 	RefreshTokenHash      string               `json:"-" gorm:"column:refresh_token_hash;not null;uniqueIndex"`

--- a/backend/internal/models/volume_backup.go
+++ b/backend/internal/models/volume_backup.go
@@ -8,6 +8,7 @@ import (
 
 type VolumeBackup struct {
 	BaseModel
+
 	VolumeName string    `json:"volumeName" gorm:"column:volume_name;index"`
 	Size       int64     `json:"size" gorm:"column:size"`
 	CreatedAt  time.Time `json:"createdAt" gorm:"column:created_at"`

--- a/backend/internal/models/vulnerability_ignore.go
+++ b/backend/internal/models/vulnerability_ignore.go
@@ -52,8 +52,8 @@ func (v *VulnerabilityIgnore) BeforeCreate(db *gorm.DB) error {
 	return nil
 }
 
-// VulnerabilityIgnoreCompositeKey generates a composite key for deduplication
-// This helps prevent duplicate ignore records for the same vulnerability
+// CompositeKey generates a composite key for deduplication.
+// This helps prevent duplicate ignore records for the same vulnerability.
 func (v *VulnerabilityIgnore) CompositeKey() string {
 	return v.EnvironmentID + ":" + v.ImageID + ":" + v.VulnerabilityID + ":" + v.PkgName + ":" + v.InstalledVersion
 }

--- a/backend/internal/models/vulnerability_scan.go
+++ b/backend/internal/models/vulnerability_scan.go
@@ -6,6 +6,8 @@ import (
 
 // VulnerabilityScanRecord stores vulnerability scan results for images
 type VulnerabilityScanRecord struct {
+	BaseModel
+
 	// ImageID is the Docker image ID (primary key)
 	ID string `json:"id" gorm:"primaryKey;type:text"`
 
@@ -37,8 +39,6 @@ type VulnerabilityScanRecord struct {
 
 	// ScannerVersion is the version of the scanner used
 	ScannerVersion string `json:"scannerVersion" gorm:"column:scanner_version"`
-
-	BaseModel
 }
 
 func (v *VulnerabilityScanRecord) TableName() string {

--- a/backend/internal/models/webhook.go
+++ b/backend/internal/models/webhook.go
@@ -20,6 +20,8 @@ const (
 )
 
 type Webhook struct {
+	BaseModel
+
 	Name            string     `json:"name" gorm:"column:name;not null"`
 	TokenHash       string     `json:"-" gorm:"column:token_hash;not null;uniqueIndex"`
 	TokenPrefix     string     `json:"tokenPrefix" gorm:"column:token_prefix;not null"`
@@ -30,7 +32,6 @@ type Webhook struct {
 	EnvironmentID   string     `json:"environmentId" gorm:"column:environment_id;not null;default:''"`
 	Enabled         bool       `json:"enabled" gorm:"column:enabled;not null;default:true"`
 	LastTriggeredAt *time.Time `json:"lastTriggeredAt,omitempty" gorm:"column:last_triggered_at"`
-	BaseModel
 }
 
 func (Webhook) TableName() string {

--- a/backend/internal/services/activity_service.go
+++ b/backend/internal/services/activity_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -126,7 +127,7 @@ func (s *ActivityService) releaseCancelInternal(activityID string) {
 
 func (s *ActivityService) checkInitInternal() error {
 	if s == nil || s.db == nil {
-		return fmt.Errorf("activity service not initialized")
+		return errors.New("activity service not initialized")
 	}
 	return nil
 }
@@ -189,7 +190,7 @@ func (s *ActivityService) UpdateActivity(ctx context.Context, activityID string,
 	}
 	activityID = strings.TrimSpace(activityID)
 	if activityID == "" {
-		return nil, fmt.Errorf("activity id is required")
+		return nil, errors.New("activity id is required")
 	}
 
 	updates := map[string]any{
@@ -221,7 +222,7 @@ func (s *ActivityService) UpdateActivity(ctx context.Context, activityID string,
 			return fmt.Errorf("failed to update activity: %w", result.Error)
 		}
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("activity not found")
+			return errors.New("activity not found")
 		}
 		if err := tx.First(&model, "id = ?", activityID).Error; err != nil {
 			return fmt.Errorf("failed to load updated activity: %w", err)
@@ -242,7 +243,7 @@ func (s *ActivityService) AppendMessage(ctx context.Context, activityID string, 
 	}
 	activityID = strings.TrimSpace(activityID)
 	if activityID == "" {
-		return nil, fmt.Errorf("activity id is required")
+		return nil, errors.New("activity id is required")
 	}
 
 	messageText := strings.TrimSpace(req.Message)
@@ -291,7 +292,7 @@ func (s *ActivityService) AppendMessage(ctx context.Context, activityID string, 
 			return fmt.Errorf("failed to update activity latest message: %w", result.Error)
 		}
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("activity not found")
+			return errors.New("activity not found")
 		}
 		if err := tx.First(&updated, "id = ?", activityID).Error; err != nil {
 			return fmt.Errorf("failed to load updated activity: %w", err)
@@ -320,7 +321,7 @@ func (s *ActivityService) CompleteActivity(ctx context.Context, activityID strin
 
 	activityID = strings.TrimSpace(activityID)
 	if activityID == "" {
-		return nil, fmt.Errorf("activity id is required")
+		return nil, errors.New("activity id is required")
 	}
 
 	// The activity is reaching a terminal state; release any cancel registration.
@@ -386,7 +387,7 @@ func (s *ActivityService) CancelActivity(ctx context.Context, environmentID, act
 	}
 	activityID = strings.TrimSpace(activityID)
 	if activityID == "" {
-		return nil, fmt.Errorf("activity id is required")
+		return nil, errors.New("activity id is required")
 	}
 	environmentID = strings.TrimSpace(environmentID)
 	if environmentID == "" {
@@ -411,7 +412,7 @@ func (s *ActivityService) CancelActivity(ctx context.Context, environmentID, act
 	writeCtx := utils.ActivityRuntimeContext(ctx, nil)
 	if _, err := s.AppendMessage(writeCtx, activityID, AppendActivityMessageRequest{
 		Level:   models.ActivityMessageLevelWarning,
-		Message: fmt.Sprintf("Cancellation requested by %s", requestedBy),
+		Message: "Cancellation requested by " + requestedBy,
 	}); err != nil {
 		slog.DebugContext(ctx, "failed to append cancellation message", "activityId", activityID, "error", err)
 	}
@@ -551,8 +552,8 @@ func (s *ActivityService) GetActivityDetail(ctx context.Context, environmentID, 
 	}
 
 	outMessages := make([]activitytypes.Message, 0, len(messages))
-	for i := len(messages) - 1; i >= 0; i-- {
-		outMessages = append(outMessages, activityMessageToDTOInternal(&messages[i]))
+	for _, v := range slices.Backward(messages) {
+		outMessages = append(outMessages, activityMessageToDTOInternal(&v))
 	}
 
 	return &activitytypes.Detail{
@@ -769,10 +770,7 @@ func clampProgressPtrInternal(value *int) *int {
 	if value == nil {
 		return nil
 	}
-	clamped := max(*value, 0)
-	if clamped > 100 {
-		clamped = 100
-	}
+	clamped := min(max(*value, 0), 100)
 	return &clamped
 }
 

--- a/backend/internal/services/activity_service_test.go
+++ b/backend/internal/services/activity_service_test.go
@@ -77,7 +77,7 @@ func TestActivityServiceLifecycleInternal(t *testing.T) {
 	require.Equal(t, 100, *completed.Progress)
 
 	list, paginationResp, err := service.ListActivitiesPaginated(ctx, "0", pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Limit: 10},
+		Params: pagination.Params{Limit: 10},
 	})
 	require.NoError(t, err)
 	require.Len(t, list, 1)

--- a/backend/internal/services/api_key_service.go
+++ b/backend/internal/services/api_key_service.go
@@ -408,7 +408,7 @@ func (s *ApiKeyService) CreateEnvironmentApiKey(ctx context.Context, environment
 	if len(environmentID) > 8 {
 		envIDShort = environmentID[:8]
 	}
-	name := fmt.Sprintf("Environment Bootstrap Key - %s", envIDShort)
+	name := "Environment Bootstrap Key - " + envIDShort
 	created, err := s.createAPIKeyWithRawKey(ctx, nil, rawKey, apikey.CreateApiKey{
 		Name:        name,
 		Description: new("Auto-generated key for environment pairing"),

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -30,9 +30,9 @@ var (
 	ErrOidcAuthDisabled     = errors.New("OIDC authentication is disabled")
 )
 
-type TokenPair struct { //nolint:gosec // API response contract intentionally includes token fields
+type TokenPair struct {
 	AccessToken  string    `json:"accessToken"`
-	RefreshToken string    `json:"refreshToken"` //nolint:gosec // API response contract requires refreshToken field
+	RefreshToken string    `json:"refreshToken"`
 	ExpiresAt    time.Time `json:"expiresAt"`
 }
 
@@ -45,6 +45,7 @@ type AuthSettings struct {
 
 type userClaims struct {
 	jwt.RegisteredClaims
+
 	SessionID             string `json:"sid,omitempty"`
 	UserID                string `json:"user_id"`
 	Username              string `json:"username"`
@@ -57,6 +58,7 @@ type userClaims struct {
 
 type refreshClaims struct {
 	jwt.RegisteredClaims
+
 	UserID     string `json:"user_id"`
 	SessionID  string `json:"sid,omitempty"`
 	AppVersion string `json:"app_version,omitempty"`

--- a/backend/internal/services/build_service.go
+++ b/backend/internal/services/build_service.go
@@ -273,17 +273,17 @@ func (s *BuildService) resolveBuildRequestInternal(
 		return req, func() error { return nil }, nil
 	}
 
-	writeBuildProgressStatusInternal(progressWriter, serviceName, fmt.Sprintf("resolving remote git context %s", source.RepositoryURL))
+	writeBuildProgressStatusInternal(progressWriter, serviceName, "resolving remote git context "+source.RepositoryURL)
 
 	authConfig, matchedRepository, err := s.resolveGitBuildAuthInternal(ctx, source.RepositoryURL)
 	if err != nil {
 		return imagetypes.BuildRequest{}, func() error { return nil }, err
 	}
 	if matchedRepository {
-		writeBuildProgressStatusInternal(progressWriter, serviceName, fmt.Sprintf("using saved git credentials for %s", source.RepositoryURL))
+		writeBuildProgressStatusInternal(progressWriter, serviceName, "using saved git credentials for "+source.RepositoryURL)
 	}
 	if libbuild.RequiresGitRemoteProbe(source.RepositoryURL) {
-		writeBuildProgressStatusInternal(progressWriter, serviceName, fmt.Sprintf("verifying remote git repository %s", source.RepositoryURL))
+		writeBuildProgressStatusInternal(progressWriter, serviceName, "verifying remote git repository "+source.RepositoryURL)
 		if err := s.probeGitContextInternal(ctx, source.RepositoryURL, authConfig); err != nil {
 			return imagetypes.BuildRequest{}, func() error { return nil }, fmt.Errorf("failed to verify remote git repository %q: %w", source.RepositoryURL, err)
 		}
@@ -310,10 +310,10 @@ func (s *BuildService) resolveBuildRequestInternal(
 	}
 	if !info.IsDir() {
 		_ = s.cleanupGitContextInternal(repoPath)
-		return imagetypes.BuildRequest{}, func() error { return nil }, fmt.Errorf("resolved git build context is not a directory")
+		return imagetypes.BuildRequest{}, func() error { return nil }, errors.New("resolved git build context is not a directory")
 	}
 
-	writeBuildProgressStatusInternal(progressWriter, serviceName, fmt.Sprintf("using remote build context %s", source.Raw))
+	writeBuildProgressStatusInternal(progressWriter, serviceName, "using remote build context "+source.Raw)
 
 	resolvedReq := req
 	resolvedReq.ContextDir = contextDir
@@ -395,7 +395,7 @@ func writeBuildProgressStatusInternal(progressWriter io.Writer, serviceName, sta
 
 func (s *BuildService) ListImageBuildsByEnvironmentPaginated(ctx context.Context, environmentID string, params pagination.QueryParams) ([]imagetypes.BuildRecord, pagination.Response, error) {
 	if s.db == nil {
-		return nil, pagination.Response{}, fmt.Errorf("build history not available")
+		return nil, pagination.Response{}, errors.New("build history not available")
 	}
 
 	var builds []models.ImageBuild
@@ -431,7 +431,7 @@ func (s *BuildService) ListImageBuildsByEnvironmentPaginated(ctx context.Context
 
 func (s *BuildService) GetImageBuildByID(ctx context.Context, environmentID, buildID string) (*imagetypes.BuildRecord, error) {
 	if s.db == nil {
-		return nil, fmt.Errorf("build history not available")
+		return nil, errors.New("build history not available")
 	}
 
 	var build models.ImageBuild
@@ -525,7 +525,7 @@ func (s *BuildService) completeBuildRecord(
 			return fmt.Errorf("failed to update build record: %w", result.Error)
 		}
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("build record not found")
+			return errors.New("build record not found")
 		}
 		return nil
 	})

--- a/backend/internal/services/build_workspace_service.go
+++ b/backend/internal/services/build_workspace_service.go
@@ -109,7 +109,7 @@ func (s *BuildWorkspaceService) GetFileContent(ctx context.Context, filePath str
 		return nil, "", fmt.Errorf("failed to stat file: %w", err)
 	}
 	if info.IsDir() {
-		return nil, "", fmt.Errorf("path is a directory")
+		return nil, "", errors.New("path is a directory")
 	}
 
 	if maxBytes <= 0 {
@@ -153,7 +153,7 @@ func (s *BuildWorkspaceService) DownloadFile(ctx context.Context, filePath strin
 		return nil, 0, fmt.Errorf("failed to stat file: %w", err)
 	}
 	if info.IsDir() {
-		return nil, 0, fmt.Errorf("path is a directory")
+		return nil, 0, errors.New("path is a directory")
 	}
 
 	file, err := os.Open(fullPath)
@@ -245,7 +245,7 @@ func (s *BuildWorkspaceService) DeleteFile(ctx context.Context, filePath string)
 	}
 
 	if cleaned == "/" {
-		return fmt.Errorf("cannot delete root directory")
+		return errors.New("cannot delete root directory")
 	}
 
 	fullPath, err := joinBuildRoot(root, cleaned)
@@ -271,7 +271,7 @@ func (s *BuildWorkspaceService) resolveRoot() (string, error) {
 	}
 
 	if !filepath.IsAbs(root) {
-		return "", fmt.Errorf("builds directory must be an absolute path")
+		return "", errors.New("builds directory must be an absolute path")
 	}
 
 	cleaned := filepath.Clean(root)
@@ -293,10 +293,10 @@ func sanitizeBuildPath(input string) (string, error) {
 		cleaned = "/" + cleaned
 	}
 	if strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") || cleaned == "/.." {
-		return "", fmt.Errorf("invalid path: path traversal not allowed")
+		return "", errors.New("invalid path: path traversal not allowed")
 	}
 	if !strings.HasPrefix(cleaned, "/") {
-		return "", fmt.Errorf("invalid path: must be absolute")
+		return "", errors.New("invalid path: must be absolute")
 	}
 
 	return cleaned, nil
@@ -305,25 +305,25 @@ func sanitizeBuildPath(input string) (string, error) {
 func sanitizeUploadFilename(filename string) (string, error) {
 	name := strings.TrimSpace(filename)
 	if name == "" {
-		return "", fmt.Errorf("invalid filename")
+		return "", errors.New("invalid filename")
 	}
 
 	// Reject any path separators (handle both Unix and Windows-style separators).
 	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
-		return "", fmt.Errorf("invalid filename: must not contain path separators")
+		return "", errors.New("invalid filename: must not contain path separators")
 	}
 
 	// On Windows, disallow drive/volume prefixes (e.g. C: or \\server\share).
 	if vol := filepath.VolumeName(name); vol != "" {
-		return "", fmt.Errorf("invalid filename: must not include volume prefix")
+		return "", errors.New("invalid filename: must not include volume prefix")
 	}
 
 	base := filepath.Base(name)
 	if base != name {
-		return "", fmt.Errorf("invalid filename: must not contain path separators")
+		return "", errors.New("invalid filename: must not contain path separators")
 	}
 	if base == "." || base == ".." {
-		return "", fmt.Errorf("invalid filename")
+		return "", errors.New("invalid filename")
 	}
 
 	return base, nil
@@ -333,7 +333,7 @@ func joinBuildRoot(root, cleaned string) (string, error) {
 	rel := strings.TrimPrefix(cleaned, "/")
 	fullPath := filepath.Join(root, filepath.FromSlash(rel))
 	if !isWithinRoot(root, fullPath) {
-		return "", fmt.Errorf("invalid path: outside builds directory")
+		return "", errors.New("invalid path: outside builds directory")
 	}
 	return fullPath, nil
 }

--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -392,7 +392,7 @@ func (s *ContainerRegistryService) GetAllRegistryAuthConfigs(ctx context.Context
 			Password:      token,
 			ServerAddress: serverAddress,
 		}
-		for _, key := range utilsregistry.RegistryAuthLookupKeys(normalizedHost) {
+		for _, key := range utilsregistry.LookupKeys(normalizedHost) {
 			authConfigs[key] = authConfig
 		}
 	}
@@ -708,7 +708,7 @@ func (s *ContainerRegistryService) GetImageDigest(ctx context.Context, imageRef 
 		return result.Digest, nil
 	})
 
-	var staleErr *cache.ErrStale
+	var staleErr *cache.StaleError
 	if err != nil && !errors.As(err, &staleErr) {
 		return "", err
 	}

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -285,7 +285,7 @@ func (s *ContainerService) StartContainer(ctx context.Context, containerID strin
 
 	err = s.eventService.LogContainerEvent(ctx, models.EventTypeContainerStart, containerID, "name", user.ID, user.Username, "0", metadata)
 	if err != nil {
-		fmt.Printf("Could not log container start action: %s\n", err)
+		slog.WarnContext(ctx, "could not log container start action", "error", err)
 	}
 
 	_, err = dockerClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{})
@@ -767,7 +767,7 @@ func (s *ContainerService) CreateContainer(ctx context.Context, config *containe
 	}
 
 	if logErr := s.eventService.LogContainerEvent(ctx, models.EventTypeContainerCreate, resp.ID, "name", user.ID, user.Username, "0", metadata); logErr != nil {
-		fmt.Printf("Could not log container stop action: %s\n", logErr)
+		slog.WarnContext(ctx, "could not log container stop action", "error", logErr)
 	}
 
 	if _, err := dockerClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {

--- a/backend/internal/services/container_service_test.go
+++ b/backend/internal/services/container_service_test.go
@@ -40,7 +40,7 @@ func TestPaginateContainerProjectGroupsKeepsProjectWhole(t *testing.T) {
 
 	groupedItems, resp := paginateContainerProjectGroupsInternal(
 		pagination.FilterResult[containertypes.Summary]{Items: items, TotalCount: int64(len(items)), TotalAvailable: int64(len(items))},
-		pagination.QueryParams{PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20}},
+		pagination.QueryParams{Params: pagination.Params{Start: 0, Limit: 20}},
 	)
 
 	require.Len(t, groupedItems, 19)

--- a/backend/internal/services/dashboard_service.go
+++ b/backend/internal/services/dashboard_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -65,7 +66,7 @@ func NewDashboardService(
 
 func (s *DashboardService) GetSnapshot(ctx context.Context, options DashboardActionItemsOptions) (*dashboardtypes.Snapshot, error) {
 	if s.dockerService == nil {
-		return nil, fmt.Errorf("docker service not available")
+		return nil, errors.New("docker service not available")
 	}
 
 	dockerSnapshot, err := s.dockerService.GetSnapshot(ctx, localEnvironmentID)

--- a/backend/internal/services/docker_client_service.go
+++ b/backend/internal/services/docker_client_service.go
@@ -557,7 +557,7 @@ func countImageUsageInternal(images []image.Summary, containers []container.Summ
 	return inuse, unused, total
 }
 
-func (s *DockerClientService) GetAllNetworks(ctx context.Context) (_ []network.Summary, inuseNetworks int, unusedNetworks int, totalNetworks int, error error) {
+func (s *DockerClientService) GetAllNetworks(ctx context.Context) ([]network.Summary, int, int, int, error) {
 	containers, err := s.listContainersInternal(ctx)
 	if err != nil {
 		return nil, 0, 0, 0, err

--- a/backend/internal/services/ecr_token_service.go
+++ b/backend/internal/services/ecr_token_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
 )
@@ -48,7 +49,10 @@ func (s *ContainerRegistryService) GetOrRefreshECRToken(ctx context.Context, reg
 	if sErr != nil {
 		return "", "", sErr
 	}
-	r := result.(*ecrTokenResult)
+	r, ok := result.(*ecrTokenResult)
+	if !ok {
+		return "", "", &common.ECRTokenResultTypeError{}
+	}
 	return r.username, r.password, nil
 }
 

--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -303,12 +304,12 @@ func (s *EnvironmentService) ListSwarmNodeAgentEnvironments(ctx context.Context,
 func buildSwarmNodeAgentNameInternal(hostname, nodeID string) string {
 	trimmedHostname := strings.TrimSpace(hostname)
 	if trimmedHostname != "" {
-		return fmt.Sprintf("Swarm Node Agent - %s", trimmedHostname)
+		return "Swarm Node Agent - " + trimmedHostname
 	}
 	if len(nodeID) > 12 {
 		nodeID = nodeID[:12]
 	}
-	return fmt.Sprintf("Swarm Node Agent - %s", nodeID)
+	return "Swarm Node Agent - " + nodeID
 }
 
 func buildSwarmNodeAgentURLInternal(nodeID string) string {
@@ -326,7 +327,7 @@ func (s *EnvironmentService) applySwarmNodeAgentApiKeyInternal(
 	rotate bool,
 ) (string, error) {
 	if env == nil {
-		return "", fmt.Errorf("environment is required")
+		return "", errors.New("environment is required")
 	}
 
 	if !rotate && env.AccessToken != nil && strings.TrimSpace(*env.AccessToken) != "" {
@@ -334,7 +335,7 @@ func (s *EnvironmentService) applySwarmNodeAgentApiKeyInternal(
 	}
 
 	if s.apiKeyService == nil {
-		return "", fmt.Errorf("api key service not configured")
+		return "", errors.New("api key service not configured")
 	}
 
 	apiKeyDto, err := s.apiKeyService.CreateEnvironmentApiKey(ctx, env.ID, userID)
@@ -355,10 +356,10 @@ func (s *EnvironmentService) EnsureSwarmNodeAgentEnvironment(
 	rotate bool,
 ) (*models.Environment, string, error) {
 	if strings.TrimSpace(parentEnvironmentID) == "" {
-		return nil, "", fmt.Errorf("parent environment ID is required")
+		return nil, "", errors.New("parent environment ID is required")
 	}
 	if strings.TrimSpace(nodeID) == "" {
-		return nil, "", fmt.Errorf("swarm node ID is required")
+		return nil, "", errors.New("swarm node ID is required")
 	}
 
 	var env models.Environment
@@ -447,7 +448,7 @@ func (s *EnvironmentService) GetEnvironmentByID(ctx context.Context, id string) 
 	var environment models.Environment
 	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&environment).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("environment not found")
+			return nil, errors.New("environment not found")
 		}
 		return nil, fmt.Errorf("failed to get environment: %w", err)
 	}
@@ -760,7 +761,7 @@ func (s *EnvironmentService) TestConnection(ctx context.Context, id string, cust
 		}
 		return "offline", fmt.Errorf("failed to create request: %w", err)
 	}
-	resp, err := s.httpClient.Do(req) //nolint:gosec // intentional request to configured remote environment API URL
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		if customApiUrl == nil {
 			_ = s.updateEnvironmentStatusInternal(ctx, id, string(models.EnvironmentStatusOffline))
@@ -787,7 +788,7 @@ func (s *EnvironmentService) testEdgeConnection(ctx context.Context, id string) 
 	if !edge.HasActiveTunnel(id) {
 		if _, ok := edge.RequestTunnelAndWait(ctx, id, edge.DefaultTunnelDemandTTL, edge.DefaultTunnelAcquireTimeout()); !ok {
 			_ = s.updateEnvironmentStatusInternal(ctx, id, string(models.EnvironmentStatusOffline))
-			return "offline", fmt.Errorf("edge agent is not connected")
+			return "offline", errors.New("edge agent is not connected")
 		}
 	}
 
@@ -1075,13 +1076,13 @@ func (s *EnvironmentService) GenerateDeploymentSnippets(ctx context.Context, env
 		"    environment:",
 		"      - AGENT_MODE=true",
 		"      - EDGE_TRANSPORT=poll",
-		fmt.Sprintf("      - AGENT_TOKEN=%s", apiKey),
-		fmt.Sprintf("      - MANAGER_API_URL=%s", managerURL),
+		"      - AGENT_TOKEN=" + apiKey,
+		"      - MANAGER_API_URL=" + managerURL,
 		"    ports:",
 		"      - \"3553:3553\"",
 		"    volumes:",
 		"      - /var/run/docker.sock:/var/run/docker.sock",
-		fmt.Sprintf("      - arcane-data:%s", deploymentSnippetsDataPath),
+		"      - arcane-data:" + deploymentSnippetsDataPath,
 		"",
 		"volumes:",
 		"  arcane-data:",
@@ -1121,11 +1122,11 @@ func (s *EnvironmentService) GenerateEdgeDeploymentSnippets(ctx context.Context,
 		"    environment:",
 		"      - EDGE_AGENT=true",
 		"      - EDGE_TRANSPORT=poll",
-		fmt.Sprintf("      - AGENT_TOKEN=%s", apiKey),
-		fmt.Sprintf("      - MANAGER_API_URL=%s", managerURL),
+		"      - AGENT_TOKEN=" + apiKey,
+		"      - MANAGER_API_URL=" + managerURL,
 		"    volumes:",
 		"      - /var/run/docker.sock:/var/run/docker.sock",
-		fmt.Sprintf("      - arcane-data:%s", deploymentSnippetsDataPath),
+		"      - arcane-data:" + deploymentSnippetsDataPath,
 		"",
 		"volumes:",
 		"  arcane-data:",
@@ -1224,12 +1225,12 @@ func buildMTLSDeploymentSnippetInternal(managerURL string, apiKey string, genera
 		"      - EDGE_AGENT=true",
 		"      - EDGE_TRANSPORT=poll",
 		"      - EDGE_MTLS_MODE=required",
-		fmt.Sprintf("      - EDGE_MTLS_ASSETS_DIR=%s", deploymentSnippetsMTLSPath),
-		fmt.Sprintf("      - AGENT_TOKEN=%s", apiKey),
-		fmt.Sprintf("      - MANAGER_API_URL=%s", managerURL),
+		"      - EDGE_MTLS_ASSETS_DIR=" + deploymentSnippetsMTLSPath,
+		"      - AGENT_TOKEN=" + apiKey,
+		"      - MANAGER_API_URL=" + managerURL,
 		"    volumes:",
 		"      - /var/run/docker.sock:/var/run/docker.sock",
-		fmt.Sprintf("      - arcane-data:%s", deploymentSnippetsDataPath),
+		"      - arcane-data:" + deploymentSnippetsDataPath,
 		"",
 		"volumes:",
 		"  arcane-data:",
@@ -1268,7 +1269,7 @@ func (s *EnvironmentService) resolveRemoteEnvironmentTargetInternal(ctx context.
 	}
 
 	if envID == "0" {
-		return nil, fmt.Errorf("cannot proxy request to local environment")
+		return nil, errors.New("cannot proxy request to local environment")
 	}
 
 	targetURL := strings.TrimRight(environment.ApiUrl, "/")
@@ -1316,7 +1317,7 @@ func (s *EnvironmentService) getProxyRequestContextInternal(ctx context.Context)
 		return timeouts.WithTimeout(ctx, settings.ProxyRequestTimeout.AsInt(), timeouts.DefaultProxyRequest)
 	}
 
-	return context.WithTimeout(ctx, timeouts.DefaultProxyRequest) //nolint:gosec // helper intentionally returns the cancel func to callers.
+	return context.WithTimeout(ctx, timeouts.DefaultProxyRequest)
 }
 
 func (s *EnvironmentService) buildRemoteRequestInternal(
@@ -1327,13 +1328,11 @@ func (s *EnvironmentService) buildRemoteRequestInternal(
 	headers map[string]string,
 ) (remenv.Request, error) {
 	if target == nil {
-		return remenv.Request{}, fmt.Errorf("remote environment target is required")
+		return remenv.Request{}, errors.New("remote environment target is required")
 	}
 
 	requestHeaders := make(map[string]string, len(headers)+2)
-	for key, value := range headers {
-		requestHeaders[key] = value
-	}
+	maps.Copy(requestHeaders, headers)
 	if len(body) > 0 && method != http.MethodGet && requestHeaders["Content-Type"] == "" {
 		requestHeaders["Content-Type"] = "application/json"
 	}
@@ -1422,7 +1421,7 @@ func ensureRemoteEnvironmentTunnelAvailableInternal(ctx context.Context, envID s
 		return nil
 	}
 
-	return fmt.Errorf("edge agent is not connected")
+	return errors.New("edge agent is not connected")
 }
 
 func doRemoteEnvironmentTunnelRequestInternal(

--- a/backend/internal/services/environment_service_test.go
+++ b/backend/internal/services/environment_service_test.go
@@ -736,8 +736,8 @@ func TestEnvironmentService_ListMethods_ExcludeHiddenEnvironments(t *testing.T) 
 		}).Error)
 
 	listedEnvironments, _, err := svc.ListEnvironmentsPaginated(ctx, pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
-		Filters:          map[string]string{},
+		Params:  pagination.Params{Start: 0, Limit: 20},
+		Filters: map[string]string{},
 	})
 	require.NoError(t, err)
 	require.Len(t, listedEnvironments, 2)
@@ -834,8 +834,8 @@ func TestEnvironmentService_ListEnvironmentsPaginated_FiltersByRuntimeType(t *te
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			listedEnvironments, _, err := svc.ListEnvironmentsPaginated(ctx, pagination.QueryParams{
-				PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
-				Filters:          map[string]string{"type": tt.typeFilter},
+				Params:  pagination.Params{Start: 0, Limit: 20},
+				Filters: map[string]string{"type": tt.typeFilter},
 			})
 			require.NoError(t, err)
 			require.ElementsMatch(t, tt.wantIDs, environmentIDsInternal(listedEnvironments))

--- a/backend/internal/services/event_service.go
+++ b/backend/internal/services/event_service.go
@@ -165,10 +165,10 @@ func (s *EventService) canForwardEventToManagerHTTP() bool {
 
 func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel *models.Event) error {
 	if eventModel == nil {
-		return fmt.Errorf("event is required")
+		return errors.New("event is required")
 	}
 	if s.cfg == nil || strings.TrimSpace(s.cfg.AgentToken) == "" {
-		return fmt.Errorf("agent token is required for manager event sync")
+		return errors.New("agent token is required for manager event sync")
 	}
 
 	managerEventsURL, err := managerEventEndpointURL(s.cfg.GetManagerBaseURL())
@@ -203,9 +203,9 @@ func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel
 		return fmt.Errorf("failed to create manager event request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", s.cfg.AgentToken)
+	req.Header.Set("X-Api-Key", s.cfg.AgentToken)
 
-	resp, err := s.httpClient.Do(req) //nolint:gosec // managerEventsURL is validated in managerEventEndpointURL before request
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send event to manager: %w", err)
 	}
@@ -225,7 +225,7 @@ func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel
 func managerEventEndpointURL(rawBaseURL string) (string, error) {
 	trimmed := strings.TrimSpace(rawBaseURL)
 	if trimmed == "" {
-		return "", fmt.Errorf("manager API URL is required")
+		return "", errors.New("manager API URL is required")
 	}
 
 	baseURL, err := url.Parse(trimmed)
@@ -236,7 +236,7 @@ func managerEventEndpointURL(rawBaseURL string) (string, error) {
 		return "", fmt.Errorf("unsupported scheme %q", baseURL.Scheme)
 	}
 	if baseURL.Host == "" {
-		return "", fmt.Errorf("manager API URL host is required")
+		return "", errors.New("manager API URL host is required")
 	}
 
 	baseURL.RawQuery = ""
@@ -382,7 +382,7 @@ func (s *EventService) DeleteEvent(ctx context.Context, eventID string) error {
 			return fmt.Errorf("failed to delete event: %w", result.Error)
 		}
 		if result.RowsAffected == 0 {
-			return fmt.Errorf("event not found")
+			return errors.New("event not found")
 		}
 		return nil
 	})
@@ -534,7 +534,7 @@ func (s *EventService) LogErrorEvent(ctx context.Context, eventType models.Event
 	eventMetadata["error"] = err.Error()
 
 	titleCaser := cases.Title(language.English)
-	title := fmt.Sprintf("%s error", titleCaser.String(resourceType))
+	title := titleCaser.String(resourceType) + " error"
 	if resourceName != "" {
 		title = fmt.Sprintf("%s error: %s", titleCaser.String(resourceType), resourceName)
 	}
@@ -670,7 +670,7 @@ func (s *EventService) generateEventTitle(eventType models.EventType, resourceNa
 	if def, ok := eventDefinitions[eventType]; ok {
 		return fmt.Sprintf(def.TitleFormat, resourceName)
 	}
-	return fmt.Sprintf("Event: %s", string(eventType))
+	return "Event: " + string(eventType)
 }
 
 func (s *EventService) generateEventDescription(eventType models.EventType, resourceType, resourceName string) string {

--- a/backend/internal/services/federated_credential_service.go
+++ b/backend/internal/services/federated_credential_service.go
@@ -474,7 +474,7 @@ func (s *FederatedCredentialService) providerForIssuerInternal(ctx context.Conte
 
 	provider, ok := v.(*oidc.Provider)
 	if !ok || provider == nil {
-		return nil, fmt.Errorf("federated issuer discovery returned invalid provider")
+		return nil, errors.New("federated issuer discovery returned invalid provider")
 	}
 	return provider, nil
 }
@@ -612,7 +612,6 @@ func normalizeCreateFederatedCredentialInternal(req federatedtypes.CreateFederat
 }
 
 func applyFederatedCredentialUpdateInternal(existing models.FederatedCredential, req federatedtypes.UpdateFederatedCredential) (models.FederatedCredential, bool, error) {
-	roleChanged := false
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
 		if name == "" {

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -55,7 +55,7 @@ func (s *GitRepositoryService) GetRepositoryByID(ctx context.Context, id string)
 	var repository models.GitRepository
 	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&repository).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("repository not found")
+			return nil, errors.New("repository not found")
 		}
 		return nil, fmt.Errorf("failed to get repository: %w", err)
 	}
@@ -66,7 +66,7 @@ func (s *GitRepositoryService) GetRepositoryByName(ctx context.Context, name str
 	var repository models.GitRepository
 	if err := s.db.WithContext(ctx).Where("name = ?", name).First(&repository).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("repository not found")
+			return nil, errors.New("repository not found")
 		}
 		return nil, fmt.Errorf("failed to get repository: %w", err)
 	}
@@ -268,14 +268,11 @@ func validateGitRepositoryCredentialChangeInternal(repository *models.GitReposit
 
 	if len(missingFields) == 1 {
 		field := missingFields[0]
-		return &models.ValidationError{Field: field, Message: fmt.Sprintf("Changing repository URL requires re-supplying or clearing the %s", missingCredentialLabels[0])}
+		return &models.ValidationError{Field: field, Message: "Changing repository URL requires re-supplying or clearing the " + missingCredentialLabels[0]}
 	}
 
 	return models.NewValidationError(
-		fmt.Sprintf(
-			"Changing repository URL requires re-supplying or clearing all stored credentials: %s",
-			strings.Join(missingCredentialLabels, " and "),
-		),
+		"Changing repository URL requires re-supplying or clearing all stored credentials: "+strings.Join(missingCredentialLabels, " and "),
 		map[string]any{"fields": missingFields},
 	)
 }

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -73,13 +73,13 @@ type stagedDirectorySync struct {
 
 func validateSyncLimits(maxFiles *int, maxTotalSize, maxBinarySize *int64) error {
 	if maxFiles != nil && *maxFiles < 0 {
-		return fmt.Errorf("maxSyncFiles must be non-negative")
+		return errors.New("maxSyncFiles must be non-negative")
 	}
 	if maxTotalSize != nil && *maxTotalSize < 0 {
-		return fmt.Errorf("maxSyncTotalSize must be non-negative")
+		return errors.New("maxSyncTotalSize must be non-negative")
 	}
 	if maxBinarySize != nil && *maxBinarySize < 0 {
-		return fmt.Errorf("maxSyncBinarySize must be non-negative")
+		return errors.New("maxSyncBinarySize must be non-negative")
 	}
 	return nil
 }
@@ -214,7 +214,7 @@ func (s *GitOpsSyncService) GetSyncByID(ctx context.Context, environmentID, id s
 	if err := q.First(&sync).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			slog.WarnContext(ctx, "GitOps sync not found", "syncID", id, "environmentID", environmentID)
-			return nil, fmt.Errorf("sync not found")
+			return nil, errors.New("sync not found")
 		}
 		slog.ErrorContext(ctx, "Failed to get GitOps sync", "syncID", id, "environmentID", environmentID, "error", err)
 		return nil, fmt.Errorf("failed to get sync: %w", err)
@@ -280,7 +280,7 @@ func (s *GitOpsSyncService) CreateSync(ctx context.Context, environmentID string
 		sync.MaxSyncBinarySize = *req.MaxSyncBinarySize
 	}
 
-	if err := s.db.WithContext(ctx).Select("*").Omit("Environment", "Repository", "Project").Create(&sync).Error; err != nil {
+	if err := s.db.WithContext(ctx).Omit("Environment", "Repository", "Project").Create(&sync).Error; err != nil {
 		slog.ErrorContext(ctx, "Failed to create GitOps sync in database", "name", req.Name, "repositoryID", req.RepositoryID, "environmentID", environmentID, "error", err)
 		return nil, fmt.Errorf("failed to create sync: %w", err)
 	}
@@ -488,8 +488,8 @@ func (s *GitOpsSyncService) prepareSyncSource(ctx context.Context, sync *models.
 	}
 
 	if !s.repoService.gitClient.FileExists(ctx, repoPath, sync.ComposePath) {
-		errMsg := fmt.Sprintf("compose file not found: %s", sync.ComposePath)
-		return &preparedSyncSource{repoPath: repoPath, commitHash: commitHash}, s.failSync(ctx, sync.ID, result, sync, actor, fmt.Sprintf("Compose file not found at %s", sync.ComposePath), errMsg)
+		errMsg := "compose file not found: " + sync.ComposePath
+		return &preparedSyncSource{repoPath: repoPath, commitHash: commitHash}, s.failSync(ctx, sync.ID, result, sync, actor, "Compose file not found at "+sync.ComposePath, errMsg)
 	}
 
 	composeContent, err := s.repoService.gitClient.ReadFile(ctx, repoPath, sync.ComposePath)
@@ -521,7 +521,7 @@ func (s *GitOpsSyncService) prepareSyncSource(ctx context.Context, sync *models.
 func (s *GitOpsSyncService) performDirectorySync(ctx context.Context, sync *models.GitOpsSync, id string, actor models.User, result *gitops.SyncResult, source *preparedSyncSource) (*gitops.SyncResult, error) {
 	slog.InfoContext(ctx, "Using directory sync mode", "syncId", id, "composePath", sync.ComposePath)
 
-	_, syncFiles, err := s.walkAndParseSyncDirectory(ctx, sync, source.repoPath)
+	syncFiles, err := s.walkAndParseSyncDirectory(ctx, sync, source.repoPath)
 	if err != nil {
 		return result, s.failSync(ctx, id, result, sync, actor, "Failed to walk directory", err.Error())
 	}
@@ -578,7 +578,7 @@ func (s *GitOpsSyncService) performSwarmStackSyncInternal(ctx context.Context, s
 
 	var syncFiles []projects.SyncFile
 	if sync.SyncDirectory {
-		_, files, err := s.walkAndParseSyncDirectory(ctx, sync, source.repoPath)
+		files, err := s.walkAndParseSyncDirectory(ctx, sync, source.repoPath)
 		if err != nil {
 			return result, s.failSync(ctx, id, result, sync, actor, "Failed to walk directory", err.Error())
 		}
@@ -789,7 +789,7 @@ func (s *GitOpsSyncService) BrowseFiles(ctx context.Context, environmentID, id s
 
 	repository := sync.Repository
 	if repository == nil {
-		return nil, fmt.Errorf("repository not found")
+		return nil, errors.New("repository not found")
 	}
 
 	authConfig, err := s.repoService.GetAuthConfig(browseCtx, repository)
@@ -1001,8 +1001,8 @@ func marshalSyncedFiles(files []string) *string {
 }
 
 // walkAndParseSyncDirectory walks the repository directory and returns all files with their contents.
-// Returns the compose file content, the list of SyncFile entries, and an error if any.
-func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync *models.GitOpsSync, repoPath string) (string, []projects.SyncFile, error) {
+// Returns the list of SyncFile entries and an error if any; it fails if the compose file is missing.
+func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync *models.GitOpsSync, repoPath string) ([]projects.SyncFile, error) {
 	slog.InfoContext(ctx, "Starting directory walk", "syncId", sync.ID, "composePath", sync.ComposePath)
 
 	// Walk the directory to get all files
@@ -1010,7 +1010,7 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 
 	walkResult, err := s.repoService.gitClient.WalkDirectory(ctx, repoPath, sync.ComposePath, maxFiles, maxTotalSize, maxBinarySize)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to walk directory: %w", err)
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
 	}
 
 	slog.InfoContext(ctx, "Directory walk complete",
@@ -1022,7 +1022,7 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 	// WalkDirectory roots the walk at filepath.Dir(sync.ComposePath), so the
 	// compose file is always emitted at the top level as filepath.Base(sync.ComposePath).
 	composeFileName := filepath.Base(sync.ComposePath)
-	var composeContent string
+	composeFound := false
 
 	// Convert walked files to SyncFile format
 	syncFiles := make([]projects.SyncFile, len(walkResult.Files))
@@ -1032,15 +1032,15 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 			Content:      f.Content,
 		}
 		if f.RelativePath == composeFileName {
-			composeContent = string(f.Content)
+			composeFound = true
 		}
 	}
 
-	if composeContent == "" {
-		return "", nil, fmt.Errorf("compose file %s not found in walked directory", composeFileName)
+	if !composeFound {
+		return nil, fmt.Errorf("compose file %s not found in walked directory", composeFileName)
 	}
 
-	return composeContent, syncFiles, nil
+	return syncFiles, nil
 }
 
 // syncProjectDirectoryInternal runs the new directory-sync path end to end:
@@ -1505,10 +1505,7 @@ func (s *GitOpsSyncService) validateDirectorySyncStageInternal(ctx context.Conte
 		return 0, err
 	}
 
-	pathMapper, pmErr := s.projectService.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper for directory sync validation, continuing without translation", "error", pmErr)
-	}
+	pathMapper := s.projectService.getPathMapper(ctx)
 
 	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
 	project, err := projects.LoadComposeProjectLenient(

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -232,8 +232,14 @@ func TestGitOpsSyncService_DirectorySync_RealWalkWithNestedConfig(t *testing.T) 
 	}
 	require.NoError(t, db.Create(sync).Error)
 
-	composeContent, syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
+	syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
 	require.NoError(t, err)
+	var composeContent string
+	for _, f := range syncFiles {
+		if f.RelativePath == "docker-compose.yml" {
+			composeContent = string(f.Content)
+		}
+	}
 	assert.Contains(t, composeContent, "./config/dynamic_config.yml")
 
 	project, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
@@ -307,7 +313,7 @@ func TestGitOpsSyncService_DirectorySync_OverwritesExistingDirectoryAtFilePath(t
 	}
 	require.NoError(t, db.Create(sync).Error)
 
-	_, syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
+	syncFiles, err := svc.walkAndParseSyncDirectory(ctx, sync, repoPath)
 	require.NoError(t, err)
 
 	updatedProject, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})

--- a/backend/internal/services/image_service.go
+++ b/backend/internal/services/image_service.go
@@ -401,14 +401,14 @@ func (s *ImageService) PruneImages(ctx context.Context, options systemtypes.Prun
 	filterArgs := make(client.Filters)
 	switch options.Mode {
 	case systemtypes.PruneImageModeNone:
-		return nil, fmt.Errorf("image prune mode none is not allowed")
+		return nil, errors.New("image prune mode none is not allowed")
 	case systemtypes.PruneImageModeDangling:
 		filterArgs = filterArgs.Add("dangling", "true")
 	case systemtypes.PruneImageModeAll:
 		filterArgs = filterArgs.Add("dangling", "false")
 	case systemtypes.PruneImageModeOlderThan:
 		if strings.TrimSpace(options.Until) == "" {
-			return nil, fmt.Errorf("image prune mode olderThan requires until")
+			return nil, errors.New("image prune mode olderThan requires until")
 		}
 		filterArgs = filterArgs.Add("until", options.Until)
 	default:

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -135,7 +136,7 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 	startTime := time.Now()
 	activityID := s.startImageUpdateActivityInternal(ctx, imageRef, 1)
 	ctx = s.activityService.Track(ctx, activityID)
-	s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, fmt.Sprintf("Checking %s", imageRef), 20, "Checking remote digest")
+	s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, "Checking "+imageRef, 20, "Checking remote digest")
 
 	parts := s.parseImageReference(imageRef)
 	if parts == nil {
@@ -208,7 +209,7 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 
 func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.Context, parts *ImageParts) (*imageupdate.Response, *localImageSnapshot, error) {
 	if s.registryService == nil {
-		return nil, nil, fmt.Errorf("registry service unavailable")
+		return nil, nil, errors.New("registry service unavailable")
 	}
 
 	imageRef := fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag)
@@ -395,7 +396,7 @@ func (s *ImageUpdateService) resolveImageRefFromInspect(ctx context.Context, doc
 			}
 		}
 	}
-	return "", fmt.Errorf("no valid tags or digests")
+	return "", errors.New("no valid tags or digests")
 }
 
 func (s *ImageUpdateService) resolveImageRefFromContainers(ctx context.Context, dockerClient client.APIClient, imageID string) (string, error) {
@@ -534,7 +535,7 @@ func (s *ImageUpdateService) saveUpdateResultWithSnapshotInternal(ctx context.Co
 
 	parts := s.parseImageReference(imageRef)
 	if parts == nil {
-		return fmt.Errorf("invalid image reference")
+		return errors.New("invalid image reference")
 	}
 	imageID, err := s.getImageIDByRef(ctx, imageRef)
 	if err != nil {
@@ -595,15 +596,15 @@ func countBatchResultOutcomesInternal(imageRefs []string, results map[string]*im
 // SUCCESS, and up-to-date images stay INFO.
 func imageCheckResultMessageInternal(imageRef string, res *imageupdate.Response) (models.ActivityMessageLevel, string) {
 	if res == nil {
-		return models.ActivityMessageLevelError, fmt.Sprintf("%s: check failed", imageRef)
+		return models.ActivityMessageLevelError, imageRef + ": check failed"
 	}
 	if err := strings.TrimSpace(res.Error); err != "" {
 		return models.ActivityMessageLevelError, fmt.Sprintf("%s: %s", imageRef, err)
 	}
 	if res.HasUpdate {
-		return models.ActivityMessageLevelSuccess, fmt.Sprintf("%s — update available", imageRef)
+		return models.ActivityMessageLevelSuccess, imageRef + " — update available"
 	}
-	return models.ActivityMessageLevelInfo, fmt.Sprintf("%s — up to date", imageRef)
+	return models.ActivityMessageLevelInfo, imageRef + " — up to date"
 }
 
 func extractRepoAndTagFromImage(dockerImage image.InspectResponse) (repo, tag string) {
@@ -1053,7 +1054,7 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	if err := g.Wait(); err != nil {
 		slog.ErrorContext(ctx, "Batch check error", "error", err)
-		s.completeImageUpdateActivityInternal(ctx, activityID, false, fmt.Sprintf("Image update check failed: %s", err.Error()))
+		s.completeImageUpdateActivityInternal(ctx, activityID, false, "Image update check failed: "+err.Error())
 		return results, err
 	}
 

--- a/backend/internal/services/job_service.go
+++ b/backend/internal/services/job_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -74,10 +75,10 @@ func (s *JobService) GetJobSchedules(ctx context.Context) jobschedule.Config {
 
 func (s *JobService) UpdateJobSchedules(ctx context.Context, updates jobschedule.Update) (jobschedule.Config, error) {
 	if s == nil || s.db == nil || s.settings == nil {
-		return jobschedule.Config{}, fmt.Errorf("job service not initialized")
+		return jobschedule.Config{}, errors.New("job service not initialized")
 	}
 	if s.cfg != nil && s.cfg.UIConfigurationDisabled {
-		return jobschedule.Config{}, fmt.Errorf("job schedule updates are disabled")
+		return jobschedule.Config{}, errors.New("job schedule updates are disabled")
 	}
 
 	current := s.GetJobSchedules(ctx)
@@ -200,7 +201,7 @@ func jobMetadataAffectedBySettingInternal(jobMeta meta.JobMetadata, changed map[
 
 func (s *JobService) ListJobs(ctx context.Context) (*jobschedule.JobListResponse, error) {
 	if s == nil || s.settings == nil {
-		return nil, fmt.Errorf("job service not initialized")
+		return nil, errors.New("job service not initialized")
 	}
 
 	allMetadata := meta.GetAllJobMetadata()
@@ -243,7 +244,7 @@ func (s *JobService) RunJobNowInline(ctx context.Context, jobID string) error {
 
 func (s *JobService) getRunnableJobInternal(jobID string) (schedulertypes.Job, error) {
 	if s == nil || s.scheduler == nil {
-		return nil, fmt.Errorf("job service or scheduler not initialized")
+		return nil, errors.New("job service or scheduler not initialized")
 	}
 
 	meta, ok := meta.GetJobMetadata(jobID)

--- a/backend/internal/services/network_service.go
+++ b/backend/internal/services/network_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 
@@ -188,7 +189,7 @@ func (s *NetworkService) CreateNetwork(ctx context.Context, name string, options
 		"name":   name,
 	}
 	if logErr := s.eventService.LogNetworkEvent(ctx, models.EventTypeNetworkCreate, response.ID, name, user.ID, user.Username, "0", metadata); logErr != nil {
-		fmt.Printf("Could not log network creation action: %s\n", logErr)
+		slog.WarnContext(ctx, "could not log network creation action", "error", logErr)
 	}
 
 	warning := ""
@@ -229,7 +230,7 @@ func (s *NetworkService) RemoveNetwork(ctx context.Context, id string, user mode
 		"networkId": id,
 	}
 	if logErr := s.eventService.LogNetworkEvent(ctx, models.EventTypeNetworkDelete, id, networkName, user.ID, user.Username, "0", metadata); logErr != nil {
-		fmt.Printf("Could not log network delete action: %s\n", logErr)
+		slog.WarnContext(ctx, "could not log network delete action", "error", logErr)
 	}
 
 	return nil
@@ -254,7 +255,7 @@ func (s *NetworkService) PruneNetworks(ctx context.Context) (*network.PruneRepor
 		"networksDeleted": len(pruneReport.NetworksDeleted),
 	}
 	if logErr := s.eventService.LogNetworkEvent(ctx, models.EventTypeNetworkDelete, "", "bulk_prune", systemUser.ID, systemUser.Username, "0", metadata); logErr != nil {
-		fmt.Printf("Could not log network prune action: %s\n", logErr)
+		slog.WarnContext(ctx, "could not log network prune action", "error", logErr)
 	}
 
 	return &pruneReport, nil

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -128,7 +128,7 @@ func (s *NotificationService) resolveNotificationTargetInternal(ctx context.Cont
 
 func (s *NotificationService) resolveNotificationTargetForAccessTokenInternal(ctx context.Context, accessToken string) (NotificationTarget, error) {
 	if s.environmentSvc == nil {
-		return NotificationTarget{}, fmt.Errorf("environment service not initialized")
+		return NotificationTarget{}, errors.New("environment service not initialized")
 	}
 
 	env, err := s.environmentSvc.ResolveEnvironmentByAccessToken(ctx, accessToken)
@@ -152,10 +152,10 @@ func (s *NotificationService) resolveNotificationTargetForAccessTokenInternal(ct
 
 func (s *NotificationService) dispatchNotificationToManagerInternal(ctx context.Context, payload notificationdto.DispatchRequest) error {
 	if s.config == nil || strings.TrimSpace(s.config.GetManagerBaseURL()) == "" {
-		return fmt.Errorf("manager API URL is required for notification dispatch")
+		return errors.New("manager API URL is required for notification dispatch")
 	}
 	if strings.TrimSpace(s.config.AgentToken) == "" {
-		return fmt.Errorf("agent token is required for notification dispatch")
+		return errors.New("agent token is required for notification dispatch")
 	}
 
 	body, err := json.Marshal(payload)
@@ -169,9 +169,9 @@ func (s *NotificationService) dispatchNotificationToManagerInternal(ctx context.
 		return fmt.Errorf("failed to create notification dispatch request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", s.config.AgentToken)
+	req.Header.Set("X-Api-Key", s.config.AgentToken)
 
-	resp, err := s.httpClient.Do(req) //nolint:gosec // dispatch URL is derived from validated manager configuration
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to dispatch notification to manager: %w", err)
 	}
@@ -187,7 +187,7 @@ func (s *NotificationService) dispatchNotificationToManagerInternal(ctx context.
 
 func (s *NotificationService) DispatchNotification(ctx context.Context, accessToken string, payload notificationdto.DispatchRequest) error {
 	if s.config != nil && s.config.AgentMode {
-		return fmt.Errorf("notification dispatch is manager-only")
+		return errors.New("notification dispatch is manager-only")
 	}
 
 	target, err := s.resolveNotificationTargetForAccessTokenInternal(ctx, accessToken)
@@ -198,25 +198,25 @@ func (s *NotificationService) DispatchNotification(ctx context.Context, accessTo
 	switch payload.Kind {
 	case notificationdto.DispatchKindImageUpdate:
 		if payload.ImageUpdate == nil {
-			return fmt.Errorf("image update payload is required")
+			return errors.New("image update payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendImageUpdateNotificationForTargetInternal(ctx, target, payload.ImageUpdate.ImageRef, &payload.ImageUpdate.UpdateInfo, models.NotificationEventImageUpdate)
 	case notificationdto.DispatchKindBatchImageUpdate:
 		if payload.BatchImageUpdate == nil {
-			return fmt.Errorf("batch image update payload is required")
+			return errors.New("batch image update payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendBatchImageUpdateNotificationForTargetInternal(ctx, target, payload.BatchImageUpdate.Updates)
 	case notificationdto.DispatchKindContainerUpdate:
 		if payload.ContainerUpdate == nil {
-			return fmt.Errorf("container update payload is required")
+			return errors.New("container update payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendContainerUpdateNotificationForTargetInternal(ctx, target, payload.ContainerUpdate.ContainerName, payload.ContainerUpdate.ImageRef, payload.ContainerUpdate.OldDigest, payload.ContainerUpdate.NewDigest)
 	case notificationdto.DispatchKindVulnerabilityFound:
 		if payload.VulnerabilityFound == nil {
-			return fmt.Errorf("vulnerability payload is required")
+			return errors.New("vulnerability payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendVulnerabilityNotificationForTargetInternal(ctx, target, VulnerabilityNotificationPayload{
@@ -230,13 +230,13 @@ func (s *NotificationService) DispatchNotification(ctx context.Context, accessTo
 		})
 	case notificationdto.DispatchKindPruneReport:
 		if payload.PruneReport == nil {
-			return fmt.Errorf("prune report payload is required")
+			return errors.New("prune report payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendPruneReportNotificationForTargetInternal(ctx, target, &payload.PruneReport.Result)
 	case notificationdto.DispatchKindAutoHeal:
 		if payload.AutoHeal == nil {
-			return fmt.Errorf("auto-heal payload is required")
+			return errors.New("auto-heal payload is required")
 		}
 		logManagerDispatchNotificationInternal(ctx, target, payload.Kind)
 		return s.sendAutoHealNotificationForTargetInternal(ctx, target, payload.AutoHeal.ContainerName, payload.AutoHeal.ContainerID)
@@ -299,7 +299,7 @@ func (s *NotificationService) DeleteSettings(ctx context.Context, provider model
 
 func (s *NotificationService) SendImageUpdateNotification(ctx context.Context, imageRef string, updateInfo *imageupdate.Response, eventType models.NotificationEventType) error {
 	if updateInfo == nil {
-		return fmt.Errorf("updateInfo is required")
+		return errors.New("updateInfo is required")
 	}
 
 	if s.config != nil && s.config.AgentMode {
@@ -586,7 +586,7 @@ func (s *NotificationService) sendDiscordNotification(ctx context.Context, envir
 	}
 
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
-		return fmt.Errorf("discord webhook ID or token not configured")
+		return errors.New("discord webhook ID or token not configured")
 	}
 
 	// Decrypt token if encrypted
@@ -623,10 +623,10 @@ func (s *NotificationService) sendTelegramNotification(ctx context.Context, envi
 	}
 
 	if telegramConfig.BotToken == "" {
-		return fmt.Errorf("telegram bot token not configured")
+		return errors.New("telegram bot token not configured")
 	}
 	if len(telegramConfig.ChatIDs) == 0 {
-		return fmt.Errorf("no telegram chat IDs configured")
+		return errors.New("no telegram chat IDs configured")
 	}
 
 	// Decrypt bot token if encrypted
@@ -668,10 +668,10 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, environ
 	}
 
 	if emailConfig.SMTPHost == "" || emailConfig.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(emailConfig.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 
 	if _, err := mail.ParseAddress(emailConfig.FromAddress); err != nil {
@@ -696,7 +696,7 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, environ
 		return fmt.Errorf("failed to render email template: %w", err)
 	}
 
-	subject := notifications.BuildEmailSubject(environmentName, fmt.Sprintf("Container Update Available: %s", notifications.SanitizeForEmail(imageRef)))
+	subject := notifications.BuildEmailSubject(environmentName, "Container Update Available: "+notifications.SanitizeForEmail(imageRef))
 	if err := notifications.SendEmail(ctx, emailConfig, subject, htmlBody); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
@@ -763,7 +763,7 @@ func (s *NotificationService) sendDiscordContainerUpdateNotification(ctx context
 	}
 
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
-		return fmt.Errorf("discord webhook ID or token not configured")
+		return errors.New("discord webhook ID or token not configured")
 	}
 
 	// Decrypt token if encrypted
@@ -802,10 +802,10 @@ func (s *NotificationService) sendTelegramContainerUpdateNotification(ctx contex
 	}
 
 	if telegramConfig.BotToken == "" {
-		return fmt.Errorf("telegram bot token not configured")
+		return errors.New("telegram bot token not configured")
 	}
 	if len(telegramConfig.ChatIDs) == 0 {
-		return fmt.Errorf("no telegram chat IDs configured")
+		return errors.New("no telegram chat IDs configured")
 	}
 
 	// Decrypt bot token if encrypted
@@ -849,10 +849,10 @@ func (s *NotificationService) sendEmailContainerUpdateNotification(ctx context.C
 	}
 
 	if emailConfig.SMTPHost == "" || emailConfig.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(emailConfig.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 
 	if _, err := mail.ParseAddress(emailConfig.FromAddress); err != nil {
@@ -877,7 +877,7 @@ func (s *NotificationService) sendEmailContainerUpdateNotification(ctx context.C
 		return fmt.Errorf("failed to render email template: %w", err)
 	}
 
-	subject := notifications.BuildEmailSubject(environmentName, fmt.Sprintf("Container Updated: %s", notifications.SanitizeForEmail(containerName)))
+	subject := notifications.BuildEmailSubject(environmentName, "Container Updated: "+notifications.SanitizeForEmail(containerName))
 	if err := notifications.SendEmail(ctx, emailConfig, subject, htmlBody); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
@@ -953,7 +953,7 @@ func (s *NotificationService) TestNotification(ctx context.Context, environmentI
 	// Test vulnerability notification (all providers)
 	if testType == notificationTestTypeVulnerability {
 		payload := VulnerabilityNotificationPayload{
-			CVEID:        fmt.Sprintf("Daily Summary - %s", time.Now().UTC().Format("2006-01-02")),
+			CVEID:        "Daily Summary - " + time.Now().UTC().Format("2006-01-02"),
 			Severity:     "Critical:1 High:3 Medium:2 Low:1 Unknown:0",
 			ImageName:    "5 image(s) scanned, 2 with fixable vulnerabilities",
 			FixedVersion: "7 fixable vulnerability record(s)",
@@ -1209,10 +1209,10 @@ func (s *NotificationService) sendTestEmail(ctx context.Context, environmentName
 	}
 
 	if emailConfig.SMTPHost == "" || emailConfig.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(emailConfig.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 
 	if _, err := mail.ParseAddress(emailConfig.FromAddress); err != nil {
@@ -1454,10 +1454,10 @@ func (s *NotificationService) sendBatchEmailNotification(ctx context.Context, en
 	}
 
 	if emailConfig.SMTPHost == "" || emailConfig.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(emailConfig.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 
 	if _, err := mail.ParseAddress(emailConfig.FromAddress); err != nil {
@@ -1558,26 +1558,26 @@ func (s *NotificationService) sendSignalNotification(ctx context.Context, enviro
 	}
 
 	if signalConfig.Host == "" {
-		return fmt.Errorf("signal host not configured")
+		return errors.New("signal host not configured")
 	}
 	if signalConfig.Port == 0 {
-		return fmt.Errorf("signal port not configured")
+		return errors.New("signal port not configured")
 	}
 	if signalConfig.Source == "" {
-		return fmt.Errorf("signal source phone number not configured")
+		return errors.New("signal source phone number not configured")
 	}
 	if len(signalConfig.Recipients) == 0 {
-		return fmt.Errorf("no signal recipients configured")
+		return errors.New("no signal recipients configured")
 	}
 
 	// Validate authentication
 	hasBasicAuth := signalConfig.User != "" && signalConfig.Password != ""
 	hasTokenAuth := signalConfig.Token != ""
 	if !hasBasicAuth && !hasTokenAuth {
-		return fmt.Errorf("signal requires either basic auth (user/password) or token authentication")
+		return errors.New("signal requires either basic auth (user/password) or token authentication")
 	}
 	if hasBasicAuth && hasTokenAuth {
-		return fmt.Errorf("signal cannot use both basic auth and token authentication simultaneously")
+		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
 	// Decrypt sensitive fields if encrypted
@@ -1621,26 +1621,26 @@ func (s *NotificationService) sendSignalContainerUpdateNotification(ctx context.
 	}
 
 	if signalConfig.Host == "" {
-		return fmt.Errorf("signal host not configured")
+		return errors.New("signal host not configured")
 	}
 	if signalConfig.Port == 0 {
-		return fmt.Errorf("signal port not configured")
+		return errors.New("signal port not configured")
 	}
 	if signalConfig.Source == "" {
-		return fmt.Errorf("signal source phone number not configured")
+		return errors.New("signal source phone number not configured")
 	}
 	if len(signalConfig.Recipients) == 0 {
-		return fmt.Errorf("no signal recipients configured")
+		return errors.New("no signal recipients configured")
 	}
 
 	// Validate authentication
 	hasBasicAuth := signalConfig.User != "" && signalConfig.Password != ""
 	hasTokenAuth := signalConfig.Token != ""
 	if !hasBasicAuth && !hasTokenAuth {
-		return fmt.Errorf("signal requires either basic auth (user/password) or token authentication")
+		return errors.New("signal requires either basic auth (user/password) or token authentication")
 	}
 	if hasBasicAuth && hasTokenAuth {
-		return fmt.Errorf("signal cannot use both basic auth and token authentication simultaneously")
+		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
 	// Decrypt sensitive fields if encrypted
@@ -1689,10 +1689,10 @@ func (s *NotificationService) sendBatchSignalNotification(ctx context.Context, e
 	hasBasicAuth := signalConfig.User != "" && signalConfig.Password != ""
 	hasTokenAuth := signalConfig.Token != ""
 	if !hasBasicAuth && !hasTokenAuth {
-		return fmt.Errorf("signal requires either basic auth (user/password) or token authentication")
+		return errors.New("signal requires either basic auth (user/password) or token authentication")
 	}
 	if hasBasicAuth && hasTokenAuth {
-		return fmt.Errorf("signal cannot use both basic auth and token authentication simultaneously")
+		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
 	// Decrypt sensitive fields if encrypted
@@ -1853,10 +1853,10 @@ func (s *NotificationService) sendPushoverNotification(ctx context.Context, envi
 	}
 
 	if pushoverConfig.Token == "" {
-		return fmt.Errorf("pushover API token not configured")
+		return errors.New("pushover API token not configured")
 	}
 	if pushoverConfig.User == "" {
-		return fmt.Errorf("pushover user key not configured")
+		return errors.New("pushover user key not configured")
 	}
 
 	message := notifications.BuildImageUpdateNotificationMessage(
@@ -1880,10 +1880,10 @@ func (s *NotificationService) sendPushoverContainerUpdateNotification(ctx contex
 	}
 
 	if pushoverConfig.Token == "" {
-		return fmt.Errorf("pushover API token not configured")
+		return errors.New("pushover API token not configured")
 	}
 	if pushoverConfig.User == "" {
-		return fmt.Errorf("pushover user key not configured")
+		return errors.New("pushover user key not configured")
 	}
 
 	message := notifications.BuildContainerUpdateNotificationMessage(
@@ -1932,7 +1932,7 @@ func (s *NotificationService) sendGenericNotification(ctx context.Context, envir
 	}
 
 	if genericConfig.WebhookURL == "" {
-		return fmt.Errorf("webhook URL not configured")
+		return errors.New("webhook URL not configured")
 	}
 
 	message := notifications.BuildImageUpdateNotificationMessage(
@@ -1961,7 +1961,7 @@ func (s *NotificationService) sendGenericContainerUpdateNotification(ctx context
 	}
 
 	if genericConfig.WebhookURL == "" {
-		return fmt.Errorf("webhook URL not configured")
+		return errors.New("webhook URL not configured")
 	}
 
 	message := notifications.BuildContainerUpdateNotificationMessage(
@@ -2033,10 +2033,10 @@ func (s *NotificationService) sendEmailVulnerabilityNotification(ctx context.Con
 		return fmt.Errorf("failed to unmarshal email config: %w", err)
 	}
 	if emailConfig.SMTPHost == "" || emailConfig.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(emailConfig.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 	if _, err := mail.ParseAddress(emailConfig.FromAddress); err != nil {
 		return fmt.Errorf("invalid from address: %w", err)
@@ -2057,7 +2057,7 @@ func (s *NotificationService) sendEmailVulnerabilityNotification(ctx context.Con
 	if err != nil {
 		return fmt.Errorf("failed to render summary email template: %w", err)
 	}
-	subject := notifications.BuildEmailSubject(environmentName, fmt.Sprintf("Daily Vulnerability Summary: %s", notifications.SanitizeForEmail(payload.CVEID)))
+	subject := notifications.BuildEmailSubject(environmentName, "Daily Vulnerability Summary: "+notifications.SanitizeForEmail(payload.CVEID))
 	if err := notifications.SendEmail(ctx, emailConfig, subject, htmlBody); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
@@ -2074,7 +2074,7 @@ func (s *NotificationService) sendDiscordVulnerabilityNotification(ctx context.C
 		return fmt.Errorf("failed to unmarshal Discord config: %w", err)
 	}
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
-		return fmt.Errorf("discord webhook ID or token not configured")
+		return errors.New("discord webhook ID or token not configured")
 	}
 	if discordConfig.Token != "" {
 		decrypted, err := crypto.Decrypt(discordConfig.Token)
@@ -2108,10 +2108,10 @@ func (s *NotificationService) sendTelegramVulnerabilityNotification(ctx context.
 		return fmt.Errorf("failed to unmarshal Telegram config: %w", err)
 	}
 	if telegramConfig.BotToken == "" {
-		return fmt.Errorf("telegram bot token not configured")
+		return errors.New("telegram bot token not configured")
 	}
 	if len(telegramConfig.ChatIDs) == 0 {
-		return fmt.Errorf("no telegram chat IDs configured")
+		return errors.New("no telegram chat IDs configured")
 	}
 	if telegramConfig.BotToken != "" {
 		decrypted, err := crypto.Decrypt(telegramConfig.BotToken)
@@ -2148,7 +2148,7 @@ func (s *NotificationService) sendSignalVulnerabilityNotification(ctx context.Co
 		return fmt.Errorf("failed to unmarshal Signal config: %w", err)
 	}
 	if signalConfig.Host == "" || signalConfig.Port == 0 || signalConfig.Source == "" || len(signalConfig.Recipients) == 0 {
-		return fmt.Errorf("signal not fully configured")
+		return errors.New("signal not fully configured")
 	}
 	if signalConfig.Password != "" {
 		decrypted, err := crypto.Decrypt(signalConfig.Password)
@@ -2209,7 +2209,7 @@ func (s *NotificationService) sendPushoverVulnerabilityNotification(ctx context.
 		return err
 	}
 	if pushoverConfig.Token == "" || pushoverConfig.User == "" {
-		return fmt.Errorf("pushover token or user not configured")
+		return errors.New("pushover token or user not configured")
 	}
 	message := buildVulnerabilitySummaryMessageInternal(notifications.MessageFormatPlain, environmentName, payload)
 	if pushoverConfig.Title == "" {
@@ -2237,7 +2237,7 @@ func (s *NotificationService) sendGotifyVulnerabilityNotification(ctx context.Co
 }
 
 func (s *NotificationService) sendMatrixVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config, "Matrix")
+	matrixConfig, err := prepareMatrixConfigInternal(config)
 	if err != nil {
 		return err
 	}
@@ -2258,7 +2258,7 @@ func (s *NotificationService) sendGenericVulnerabilityNotification(ctx context.C
 		return fmt.Errorf("failed to unmarshal Generic config: %w", err)
 	}
 	if genericConfig.WebhookURL == "" {
-		return fmt.Errorf("webhook URL not configured")
+		return errors.New("webhook URL not configured")
 	}
 	message := notifications.BuildVulnerabilitySummaryNotificationMessage(
 		notifications.MessageFormatPlain,
@@ -2287,7 +2287,7 @@ func (s *NotificationService) sendBatchGenericNotification(ctx context.Context, 
 	}
 
 	if genericConfig.WebhookURL == "" {
-		return fmt.Errorf("webhook URL not configured")
+		return errors.New("webhook URL not configured")
 	}
 
 	title := "Container Image Updates Available"
@@ -2366,7 +2366,7 @@ func (s *NotificationService) sendBatchGotifyNotification(ctx context.Context, e
 }
 
 func (s *NotificationService) sendMatrixNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config, "Matrix")
+	matrixConfig, err := prepareMatrixConfigInternal(config)
 	if err != nil {
 		return err
 	}
@@ -2386,7 +2386,7 @@ func (s *NotificationService) sendMatrixNotification(ctx context.Context, enviro
 }
 
 func (s *NotificationService) sendMatrixContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config, "Matrix")
+	matrixConfig, err := prepareMatrixConfigInternal(config)
 	if err != nil {
 		return err
 	}
@@ -2408,7 +2408,7 @@ func (s *NotificationService) sendMatrixContainerUpdateNotification(ctx context.
 }
 
 func (s *NotificationService) sendBatchMatrixNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config, "Matrix")
+	matrixConfig, err := prepareMatrixConfigInternal(config)
 	if err != nil {
 		return err
 	}
@@ -2516,7 +2516,7 @@ func (s *NotificationService) sendDiscordPruneNotification(ctx context.Context, 
 	}
 
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
-		return fmt.Errorf("discord webhook ID or token not configured")
+		return errors.New("discord webhook ID or token not configured")
 	}
 
 	if err := s.decryptDiscordTokenInternal(&discordConfig); err != nil {
@@ -2539,7 +2539,7 @@ func (s *NotificationService) sendTelegramPruneNotification(ctx context.Context,
 	}
 
 	if telegramConfig.BotToken == "" || len(telegramConfig.ChatIDs) == 0 {
-		return fmt.Errorf("telegram bot token or chat IDs not configured")
+		return errors.New("telegram bot token or chat IDs not configured")
 	}
 
 	if err := s.decryptTelegramTokenInternal(&telegramConfig); err != nil {
@@ -2759,7 +2759,7 @@ func (s *NotificationService) sendDiscordAutoHealNotification(ctx context.Contex
 		return err
 	}
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
-		return fmt.Errorf("discord webhook ID or token not configured")
+		return errors.New("discord webhook ID or token not configured")
 	}
 	if err := s.decryptDiscordTokenInternal(&discordConfig); err != nil {
 		return err
@@ -2794,7 +2794,7 @@ func (s *NotificationService) sendTelegramAutoHealNotification(ctx context.Conte
 		return err
 	}
 	if telegramConfig.BotToken == "" || len(telegramConfig.ChatIDs) == 0 {
-		return fmt.Errorf("telegram bot token or chat IDs not configured")
+		return errors.New("telegram bot token or chat IDs not configured")
 	}
 	if err := s.decryptTelegramTokenInternal(&telegramConfig); err != nil {
 		return err
@@ -2909,10 +2909,10 @@ func decodeNotificationConfigInternal[T any](config models.JSON, providerName st
 
 func (s *NotificationService) validateEmailConfigInternal(config *models.EmailConfig) error {
 	if config.SMTPHost == "" || config.SMTPPort == 0 {
-		return fmt.Errorf("SMTP host or port not configured")
+		return errors.New("SMTP host or port not configured")
 	}
 	if len(config.ToAddresses) == 0 {
-		return fmt.Errorf("no recipient email addresses configured")
+		return errors.New("no recipient email addresses configured")
 	}
 	return nil
 }
@@ -2936,7 +2936,7 @@ func prepareSlackConfigInternal(config models.JSON, providerName string, require
 		return models.SlackConfig{}, err
 	}
 	if requireToken && slackConfig.Token == "" {
-		return models.SlackConfig{}, fmt.Errorf("slack token not configured")
+		return models.SlackConfig{}, errors.New("slack token not configured")
 	}
 	if err := decryptStringCredentialInternal(&slackConfig.Token); err != nil {
 		return models.SlackConfig{}, err
@@ -2950,7 +2950,7 @@ func prepareNtfyConfigInternal(config models.JSON, providerName string, requireT
 		return models.NtfyConfig{}, err
 	}
 	if requireTopic && ntfyConfig.Topic == "" {
-		return models.NtfyConfig{}, fmt.Errorf("ntfy topic is required")
+		return models.NtfyConfig{}, errors.New("ntfy topic is required")
 	}
 	if err := decryptStringCredentialInternal(&ntfyConfig.Password); err != nil {
 		return models.NtfyConfig{}, err
@@ -2980,8 +2980,8 @@ func prepareGotifyConfigInternal(config models.JSON, providerName string) (model
 	return gotifyConfig, nil
 }
 
-func prepareMatrixConfigInternal(config models.JSON, providerName string) (models.MatrixConfig, error) {
-	matrixConfig, err := decodeNotificationConfigInternal[models.MatrixConfig](config, providerName)
+func prepareMatrixConfigInternal(config models.JSON) (models.MatrixConfig, error) {
+	matrixConfig, err := decodeNotificationConfigInternal[models.MatrixConfig](config, "Matrix")
 	if err != nil {
 		return models.MatrixConfig{}, err
 	}

--- a/backend/internal/services/oidc_service.go
+++ b/backend/internal/services/oidc_service.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/getarcaneapp/arcane/backend/internal/common"
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils"
@@ -206,10 +207,8 @@ func (s *OidcService) ValidateMobileRedirectURI(ctx context.Context, uri string)
 	if uri == "" {
 		return errors.New("mobile redirect URI is empty")
 	}
-	for _, allowed := range s.GetMobileRedirectAllowlist(ctx) {
-		if allowed == uri {
-			return nil
-		}
+	if slices.Contains(s.GetMobileRedirectAllowlist(ctx), uri) {
+		return nil
 	}
 	return fmt.Errorf("mobile redirect URI %q is not in the configured allowlist", uri)
 }
@@ -328,7 +327,11 @@ func (s *OidcService) getOrDiscoverProviderInternal(ctx context.Context, cfg *mo
 		return nil, err
 	}
 
-	return v.(*oidc.Provider), nil
+	provider, ok := v.(*oidc.Provider)
+	if !ok {
+		return nil, &common.OidcProviderCacheTypeError{}
+	}
+	return provider, nil
 }
 
 func (s *OidcService) discoverProviderInternal(ctx context.Context, issuer string) (*oidc.Provider, string, error) {
@@ -450,7 +453,7 @@ func (s *OidcService) fetchUserInfoClaimsInternal(ctx context.Context, cfg *mode
 	request.Header.Set("Accept", "application/json")
 
 	client := s.getHttpClientInternal(cfg.SkipTlsVerify)
-	resp, err := client.Do(request) //nolint:gosec // intentional request to configured OIDC userinfo endpoint
+	resp, err := client.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +752,7 @@ func (s *OidcService) makeDeviceAuthRequestInternal(ctx context.Context, endpoin
 	req.Header.Set("Accept", "application/json")
 
 	client := s.getHttpClientInternal(skipTls)
-	resp, err := client.Do(req) //nolint:gosec // intentional request to configured OIDC device authorization endpoint
+	resp, err := client.Do(req)
 	if err != nil {
 		slog.Error("makeDeviceAuthRequestInternal: request failed", "error", err)
 		return nil, fmt.Errorf("device authorization request failed: %w", err)
@@ -858,7 +861,7 @@ func (s *OidcService) makeTokenRequestInternal(ctx context.Context, endpoint str
 	req.Header.Set("Accept", "application/json")
 
 	client := s.getHttpClientInternal(skipTls)
-	resp, err := client.Do(req) //nolint:gosec // intentional request to configured OIDC token endpoint
+	resp, err := client.Do(req)
 	if err != nil {
 		slog.Error("makeTokenRequestInternal: request failed", "error", err)
 		return nil, fmt.Errorf("token request failed: %w", err)

--- a/backend/internal/services/playwright_service.go
+++ b/backend/internal/services/playwright_service.go
@@ -78,7 +78,7 @@ func (ps *PlaywrightService) DeleteAllTestApiKeys(ctx context.Context) error {
 		SearchQuery: pagination.SearchQuery{
 			Search: "test-api-key",
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: 0,
 			Limit: 1000,
 		},

--- a/backend/internal/services/port_service_test.go
+++ b/backend/internal/services/port_service_test.go
@@ -53,7 +53,7 @@ func TestPortService_ListPortsPaginated_FlattensPublishedAndExposedPorts(t *test
 	}))
 
 	items, page, err := svc.ListPortsPaginated(context.Background(), pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Limit: 20},
+		Params: pagination.Params{Limit: 20},
 	})
 	require.NoError(t, err)
 	require.Len(t, items, 3)
@@ -107,7 +107,7 @@ func TestPortService_ListPortsPaginated_SortsByHostPortWithUnpublishedLast(t *te
 			Sort:  "hostPort",
 			Order: pagination.SortAsc,
 		},
-		PaginationParams: pagination.PaginationParams{Limit: 20},
+		Params: pagination.Params{Limit: 20},
 	})
 	require.NoError(t, err)
 	require.Len(t, items, 3)
@@ -154,7 +154,7 @@ func TestPortService_ListPortsPaginated_SortsByHostPortDescWithUnpublishedLast(t
 			Sort:  "hostPort",
 			Order: pagination.SortDesc,
 		},
-		PaginationParams: pagination.PaginationParams{Limit: 20},
+		Params: pagination.Params{Limit: 20},
 	})
 	require.NoError(t, err)
 	require.Len(t, items, 3)
@@ -201,7 +201,7 @@ func TestPortService_ListPortsPaginated_SortsByHostIPDescWithUnpublishedLast(t *
 			Sort:  "hostIp",
 			Order: pagination.SortDesc,
 		},
-		PaginationParams: pagination.PaginationParams{Limit: 20},
+		Params: pagination.Params{Limit: 20},
 	})
 	require.NoError(t, err)
 	require.Len(t, items, 3)

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -74,7 +75,7 @@ func NewProjectService(db *database.DB, settingsService *SettingsService, eventS
 	}
 }
 
-func (s *ProjectService) getPathMapper(ctx context.Context) (*projects.PathMapper, error) {
+func (s *ProjectService) getPathMapper(ctx context.Context) *projects.PathMapper {
 	configuredPath := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
 
 	var containerDir, hostDir string
@@ -118,10 +119,10 @@ func (s *ProjectService) getPathMapper(ctx context.Context) (*projects.PathMappe
 
 	pm := projects.NewPathMapper(containerDirResolved, hostDirResolved)
 	if !pm.IsNonMatchingMount() {
-		return nil, nil
+		return nil
 	}
 
-	return pm, nil
+	return pm
 }
 
 func (s *ProjectService) getProjectsDirectoryInternal(ctx context.Context) (string, error) {
@@ -377,10 +378,10 @@ func (s *ProjectService) GetProjectFromDatabaseByID(ctx context.Context, id stri
 	var project models.Project
 	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&project).Error; err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("request canceled or timed out")
+			return nil, errors.New("request canceled or timed out")
 		}
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("project not found")
+			return nil, errors.New("project not found")
 		}
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
@@ -389,7 +390,7 @@ func (s *ProjectService) GetProjectFromDatabaseByID(ctx context.Context, id stri
 
 func (s *ProjectService) GetProjectByComposeName(ctx context.Context, name string) (*models.Project, error) {
 	if name == "" {
-		return nil, fmt.Errorf("project name is empty")
+		return nil, errors.New("project name is empty")
 	}
 	normalized := normalizeComposeProjectName(name)
 
@@ -424,7 +425,7 @@ func (s *ProjectService) GetProjectByComposeName(ctx context.Context, name strin
 
 func (s *ProjectService) resolveProjectComposeFileInternal(ctx context.Context, proj *models.Project) (string, error) {
 	if proj == nil {
-		return "", fmt.Errorf("project is nil")
+		return "", errors.New("project is nil")
 	}
 
 	if proj.GitOpsManagedBy != nil && strings.TrimSpace(*proj.GitOpsManagedBy) != "" {
@@ -472,10 +473,7 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 		projectsDirectory = "/app/data/projects"
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
+	pathMapper := s.getPathMapper(ctx)
 
 	composeProject, loadErr := projects.LoadComposeProject(ctx, composeFileFullPath, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if loadErr != nil {
@@ -485,9 +483,9 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 	return composeProject, composeFileFullPath, nil
 }
 
-func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, proj *models.Project, cfg *models.Settings) (*composetypes.Project, string, error) {
+func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, proj *models.Project, cfg *models.Settings) (*composetypes.Project, error) {
 	if proj == nil {
-		return nil, "", fmt.Errorf("project is nil")
+		return nil, errors.New("project is nil")
 	}
 	if s.composeCache == nil {
 		s.composeCache = cache.NewKeyed[string, composeCacheEntry]()
@@ -525,10 +523,10 @@ func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, pr
 		return entry, nil
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return entry.project, entry.composePath, nil
+	return entry.project, nil
 }
 
 func validComposeCacheEntryInternal(entry composeCacheEntry) bool {
@@ -1054,7 +1052,7 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 		return project.IncludeFile{}, err
 	}
 	if strings.TrimSpace(relativePath) == "" {
-		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("relative path is required")}
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: errors.New("relative path is required")}
 	}
 
 	composeFile, detectErr := s.resolveProjectComposeFileInternal(ctx, proj)
@@ -1071,7 +1069,7 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 					continue
 				}
 				if !projects.IsSafeSubdirectory(proj.Path, inc.Path) {
-					return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+					return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: errors.New("file path is outside project directory")}
 				}
 				return readProjectIncludeFileContentInternal(proj.Path, inc)
 			}
@@ -1088,7 +1086,7 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 		return project.IncludeFile{}, fmt.Errorf("failed to resolve file path: %w", err)
 	}
 	if !projects.IsSafeSubdirectory(absProjectPath, absFilePath) {
-		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: errors.New("file path is outside project directory")}
 	}
 
 	info, err := os.Lstat(absFilePath)
@@ -1099,10 +1097,10 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 		return project.IncludeFile{}, fmt.Errorf("failed to stat file: %w", err)
 	}
 	if info.IsDir() {
-		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("path refers to a directory")}
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: errors.New("path refers to a directory")}
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("symlink files are not supported")}
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: errors.New("symlink files are not supported")}
 	}
 
 	content, err := os.ReadFile(absFilePath)
@@ -1113,7 +1111,7 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 		return project.IncludeFile{}, fmt.Errorf("failed to read file: %w", err)
 	}
 	if projects.IsBinaryProjectFileContent(content) {
-		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("binary files are not supported")}
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: errors.New("binary files are not supported")}
 	}
 
 	return project.IncludeFile{
@@ -1126,7 +1124,7 @@ func (s *ProjectService) GetProjectFileContent(ctx context.Context, projectID, r
 func readProjectIncludeFileContentInternal(projectPath string, inc projects.IncludeFile) (project.IncludeFile, error) {
 	validatedPath, err := projects.ValidateIncludePathForWrite(projectPath, inc.Path)
 	if err != nil {
-		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: errors.New("file path is outside project directory")}
 	}
 
 	resolvedProjectPath, err := filepath.EvalSymlinks(projectPath)
@@ -1145,7 +1143,7 @@ func readProjectIncludeFileContentInternal(projectPath string, inc projects.Incl
 		return project.IncludeFile{}, fmt.Errorf("failed to resolve include file: %w", err)
 	}
 	if !projects.IsSafeSubdirectory(resolvedProjectPath, resolvedPath) {
-		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: fmt.Errorf("file path is outside project directory")}
+		return project.IncludeFile{}, &common.ProjectFileForbiddenError{Err: errors.New("file path is outside project directory")}
 	}
 
 	info, err := os.Stat(resolvedPath)
@@ -1156,7 +1154,7 @@ func readProjectIncludeFileContentInternal(projectPath string, inc projects.Incl
 		return project.IncludeFile{}, fmt.Errorf("failed to stat include file: %w", err)
 	}
 	if info.IsDir() {
-		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("path refers to a directory")}
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: errors.New("path refers to a directory")}
 	}
 
 	content, err := os.ReadFile(resolvedPath)
@@ -1167,7 +1165,7 @@ func readProjectIncludeFileContentInternal(projectPath string, inc projects.Incl
 		return project.IncludeFile{}, fmt.Errorf("failed to read include file: %w", err)
 	}
 	if projects.IsBinaryProjectFileContent(content) {
-		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: fmt.Errorf("binary files are not supported")}
+		return project.IncludeFile{}, &common.ProjectFileBadRequestError{Err: errors.New("binary files are not supported")}
 	}
 
 	return project.IncludeFile{
@@ -1324,7 +1322,7 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 }
 
 func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project, cfg *models.Settings) ([]string, error) {
-	composeProject, _, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
+	composeProject, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("load compose project: %w", err)
 	}
@@ -1429,7 +1427,7 @@ func (s *ProjectService) enrichWithGitOpsInfo(ctx context.Context, proj *models.
 }
 
 func (s *ProjectService) enrichWithComposeServiceConfigs(ctx context.Context, proj *models.Project, composeFile string, resp *project.Details) {
-	composeProj, _, loadErr := s.getCachedComposeProjectInternal(ctx, proj, nil)
+	composeProj, loadErr := s.getCachedComposeProjectInternal(ctx, proj, nil)
 	if loadErr != nil {
 		slog.WarnContext(ctx, "failed to load compose service configs", "path", composeFile, "error", loadErr)
 		return
@@ -2046,10 +2044,7 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 		return err
 	}
 
-	disabled, err := s.projectRedeployDisabledInternal(ctx, *proj)
-	if err != nil {
-		return err
-	}
+	disabled := s.projectRedeployDisabledInternal(ctx, *proj)
 	if disabled {
 		return &common.ArcaneSelfRedeployError{}
 	}
@@ -2078,11 +2073,11 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 	return s.DeployProject(ctx, projectID, user, nil)
 }
 
-func (s *ProjectService) projectRedeployDisabledInternal(ctx context.Context, proj models.Project) (bool, error) {
+func (s *ProjectService) projectRedeployDisabledInternal(ctx context.Context, proj models.Project) bool {
 	containers, err := projects.ListGlobalComposeContainers(ctx)
 	if err != nil {
 		slog.WarnContext(ctx, "could not list compose containers to check self-redeploy guard; skipping guard", "error", err)
-		return false, nil
+		return false
 	}
 
 	containersByProject := make(map[string][]container.Summary)
@@ -2096,11 +2091,11 @@ func (s *ProjectService) projectRedeployDisabledInternal(ctx context.Context, pr
 	currentContainerID, currentContainerErr := dockerutil.GetCurrentContainerID()
 	for _, container := range lookupProjectContainers(proj, containersByProject) {
 		if libupdater.ShouldDisableArcaneServerRedeploy(container.Labels, container.ID, currentContainerID, currentContainerErr) {
-			return true, nil
+			return true
 		}
 	}
 
-	return false, nil
+	return false
 }
 
 func (s *ProjectService) PullProjectImages(ctx context.Context, projectID string, progressWriter io.Writer, user models.User, credentials []containerregistry.Credential) error {
@@ -2223,11 +2218,6 @@ func (s *ProjectService) prepareProjectImagesForDeploy(
 		return nil
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
-
 	for name, svc := range project.Services {
 		svc, imageName, updated := prepareDeployServiceConfig(projectID, project.Name, name, svc)
 		if updated {
@@ -2242,7 +2232,7 @@ func (s *ProjectService) prepareProjectImagesForDeploy(
 		if updated {
 			decision = deployImageDecision{Build: true}
 		}
-		if err := s.ensureDeployServiceImageReady(ctx, projectID, project, name, svc, imageName, decision, progressWriter, credentials, user, pathMapper); err != nil {
+		if err := s.ensureDeployServiceImageReady(ctx, projectID, project, name, svc, imageName, decision, progressWriter, credentials, user); err != nil {
 			return err
 		}
 	}
@@ -2274,10 +2264,9 @@ func (s *ProjectService) ensureDeployServiceImageReady(
 	progressWriter io.Writer,
 	credentials []containerregistry.Credential,
 	user *models.User,
-	pathMapper *projects.PathMapper,
 ) error {
 	if decision.Build {
-		return s.buildServiceImageForDeploy(ctx, projectID, project, serviceName, svc, progressWriter, user, pathMapper)
+		return s.buildServiceImageForDeploy(ctx, projectID, project, serviceName, svc, progressWriter, user)
 	}
 
 	exists, err := s.imageService.ImageExistsLocally(ctx, imageName)
@@ -2296,14 +2285,15 @@ func (s *ProjectService) ensureDeployServiceImageReady(
 		return nil
 	}
 
-	if err := s.pullAndReconcileImageInternal(ctx, imageName, progressWriter, systemUser, credentials); err == nil {
+	err = s.pullAndReconcileImageInternal(ctx, imageName, progressWriter, systemUser, credentials)
+	if err == nil {
 		return nil
-	} else if svc.Build != nil && decision.FallbackBuildOnPullFail {
-		slog.WarnContext(ctx, "image pull failed, falling back to build", "service", serviceName, "image", imageName, "error", err)
-		return s.buildServiceImageForDeploy(ctx, projectID, project, serviceName, svc, progressWriter, user, pathMapper)
-	} else {
-		return fmt.Errorf("failed to pull image %s: %w", imageName, err)
 	}
+	if svc.Build != nil && decision.FallbackBuildOnPullFail {
+		slog.WarnContext(ctx, "image pull failed, falling back to build", "service", serviceName, "image", imageName, "error", err)
+		return s.buildServiceImageForDeploy(ctx, projectID, project, serviceName, svc, progressWriter, user)
+	}
+	return fmt.Errorf("failed to pull image %s: %w", imageName, err)
 }
 
 func (s *ProjectService) buildServiceImageForDeploy(
@@ -2314,13 +2304,12 @@ func (s *ProjectService) buildServiceImageForDeploy(
 	svc composetypes.ServiceConfig,
 	progressWriter io.Writer,
 	user *models.User,
-	pathMapper *projects.PathMapper,
 ) error {
 	if s.buildService == nil {
 		return fmt.Errorf("build service not available for service %s", serviceName)
 	}
 
-	buildReq, updatedSvc, updated, err := s.prepareServiceBuildRequest(ctx, projectID, project, serviceName, svc, ProjectBuildOptions{}, pathMapper)
+	buildReq, updatedSvc, updated, err := s.prepareServiceBuildRequest(ctx, projectID, project, serviceName, svc, ProjectBuildOptions{})
 	if err != nil {
 		return err
 	}
@@ -2443,13 +2432,13 @@ func resolveBuildContextInternal(workingDir string, svc composetypes.ServiceConf
 	return contextDir, nil
 }
 
-func resolveDockerfilePathInternal(svc composetypes.ServiceConfig) (string, error) {
+func resolveDockerfilePathInternal(svc composetypes.ServiceConfig) string {
 	dockerfilePath := strings.TrimSpace(svc.Build.Dockerfile)
 	if dockerfilePath == "" {
 		dockerfilePath = "Dockerfile"
 	}
 
-	return dockerfilePath, nil
+	return dockerfilePath
 }
 
 func buildArgsFromCompose(args map[string]*string) map[string]string {
@@ -2504,7 +2493,7 @@ func ulimitsFromCompose(ulimits map[string]*composetypes.UlimitsConfig) map[stri
 
 		switch {
 		case cfg.Single > 0:
-			out[name] = fmt.Sprintf("%d", cfg.Single)
+			out[name] = strconv.Itoa(cfg.Single)
 		case cfg.Soft > 0 || cfg.Hard > 0:
 			out[name] = fmt.Sprintf("%d:%d", cfg.Soft, cfg.Hard)
 		}
@@ -2567,7 +2556,6 @@ func (s *ProjectService) prepareServiceBuildRequest(
 	serviceName string,
 	svc composetypes.ServiceConfig,
 	options ProjectBuildOptions,
-	pathMapper *projects.PathMapper,
 ) (imagetypes.BuildRequest, composetypes.ServiceConfig, bool, error) {
 	_ = ctx
 	imageName, updatedSvc, updated := ensureServiceImage(projectID, project.Name, serviceName, svc)
@@ -2587,7 +2575,7 @@ func (s *ProjectService) prepareServiceBuildRequest(
 	// therefore stay as a container path; translating it to the host path
 	// (which is what bind mount sources need) makes `os.Stat` fail because
 	// the host path doesn't exist inside the Arcane container. See #2314.
-	// pathMapper is intentionally not consumed here for that reason.
+	// For that reason the build context dir is deliberately left untranslated.
 	contextDir, err := resolveBuildContextInternal(project.WorkingDir, updatedSvc, serviceName)
 	if err != nil {
 		return imagetypes.BuildRequest{}, updatedSvc, updated, err
@@ -2600,10 +2588,7 @@ func (s *ProjectService) prepareServiceBuildRequest(
 
 	dockerfilePath := ""
 	if strings.TrimSpace(dockerfileInline) == "" {
-		dockerfilePath, err = resolveDockerfilePathInternal(updatedSvc)
-		if err != nil {
-			return imagetypes.BuildRequest{}, updatedSvc, updated, err
-		}
+		dockerfilePath = resolveDockerfilePathInternal(updatedSvc)
 	}
 
 	buildReq := imagetypes.BuildRequest{
@@ -2646,16 +2631,16 @@ func (s *ProjectService) restoreProjectStatusAfterFailedDeployInternal(ctx conte
 	if err == nil {
 		serviceCount, runningCount := s.getServiceCounts(services)
 		status := s.calculateProjectStatus(services)
-		if updateErr := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", projectID).Updates(map[string]any{
+		updateErr := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", projectID).Updates(map[string]any{
 			"status":        status,
 			"service_count": serviceCount,
 			"running_count": runningCount,
 			"updated_at":    time.Now(),
-		}).Error; updateErr == nil {
+		}).Error
+		if updateErr == nil {
 			return
-		} else {
-			slog.WarnContext(ctx, "failed to restore project status after deploy failure", "projectID", projectID, "error", updateErr)
 		}
+		slog.WarnContext(ctx, "failed to restore project status after deploy failure", "projectID", projectID, "error", updateErr)
 	} else {
 		slog.WarnContext(ctx, "failed to inspect project services after deploy failure", "projectID", projectID, "error", err)
 	}
@@ -2675,11 +2660,6 @@ func (s *ProjectService) buildProjectServicesInternal(ctx context.Context, proje
 
 	selected := normalizeBuildSelections(options.Services)
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
-
 	buildCount := 0
 	for name, svc := range project.Services {
 		if svc.Build == nil {
@@ -2689,7 +2669,7 @@ func (s *ProjectService) buildProjectServicesInternal(ctx context.Context, proje
 			continue
 		}
 
-		buildReq, updatedSvc, updated, err := s.prepareServiceBuildRequest(ctx, projectID, project, name, svc, options, pathMapper)
+		buildReq, updatedSvc, updated, err := s.prepareServiceBuildRequest(ctx, projectID, project, name, svc, options)
 		if err != nil {
 			return err
 		}
@@ -2767,10 +2747,7 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 		projectsDirectory = "/app/data/projects"
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
+	pathMapper := s.getPathMapper(ctx)
 
 	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if lerr != nil {
@@ -2908,7 +2885,7 @@ func (s *ProjectService) getProjectForUpdate(ctx context.Context, projectID stri
 	var proj models.Project
 	if err := s.db.WithContext(ctx).First(&proj, "id = ?", projectID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return models.Project{}, "", fmt.Errorf("project not found")
+			return models.Project{}, "", errors.New("project not found")
 		}
 		return models.Project{}, "", fmt.Errorf("failed to get project: %w", err)
 	}
@@ -3164,7 +3141,7 @@ func parseComposeValidationEnvContent(content string, contextEnv projects.EnvMap
 		return nil, fmt.Errorf("parse env: %w", err)
 	}
 
-	return projects.EnvMap(envMap), nil
+	return envMap, nil
 }
 
 func withTransientValidationEnvFile(projectPath string, effectiveEnvContent *string, run func() error) (err error) {
@@ -3411,7 +3388,7 @@ func (s *ProjectService) persistGitSyncEnvFilesInternal(projectPath, projectsDir
 	}
 
 	if update.effectiveContent == nil {
-		return fmt.Errorf("missing effective env content for git sync update")
+		return errors.New("missing effective env content for git sync update")
 	}
 
 	if err := projects.WriteEnvFile(projectsDirectory, projectPath, *update.effectiveContent); err != nil {
@@ -3447,7 +3424,7 @@ func (s *ProjectService) applyProjectRenameIfNeeded(proj *models.Project, name *
 
 	newDirName := projects.SanitizeProjectName(newName)
 	if newDirName == "" || strings.Trim(newDirName, "_") == "" {
-		return fmt.Errorf("invalid project name: results in empty directory name")
+		return errors.New("invalid project name: results in empty directory name")
 	}
 
 	currentPath := filepath.Clean(proj.Path)
@@ -3676,7 +3653,6 @@ func (s *ProjectService) listProjectsWithDerivedFiltersInternal(
 	paginationResp := pagination.BuildResponseFromFilterResult(result, params)
 
 	return result.Items, paginationResp, nil
-
 }
 
 func (s *ProjectService) filterProjectsWithDerivedFiltersInternal(
@@ -4077,7 +4053,7 @@ func (s *ProjectService) countProjectsByUpdateStatusInternal(ctx context.Context
 		Filters: map[string]string{
 			"updates": status,
 		},
-		PaginationParams: pagination.PaginationParams{
+		Params: pagination.Params{
 			Start: 0,
 			Limit: 0,
 		},
@@ -4154,7 +4130,7 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 
 	projectContainers := lookupProjectContainers(p, containersByProject)
 
-	var services []ProjectServiceInfo
+	services := make([]ProjectServiceInfo, 0, len(projectContainers))
 	runningCount := 0
 
 	for _, c := range projectContainers {
@@ -4298,10 +4274,7 @@ func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context,
 		return 0, nil, pErr
 	}
 
-	pathMapper, pmErr := s.getPathMapper(ctx)
-	if pmErr != nil {
-		slog.WarnContext(ctx, "failed to create path mapper, continuing without translation", "error", pmErr)
-	}
+	pathMapper := s.getPathMapper(ctx)
 
 	normName := normalizeComposeProjectName(dirName)
 	autoInjectEnv := utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -2434,8 +2434,8 @@ func TestProjectService_ListProjects_FiltersByUpdateStatus(t *testing.T) {
 				Filters: map[string]string{
 					"updates": tt.filter,
 				},
-				PaginationParams: pagination.PaginationParams{Limit: -1},
-				SortParams:       pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
+				Params:     pagination.Params{Limit: -1},
+				SortParams: pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
 			})
 			require.NoError(t, err)
 			require.EqualValues(t, len(tt.expected), page.TotalItems)
@@ -2581,8 +2581,8 @@ func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Limit: -1},
-		SortParams:       pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
+		Params:     pagination.Params{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, page.TotalItems)
@@ -2590,9 +2590,9 @@ func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 	assert.Equal(t, "active-demo", items[0].Name)
 
 	items, page, err = svc.ListProjects(ctx, pagination.QueryParams{
-		Filters:          map[string]string{"archived": "true"},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
-		SortParams:       pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
+		Filters:    map[string]string{"archived": "true"},
+		Params:     pagination.Params{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, page.TotalItems)
@@ -2601,9 +2601,9 @@ func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 	assert.True(t, items[0].IsArchived)
 
 	items, page, err = svc.ListProjects(ctx, pagination.QueryParams{
-		Filters:          map[string]string{"archived": "all"},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
-		SortParams:       pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
+		Filters:    map[string]string{"archived": "all"},
+		Params:     pagination.Params{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, page.TotalItems)
@@ -2800,8 +2800,8 @@ func TestProjectService_ListProjects_WithDerivedStatusFilter_AllowsAllPageSizeSe
 		Filters: map[string]string{
 			"status": string(models.ProjectStatusStopped),
 		},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
-		SortParams:       pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
+		Params:     pagination.Params{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "name", Order: pagination.SortAsc},
 	})
 	require.NoError(t, err)
 	assert.EqualValues(t, 25, page.TotalItems)
@@ -2881,7 +2881,6 @@ func TestProjectService_PrepareServiceBuildRequest_MapsComposeFields(t *testing.
 		"web",
 		serviceCfg,
 		ProjectBuildOptions{},
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -2916,7 +2915,6 @@ func TestProjectService_PrepareServiceBuildRequest_MapsComposeFields(t *testing.
 func TestProjectService_PrepareServiceBuildRequest_KeepsContainerPaths(t *testing.T) {
 	svc := &ProjectService{}
 	proj := &composetypes.Project{WorkingDir: "/app/data/projects/demo", Name: "demo"}
-	pm := projects.NewPathMapper("/app/data/projects", "/docker-data/arcane/projects")
 
 	serviceCfg := composetypes.ServiceConfig{
 		Name:  "web",
@@ -2934,7 +2932,6 @@ func TestProjectService_PrepareServiceBuildRequest_KeepsContainerPaths(t *testin
 		"web",
 		serviceCfg,
 		ProjectBuildOptions{},
-		pm,
 	)
 	require.NoError(t, err)
 
@@ -2951,7 +2948,6 @@ func TestProjectService_PrepareServiceBuildRequest_KeepsContainerPaths(t *testin
 func TestProjectService_PrepareServiceBuildRequest_BuildDotKeepsContainerPath(t *testing.T) {
 	svc := &ProjectService{}
 	proj := &composetypes.Project{WorkingDir: "/app/data/projects/caddy", Name: "caddy"}
-	pm := projects.NewPathMapper("/app/data/projects", "/storage/volumes/arcane/projects")
 
 	serviceCfg := composetypes.ServiceConfig{
 		Name:  "caddy",
@@ -2968,7 +2964,6 @@ func TestProjectService_PrepareServiceBuildRequest_BuildDotKeepsContainerPath(t 
 		"caddy",
 		serviceCfg,
 		ProjectBuildOptions{},
-		pm,
 	)
 	require.NoError(t, err)
 
@@ -2996,7 +2991,6 @@ func TestProjectService_PrepareServiceBuildRequest_UsesInlineDockerfile(t *testi
 		"web",
 		serviceCfg,
 		ProjectBuildOptions{},
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -3064,7 +3058,6 @@ func TestProjectService_PrepareServiceBuildRequest_GeneratedImageProviderGuardra
 		"web",
 		serviceCfg,
 		ProjectBuildOptions{Provider: "depot"},
-		nil,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must define an image when using depot")
@@ -3076,7 +3069,6 @@ func TestProjectService_PrepareServiceBuildRequest_GeneratedImageProviderGuardra
 		"web",
 		serviceCfg,
 		ProjectBuildOptions{Provider: "local", Push: new(true)},
-		nil,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must define an image when push is enabled")
@@ -3281,8 +3273,8 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversNestedProjectsAndRel
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
-		SortParams:       pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
+		Params:     pagination.Params{Limit: -1},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, page.TotalItems)
@@ -3360,8 +3352,8 @@ services:
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
-		SortParams:       pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
+		Params:     pagination.Params{Limit: -1},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, page.TotalItems)
@@ -3527,8 +3519,8 @@ func TestProjectService_SyncProjectsFromFileSystem_DetectsNestedSymlinkedProject
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
-		SortParams:       pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
-		PaginationParams: pagination.PaginationParams{Limit: -1},
+		SortParams: pagination.SortParams{Sort: "path", Order: pagination.SortAsc},
+		Params:     pagination.Params{Limit: -1},
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, page.TotalItems)

--- a/backend/internal/services/role_service.go
+++ b/backend/internal/services/role_service.go
@@ -302,7 +302,7 @@ func (s *RoleService) GetRole(ctx context.Context, id string) (*models.Role, err
 
 func (s *RoleService) CreateRole(ctx context.Context, name string, description *string, permissions []string) (*models.Role, error) {
 	if strings.TrimSpace(name) == "" {
-		return nil, fmt.Errorf("role name is required")
+		return nil, errors.New("role name is required")
 	}
 	if err := validatePermissionsInternal(permissions); err != nil {
 		return nil, err
@@ -722,10 +722,10 @@ func (s *RoleService) GetOidcMapping(ctx context.Context, id string) (*models.Oi
 
 func (s *RoleService) CreateOidcMapping(ctx context.Context, claimValue, roleID string, environmentID *string) (*models.OidcRoleMapping, error) {
 	if strings.TrimSpace(claimValue) == "" {
-		return nil, fmt.Errorf("claim value is required")
+		return nil, errors.New("claim value is required")
 	}
 	if strings.TrimSpace(roleID) == "" {
-		return nil, fmt.Errorf("role id is required")
+		return nil, errors.New("role id is required")
 	}
 	mapping := &models.OidcRoleMapping{
 		ClaimValue:    claimValue,

--- a/backend/internal/services/settings_service.go
+++ b/backend/internal/services/settings_service.go
@@ -277,14 +277,14 @@ func (s *SettingsService) loadDatabaseConfigFromEnv(ctx context.Context, db *dat
 			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env override found", "key", key, "env", envVarName, "valueMasked", mask)
 			rv.Field(i).FieldByName("Value").SetString(utils.TrimQuotes(val))
 			continue
-		} else if val, ok := settingsMap[key]; ok {
+		}
+		if val, ok := settingsMap[key]; ok {
 			// Fallback to database if environment variable is not set
 			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: using database fallback", "key", key)
 			rv.Field(i).FieldByName("Value").SetString(val)
 			continue
-		} else {
-			slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env not set and no database value", "key", key, "env", envVarName)
 		}
+		slog.DebugContext(ctx, "loadDatabaseConfigFromEnv: env not set and no database value", "key", key, "env", envVarName)
 	}
 
 	// debug: final snapshot (only show which fields are non-empty)
@@ -466,7 +466,7 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 	changedAutoHeal := false
 	changedTimeouts := make([]libarcane.SettingUpdate, 0)
 
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		field := rt.Field(i)
 		fieldValue := rv.Field(i)
 
@@ -499,7 +499,7 @@ func (s *SettingsService) prepareUpdateValues(updates settings.Update, cfg, defa
 		}
 
 		if key == "accentColor" && value != "" && value != "default" && !settings.SafeAccentColor.MatchString(value) {
-			return nil, false, false, false, false, false, nil, fmt.Errorf("invalid accentColor value")
+			return nil, false, false, false, false, false, nil, errors.New("invalid accentColor value")
 		}
 
 		var valueToSave string
@@ -828,11 +828,11 @@ func (s *SettingsService) GetStringSetting(ctx context.Context, key, defaultValu
 }
 
 func (s *SettingsService) SetBoolSetting(ctx context.Context, key string, value bool) error {
-	return s.UpdateSetting(ctx, key, fmt.Sprintf("%t", value))
+	return s.UpdateSetting(ctx, key, strconv.FormatBool(value))
 }
 
 func (s *SettingsService) SetIntSetting(ctx context.Context, key string, value int) error {
-	return s.UpdateSetting(ctx, key, fmt.Sprintf("%d", value))
+	return s.UpdateSetting(ctx, key, strconv.Itoa(value))
 }
 
 func (s *SettingsService) SetStringSetting(ctx context.Context, key, value string) error {

--- a/backend/internal/services/swarm_service.go
+++ b/backend/internal/services/swarm_service.go
@@ -648,7 +648,7 @@ func (s *SwarmService) fetchSwarmNodeIdentityViaEdgeInternal(ctx context.Context
 		return nil, err
 	}
 	if !parsed.Success {
-		return nil, fmt.Errorf("swarm node identity probe failed")
+		return nil, errors.New("swarm node identity probe failed")
 	}
 
 	return &parsed.Data, nil
@@ -841,10 +841,7 @@ func (s *SwarmService) DeployStack(ctx context.Context, environmentID string, re
 		workingDir = stackSourceDir
 	}
 
-	pm, err := s.getPathMapperInternal(ctx)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to initialize path mapper, deploying without path translation", "error", err)
-	}
+	pm := s.getPathMapperInternal(ctx)
 
 	if err := libswarm.DeployStack(ctx, dockerClient, libswarm.StackDeployOptions{
 		Name:             stackName,
@@ -1652,10 +1649,7 @@ func (s *SwarmService) RenderStackConfig(ctx context.Context, req swarmtypes.Sta
 		return nil, err
 	}
 
-	pm, err := s.getPathMapperInternal(ctx)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to initialize path mapper, deploying without path translation", "error", err)
-	}
+	pm := s.getPathMapperInternal(ctx)
 
 	result, err := libswarm.RenderStackConfig(ctx, libswarm.StackRenderOptions{
 		Name:           req.Name,
@@ -2241,7 +2235,7 @@ func (s *SwarmService) resolveSwarmStackSourceEnvironmentDirInternal(ctx context
 	return rootDir, environmentDir, nil
 }
 
-func (s *SwarmService) getPathMapperInternal(ctx context.Context) (*appfs.PathMapper, error) {
+func (s *SwarmService) getPathMapperInternal(ctx context.Context) *appfs.PathMapper {
 	configuredPath := s.settingsService.GetStringSetting(ctx, "swarmStackSourcesDirectory", defaultSwarmStackSourceRootDir)
 
 	var containerDir, hostDir string
@@ -2284,10 +2278,10 @@ func (s *SwarmService) getPathMapperInternal(ctx context.Context) (*appfs.PathMa
 
 	pm := appfs.NewPathMapper(containerDirResolved, hostDirResolved)
 	if !pm.IsNonMatchingMount() {
-		return nil, nil
+		return nil
 	}
 
-	return pm, nil
+	return pm
 }
 
 func (s *SwarmService) ensureSwarmManagerInternal(ctx context.Context) error {
@@ -2449,7 +2443,7 @@ func (s *SwarmService) buildStackPaginationConfigInternal() pagination.Config[sw
 func buildPaginationResponseInternal[T any](result pagination.FilterResult[T], params pagination.QueryParams) pagination.Response {
 	totalPages := int64(0)
 	if params.Limit > 0 {
-		totalPages = (int64(result.TotalCount) + int64(params.Limit) - 1) / int64(params.Limit)
+		totalPages = (result.TotalCount + int64(params.Limit) - 1) / int64(params.Limit)
 	}
 
 	page := 1
@@ -2459,10 +2453,10 @@ func buildPaginationResponseInternal[T any](result pagination.FilterResult[T], p
 
 	return pagination.Response{
 		TotalPages:      totalPages,
-		TotalItems:      int64(result.TotalCount),
+		TotalItems:      result.TotalCount,
 		CurrentPage:     page,
 		ItemsPerPage:    params.Limit,
-		GrandTotalItems: int64(result.TotalAvailable),
+		GrandTotalItems: result.TotalAvailable,
 	}
 }
 

--- a/backend/internal/services/swarm_service_test.go
+++ b/backend/internal/services/swarm_service_test.go
@@ -129,8 +129,7 @@ func TestSwarmService_getPathMapperInternal(t *testing.T) {
 	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
 
 	t.Run("returns nil when paths match", func(t *testing.T) {
-		pm, err := svc.getPathMapperInternal(ctx)
-		require.NoError(t, err)
+		pm := svc.getPathMapperInternal(ctx)
 		require.Nil(t, pm) // Default is /app/data/swarm/sources which matches itself
 	})
 
@@ -140,8 +139,7 @@ func TestSwarmService_getPathMapperInternal(t *testing.T) {
 		err := settingsSvc.UpdateSetting(ctx, "swarmStackSourcesDirectory", containerDir+":"+hostDir)
 		require.NoError(t, err)
 
-		pm, err := svc.getPathMapperInternal(ctx)
-		require.NoError(t, err)
+		pm := svc.getPathMapperInternal(ctx)
 		require.NotNil(t, pm)
 		require.True(t, pm.IsNonMatchingMount())
 

--- a/backend/internal/services/system_service.go
+++ b/backend/internal/services/system_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -454,7 +455,7 @@ func (s *SystemService) pruneContainersInternal(ctx context.Context, options sys
 	filterArgs := make(client.Filters)
 	if options.Mode == system.PruneContainerModeOlderThan {
 		if strings.TrimSpace(options.Until) == "" {
-			return fmt.Errorf("container prune mode olderThan requires until")
+			return errors.New("container prune mode olderThan requires until")
 		}
 		filterArgs = filterArgs.Add("until", options.Until)
 	}
@@ -479,14 +480,14 @@ func (s *SystemService) pruneImagesInternal(ctx context.Context, options system.
 	filterArgs := make(client.Filters)
 	switch options.Mode {
 	case system.PruneImageModeNone:
-		return fmt.Errorf("image prune mode none is not allowed")
+		return errors.New("image prune mode none is not allowed")
 	case system.PruneImageModeDangling:
 		filterArgs = filterArgs.Add("dangling", "true")
 	case system.PruneImageModeAll:
 		filterArgs = filterArgs.Add("dangling", "false")
 	case system.PruneImageModeOlderThan:
 		if strings.TrimSpace(options.Until) == "" {
-			return fmt.Errorf("image prune mode olderThan requires until")
+			return errors.New("image prune mode olderThan requires until")
 		}
 		filterArgs = filterArgs.Add("dangling", "false")
 		filterArgs = filterArgs.Add("until", options.Until)
@@ -537,7 +538,7 @@ func (s *SystemService) pruneBuildCacheInternal(ctx context.Context, options sys
 	}
 	if options.Mode == system.PruneBuildCacheModeOlderThan {
 		if strings.TrimSpace(options.Until) == "" {
-			return fmt.Errorf("build cache prune mode olderThan requires until")
+			return errors.New("build cache prune mode olderThan requires until")
 		}
 		pruneOptions.Filters = make(client.Filters)
 		pruneOptions.Filters = pruneOptions.Filters.Add("until", options.Until)
@@ -582,7 +583,7 @@ func (s *SystemService) pruneNetworksInternal(ctx context.Context, options syste
 	filterArgs := make(client.Filters)
 	if options.Mode == system.PruneNetworkModeOlderThan {
 		if strings.TrimSpace(options.Until) == "" {
-			return fmt.Errorf("network prune mode olderThan requires until")
+			return errors.New("network prune mode olderThan requires until")
 		}
 		filterArgs = filterArgs.Add("until", options.Until)
 	}
@@ -600,14 +601,14 @@ func (s *SystemService) pruneNetworksInternal(ctx context.Context, options syste
 
 func (s *SystemService) ParseDockerRunCommand(command string) (*system.DockerRunCommand, error) {
 	if command == "" {
-		return nil, fmt.Errorf("docker run command must be a non-empty string")
+		return nil, errors.New("docker run command must be a non-empty string")
 	}
 
 	cmd := strings.TrimSpace(command)
 	cmd = regexp.MustCompile(`^docker\s+run\s+`).ReplaceAllString(cmd, "")
 
 	if cmd == "" {
-		return nil, fmt.Errorf("no arguments found after 'docker run'")
+		return nil, errors.New("no arguments found after 'docker run'")
 	}
 
 	result := &system.DockerRunCommand{}
@@ -617,7 +618,7 @@ func (s *SystemService) ParseDockerRunCommand(command string) (*system.DockerRun
 	}
 
 	if len(tokens) == 0 {
-		return nil, fmt.Errorf("no valid tokens found in docker run command")
+		return nil, errors.New("no valid tokens found in docker run command")
 	}
 
 	if err := dockerrun.ParseTokens(tokens, result); err != nil {
@@ -625,7 +626,7 @@ func (s *SystemService) ParseDockerRunCommand(command string) (*system.DockerRun
 	}
 
 	if result.Image == "" {
-		return nil, fmt.Errorf("no Docker image specified in command")
+		return nil, errors.New("no Docker image specified in command")
 	}
 
 	return result, nil
@@ -633,7 +634,7 @@ func (s *SystemService) ParseDockerRunCommand(command string) (*system.DockerRun
 
 func (s *SystemService) ConvertToDockerCompose(parsed *system.DockerRunCommand) (string, string, string, error) {
 	if parsed.Image == "" {
-		return "", "", "", fmt.Errorf("cannot convert to Docker Compose: no image specified")
+		return "", "", "", errors.New("cannot convert to Docker Compose: no image specified")
 	}
 
 	serviceName := parsed.Name

--- a/backend/internal/services/template_service.go
+++ b/backend/internal/services/template_service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -147,7 +148,7 @@ func (s *TemplateService) ensureRemoteTemplatesLoaded(ctx context.Context) error
 					s.remoteMu.Unlock()
 				}()
 
-				if _, err := s.refreshRemoteTemplates(bgCtx); err != nil {
+				if err := s.refreshRemoteTemplates(bgCtx); err != nil {
 					slog.WarnContext(bgCtx, "background remote template refresh failed", "error", err)
 				}
 			}(ctx)
@@ -160,21 +161,20 @@ func (s *TemplateService) ensureRemoteTemplatesLoaded(ctx context.Context) error
 	s.remoteMu.Unlock()
 
 	// No cache at all, must block
-	_, err := s.refreshRemoteTemplates(ctx)
-	return err
+	return s.refreshRemoteTemplates(ctx)
 }
 
-func (s *TemplateService) refreshRemoteTemplates(ctx context.Context) ([]models.ComposeTemplate, error) {
+func (s *TemplateService) refreshRemoteTemplates(ctx context.Context) error {
 	templates, err := s.loadRemoteTemplates(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load remote templates: %w", err)
+		return fmt.Errorf("failed to load remote templates: %w", err)
 	}
 
 	s.remoteMu.Lock()
 	defer s.remoteMu.Unlock()
 	s.remoteCache.templates = templates
 	s.remoteCache.lastFetch = time.Now()
-	return templates, nil
+	return nil
 }
 
 func (s *TemplateService) GetAllTemplates(ctx context.Context) ([]models.ComposeTemplate, error) {
@@ -286,7 +286,7 @@ func (s *TemplateService) GetTemplate(ctx context.Context, id string) (*models.C
 	// silently returned empty.
 	if strings.HasPrefix(id, remoteIDPrefix+":") {
 		slog.InfoContext(ctx, "remote template not in cache, forcing registry refresh", "templateID", id, "cacheSize", s.remoteCacheSizeInternal())
-		if _, refreshErr := s.refreshRemoteTemplates(ctx); refreshErr != nil {
+		if refreshErr := s.refreshRemoteTemplates(ctx); refreshErr != nil {
 			return nil, fmt.Errorf("template %q not found and registry refresh failed: %w", id, refreshErr)
 		}
 		if found := s.lookupRemoteFromCacheInternal(id); found != nil {
@@ -344,7 +344,7 @@ func (s *TemplateService) UpdateTemplate(ctx context.Context, id string, updates
 		}
 
 		if existing.IsRemote {
-			return fmt.Errorf("cannot update remote template")
+			return errors.New("cannot update remote template")
 		}
 
 		existing.Name = updates.Name
@@ -372,20 +372,19 @@ func (s *TemplateService) DeleteTemplate(ctx context.Context, id string) error {
 		}
 
 		if existing.IsRemote {
-			return fmt.Errorf("cannot delete remote template directly")
+			return errors.New("cannot delete remote template directly")
 		}
 
 		baseDir, err := s.getTemplatesDirectoryInternal(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get templates directory: %w", err)
-		} else {
-			templatePath := filepath.Join(baseDir, existing.Name)
+		}
 
-			if stat, err := os.Stat(templatePath); err == nil && stat.IsDir() {
-				if _, err := projects.DetectComposeFile(templatePath); err == nil {
-					if err := os.RemoveAll(templatePath); err != nil {
-						return fmt.Errorf("failed to delete template directory: %w", err)
-					}
+		templatePath := filepath.Join(baseDir, existing.Name)
+		if stat, err := os.Stat(templatePath); err == nil && stat.IsDir() {
+			if _, err := projects.DetectComposeFile(templatePath); err == nil {
+				if err := os.RemoveAll(templatePath); err != nil {
+					return fmt.Errorf("failed to delete template directory: %w", err)
 				}
 			}
 		}
@@ -464,9 +463,7 @@ func (s *TemplateService) GetRegistryFetchErrors() map[string]string {
 	s.registryMu.RLock()
 	defer s.registryMu.RUnlock()
 	out := make(map[string]string, len(s.registryErrors))
-	for k, v := range s.registryErrors {
-		out[k] = v
-	}
+	maps.Copy(out, s.registryErrors)
 	return out
 }
 
@@ -474,7 +471,7 @@ func (s *TemplateService) CreateRegistry(ctx context.Context, registry *models.T
 	// Hydrate metadata if needed
 	if registry.Name == "" || registry.Description == "" {
 		if registry.URL == "" {
-			return fmt.Errorf("registry URL is required")
+			return errors.New("registry URL is required")
 		}
 		if manifest, err := s.fetchRegistryManifest(ctx, registry.URL); err == nil {
 			if registry.Name == "" {
@@ -637,7 +634,7 @@ func (s *TemplateService) doGET(ctx context.Context, url string) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Do(req) //nolint:gosec // intentional request to configured template registry URL
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch %s: %w", url, err)
 	}
@@ -669,7 +666,7 @@ func (s *TemplateService) fetchRegistryTemplates(ctx context.Context, reg *model
 		req.Header.Set("If-Modified-Since", fetchMeta.LastModified)
 	}
 
-	resp, err := client.Do(req) //nolint:gosec // intentional request to configured template registry URL
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -679,7 +676,7 @@ func (s *TemplateService) fetchRegistryTemplates(ctx context.Context, reg *model
 		if fetchMeta != nil {
 			return cloneRemoteTemplates(fetchMeta.Templates), nil
 		}
-		return nil, fmt.Errorf("received 304 without cached data")
+		return nil, errors.New("received 304 without cached data")
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
@@ -723,7 +720,7 @@ func (s *TemplateService) fetchRegistryManifest(ctx context.Context, url string)
 		return nil, fmt.Errorf("failed to parse registry JSON: %w", err)
 	}
 	if reg.Name == "" || len(reg.Templates) == 0 {
-		return nil, fmt.Errorf("invalid registry manifest: missing required fields (name, templates)")
+		return nil, errors.New("invalid registry manifest: missing required fields (name, templates)")
 	}
 	return &reg, nil
 }
@@ -769,7 +766,7 @@ func (s *TemplateService) FetchTemplateContent(ctx context.Context, template *mo
 
 func (s *TemplateService) fetchRemoteTemplateFiles(ctx context.Context, template *models.ComposeTemplate) (string, string, error) {
 	if template == nil || template.Metadata == nil || template.Metadata.RemoteURL == nil {
-		return "", "", fmt.Errorf("not a remote template or missing remote URL")
+		return "", "", errors.New("not a remote template or missing remote URL")
 	}
 
 	composeContent, err := s.fetchURL(ctx, *template.Metadata.RemoteURL)
@@ -842,7 +839,7 @@ func (s *TemplateService) newSafeRequestInternal(ctx context.Context, method, ra
 	if client == nil {
 		client = s.newSafeHTTPClientInternal()
 		if client == nil {
-			return nil, nil, fmt.Errorf("failed to configure safe HTTP client")
+			return nil, nil, errors.New("failed to configure safe HTTP client")
 		}
 		s.safeHTTPClient = client
 	}
@@ -857,7 +854,7 @@ func (s *TemplateService) newSafeRequestInternal(ctx context.Context, method, ra
 
 func (s *TemplateService) DownloadTemplate(ctx context.Context, remoteTemplate *models.ComposeTemplate) (*models.ComposeTemplate, error) {
 	if !remoteTemplate.IsRemote {
-		return nil, fmt.Errorf("template is not remote")
+		return nil, errors.New("template is not remote")
 	}
 
 	base := s.templateBaseFromRemote(remoteTemplate)

--- a/backend/internal/services/template_service_test.go
+++ b/backend/internal/services/template_service_test.go
@@ -355,8 +355,8 @@ func TestGetAllTemplatesPaginated_FiltersByType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			templates, _, err := service.GetAllTemplatesPaginated(context.Background(), pagination.QueryParams{
-				PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
-				Filters:          map[string]string{"type": tt.typeFilter},
+				Params:  pagination.Params{Start: 0, Limit: 20},
+				Filters: map[string]string{"type": tt.typeFilter},
 			})
 			require.NoError(t, err)
 			require.ElementsMatch(t, tt.wantIDs, templateIDsInternal(templates))

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -90,7 +90,7 @@ func NewUpdaterService(
 // per-resource result summary. When dryRun is true, it reports the planned
 // actions without mutating containers or projects.
 //
-//nolint:gocognit
+//nolint:gocognit,gocyclo,maintidx // large but sequential update-orchestration flow; refactor tracked separately
 func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *updater.Result, err error) {
 	start := time.Now()
 	out = &updater.Result{Items: []updater.ResourceResult{}}
@@ -191,7 +191,7 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *up
 
 	for i := range plans {
 		p := plans[i]
-		s.appendAutoUpdateActivityMessageInternal(ctx, activityID, fmt.Sprintf("Checking update for %s", p.oldRef), "Checking image", 20)
+		s.appendAutoUpdateActivityMessageInternal(ctx, activityID, "Checking update for "+p.oldRef, "Checking image", 20)
 		item := updater.ResourceResult{
 			ResourceID:   p.oldRef,
 			ResourceType: "image",
@@ -501,7 +501,7 @@ func (s *UpdaterService) completeAutoUpdateActivityInternal(ctx context.Context,
 // UpdateSingleContainer updates a single container by ID to the latest available image.
 // It pulls the new image, stops the container, removes it, and recreates it with the new image.
 //
-//nolint:gocognit // single-container update flow is intentionally linear with explicit early exits for failure reporting
+//nolint:gocognit,gocyclo,maintidx // single-container update flow is intentionally linear with explicit early exits for failure reporting
 func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID string) (out *updater.Result, err error) {
 	start := time.Now()
 	out = &updater.Result{Items: []updater.ResourceResult{}}
@@ -876,7 +876,6 @@ func (s *UpdaterService) GetHistory(ctx context.Context, limit int) ([]models.Au
 
 // --- internals ---
 
-//nolint:gocognit
 func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summary, inspect container.InspectResponse, newRef string) error {
 	dcli, err := s.dockerService.GetClient(ctx)
 	if err != nil {
@@ -891,7 +890,7 @@ func (s *UpdaterService) updateContainer(ctx context.Context, cnt container.Summ
 	// This method should not be called for Arcane containers
 	if isArcane {
 		slog.ErrorContext(ctx, "updateContainer: called for Arcane container - should use CLI upgrade instead", "containerId", cnt.ID, "containerName", name)
-		return fmt.Errorf("arcane containers must use CLI upgrade method (TriggerUpgradeViaCLI), not inline update")
+		return errors.New("arcane containers must use CLI upgrade method (TriggerUpgradeViaCLI), not inline update")
 	}
 
 	slog.DebugContext(ctx, "updateContainer: starting update", "containerId", cnt.ID, "containerName", name, "newRef", newRef, "isArcane", isArcane)
@@ -1054,11 +1053,11 @@ func normalizeImageUpdateRefInternal(imageRef string) string {
 	return parts.NormalizedRef
 }
 
-func addNormalizedImageUpdateRefInternal(ctx context.Context, out map[string]struct{}, imageRef, logMessage string, attrs ...any) bool {
+func addNormalizedImageUpdateRefInternal(ctx context.Context, out map[string]struct{}, imageRef, logMessage string, attrs ...any) {
 	normalizedRef := normalizeImageUpdateRefInternal(imageRef)
 	if normalizedRef != "" {
 		out[normalizedRef] = struct{}{}
-		return true
+		return
 	}
 
 	args := slices.Clone(attrs)
@@ -1068,7 +1067,6 @@ func addNormalizedImageUpdateRefInternal(ctx context.Context, out map[string]str
 	} else {
 		slog.Debug(logMessage, args...)
 	}
-	return false
 }
 
 func (s *UpdaterService) stripDigest(ref string) string {
@@ -1361,7 +1359,7 @@ type restartPlan struct {
 	implicit bool
 }
 
-//nolint:gocognit
+//nolint:gocognit,gocyclo,maintidx // restart-orchestration flow remaps old/new container IDs in one pass; refactor tracked separately
 func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldIDToNewRef map[string]string, oldRefToNewRef map[string]string) ([]updater.ResourceResult, error) {
 	dcli, err := s.dockerService.GetClient(ctx)
 	if err != nil {
@@ -1942,14 +1940,14 @@ func (s *UpdaterService) logAutoUpdate(ctx context.Context, sev models.EventSeve
 			img = fmt.Sprint(metadata["imageOld"])
 		}
 		if img != "" {
-			title = fmt.Sprintf("Auto-update: image pull %s", img)
+			title = "Auto-update: image pull " + img
 		} else {
 			title = "Auto-update: image pull"
 		}
 	case "image_prune":
 		imageID := fmt.Sprint(metadata["imageId"])
 		if imageID != "" {
-			title = fmt.Sprintf("Auto-update: image prune %s", imageID)
+			title = "Auto-update: image prune " + imageID
 		} else {
 			title = "Auto-update: image prune"
 		}
@@ -1959,7 +1957,7 @@ func (s *UpdaterService) logAutoUpdate(ctx context.Context, sev models.EventSeve
 			name = fmt.Sprint(metadata["containerId"])
 		}
 		if name != "" {
-			title = fmt.Sprintf("Auto-update: container %s", name)
+			title = "Auto-update: container " + name
 		} else {
 			title = "Auto-update: container"
 		}
@@ -1969,7 +1967,7 @@ func (s *UpdaterService) logAutoUpdate(ctx context.Context, sev models.EventSeve
 			name = fmt.Sprint(metadata["projectId"])
 		}
 		if name != "" {
-			title = fmt.Sprintf("Auto-update: project %s", name)
+			title = "Auto-update: project " + name
 		} else {
 			title = "Auto-update: project"
 		}

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -98,7 +98,7 @@ func (s *UserService) validateBcryptPassword(hash, password string) error {
 func (s *UserService) validateArgon2Password(encodedHash, password string) error {
 	parts := strings.Split(encodedHash, "$")
 	if len(parts) != 6 {
-		return fmt.Errorf("invalid hash format")
+		return errors.New("invalid hash format")
 	}
 
 	var version int
@@ -107,7 +107,7 @@ func (s *UserService) validateArgon2Password(encodedHash, password string) error
 		return err
 	}
 	if version != argon2.Version {
-		return fmt.Errorf("incompatible version of argon2")
+		return errors.New("incompatible version of argon2")
 	}
 
 	var memory, iterations uint32
@@ -129,14 +129,14 @@ func (s *UserService) validateArgon2Password(encodedHash, password string) error
 
 	hashLen := len(decodedHash)
 	if hashLen < 0 || hashLen > 0x7fffffff {
-		return fmt.Errorf("invalid hash length")
+		return errors.New("invalid hash length")
 	}
 
 	comparisonHash := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, uint32(hashLen))
 
 	// constant-time compare
 	if subtle.ConstantTimeCompare(comparisonHash, decodedHash) != 1 {
-		return fmt.Errorf("invalid password")
+		return errors.New("invalid password")
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func (s *UserService) AttachOidcSubjectTransactional(ctx context.Context, userID
 
 		// If already linked to a different subject, abort
 		if u.OidcSubjectId != nil && *u.OidcSubjectId != "" && *u.OidcSubjectId != subject {
-			return fmt.Errorf("user already linked to another OIDC subject")
+			return errors.New("user already linked to another OIDC subject")
 		}
 
 		// Link subject
@@ -420,10 +420,7 @@ func (s *UserService) ListUsersPaginated(ctx context.Context, params pagination.
 		return nil, pagination.Response{}, fmt.Errorf("failed to paginate users: %w", err)
 	}
 
-	result, err := s.toUserResponseDtosInternal(ctx, users)
-	if err != nil {
-		return nil, pagination.Response{}, err
-	}
+	result := s.toUserResponseDtosInternal(ctx, users)
 
 	return result, paginationResp, nil
 }
@@ -432,12 +429,12 @@ func (s *UserService) ToUserResponseDto(ctx context.Context, u models.User) (use
 	return s.toUserResponseDtoInternal(ctx, u), nil
 }
 
-func (s *UserService) toUserResponseDtosInternal(ctx context.Context, users []models.User) ([]user.User, error) {
+func (s *UserService) toUserResponseDtosInternal(ctx context.Context, users []models.User) []user.User {
 	result := make([]user.User, len(users))
 	for i, u := range users {
 		result[i] = s.toUserResponseDtoInternal(ctx, u)
 	}
-	return result, nil
+	return result
 }
 
 // toUserResponseDtoInternal builds the public User DTO. RoleAssignments and

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -94,9 +94,9 @@ func TestListUsersPaginatedSetsCanDeleteFromGlobalAdminCount(t *testing.T) {
 	nonAdmin := createTestUser(t, userSvc, "user-1", "user")
 
 	users, _, err := userSvc.ListUsersPaginated(ctx, pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
-		SortParams:       pagination.SortParams{Sort: "Username", Order: pagination.SortOrder("asc")},
-		Filters:          map[string]string{},
+		Params:     pagination.Params{Start: 0, Limit: 20},
+		SortParams: pagination.SortParams{Sort: "Username", Order: pagination.SortOrder("asc")},
+		Filters:    map[string]string{},
 	})
 	require.NoError(t, err)
 	require.Len(t, users, 2)

--- a/backend/internal/services/version_service.go
+++ b/backend/internal/services/version_service.go
@@ -70,7 +70,7 @@ func (s *VersionService) getLatestReleaseInternal(ctx context.Context) (latestRe
 			return latestRelease{}, fmt.Errorf("create GitHub request: %w", err)
 		}
 
-		resp, err := s.httpClient.Do(req) //nolint:gosec // intentional request to fixed GitHub releases API endpoint
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return latestRelease{}, fmt.Errorf("get latest release: %w", err)
 		}
@@ -89,7 +89,7 @@ func (s *VersionService) getLatestReleaseInternal(ctx context.Context) (latestRe
 			return latestRelease{}, fmt.Errorf("decode payload: %w", err)
 		}
 		if payload.TagName == "" {
-			return latestRelease{}, fmt.Errorf("GitHub API returned empty tag name")
+			return latestRelease{}, errors.New("GitHub API returned empty tag name")
 		}
 
 		return latestRelease{
@@ -99,7 +99,7 @@ func (s *VersionService) getLatestReleaseInternal(ctx context.Context) (latestRe
 		}, nil
 	})
 
-	if staleErr, ok := errors.AsType[*cache.ErrStale](err); ok {
+	if staleErr, ok := errors.AsType[*cache.StaleError](err); ok {
 		slog.Warn("Failed to fetch latest release, returning stale cache", "error", staleErr.Err)
 		return rel, nil
 	}
@@ -176,7 +176,7 @@ func (s *VersionService) GetVersionInformation(ctx context.Context, currentVersi
 
 	latest, err := s.GetLatestVersion(ctx)
 	if err != nil {
-		if staleErr, ok := errors.AsType[*cache.ErrStale](err); ok {
+		if staleErr, ok := errors.AsType[*cache.StaleError](err); ok {
 			slog.Warn("Failed to refresh latest version; using stale cache", "error", staleErr.Err)
 		} else {
 			return check, err
@@ -207,7 +207,7 @@ func (s *VersionService) isSemverVersion() bool {
 func (s *VersionService) getDisplayVersion() string {
 	version := strings.TrimPrefix(strings.TrimSpace(s.version), "v")
 	if strings.Contains(strings.ToLower(version), "next") && s.revision != "" && s.revision != "unknown" {
-		return fmt.Sprintf("next-%s", config.ShortRevision())
+		return "next-" + config.ShortRevision()
 	}
 	if s.isSemverVersion() {
 		return "v" + version
@@ -246,7 +246,7 @@ func (s *VersionService) GetAppVersionInfo(ctx context.Context) *version.Info {
 	// For semver versions, check GitHub releases
 	if isSemver {
 		rel, err := s.getLatestReleaseInternal(ctx)
-		var staleErr *cache.ErrStale
+		var staleErr *cache.StaleError
 		if err == nil || errors.As(err, &staleErr) {
 			if rel.TagName != "" {
 				info.NewestVersion = rel.TagName

--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -445,7 +446,7 @@ func (s *VolumeService) getHelperImageInternal(ctx context.Context, dockerClient
 		pullErr = pullImageErr
 		slog.WarnContext(ctx, "volume service: failed to pull tools helper image, attempting arcane fallback", "error", pullImageErr.Error())
 	} else {
-		pullErr = fmt.Errorf("image service unavailable")
+		pullErr = errors.New("image service unavailable")
 		slog.WarnContext(ctx, "volume service: image service unavailable, attempting arcane fallback")
 	}
 
@@ -496,7 +497,7 @@ func resolveBackupStorageMountFromMountsInternal(mounts []container.MountPoint, 
 	}, true
 }
 
-func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) (backupStorageMountInternal, error) {
+func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) backupStorageMountInternal {
 	if dockerClient != nil {
 		containerID := s.getArcaneContainerIDInternal(ctx, dockerClient)
 		if containerID != "" {
@@ -504,7 +505,7 @@ func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, d
 			if err != nil {
 				slog.WarnContext(ctx, "volume service: failed to inspect arcane container for backup mount resolution, falling back to named volume", "container_id", containerID, "error", err.Error())
 			} else if resolved, ok := resolveBackupStorageMountFromMountsInternal(inspect.Container.Mounts, target, readOnly); ok {
-				return resolved, nil
+				return resolved
 			}
 		}
 	}
@@ -518,14 +519,11 @@ func (s *VolumeService) resolveBackupStorageMountInternal(ctx context.Context, d
 			ReadOnly: readOnly,
 		},
 		requiresEnsure: true,
-	}, nil
+	}
 }
 
 func (s *VolumeService) resolveUsableBackupStorageMountInternal(ctx context.Context, dockerClient *client.Client, target string, readOnly bool) (backupStorageMountInternal, error) {
-	backupStorage, err := s.resolveBackupStorageMountInternal(ctx, dockerClient, target, readOnly)
-	if err != nil {
-		return backupStorageMountInternal{}, err
-	}
+	backupStorage := s.resolveBackupStorageMountInternal(ctx, dockerClient, target, readOnly)
 	if backupStorage.requiresEnsure {
 		if err := s.ensureBackupVolumeInternal(ctx); err != nil {
 			return backupStorageMountInternal{}, err
@@ -668,6 +666,7 @@ func (s *VolumeService) createBackupTempContainerInternal(ctx context.Context, d
 type cleanupReadCloser struct {
 	io.Reader
 	io.Closer
+
 	cleanup func()
 }
 
@@ -936,7 +935,7 @@ func (s *VolumeService) DeleteFile(ctx context.Context, volumeName, filePath str
 	}
 	// Prevent deleting root
 	if sanitizedPath == "/" {
-		return fmt.Errorf("cannot delete root directory")
+		return errors.New("cannot delete root directory")
 	}
 
 	containerID, cleanup, err := s.createTempContainerInternal(ctx, volumeName, false)
@@ -1122,7 +1121,7 @@ func (s *VolumeService) CreateBackup(ctx context.Context, volumeName string, use
 	}
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
-		fmt.Sprintf("%s:/volume:ro", volumeName),
+		volumeName + ":/volume:ro",
 	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
@@ -1369,7 +1368,7 @@ func (s *VolumeService) RestoreBackup(ctx context.Context, volumeName, backupID 
 	}
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
-		fmt.Sprintf("%s:/volume", volumeName),
+		volumeName + ":/volume",
 	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
@@ -1414,7 +1413,7 @@ func (s *VolumeService) RestoreBackup(ctx context.Context, volumeName, backupID 
 func (s *VolumeService) sanitizeBackupPathInternal(input string) (string, error) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
-		return "", fmt.Errorf("invalid path: empty")
+		return "", errors.New("invalid path: empty")
 	}
 	cleaned := path.Clean(trimmed)
 	if cleaned == "." || cleaned == "/" {
@@ -1435,7 +1434,7 @@ func (s *VolumeService) sanitizeBackupIDInternal(backupID string) (string, error
 		return "", fmt.Errorf("invalid backup id: %w", err)
 	}
 	if strings.Contains(cleaned, "/") {
-		return "", fmt.Errorf("invalid backup id: path separators not allowed")
+		return "", errors.New("invalid backup id: path separators not allowed")
 	}
 	return cleaned, nil
 }
@@ -1446,7 +1445,7 @@ func (s *VolumeService) backupArchiveFilenameInternal(backupID string) (string, 
 		return "", err
 	}
 
-	return fmt.Sprintf("%s.tar.gz", sanitizedBackupID), nil
+	return sanitizedBackupID + ".tar.gz", nil
 }
 
 // sanitizeBrowsePath validates and cleans a path for file browser operations.
@@ -1463,11 +1462,11 @@ func (s *VolumeService) sanitizeBrowsePathInternal(input string) (string, error)
 	}
 	// Check for path traversal attempts
 	if strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") || cleaned == "/.." {
-		return "", fmt.Errorf("invalid path: path traversal not allowed")
+		return "", errors.New("invalid path: path traversal not allowed")
 	}
 	// After cleaning, the path should not escape root
 	if !strings.HasPrefix(cleaned, "/") {
-		return "", fmt.Errorf("invalid path: must be absolute")
+		return "", errors.New("invalid path: must be absolute")
 	}
 	return cleaned, nil
 }
@@ -1598,7 +1597,7 @@ func (s *VolumeService) ListBackupFiles(ctx context.Context, backupID string) ([
 func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, backupID string, paths []string, user models.User) error {
 	slog.DebugContext(ctx, "volume service: restore backup files", "volume", volumeName, "backup_id", backupID, "paths_count", len(paths), "user", user.ID)
 	if len(paths) == 0 {
-		return fmt.Errorf("no paths provided")
+		return errors.New("no paths provided")
 	}
 	filename, err := s.backupArchiveFilenameInternal(backupID)
 	if err != nil {
@@ -1610,7 +1609,7 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 		return err
 	}
 	if backup.VolumeName != volumeName {
-		return fmt.Errorf("backup does not belong to volume")
+		return errors.New("backup does not belong to volume")
 	}
 
 	// Create pre-restore backup for safety (consistent with RestoreBackup behavior)
@@ -1629,7 +1628,7 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 		cleanedPaths = append(cleanedPaths, cleaned)
 	}
 	if len(cleanedPaths) == 0 {
-		return fmt.Errorf("no valid paths provided")
+		return errors.New("no valid paths provided")
 	}
 
 	tarPaths := make([]string, 0, len(cleanedPaths))
@@ -1660,7 +1659,7 @@ func (s *VolumeService) RestoreBackupFiles(ctx context.Context, volumeName, back
 	}
 
 	hostConfig := s.buildHelperHostConfigInternal(helperImage, []string{
-		fmt.Sprintf("%s:/volume", volumeName),
+		volumeName + ":/volume",
 	}, []mount.Mount{backupStorage.mount})
 
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
@@ -1760,7 +1759,7 @@ func (s *VolumeService) UploadAndRestore(ctx context.Context, volumeName string,
 	}
 	defer func() {
 		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name()) //nolint:gosec // temp file path is generated by os.CreateTemp
+		_ = os.Remove(tmpFile.Name())
 	}()
 	if _, err := io.Copy(tmpFile, archive); err != nil {
 		return fmt.Errorf("failed to buffer upload: %w", err)
@@ -2209,7 +2208,7 @@ func (s *VolumeService) downloadFileFromContainerInternal(
 	if hdr.FileInfo().IsDir() {
 		_ = reader.Close()
 		cleanup()
-		return nil, 0, fmt.Errorf("path is a directory")
+		return nil, 0, errors.New("path is a directory")
 	}
 
 	return &cleanupReadCloser{

--- a/backend/internal/services/volume_service_test.go
+++ b/backend/internal/services/volume_service_test.go
@@ -250,8 +250,7 @@ func TestResolveBackupStorageMountFromMountsInternal(t *testing.T) {
 func TestResolveBackupStorageMountInternalFallsBackToNamedVolume(t *testing.T) {
 	svc := &VolumeService{backupVolumeName: "arcane-backups"}
 
-	got, err := svc.resolveBackupStorageMountInternal(context.Background(), nil, "/backups", true)
-	require.NoError(t, err)
+	got := svc.resolveBackupStorageMountInternal(context.Background(), nil, "/backups", true)
 	require.Equal(t, backupStorageModeNamedVolumeFallback, got.mode)
 	require.Equal(t, mount.TypeVolume, got.mount.Type)
 	require.Equal(t, "arcane-backups", got.mount.Source)

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -102,7 +102,10 @@ type VulnerabilityService struct {
 // getImageLock returns a mutex for the given image ID, creating one if needed
 func (s *VulnerabilityService) getImageLock(imageID string) *sync.Mutex {
 	lock, _ := s.scanLocks.LoadOrStore(imageID, &sync.Mutex{})
-	return lock.(*sync.Mutex)
+	if mu, ok := lock.(*sync.Mutex); ok {
+		return mu
+	}
+	return &sync.Mutex{}
 }
 
 func (s *VulnerabilityService) setScanPhaseInternal(imageID string, phase vulnerability.ScanPhase) {
@@ -347,7 +350,7 @@ func (s *VulnerabilityService) ScanImage(ctx context.Context, envID string, imag
 		ActivityID: utils.StringPtrFromTrimmed(activityID),
 	}
 	s.applyScanPhaseToResultInternal(pendingResult)
-	if saveErr := s.saveScanResultWithRetryInternal(scanCtx, pendingResult, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+	if saveErr := s.saveScanResultWithRetryInternal(scanCtx, pendingResult); saveErr != nil {
 		slog.WarnContext(scanCtx,
 			"failed to save pending scan result",
 			"error", saveErr,
@@ -370,15 +373,15 @@ func (s *VulnerabilityService) ScanImage(ctx context.Context, envID string, imag
 	return pendingResult, nil
 }
 
-func (s *VulnerabilityService) markStaleScanIfNeeded(ctx context.Context, record *models.VulnerabilityScanRecord) bool {
+func (s *VulnerabilityService) markStaleScanIfNeeded(ctx context.Context, record *models.VulnerabilityScanRecord) {
 	if record == nil {
-		return false
+		return
 	}
 	if record.Status != models.ScanStatusScanning && record.Status != models.ScanStatusPending {
-		return false
+		return
 	}
 	if time.Since(record.ScanTime) <= scanStaleTimeout {
-		return false
+		return
 	}
 
 	errMsg := "Scan timed out or was interrupted. Please retry."
@@ -388,7 +391,7 @@ func (s *VulnerabilityService) markStaleScanIfNeeded(ctx context.Context, record
 	s.clearScanPhaseInternal(record.ID)
 
 	if s.db == nil {
-		return true
+		return
 	}
 
 	if err := s.db.WithContext(ctx).
@@ -400,10 +403,8 @@ func (s *VulnerabilityService) markStaleScanIfNeeded(ctx context.Context, record
 			"duration": record.Duration,
 		}).Error; err != nil {
 		slog.WarnContext(ctx, "failed to mark stale scan as failed", "error", err, "scan_id", record.ID)
-		return false
+		return
 	}
-
-	return true
 }
 
 func (s *VulnerabilityService) scanImageInBackgroundInternal(ctx context.Context, envID string, imageID, imageName string, user models.User, activityID string) {
@@ -428,9 +429,9 @@ func (s *VulnerabilityService) scanImageInBackgroundInternal(ctx context.Context
 			ScanTime:   time.Now(),
 			Status:     vulnerability.ScanStatusFailed,
 			ActivityID: utils.StringPtrFromTrimmed(activityID),
-			Error:      fmt.Sprintf("Trivy scanner is not available: %s", err.Error()),
+			Error:      "Trivy scanner is not available: " + err.Error(),
 		}
-		if saveErr := s.saveScanResultWithRetryInternal(ctx, result, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+		if saveErr := s.saveScanResultWithRetryInternal(ctx, result); saveErr != nil {
 			slog.WarnContext(ctx, "failed to save scan result", "error", saveErr)
 		}
 		slog.WarnContext(ctx,
@@ -462,7 +463,7 @@ func (s *VulnerabilityService) scanImageInBackgroundInternal(ctx context.Context
 			Error:      err.Error(),
 			Duration:   duration,
 		}
-		if saveErr := s.saveScanResultWithRetryInternal(ctx, failedResult, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+		if saveErr := s.saveScanResultWithRetryInternal(ctx, failedResult); saveErr != nil {
 			slog.WarnContext(ctx, "failed to save failed scan result", "error", saveErr)
 		}
 		slog.WarnContext(ctx,
@@ -483,7 +484,7 @@ func (s *VulnerabilityService) scanImageInBackgroundInternal(ctx context.Context
 	s.ensureSummary(result)
 	s.setScanPhaseInternal(imageID, vulnerability.ScanPhaseStoringResults)
 	s.updateVulnerabilityScanActivityInternal(ctx, activityID, vulnerability.ScanPhaseStoringResults, 90, "Storing vulnerability results")
-	if saveErr := s.saveScanResultWithRetryInternal(ctx, result, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+	if saveErr := s.saveScanResultWithRetryInternal(ctx, result); saveErr != nil {
 		slog.WarnContext(ctx, "failed to save scan result", "error", saveErr)
 	}
 
@@ -1292,7 +1293,7 @@ func (s *VulnerabilityService) saveScheduledFailedScanInternal(
 		Error:     scanErr.Error(),
 		Duration:  duration,
 	}
-	if saveErr := s.saveScanResultWithRetryInternal(ctx, failedResult, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+	if saveErr := s.saveScanResultWithRetryInternal(ctx, failedResult); saveErr != nil {
 		slog.WarnContext(ctx, "failed to save failed scan result", "error", saveErr)
 	}
 	s.logScheduledScanEvent(ctx, envID, imageID, imageName, user, false, scanErr.Error())
@@ -1307,7 +1308,7 @@ func (s *VulnerabilityService) saveScheduledSuccessfulScanInternal(
 ) {
 	result.Duration = duration
 	s.ensureSummary(result)
-	if saveErr := s.saveScanResultWithRetryInternal(ctx, result, defaultScanSaveRetryAttempts, defaultScanSaveRetryDelay); saveErr != nil {
+	if saveErr := s.saveScanResultWithRetryInternal(ctx, result); saveErr != nil {
 		slog.WarnContext(ctx, "failed to save scan result", "error", saveErr)
 	}
 	s.logScheduledScanEvent(ctx, envID, imageID, imageName, user, true, "")
@@ -1359,7 +1360,7 @@ func (s *VulnerabilityService) sendScheduledVulnerabilitySummaryInternal(
 
 	summaryDate := time.Now().UTC().Format("2006-01-02")
 	payload := VulnerabilityNotificationPayload{
-		CVEID:        fmt.Sprintf("Daily Summary - %s", summaryDate),
+		CVEID:        "Daily Summary - " + summaryDate,
 		Severity:     fmt.Sprintf("Critical:%d High:%d Medium:%d Low:%d Unknown:%d", summary.severityCounts["CRITICAL"], summary.severityCounts["HIGH"], summary.severityCounts["MEDIUM"], summary.severityCounts["LOW"], summary.severityCounts["UNKNOWN"]),
 		ImageName:    fmt.Sprintf("%d image(s) scanned, %d with fixable vulnerabilities", scanned, summary.imagesWithFixable),
 		FixedVersion: fmt.Sprintf("%d fixable vulnerability record(s)", summary.totalFixable),
@@ -1552,7 +1553,8 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	outputPath := newTrivyOutputPathInternal()
 	defer cleanupTrivyOutputFileInContainerInternal(ctx, dockerClient, containerID, outputPath)
 
-	execCmd := []string{"trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout}
+	execCmd := make([]string, 0, 16)
+	execCmd = append(execCmd, "trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout)
 	execCmd = append(execCmd, trivyScanCacheBackendArgsInternal()...)
 	execCmd = append(execCmd, trivyDefaultRepositoryArgsInternal()...)
 	execCmd = append(execCmd, imageName)
@@ -1586,9 +1588,9 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	}
 
 	if execInspect.ExitCode != 0 {
-		errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+		errMsg := readTempFileExcerptInternal(stderrFile)
 		if errMsg == "" {
-			errMsg = readTempFileExcerptInternal(stdoutFile, trivyErrorExcerptSize)
+			errMsg = readTempFileExcerptInternal(stdoutFile)
 		}
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("exit status %d", execInspect.ExitCode)
@@ -1616,7 +1618,7 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	}
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+			errMsg := readTempFileExcerptInternal(stderrFile)
 			if errMsg == "" {
 				errMsg = "trivy scan produced no output"
 			}
@@ -1629,7 +1631,7 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	}
 
 	if trivyReport == nil {
-		errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+		errMsg := readTempFileExcerptInternal(stderrFile)
 		if errMsg == "" {
 			errMsg = "trivy scan produced no output"
 		}
@@ -1799,7 +1801,7 @@ func (s *VulnerabilityService) GetTrivyVersion(ctx context.Context) string {
 		return ""
 	}
 
-	return parseTrivyVersion(readTempFileExcerptInternal(stdoutFile, trivyErrorExcerptSize))
+	return parseTrivyVersion(readTempFileExcerptInternal(stdoutFile))
 }
 
 func parseTrivyVersion(output string) string {
@@ -2220,17 +2222,17 @@ func (s *VulnerabilityService) ensureTrivyCacheVolumeInternal(ctx context.Contex
 }
 
 // runTrivyScan executes Trivy scan on an image
-func (s *VulnerabilityService) getTrivyConfigFiles() (configContent, ignoreContent string, err error) {
+func (s *VulnerabilityService) getTrivyConfigFiles() (configContent, ignoreContent string) {
 	if s.settingsService == nil {
-		return "", "", nil
+		return "", ""
 	}
 
 	cfg := s.settingsService.GetSettingsConfig()
 	if cfg == nil {
-		return "", "", nil
+		return "", ""
 	}
 
-	return cfg.TrivyConfig.Value, cfg.TrivyIgnore.Value, nil
+	return cfg.TrivyConfig.Value, cfg.TrivyIgnore.Value
 }
 
 func (s *VulnerabilityService) createTrivyConfigTempFile(ctx context.Context, content string) (string, bool) {
@@ -2242,7 +2244,7 @@ func (s *VulnerabilityService) createTrivyConfigTempFile(ctx context.Context, co
 	if _, err := configFile.WriteString(content); err != nil {
 		slog.WarnContext(ctx, "failed to write trivy config", "error", err)
 		_ = configFile.Close()
-		_ = os.Remove(configFile.Name()) //nolint:gosec // temp file path is generated by os.CreateTemp
+		_ = os.Remove(configFile.Name())
 		return "", false
 	}
 	_ = configFile.Close()
@@ -2258,7 +2260,7 @@ func (s *VulnerabilityService) createTrivyIgnoreTempFile(ctx context.Context, co
 	if _, err := ignoreFile.WriteString(content); err != nil {
 		slog.WarnContext(ctx, "failed to write trivy ignore", "error", err)
 		_ = ignoreFile.Close()
-		_ = os.Remove(ignoreFile.Name()) //nolint:gosec // temp file path is generated by os.CreateTemp
+		_ = os.Remove(ignoreFile.Name())
 		return "", false
 	}
 	_ = ignoreFile.Close()
@@ -2495,7 +2497,7 @@ func cleanupTrivyLogTempFilesInternal(ctx context.Context, files ...*os.File) {
 			continue
 		}
 
-		if err := os.Remove(path); err != nil { //nolint:gosec // temp file path comes from os.CreateTemp
+		if err := os.Remove(path); err != nil {
 			slog.WarnContext(ctx, "failed to remove trivy temp file", "path", path, "error", err)
 		}
 	}
@@ -2896,7 +2898,7 @@ func tempFileSizeInternal(file *os.File) int64 {
 	return stat.Size()
 }
 
-func readTempFileExcerptInternal(file *os.File, maxBytes int64) string {
+func readTempFileExcerptInternal(file *os.File) string {
 	if file == nil {
 		return ""
 	}
@@ -2905,12 +2907,7 @@ func readTempFileExcerptInternal(file *os.File, maxBytes int64) string {
 		return ""
 	}
 
-	reader := io.Reader(file)
-	if maxBytes > 0 {
-		reader = io.LimitReader(file, maxBytes)
-	}
-
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(io.LimitReader(file, trivyErrorExcerptSize))
 	if err != nil {
 		return ""
 	}
@@ -3422,10 +3419,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	}
 
 	// Get Trivy config files if they exist
-	configContent, ignoreContent, err := s.getTrivyConfigFiles()
-	if err != nil {
-		slog.WarnContext(ctx, "failed to get trivy config files", "error", err)
-	}
+	configContent, ignoreContent := s.getTrivyConfigFiles()
 
 	cacheDir := s.getTrivySingleScanCacheDirForSlotInternal(slotID)
 	if cacheDir != "" {
@@ -3476,9 +3470,9 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	defer removeDockerContainerInternal(ctx, dockerClient, containerID, "failed to cleanup trivy scan container")
 
 	if statusCode != 0 {
-		errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+		errMsg := readTempFileExcerptInternal(stderrFile)
 		if errMsg == "" {
-			errMsg = readTempFileExcerptInternal(stdoutFile, trivyErrorExcerptSize)
+			errMsg = readTempFileExcerptInternal(stdoutFile)
 		}
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("exit status %d", statusCode)
@@ -3505,7 +3499,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	}
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+			errMsg := readTempFileExcerptInternal(stderrFile)
 			if errMsg == "" {
 				errMsg = "trivy scan produced no output"
 			}
@@ -3518,7 +3512,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	}
 
 	if trivyReport == nil {
-		errMsg := readTempFileExcerptInternal(stderrFile, trivyErrorExcerptSize)
+		errMsg := readTempFileExcerptInternal(stderrFile)
 		if errMsg == "" {
 			errMsg = "trivy scan produced no output"
 		}
@@ -3549,15 +3543,11 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 func (s *VulnerabilityService) saveScanResultWithRetryInternal(
 	ctx context.Context,
 	result *vulnerability.ScanResult,
-	maxAttempts int,
-	retryDelay time.Duration,
 ) error {
-	if maxAttempts <= 0 {
-		maxAttempts = 1
-	}
-	if retryDelay < 0 {
-		retryDelay = 0
-	}
+	const (
+		maxAttempts = defaultScanSaveRetryAttempts
+		retryDelay  = defaultScanSaveRetryDelay
+	)
 
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -1004,7 +1004,7 @@ func TestVulnerabilityService_ListAllVulnerabilities_FiltersIgnoredInline(t *tes
 	require.NoError(t, db.Create(&ignore).Error)
 
 	items, page, err := svc.ListAllVulnerabilities(ctx, "env-1", pagination.QueryParams{
-		PaginationParams: pagination.PaginationParams{Start: 0, Limit: 20},
+		Params: pagination.Params{Start: 0, Limit: 20},
 	})
 	require.NoError(t, err)
 	require.Empty(t, items)

--- a/backend/internal/services/webhook_service.go
+++ b/backend/internal/services/webhook_service.go
@@ -202,7 +202,7 @@ func (s *WebhookService) CreateWebhook(ctx context.Context, name, targetType, ac
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:          models.EventTypeWebhookCreate,
 			Severity:      models.EventSeveritySuccess,
-			Title:         fmt.Sprintf("Webhook created: %s", wh.Name),
+			Title:         "Webhook created: " + wh.Name,
 			Description:   fmt.Sprintf("Created webhook '%s' targeting %s (%s)", wh.Name, wh.TargetType, wh.ActionType),
 			ResourceType:  new("webhook"),
 			ResourceID:    &wh.ID,
@@ -337,7 +337,7 @@ func (s *WebhookService) DeleteWebhook(ctx context.Context, id, environmentID st
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:          models.EventTypeWebhookDelete,
 			Severity:      models.EventSeverityInfo,
-			Title:         fmt.Sprintf("Webhook deleted: %s", wh.Name),
+			Title:         "Webhook deleted: " + wh.Name,
 			Description:   fmt.Sprintf("Deleted webhook '%s'", wh.Name),
 			ResourceType:  new("webhook"),
 			ResourceID:    &wh.ID,
@@ -372,7 +372,7 @@ func (s *WebhookService) UpdateWebhook(ctx context.Context, id, environmentID st
 		_, _ = s.eventService.CreateEvent(ctx, CreateEventRequest{
 			Type:          models.EventTypeWebhookUpdate,
 			Severity:      models.EventSeveritySuccess,
-			Title:         fmt.Sprintf("Webhook updated: %s", wh.Name),
+			Title:         "Webhook updated: " + wh.Name,
 			Description:   fmt.Sprintf("Updated webhook '%s' enabled=%v", wh.Name, enabled),
 			ResourceType:  new("webhook"),
 			ResourceID:    &wh.ID,
@@ -430,7 +430,7 @@ func (s *WebhookService) TriggerByToken(ctx context.Context, rawToken string) (*
 
 	// Record trigger time — best-effort, do not fail the request if this update fails.
 	now := time.Now()
-	_ = s.db.WithContext(ctx).Model(wh).Update("last_triggered_at", now).Error //nolint:errcheck
+	_ = s.db.WithContext(ctx).Model(wh).Update("last_triggered_at", now).Error
 
 	s.logWebhookEventInternal(ctx, wh, actionType, models.EventSeveritySuccess, "")
 
@@ -550,7 +550,7 @@ func (s *WebhookService) syncWebhookContainerTargetInternal(ctx context.Context,
 		return
 	}
 
-	_ = s.db.WithContext(ctx).Model(wh).Updates(updates).Error //nolint:errcheck
+	_ = s.db.WithContext(ctx).Model(wh).Updates(updates).Error
 }
 
 func (s *WebhookService) executeProjectWebhookActionInternal(ctx context.Context, wh *models.Webhook, actionType string) (*updater.Result, error) {
@@ -620,9 +620,9 @@ func (s *WebhookService) logWebhookEventInternal(ctx context.Context, wh *models
 	if s.eventService == nil {
 		return
 	}
-	title := fmt.Sprintf("Webhook triggered: %s", wh.Name)
+	title := "Webhook triggered: " + wh.Name
 	if severity == models.EventSeverityError {
-		title = fmt.Sprintf("Webhook trigger failed: %s", wh.Name)
+		title = "Webhook trigger failed: " + wh.Name
 	}
 	description := fmt.Sprintf("Target type: %s, action: %s", wh.TargetType, actionType)
 	if errMsg != "" {

--- a/backend/pkg/authz/permissions.go
+++ b/backend/pkg/authz/permissions.go
@@ -24,11 +24,12 @@ const (
 	PermUsersUpdate = "users:update"
 	PermUsersDelete = "users:delete"
 
-	// Role management (Create / Update / Delete) and role assignment to users
-	// are reserved for global admins and intentionally not exposed as delegated
-	// permissions — see backend/api/middleware/role.go::RequireGlobalAdmin.
-	// Likewise, managing OIDC group → role mappings is admin-only because it
-	// is effectively another path for granting role assignments.
+	// PermRolesList and the role permissions below cover role management
+	// (Create / Update / Delete) and role assignment to users. They are reserved
+	// for global admins and intentionally not exposed as delegated permissions —
+	// see backend/api/middleware/role.go::RequireGlobalAdmin. Likewise, managing
+	// OIDC group → role mappings is admin-only because it is effectively another
+	// path for granting role assignments.
 	PermRolesList = "roles:list"
 	PermRolesRead = "roles:read"
 

--- a/backend/pkg/dockerutil/cgroup_utils.go
+++ b/backend/pkg/dockerutil/cgroup_utils.go
@@ -34,7 +34,7 @@ func DetectCgroupLimits() (*CgroupLimits, error) {
 	}
 
 	if !isInCgroup() {
-		return nil, fmt.Errorf("not running in a cgroup")
+		return nil, errors.New("not running in a cgroup")
 	}
 
 	if isCgroupV2() {
@@ -178,7 +178,7 @@ func getCgroupV1Path() (string, error) {
 		return "", fmt.Errorf("error scanning cgroup file: %w", err)
 	}
 
-	return "", fmt.Errorf("cgroup path not found")
+	return "", errors.New("cgroup path not found")
 }
 
 func readCgroupV1Int64(path string) (int64, error) {

--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -2,7 +2,7 @@ package fswatch
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -79,7 +79,7 @@ func (fw *Watcher) Start(ctx context.Context) error {
 		return nil
 	}
 	if fw.stopped {
-		return fmt.Errorf("watcher already stopped")
+		return errors.New("watcher already stopped")
 	}
 
 	if err := fw.watcher.Add(fw.watchedPath); err != nil {

--- a/backend/pkg/gitutil/git.go
+++ b/backend/pkg/gitutil/git.go
@@ -86,7 +86,7 @@ func (c *Client) getAuth(config AuthConfig) (transport.AuthMethod, error) {
 
 			return publicKeys, nil
 		}
-		return nil, fmt.Errorf("ssh key required for ssh authentication")
+		return nil, errors.New("ssh key required for ssh authentication")
 	case "none":
 		return nil, nil
 	default:
@@ -410,7 +410,7 @@ func ValidatePath(repoPath, requestedPath string) error {
 		return fmt.Errorf("invalid path: %w", err)
 	}
 	if strings.HasPrefix(rel, "..") || strings.Contains(rel, string(filepath.Separator)+".."+string(filepath.Separator)) {
-		return fmt.Errorf("path traversal attempt detected")
+		return errors.New("path traversal attempt detected")
 	}
 
 	return nil
@@ -435,7 +435,7 @@ func (c *Client) BrowseTree(ctx context.Context, repoPath, targetPath string) ([
 	}
 
 	if !info.IsDir() {
-		return nil, fmt.Errorf("path is not a directory")
+		return nil, errors.New("path is not a directory")
 	}
 
 	entries, err := os.ReadDir(fullPath)
@@ -604,7 +604,7 @@ func (c *Client) WalkDirectory(ctx context.Context, repoPath, composePath string
 
 	// Validate we found at least one file
 	if len(result.Files) == 0 {
-		return nil, fmt.Errorf("no files found in sync directory (directory may be empty or all files were skipped)")
+		return nil, errors.New("no files found in sync directory (directory may be empty or all files were skipped)")
 	}
 
 	return result, nil

--- a/backend/pkg/libarcane/activity/writer.go
+++ b/backend/pkg/libarcane/activity/writer.go
@@ -210,7 +210,7 @@ func (w *Writer) updateLayerProgressInternal(id, status string, rawDetail any) *
 		statusLower := strings.ToLower(item.status)
 		switch {
 		case layerCompleteInternal(statusLower):
-			weighted += 1
+			weighted++
 		case strings.Contains(statusLower, "extracting"):
 			weighted += 0.95
 		case strings.Contains(statusLower, "verifying"):
@@ -224,10 +224,7 @@ func (w *Writer) updateLayerProgressInternal(id, status string, rawDetail any) *
 		}
 	}
 
-	progress := min(int((weighted/float64(len(w.layers)))*100), 100)
-	if progress < 0 {
-		progress = 0
-	}
+	progress := max(min(int((weighted/float64(len(w.layers)))*100), 100), 0)
 	return &progress
 }
 
@@ -420,7 +417,7 @@ func containerEventMessageInternal(payload map[string]any) string {
 	if state != "" {
 		return fmt.Sprintf("Container %s: %s", service, state)
 	}
-	return fmt.Sprintf("Container %s", service)
+	return "Container " + service
 }
 
 func fallbackStepInternal(value, fallback string) string {

--- a/backend/pkg/libarcane/crypto/encryption.go
+++ b/backend/pkg/libarcane/crypto/encryption.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -145,7 +146,7 @@ func atomicWriteHexFile(path string, key []byte, mode os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil { //nolint:gosec // destination path is internally derived from app-controlled config directory
+	if err := os.Rename(tmpPath, path); err != nil {
 		return err
 	}
 	if err := os.Chmod(path, mode); err != nil {
@@ -163,7 +164,7 @@ func deriveDevKey() []byte {
 // Encrypt encrypts a plaintext string using AES-GCM
 func Encrypt(plaintext string) (string, error) {
 	if encryptionKey == nil {
-		return "", fmt.Errorf("encryption not initialized - call InitEncryption first")
+		return "", errors.New("encryption not initialized - call InitEncryption first")
 	}
 
 	if plaintext == "" {
@@ -192,7 +193,7 @@ func Encrypt(plaintext string) (string, error) {
 // Decrypt decrypts a base64 encoded ciphertext string using AES-GCM
 func Decrypt(ciphertext string) (string, error) {
 	if encryptionKey == nil {
-		return "", fmt.Errorf("encryption not initialized - call InitEncryption first")
+		return "", errors.New("encryption not initialized - call InitEncryption first")
 	}
 
 	if ciphertext == "" {
@@ -216,7 +217,7 @@ func Decrypt(ciphertext string) (string, error) {
 
 	nonceSize := gcm.NonceSize()
 	if len(data) < nonceSize {
-		return "", fmt.Errorf("ciphertext too short")
+		return "", errors.New("ciphertext too short")
 	}
 
 	nonce, ciphertextBytes := data[:nonceSize], data[nonceSize:]

--- a/backend/pkg/libarcane/docker_compat.go
+++ b/backend/pkg/libarcane/docker_compat.go
@@ -2,6 +2,7 @@ package libarcane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -82,7 +83,7 @@ func IsDockerAPIVersionAtLeast(current, minimum string) bool {
 		return false
 	}
 
-	for i := range len(cur) {
+	for i := range cur {
 		if cur[i] > minV[i] {
 			return true
 		}
@@ -227,7 +228,7 @@ func ContainerCreateWithCompatibility(ctx context.Context, dockerClient client.A
 // already resolved the daemon API version.
 func ContainerCreateWithCompatibilityForAPIVersion(ctx context.Context, dockerClient client.APIClient, options client.ContainerCreateOptions, apiVersion string) (client.ContainerCreateResult, error) {
 	if dockerClient == nil {
-		return client.ContainerCreateResult{}, fmt.Errorf("docker api client is nil")
+		return client.ContainerCreateResult{}, errors.New("docker api client is nil")
 	}
 
 	adjustedOptions, extraEndpoints := PrepareContainerCreateOptionsForDockerAPI(options, apiVersion)

--- a/backend/pkg/libarcane/dockerrun/dockerrun.go
+++ b/backend/pkg/libarcane/dockerrun/dockerrun.go
@@ -1,6 +1,7 @@
 package dockerrun
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -20,7 +21,7 @@ func ParseTokens(tokens []string, result *systemtypes.DockerRunCommand) error {
 		} else {
 			if result.Image == "" {
 				if token == "" {
-					return fmt.Errorf("image name cannot be empty")
+					return errors.New("image name cannot be empty")
 				}
 				result.Image = token
 			} else {

--- a/backend/pkg/libarcane/edge/client.go
+++ b/backend/pkg/libarcane/edge/client.go
@@ -3,6 +3,7 @@ package edge
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -228,7 +229,7 @@ func (c *TunnelClient) connectAndServeManagedTunnelInternal(ctx context.Context)
 	if c.shouldAttemptWebSocketTunnelInternal() {
 		return c.connectAndServeWebSocket(ctx)
 	}
-	return fmt.Errorf("no edge tunnel transport is available")
+	return errors.New("no edge tunnel transport is available")
 }
 
 func (c *TunnelClient) shouldFallbackToWebSocketInternal() bool {
@@ -355,7 +356,7 @@ func (c *TunnelClient) registerMessageInternal() *TunnelMessage {
 
 func (c *TunnelClient) awaitRegistrationInternal(ctx context.Context) (*TunnelMessage, error) {
 	if c == nil || c.conn == nil {
-		return nil, fmt.Errorf("edge tunnel connection is not initialized")
+		return nil, errors.New("edge tunnel connection is not initialized")
 	}
 	conn := c.conn
 
@@ -386,7 +387,7 @@ func (c *TunnelClient) awaitRegistrationInternal(ctx context.Context) (*TunnelMe
 			return nil, fmt.Errorf("failed to receive tunnel registration response: %w", result.err)
 		}
 		if result.msg == nil {
-			return nil, fmt.Errorf("received empty tunnel registration response")
+			return nil, errors.New("received empty tunnel registration response")
 		}
 		if result.msg.Type != MessageTypeRegisterResponse {
 			return nil, fmt.Errorf("unexpected first tunnel message: %s", result.msg.Type)
@@ -940,7 +941,10 @@ func (c *TunnelClient) handleStreamData(ctx context.Context, msg *TunnelMessage)
 		slog.DebugContext(ctx, "Received WebSocket data for unknown stream", "stream_id", msg.ID)
 		return
 	}
-	stream := streamRaw.(*activeWSStream)
+	stream, ok := streamRaw.(*activeWSStream)
+	if !ok {
+		return
+	}
 	stream.mu.Lock()
 	if stream.closed {
 		stream.mu.Unlock()
@@ -966,7 +970,10 @@ func (c *TunnelClient) handleStreamClose(ctx context.Context, msg *TunnelMessage
 	if !ok {
 		return
 	}
-	stream := streamRaw.(*activeWSStream)
+	stream, ok := streamRaw.(*activeWSStream)
+	if !ok {
+		return
+	}
 	c.closeWebSocketStream(msg.ID, stream)
 	slog.DebugContext(ctx, "Closed WebSocket stream", "stream_id", msg.ID)
 }
@@ -1285,25 +1292,25 @@ func (r *streamingResponseRecorder) writeHeaderLocked(statusCode int) error {
 // StartTunnelClientWithErrors starts the tunnel client and returns a channel for connection errors.
 func StartTunnelClientWithErrors(ctx context.Context, cfg *Config, handler http.Handler) (<-chan error, error) {
 	if !cfg.EdgeAgent {
-		return nil, fmt.Errorf("edge tunnel disabled")
+		return nil, errors.New("edge tunnel disabled")
 	}
 
 	if UseGRPCEdgeTransport(cfg) {
 		if cfg.GetManagerGRPCAddr() == "" {
-			return nil, fmt.Errorf("MANAGER_API_URL with a valid host is required for gRPC transport")
+			return nil, errors.New("MANAGER_API_URL with a valid host is required for gRPC transport")
 		}
 	}
 
 	if UseWebSocketEdgeTransport(cfg) && strings.TrimSpace(cfg.GetManagerBaseURL()) == "" {
-		return nil, fmt.Errorf("MANAGER_API_URL is required for websocket transport")
+		return nil, errors.New("MANAGER_API_URL is required for websocket transport")
 	}
 
 	if UsePollEdgeTransport(cfg) && strings.TrimSpace(cfg.GetManagerBaseURL()) == "" {
-		return nil, fmt.Errorf("MANAGER_API_URL is required for poll transport")
+		return nil, errors.New("MANAGER_API_URL is required for poll transport")
 	}
 
 	if cfg.AgentToken == "" {
-		return nil, fmt.Errorf("AGENT_TOKEN is required")
+		return nil, errors.New("AGENT_TOKEN is required")
 	}
 
 	if err := EnsureAgentMTLSAssets(ctx, cfg); err != nil {

--- a/backend/pkg/libarcane/edge/client_transport_grpc.go
+++ b/backend/pkg/libarcane/edge/client_transport_grpc.go
@@ -3,6 +3,7 @@ package edge
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -21,7 +22,7 @@ import (
 func (c *TunnelClient) connectAndServeGRPC(ctx context.Context) error {
 	managerAddr := strings.TrimSpace(c.managerGRPCAddr)
 	if managerAddr == "" {
-		return fmt.Errorf("manager gRPC address is empty")
+		return errors.New("manager gRPC address is empty")
 	}
 
 	dialOpts := []grpc.DialOption{
@@ -47,7 +48,7 @@ func (c *TunnelClient) connectAndServeGRPC(ctx context.Context) error {
 			return fmt.Errorf("failed to configure edge gRPC TLS: %w", err)
 		}
 		if tlsConfig == nil {
-			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12} //nolint:gosec
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {

--- a/backend/pkg/libarcane/edge/client_transport_poll.go
+++ b/backend/pkg/libarcane/edge/client_transport_poll.go
@@ -25,7 +25,7 @@ type pollManagedTunnelSession struct {
 func (c *TunnelClient) connectAndServePoll(ctx context.Context) error {
 	managerBaseURL := strings.TrimRight(strings.TrimSpace(c.cfg.GetManagerBaseURL()), "/")
 	if managerBaseURL == "" {
-		return fmt.Errorf("manager base URL is empty")
+		return errors.New("manager base URL is empty")
 	}
 	httpClient, err := NewManagerHTTPClient(c.cfg, 0)
 	if err != nil {
@@ -202,7 +202,7 @@ func (c *TunnelClient) pollTunnelControlInternal(ctx context.Context, pollURL st
 }
 
 func (c *TunnelClient) startPollManagedSessionInternal(ctx context.Context) *pollManagedTunnelSession {
-	sessionCtx, cancel := context.WithCancel(ctx) //nolint:gosec // helper intentionally returns the cancel func via the managed session.
+	sessionCtx, cancel := context.WithCancel(ctx)
 	done := make(chan error, 1)
 
 	go func() {
@@ -228,7 +228,7 @@ func (c *TunnelClient) stopPollManagedSessionInternal(ctx context.Context, sessi
 		return err
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("timed out waiting for poll-managed websocket session to stop")
+			return errors.New("timed out waiting for poll-managed websocket session to stop")
 		}
 		return ctx.Err()
 	}

--- a/backend/pkg/libarcane/edge/client_transport_websocket.go
+++ b/backend/pkg/libarcane/edge/client_transport_websocket.go
@@ -2,6 +2,7 @@ package edge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,7 +16,7 @@ import (
 func (c *TunnelClient) connectAndServeWebSocket(ctx context.Context) error {
 	managerWSURL := c.managerWebSocketURLInternal()
 	if managerWSURL == "" {
-		return fmt.Errorf("manager WebSocket URL is empty")
+		return errors.New("manager WebSocket URL is empty")
 	}
 	c.managerURL = managerWSURL
 

--- a/backend/pkg/libarcane/edge/command_client.go
+++ b/backend/pkg/libarcane/edge/command_client.go
@@ -2,6 +2,7 @@ package edge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,13 +35,13 @@ func NewCommandClient() *CommandClient {
 
 func (c *CommandClient) Execute(ctx context.Context, tunnel *AgentTunnel, req *CommandRequest) (*CommandResult, error) {
 	if ctx == nil {
-		return nil, fmt.Errorf("context is required")
+		return nil, errors.New("context is required")
 	}
 	if err := validateConnectedTunnelInternal(tunnel); err != nil {
 		return nil, err
 	}
 	if req == nil {
-		return nil, fmt.Errorf("command request is required")
+		return nil, errors.New("command request is required")
 	}
 
 	commandName := req.Command
@@ -100,16 +101,16 @@ func (c *CommandClient) Execute(ctx context.Context, tunnel *AgentTunnel, req *C
 
 func (c *CommandClient) OpenStream(ctx context.Context, tunnel *AgentTunnel, req *CommandRequest) error {
 	if ctx == nil {
-		return fmt.Errorf("context is required")
+		return errors.New("context is required")
 	}
 	if err := validateConnectedTunnelInternal(tunnel); err != nil {
 		return err
 	}
 	if req == nil {
-		return fmt.Errorf("command request is required")
+		return errors.New("command request is required")
 	}
 	if req.ID == "" {
-		return fmt.Errorf("stream ID is required")
+		return errors.New("stream ID is required")
 	}
 
 	commandName := req.Command
@@ -143,7 +144,7 @@ var DefaultCommandClient = NewCommandClient()
 
 func validateConnectedTunnelInternal(tunnel *AgentTunnel) error {
 	if tunnel == nil || tunnel.Conn == nil || tunnel.Conn.IsClosed() {
-		return fmt.Errorf("edge tunnel is not connected")
+		return errors.New("edge tunnel is not connected")
 	}
 	return nil
 }

--- a/backend/pkg/libarcane/edge/event_sync.go
+++ b/backend/pkg/libarcane/edge/event_sync.go
@@ -2,7 +2,6 @@ package edge
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -40,13 +39,13 @@ func getActiveAgentTunnelConn() TunnelConnection {
 // PublishEventToManager sends an event from the active agent tunnel to the manager.
 func PublishEventToManager(event *TunnelEvent) error {
 	if event == nil {
-		return fmt.Errorf("event is required")
+		return errors.New("event is required")
 	}
 	if strings.TrimSpace(event.Type) == "" {
-		return fmt.Errorf("event type is required")
+		return errors.New("event type is required")
 	}
 	if strings.TrimSpace(event.Title) == "" {
-		return fmt.Errorf("event title is required")
+		return errors.New("event title is required")
 	}
 
 	conn := getActiveAgentTunnelConn()

--- a/backend/pkg/libarcane/edge/proxy.go
+++ b/backend/pkg/libarcane/edge/proxy.go
@@ -46,7 +46,7 @@ func ProxyRequest(ctx context.Context, tunnel *AgentTunnel, method, path, query 
 
 func registerPendingRequestInternal(tunnel *AgentTunnel, requestID string) (<-chan *TunnelMessage, error) {
 	if requestID == "" {
-		return nil, fmt.Errorf("request ID is required")
+		return nil, errors.New("request ID is required")
 	}
 
 	respCh := make(chan *TunnelMessage, 256)
@@ -79,9 +79,8 @@ func collectCommandResponseInternal(ctx context.Context, respCh <-chan *TunnelMe
 			case MessageTypeCommandOutput, MessageTypeStreamData, MessageTypeFileChunk:
 				state.handleStreamData(incoming)
 			case MessageTypeCommandComplete:
-				if done, status, headers, body, err := state.handleCommandComplete(incoming); done {
-					return status, headers, body, err
-				}
+				status, headers, body, err := state.handleCommandComplete(incoming)
+				return status, headers, body, err
 			case MessageTypeStreamEnd:
 				if done, status, headers, body := state.handleStreamEnd(); done {
 					return status, headers, body, nil
@@ -151,7 +150,7 @@ func (s *grpcResponseState) handleStreamEnd() (bool, int, map[string]string, []b
 	return true, s.status, stripInternalTunnelHeaders(s.respHeaders), s.respBody.Bytes()
 }
 
-func (s *grpcResponseState) handleCommandComplete(incoming *TunnelMessage) (bool, int, map[string]string, []byte, error) {
+func (s *grpcResponseState) handleCommandComplete(incoming *TunnelMessage) (int, map[string]string, []byte, error) {
 	if !s.gotResponse {
 		s.gotResponse = true
 		s.status = incoming.Status
@@ -161,9 +160,9 @@ func (s *grpcResponseState) handleCommandComplete(incoming *TunnelMessage) (bool
 		s.respBody.Write(incoming.Body)
 	}
 	if incoming.Error != "" && incoming.Status >= http.StatusBadRequest {
-		return true, incoming.Status, stripInternalTunnelHeaders(s.respHeaders), s.respBody.Bytes(), errors.New(incoming.Error)
+		return incoming.Status, stripInternalTunnelHeaders(s.respHeaders), s.respBody.Bytes(), errors.New(incoming.Error)
 	}
-	return true, incoming.Status, stripInternalTunnelHeaders(s.respHeaders), s.respBody.Bytes(), nil
+	return incoming.Status, stripInternalTunnelHeaders(s.respHeaders), s.respBody.Bytes(), nil
 }
 
 // ProxyHTTPRequest is a helper that proxies an echo context through a tunnel

--- a/backend/pkg/libarcane/edge/remenv.go
+++ b/backend/pkg/libarcane/edge/remenv.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	HeaderAPIKey        = "X-API-Key" // #nosec G101: header name, not a credential
+	HeaderAPIKey        = "X-Api-Key" // #nosec G101: header name, not a credential
 	HeaderAuthorization = "Authorization"
 	HeaderCookie        = "Cookie"
 	HeaderAgentToken    = "X-Arcane-Agent-Token" // #nosec G101: header name, not a credential

--- a/backend/pkg/libarcane/edge/server.go
+++ b/backend/pkg/libarcane/edge/server.go
@@ -516,7 +516,10 @@ func (s *TunnelServer) handleHeartbeat(ctx context.Context, tunnel *AgentTunnel,
 
 func (s *TunnelServer) deliverResponse(ctx context.Context, tunnel *AgentTunnel, msg *TunnelMessage) {
 	if req, ok := tunnel.Pending.Load(msg.ID); ok {
-		pending := req.(*PendingRequest)
+		pending, isPending := req.(*PendingRequest)
+		if !isPending {
+			return
+		}
 		select {
 		case pending.ResponseCh <- msg:
 		default:
@@ -529,7 +532,10 @@ func (s *TunnelServer) deliverResponse(ctx context.Context, tunnel *AgentTunnel,
 
 func (s *TunnelServer) deliverStream(ctx context.Context, tunnel *AgentTunnel, msg *TunnelMessage) {
 	if req, ok := tunnel.Pending.Load(msg.ID); ok {
-		pending := req.(*PendingRequest)
+		pending, isPending := req.(*PendingRequest)
+		if !isPending {
+			return
+		}
 		select {
 		case pending.ResponseCh <- msg:
 		case <-ctx.Done():
@@ -652,6 +658,7 @@ func (s *TunnelServer) recoveryStreamInterceptorInternal(ctx context.Context) gr
 
 type contextualServerStream struct {
 	grpc.ServerStream
+
 	ctx context.Context
 }
 

--- a/backend/pkg/libarcane/edge/tls.go
+++ b/backend/pkg/libarcane/edge/tls.go
@@ -105,7 +105,11 @@ func BuildManagerServerTLSConfig(cfg *Config) (*tls.Config, error) {
 // NewManagerHTTPClient creates an HTTP client for agent-to-manager requests,
 // applying edge TLS settings when the manager URL uses HTTPS.
 func NewManagerHTTPClient(cfg *Config, timeout time.Duration) (*http.Client, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, &common.DefaultTransportTypeError{}
+	}
+	transport := baseTransport.Clone()
 	tlsConfig, err := buildManagerClientTLSConfigInternal(cfg)
 	if err != nil {
 		return nil, err
@@ -144,7 +148,7 @@ func PrepareManagerMTLSAssetsWithContext(ctx context.Context, cfg *Config) error
 // GeneratedManagerMTLSCAPath returns the configured or Arcane-managed manager CA path without creating assets.
 func GeneratedManagerMTLSCAPath(cfg *Config) (string, error) {
 	if cfg == nil {
-		return "", fmt.Errorf("edge config is required")
+		return "", errors.New("edge config is required")
 	}
 	if configured := strings.TrimSpace(cfg.EdgeMTLSCAFile); configured != "" {
 		return configured, nil
@@ -162,7 +166,7 @@ func GenerateManagerClientMTLSAssetsWithContext(ctx context.Context, cfg *Config
 		return nil, nil
 	}
 	if strings.TrimSpace(envID) == "" {
-		return nil, fmt.Errorf("environment ID is required")
+		return nil, errors.New("environment ID is required")
 	}
 
 	assetsDir, err := edgeMTLSAssetsDirInternal(cfg)
@@ -243,7 +247,7 @@ func managerMTLSEnrollmentMarkerPathInternal(cfg *Config, envID string) (string,
 	}
 	safeEnvID := generatedAssetNameSanitizer.ReplaceAllString(strings.TrimSpace(envID), "_")
 	if safeEnvID == "" {
-		return "", fmt.Errorf("environment ID is required")
+		return "", errors.New("environment ID is required")
 	}
 	return filepath.Join(assetsDir, generatedClientMTLSSubdir, safeEnvID, generatedMTLSEnrolledName), nil
 }
@@ -273,7 +277,7 @@ func GeneratedManagerClientMTLSCertPath(cfg *Config, envID string) (string, erro
 
 	safeEnvID := generatedAssetNameSanitizer.ReplaceAllString(strings.TrimSpace(envID), "_")
 	if safeEnvID == "" {
-		return "", fmt.Errorf("environment ID is required")
+		return "", errors.New("environment ID is required")
 	}
 
 	return filepath.Join(assetsDir, "clients", safeEnvID, generatedMTLSClientCertName), nil
@@ -322,10 +326,10 @@ func EnsureAgentMTLSAssets(ctx context.Context, cfg *Config) error {
 func enrollAgentMTLSAssetsInternal(ctx context.Context, cfg *Config, assetsDir, certPath, keyPath string) error {
 	managerBaseURL := strings.TrimRight(strings.TrimSpace(cfg.GetManagerBaseURL()), "/")
 	if managerBaseURL == "" {
-		return fmt.Errorf("MANAGER_API_URL is required to enroll edge mTLS assets")
+		return errors.New("MANAGER_API_URL is required to enroll edge mTLS assets")
 	}
 	if !managerUsesTLSInternal(cfg) {
-		return fmt.Errorf("EDGE_MTLS_MODE requires MANAGER_API_URL to use https for certificate enrollment")
+		return errors.New("EDGE_MTLS_MODE requires MANAGER_API_URL to use https for certificate enrollment")
 	}
 
 	httpClient, err := NewManagerHTTPClient(cfg, 30*time.Second)
@@ -341,7 +345,7 @@ func enrollAgentMTLSAssetsInternal(ctx context.Context, cfg *Config, assetsDir, 
 	req.Header.Set(HeaderAPIKey, cfg.AgentToken)
 	req.Header.Set(HeaderAuthorization, "Bearer "+cfg.AgentToken)
 
-	resp, err := httpClient.Do(req) //nolint:gosec // intentional request to configured manager endpoint
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("edge mTLS enrollment request failed: %w", err)
 	}
@@ -357,7 +361,7 @@ func enrollAgentMTLSAssetsInternal(ctx context.Context, cfg *Config, assetsDir, 
 		return fmt.Errorf("failed to decode edge mTLS enrollment response: %w", err)
 	}
 	if len(enrollResp.Files) == 0 {
-		return fmt.Errorf("edge mTLS enrollment response did not include any files")
+		return errors.New("edge mTLS enrollment response did not include any files")
 	}
 
 	if err := os.MkdirAll(assetsDir, common.DirPerm); err != nil {
@@ -447,7 +451,7 @@ func ValidateAgentMTLSConfig(cfg *Config) error {
 	}
 
 	if !managerUsesTLSInternal(cfg) {
-		return fmt.Errorf("EDGE_MTLS_MODE requires MANAGER_API_URL to use https")
+		return errors.New("EDGE_MTLS_MODE requires MANAGER_API_URL to use https")
 	}
 
 	_, err := buildManagerClientTLSConfigInternal(cfg)
@@ -480,7 +484,7 @@ func ValidateManagerMTLSConfig(cfg *Config) error {
 func loadCertPoolInternal(caFile string) (*x509.CertPool, error) {
 	caFile = strings.TrimSpace(caFile)
 	if caFile == "" {
-		return nil, fmt.Errorf("CA file is required")
+		return nil, errors.New("CA file is required")
 	}
 
 	pemBytes, err := os.ReadFile(caFile)
@@ -490,7 +494,7 @@ func loadCertPoolInternal(caFile string) (*x509.CertPool, error) {
 
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(pemBytes) {
-		return nil, fmt.Errorf("failed to parse PEM certificates")
+		return nil, errors.New("failed to parse PEM certificates")
 	}
 
 	return pool, nil
@@ -513,7 +517,7 @@ func loadSystemOrCustomCertPoolInternal(caFile string) (*x509.CertPool, error) {
 		return nil, err
 	}
 	if !pool.AppendCertsFromPEM(pemBytes) {
-		return nil, fmt.Errorf("failed to parse PEM certificates")
+		return nil, errors.New("failed to parse PEM certificates")
 	}
 	return pool, nil
 }
@@ -620,11 +624,11 @@ func verifiedPeerCertificateEnvironmentIDMatchesInternal(state *tls.ConnectionSt
 	}
 	expectedPath := expectedEdgeMTLSURIPathInternal(envID)
 	if expectedPath == "" {
-		return fmt.Errorf("environment ID is required for edge mTLS certificate identity check")
+		return errors.New("environment ID is required for edge mTLS certificate identity check")
 	}
 	trustDomain = strings.TrimSpace(strings.ToLower(strings.TrimSuffix(trustDomain, ".")))
 	if trustDomain == "" {
-		return fmt.Errorf("edge mTLS trust domain is required for certificate identity check")
+		return errors.New("edge mTLS trust domain is required for certificate identity check")
 	}
 	leaf := state.VerifiedChains[0][0]
 	for _, uri := range leaf.URIs {
@@ -662,7 +666,7 @@ func expectedEdgeMTLSURIPathInternal(envID string) string {
 
 func edgeMTLSAssetsDirInternal(cfg *Config) (string, error) {
 	if cfg == nil {
-		return "", fmt.Errorf("edge config is required")
+		return "", errors.New("edge config is required")
 	}
 
 	if configured := strings.TrimSpace(cfg.EdgeMTLSAssetsDir); configured != "" {
@@ -683,7 +687,7 @@ func edgeMTLSAssetsDirInternal(cfg *Config) (string, error) {
 
 func edgeAgentMTLSAssetsDirInternal(cfg *Config) (string, error) {
 	if cfg == nil {
-		return "", fmt.Errorf("edge config is required")
+		return "", errors.New("edge config is required")
 	}
 	if configured := strings.TrimSpace(cfg.EdgeMTLSAssetsDir); configured != "" {
 		return configured, nil
@@ -777,7 +781,7 @@ func ensureClientCertificateInternal(ctx context.Context, assetsDir string, envI
 
 	caCertBlock, _ := pem.Decode(caCertPEM)
 	if caCertBlock == nil {
-		return "", "", false, fmt.Errorf("failed to parse CA certificate PEM")
+		return "", "", false, errors.New("failed to parse CA certificate PEM")
 	}
 	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
 	if err != nil {
@@ -786,7 +790,7 @@ func ensureClientCertificateInternal(ctx context.Context, assetsDir string, envI
 
 	caKeyBlock, _ := pem.Decode(caKeyPEM)
 	if caKeyBlock == nil {
-		return "", "", false, fmt.Errorf("failed to parse CA private key PEM")
+		return "", "", false, errors.New("failed to parse CA private key PEM")
 	}
 	caKey, err := x509.ParseECPrivateKey(caKeyBlock.Bytes)
 	if err != nil {
@@ -904,11 +908,11 @@ func validateGeneratedCAInternal(certPath, keyPath string) error {
 		return err
 	}
 	if !cert.IsCA {
-		return fmt.Errorf("generated CA certificate is not a CA")
+		return errors.New("generated CA certificate is not a CA")
 	}
 	publicKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
 	if !ok || publicKey.Curve != elliptic.P384() {
-		return fmt.Errorf("generated CA certificate is not ECDSA P-384")
+		return errors.New("generated CA certificate is not ECDSA P-384")
 	}
 	keyPEM, err := readCAKeyPEMInternal(keyPath)
 	if err != nil {
@@ -923,7 +927,7 @@ func validateGeneratedCAInternal(certPath, keyPath string) error {
 		return fmt.Errorf("failed to parse CA private key %s: %w", keyPath, err)
 	}
 	if privateKey.Curve != elliptic.P384() {
-		return fmt.Errorf("generated CA private key is not ECDSA P-384")
+		return errors.New("generated CA private key is not ECDSA P-384")
 	}
 	if err := validateCertificateKeyPairInternal(cert, privateKey, "generated CA"); err != nil {
 		return err
@@ -938,7 +942,7 @@ func validateGeneratedClientCertificateInternal(certPath, keyPath string, expect
 	}
 	now := time.Now()
 	if now.Before(cert.NotBefore) || !now.Before(cert.NotAfter) {
-		return fmt.Errorf("generated client certificate is not currently valid")
+		return errors.New("generated client certificate is not currently valid")
 	}
 	if strings.TrimSpace(expectedCommonName) != "" && cert.Subject.CommonName != expectedCommonName {
 		return fmt.Errorf("generated client certificate common name %q does not match expected %q", cert.Subject.CommonName, expectedCommonName)
@@ -948,14 +952,14 @@ func validateGeneratedClientCertificateInternal(certPath, keyPath string, expect
 	}
 	publicKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
 	if !ok || publicKey.Curve != elliptic.P384() {
-		return fmt.Errorf("generated client certificate is not ECDSA P-384")
+		return errors.New("generated client certificate is not ECDSA P-384")
 	}
 	privateKey, err := readECPrivateKeyInternal(keyPath)
 	if err != nil {
 		return err
 	}
 	if privateKey.Curve != elliptic.P384() {
-		return fmt.Errorf("generated client private key is not ECDSA P-384")
+		return errors.New("generated client private key is not ECDSA P-384")
 	}
 	if err := validateCertificateKeyPairInternal(cert, privateKey, "generated client"); err != nil {
 		return err
@@ -999,13 +1003,13 @@ func agentMTLSAssetsNeedEnrollmentInternal(certPath string, keyPath string, now 
 		now = time.Now()
 	}
 	if now.Before(cert.NotBefore) {
-		return true, fmt.Sprintf("certificate is not valid before %s", cert.NotBefore.UTC().Format(time.RFC3339))
+		return true, "certificate is not valid before " + cert.NotBefore.UTC().Format(time.RFC3339)
 	}
 	if !now.Before(cert.NotAfter) {
-		return true, fmt.Sprintf("certificate expired at %s", cert.NotAfter.UTC().Format(time.RFC3339))
+		return true, "certificate expired at " + cert.NotAfter.UTC().Format(time.RFC3339)
 	}
 	if now.Add(agentMTLSRenewBefore).After(cert.NotAfter) {
-		return true, fmt.Sprintf("certificate expires soon at %s", cert.NotAfter.UTC().Format(time.RFC3339))
+		return true, "certificate expires soon at " + cert.NotAfter.UTC().Format(time.RFC3339)
 	}
 	return false, ""
 }
@@ -1082,7 +1086,10 @@ func lockEdgeMTLSPathInternal(ctx context.Context, dir string, lockName string) 
 
 	lockPath := filepath.Join(absDir, lockName)
 	muValue, _ := managerCALocks.LoadOrStore(lockPath, &sync.Mutex{})
-	mu := muValue.(*sync.Mutex)
+	mu, ok := muValue.(*sync.Mutex)
+	if !ok {
+		return nil, &common.ManagerCALockTypeError{}
+	}
 
 	deadline := time.Now().Add(managerCALockTimeout)
 	for {
@@ -1158,14 +1165,14 @@ func readEdgeMTLSLockInfoInternal(lockPath string) (*edgeMTLSLockInfo, error) {
 	}
 	fields := strings.Fields(string(content))
 	if len(fields) == 0 {
-		return nil, fmt.Errorf("edge mTLS lock does not contain a PID")
+		return nil, errors.New("edge mTLS lock does not contain a PID")
 	}
 	pid, err := strconv.Atoi(fields[0])
 	if err != nil {
 		return nil, fmt.Errorf("parse edge mTLS lock PID: %w", err)
 	}
 	if pid <= 0 {
-		return nil, fmt.Errorf("edge mTLS lock PID must be positive")
+		return nil, errors.New("edge mTLS lock PID must be positive")
 	}
 	info := &edgeMTLSLockInfo{pid: pid}
 	if len(fields) > 1 {
@@ -1213,7 +1220,7 @@ var caKeyEncryptInternal = libcrypto.Encrypt
 func writeCAKeyFileInternal(path string, derBytes []byte) error {
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: derBytes})
 	if pemBytes == nil {
-		return fmt.Errorf("failed to encode CA private key to PEM")
+		return errors.New("failed to encode CA private key to PEM")
 	}
 
 	ciphertext, err := caKeyEncryptInternal(string(pemBytes))
@@ -1221,7 +1228,7 @@ func writeCAKeyFileInternal(path string, derBytes []byte) error {
 		return fmt.Errorf("failed to encrypt edge mTLS CA private key: %w", err)
 	}
 	if ciphertext == "" {
-		return fmt.Errorf("failed to encrypt edge mTLS CA private key: encrypted payload is empty")
+		return errors.New("failed to encrypt edge mTLS CA private key: encrypted payload is empty")
 	}
 
 	return writeFileAtomicInternal(path, []byte(caKeyEncryptedPrefix+ciphertext), 0o600)

--- a/backend/pkg/libarcane/edge/tunnel.go
+++ b/backend/pkg/libarcane/edge/tunnel.go
@@ -219,13 +219,13 @@ func (t *TunnelConn) SendRequest(ctx context.Context, msg *TunnelMessage, pendin
 }
 
 type grpcManagerStream interface {
-	Send(*tunnelpb.ManagerMessage) error
+	Send(msg *tunnelpb.ManagerMessage) error
 	Recv() (*tunnelpb.AgentMessage, error)
 	Context() context.Context
 }
 
 type grpcAgentStream interface {
-	Send(*tunnelpb.AgentMessage) error
+	Send(msg *tunnelpb.AgentMessage) error
 	Recv() (*tunnelpb.ManagerMessage, error)
 	Context() context.Context
 	CloseSend() error
@@ -418,7 +418,9 @@ func (t *GRPCAgentTunnelConn) markClosed() {
 	t.closedMu.Unlock()
 }
 
-func sendRequestWithPending(ctx context.Context, conn interface{ Send(*TunnelMessage) error }, msg *TunnelMessage, pending *sync.Map) (*TunnelMessage, error) {
+func sendRequestWithPending(ctx context.Context, conn interface {
+	Send(msg *TunnelMessage) error
+}, msg *TunnelMessage, pending *sync.Map) (*TunnelMessage, error) {
 	ctx, cancel := ensureSendRequestContextInternal(ctx)
 	defer cancel()
 
@@ -476,14 +478,14 @@ func (s *cancelableGRPCManagerStream) Context() context.Context {
 
 func ensureSendRequestContextInternal(ctx context.Context) (context.Context, context.CancelFunc) {
 	if ctx == nil {
-		return context.WithTimeout(context.Background(), defaultSendRequestTimeout) //nolint:gosec // helper intentionally returns the cancel func to callers.
+		return context.WithTimeout(context.Background(), defaultSendRequestTimeout)
 	}
 
 	if _, hasDeadline := ctx.Deadline(); hasDeadline {
 		return ctx, func() {}
 	}
 
-	return context.WithTimeout(ctx, defaultSendRequestTimeout) //nolint:gosec // helper intentionally returns the cancel func to callers.
+	return context.WithTimeout(ctx, defaultSendRequestTimeout)
 }
 
 func isExpectedGRPCReceiveErrorInternal(err error) bool {

--- a/backend/pkg/libarcane/edge/tunnel_proto_adapter.go
+++ b/backend/pkg/libarcane/edge/tunnel_proto_adapter.go
@@ -1,6 +1,7 @@
 package edge
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -10,7 +11,7 @@ import (
 
 func tunnelMessageToManagerProto(msg *TunnelMessage) (*tunnelpb.ManagerMessage, error) {
 	if msg == nil {
-		return nil, fmt.Errorf("message is nil")
+		return nil, errors.New("message is nil")
 	}
 
 	switch msg.Type {
@@ -119,7 +120,7 @@ func tunnelMessageToManagerProto(msg *TunnelMessage) (*tunnelpb.ManagerMessage, 
 
 func managerProtoToTunnelMessage(msg *tunnelpb.ManagerMessage) (*TunnelMessage, error) {
 	if msg == nil {
-		return nil, fmt.Errorf("manager message is nil")
+		return nil, errors.New("manager message is nil")
 	}
 
 	switch payload := msg.GetPayload().(type) {
@@ -214,7 +215,7 @@ func managerProtoToTunnelMessage(msg *tunnelpb.ManagerMessage) (*TunnelMessage, 
 
 func tunnelMessageToAgentProto(msg *TunnelMessage) (*tunnelpb.AgentMessage, error) {
 	if msg == nil {
-		return nil, fmt.Errorf("message is nil")
+		return nil, errors.New("message is nil")
 	}
 
 	switch msg.Type {
@@ -328,7 +329,7 @@ func tunnelMessageToAgentProto(msg *TunnelMessage) (*tunnelpb.AgentMessage, erro
 
 func agentProtoToTunnelMessage(msg *tunnelpb.AgentMessage) (*TunnelMessage, error) {
 	if msg == nil {
-		return nil, fmt.Errorf("agent message is nil")
+		return nil, errors.New("agent message is nil")
 	}
 
 	switch payload := msg.GetPayload().(type) {

--- a/backend/pkg/libarcane/imageupdate/digest.go
+++ b/backend/pkg/libarcane/imageupdate/digest.go
@@ -2,6 +2,7 @@ package imageupdate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -83,7 +84,7 @@ func (c *DigestChecker) CheckImageNeedsUpdate(ctx context.Context, imageRef stri
 	result.LocalDigest = localDigest
 
 	if c.digestResolver == nil {
-		result.Error = fmt.Errorf("remote digest resolver unavailable")
+		result.Error = errors.New("remote digest resolver unavailable")
 		return result
 	}
 
@@ -130,7 +131,7 @@ func (c *DigestChecker) getLocalDigestInternal(ctx context.Context, imageRef str
 		return inspect.ID, nil
 	}
 
-	return "", fmt.Errorf("no digest available for image")
+	return "", errors.New("no digest available for image")
 }
 
 // CompareWithPulled compares the current container's image with a freshly pulled image

--- a/backend/pkg/libarcane/imageupdate/labels.go
+++ b/backend/pkg/libarcane/imageupdate/labels.go
@@ -3,12 +3,12 @@ package imageupdate
 import "strings"
 
 const (
-	// Core labels
+	// LabelArcane and the constants below are the core Arcane container labels.
 	LabelArcane      = "com.getarcaneapp.arcane"         // Identifies the Arcane container itself
 	LabelArcaneAgent = "com.getarcaneapp.arcane.agent"   // Identifies an Arcane agent container
 	LabelUpdater     = "com.getarcaneapp.arcane.updater" // Enable/disable updates (true/false)
 
-	// Dependency labels
+	// LabelDependsOn and the constants below are update-dependency labels.
 	LabelDependsOn  = "com.getarcaneapp.arcane.depends-on"  // Comma-separated list of container names this depends on
 	LabelStopSignal = "com.getarcaneapp.arcane.stop-signal" // Custom stop signal (e.g., SIGINT)
 )

--- a/backend/pkg/libarcane/imageupdate/logfile.go
+++ b/backend/pkg/libarcane/imageupdate/logfile.go
@@ -2,6 +2,7 @@ package imageupdate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -130,11 +131,11 @@ func formatSlogValueInternal(v slog.Value) string {
 // SetupMessageOnlyLogFile configures slog to write structured logs to stdout and a
 // message-only format to a file under dataDir.
 //
-// The file format is: <msg> key=value key=value ... (no time/level/source) to keep
+// The file format is: <msg> key=value ... (no time/level/source) to keep
 // upgrade logs concise for end users.
 func SetupMessageOnlyLogFile(dataDir string, filePrefix string, minLevel slog.Level) (*os.File, error) {
 	if strings.TrimSpace(dataDir) == "" {
-		return nil, fmt.Errorf("dataDir is required")
+		return nil, errors.New("dataDir is required")
 	}
 	if strings.TrimSpace(filePrefix) == "" {
 		filePrefix = "arcane-upgrade"

--- a/backend/pkg/libarcane/imageupdate/registry_http.go
+++ b/backend/pkg/libarcane/imageupdate/registry_http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -197,7 +198,7 @@ func FetchDigest(ctx context.Context, registryHost, repository, tag string, cred
 
 	digest := extractDigestFromHeadersInternal(resp.Header)
 	if digest == "" {
-		return "", fmt.Errorf("no digest header found in response")
+		return "", errors.New("no digest header found in response")
 	}
 
 	return digest, nil
@@ -206,7 +207,7 @@ func FetchDigest(ctx context.Context, registryHost, repository, tag string, cred
 func fetchRateLimitWithTokenAuthInternal(ctx context.Context, httpClient *http.Client, registryHost, repository, tag, challenge string, credential *Credentials) (*RateLimitInfo, error) {
 	realm, service := parseWWWAuthInternal(challenge)
 	if realm == "" {
-		return nil, fmt.Errorf("no auth realm found")
+		return nil, errors.New("no auth realm found")
 	}
 	if err := validateAuthRealmInternal(registryHost, realm); err != nil {
 		return nil, err
@@ -233,7 +234,7 @@ func fetchRateLimitWithTokenAuthInternal(ctx context.Context, httpClient *http.C
 func fetchWithTokenAuthInternal(ctx context.Context, httpClient *http.Client, registryHost, repository, tag, challenge string, credential *Credentials) (string, error) {
 	realm, service := parseWWWAuthInternal(challenge)
 	if realm == "" {
-		return "", fmt.Errorf("no auth realm found")
+		return "", errors.New("no auth realm found")
 	}
 	if err := validateAuthRealmInternal(registryHost, realm); err != nil {
 		return "", err
@@ -256,7 +257,7 @@ func fetchWithTokenAuthInternal(ctx context.Context, httpClient *http.Client, re
 
 	digest := extractDigestFromHeadersInternal(resp.Header)
 	if digest == "" {
-		return "", fmt.Errorf("no digest header found in authenticated response")
+		return "", errors.New("no digest header found in authenticated response")
 	}
 
 	return digest, nil
@@ -287,7 +288,7 @@ func fetchRegistryTokenInternal(ctx context.Context, httpClient *http.Client, au
 		req.SetBasicAuth(strings.TrimSpace(credential.Username), strings.TrimSpace(credential.Token))
 	}
 
-	resp, err := httpClient.Do(req) //nolint:gosec // authURL comes from the registry challenge for the current image
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("token request failed: %w", err)
 	}
@@ -310,7 +311,7 @@ func fetchRegistryTokenInternal(ctx context.Context, httpClient *http.Client, au
 		token = strings.TrimSpace(tokenResponse.Legacy)
 	}
 	if token == "" {
-		return "", fmt.Errorf("no token in response")
+		return "", errors.New("no token in response")
 	}
 
 	return token, nil
@@ -325,7 +326,7 @@ func manifestRequestInternal(ctx context.Context, httpClient *http.Client, regis
 	}
 	addManifestRequestHeadersInternal(req, authHeader)
 
-	resp, err := httpClient.Do(req) //nolint:gosec // manifestURL is derived from the normalized image reference
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("manifest request failed: %w", err)
 	}
@@ -341,7 +342,7 @@ func manifestRequestInternal(ctx context.Context, httpClient *http.Client, regis
 		}
 		addManifestRequestHeadersInternal(getReq, authHeader)
 
-		getResp, err := httpClient.Do(getReq) //nolint:gosec // manifestURL is derived from the normalized image reference
+		getResp, err := httpClient.Do(getReq)
 		if err != nil {
 			return nil, fmt.Errorf("manifest fallback request failed: %w", err)
 		}
@@ -424,18 +425,18 @@ func extractDigestFromHeadersInternal(headers http.Header) string {
 }
 
 func extractRateLimitFromHeadersInternal(headers http.Header) (*RateLimitInfo, error) {
-	limit, limitWindow, limitErr := parseRateLimitHeaderInternal(headers.Get("RateLimit-Limit"))
+	limit, limitWindow, limitErr := parseRateLimitHeaderInternal(headers.Get("Ratelimit-Limit"))
 	if limitErr != nil {
 		return nil, fmt.Errorf("parse RateLimit-Limit: %w", limitErr)
 	}
 
-	remaining, remainingWindow, remainingErr := parseRateLimitHeaderInternal(headers.Get("RateLimit-Remaining"))
+	remaining, remainingWindow, remainingErr := parseRateLimitHeaderInternal(headers.Get("Ratelimit-Remaining"))
 	if remainingErr != nil {
 		return nil, fmt.Errorf("parse RateLimit-Remaining: %w", remainingErr)
 	}
 
 	if limit == nil && remaining == nil {
-		return nil, fmt.Errorf("rate limit headers not returned")
+		return nil, errors.New("rate limit headers not returned")
 	}
 
 	windowSeconds := limitWindow
@@ -453,7 +454,7 @@ func extractRateLimitFromHeadersInternal(headers http.Header) (*RateLimitInfo, e
 		Remaining:     remaining,
 		Used:          used,
 		WindowSeconds: windowSeconds,
-		Source:        strings.TrimSpace(headers.Get("Docker-RateLimit-Source")),
+		Source:        strings.TrimSpace(headers.Get("Docker-Ratelimit-Source")),
 	}, nil
 }
 
@@ -493,7 +494,7 @@ func parseRateLimitHeaderInternal(value string) (*int, *int, error) {
 
 func parsePositiveIntInternal(value string) (*int, error) {
 	if value == "" {
-		return nil, fmt.Errorf("empty integer value")
+		return nil, errors.New("empty integer value")
 	}
 
 	parsed, err := strconv.Atoi(value)
@@ -586,7 +587,7 @@ func validateAuthRealmInternal(registryHost, realm string) error {
 	registry := normalizeAuthRealmHostInternal(registryHost)
 
 	if realmHost == "" {
-		return fmt.Errorf("invalid auth realm host")
+		return errors.New("invalid auth realm host")
 	}
 	if realmHost == registry {
 		return nil

--- a/backend/pkg/libarcane/inspect_compat.go
+++ b/backend/pkg/libarcane/inspect_compat.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +56,7 @@ func (c *inspectCompatibilityClient) NetworkList(ctx context.Context, options cl
 // JSON when the primary typed decode fails on a ParseAddr-style CIDR issue.
 func ContainerInspectWithCompatibility(ctx context.Context, apiClient client.APIClient, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 	if apiClient == nil {
-		return client.ContainerInspectResult{}, fmt.Errorf("docker api client is nil")
+		return client.ContainerInspectResult{}, errors.New("docker api client is nil")
 	}
 
 	result, err := apiClient.ContainerInspect(ctx, containerID, options)
@@ -93,7 +94,7 @@ func ContainerInspectWithCompatibility(ctx context.Context, apiClient client.API
 // JSON when the primary typed decode fails on a ParseAddr-style CIDR issue.
 func NetworkInspectWithCompatibility(ctx context.Context, apiClient client.APIClient, networkID string, options client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
 	if apiClient == nil {
-		return client.NetworkInspectResult{}, fmt.Errorf("docker api client is nil")
+		return client.NetworkInspectResult{}, errors.New("docker api client is nil")
 	}
 
 	result, err := apiClient.NetworkInspect(ctx, networkID, options)
@@ -134,7 +135,7 @@ func NetworkInspectWithCompatibility(ctx context.Context, apiClient client.APICl
 // when the primary typed decode fails on a ParseAddr-style CIDR issue.
 func NetworkListWithCompatibility(ctx context.Context, apiClient client.APIClient, options client.NetworkListOptions) (client.NetworkListResult, error) {
 	if apiClient == nil {
-		return client.NetworkListResult{}, fmt.Errorf("docker api client is nil")
+		return client.NetworkListResult{}, errors.New("docker api client is nil")
 	}
 
 	result, err := apiClient.NetworkList(ctx, options)
@@ -170,7 +171,7 @@ func NetworkListWithCompatibility(ctx context.Context, apiClient client.APIClien
 func fetchDockerAPIJSONInternal(ctx context.Context, apiClient client.APIClient, resourcePath string, query url.Values) ([]byte, error) {
 	dialer := apiClient.Dialer()
 	if dialer == nil {
-		return nil, fmt.Errorf("docker api client does not expose a dialer")
+		return nil, errors.New("docker api client does not expose a dialer")
 	}
 
 	reqURL := &url.URL{

--- a/backend/pkg/libarcane/internal_resource.go
+++ b/backend/pkg/libarcane/internal_resource.go
@@ -2,7 +2,7 @@ package libarcane
 
 import "strings"
 
-// Internal containers indicate containers used for arcanes utilties, ie: temp containers used for viewing files for volumes etc
+// InternalResourceLabel marks containers used for Arcane utilities, e.g. temp containers used for viewing volume files.
 const InternalResourceLabel = "com.getarcaneapp.internal.resource"
 
 func IsInternalContainer(labels map[string]string) bool {

--- a/backend/pkg/libarcane/libbuild/build_context.go
+++ b/backend/pkg/libarcane/libbuild/build_context.go
@@ -1,7 +1,7 @@
 package libbuild
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"path"
 	"strings"
@@ -37,13 +37,13 @@ func ParseGitBuildContextSource(raw string) (*GitBuildContextSource, bool, error
 
 	fragment = strings.TrimSpace(fragment)
 	if fragment == "" {
-		return nil, true, fmt.Errorf("git build context fragment cannot be empty")
+		return nil, true, errors.New("git build context fragment cannot be empty")
 	}
 
 	ref, subdir, hasSubdir := strings.Cut(fragment, ":")
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return nil, true, fmt.Errorf("git build context ref cannot be empty")
+		return nil, true, errors.New("git build context ref cannot be empty")
 	}
 	source.Ref = ref
 
@@ -53,15 +53,15 @@ func ParseGitBuildContextSource(raw string) (*GitBuildContextSource, bool, error
 
 	subdir = strings.TrimSpace(subdir)
 	if subdir == "" {
-		return nil, true, fmt.Errorf("git build context subdir cannot be empty")
+		return nil, true, errors.New("git build context subdir cannot be empty")
 	}
 	if strings.HasPrefix(subdir, "/") {
-		return nil, true, fmt.Errorf("git build context subdir must be relative")
+		return nil, true, errors.New("git build context subdir must be relative")
 	}
 
 	cleanSubdir := path.Clean(subdir)
 	if cleanSubdir == "." || cleanSubdir == ".." || strings.HasPrefix(cleanSubdir, "../") {
-		return nil, true, fmt.Errorf("git build context subdir must stay within the repository")
+		return nil, true, errors.New("git build context subdir must stay within the repository")
 	}
 
 	source.Subdir = cleanSubdir

--- a/backend/pkg/libarcane/libbuild/builder_buildkit.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit.go
@@ -133,14 +133,14 @@ func (b *builder) buildSolveOptInternal(ctx context.Context, req imagetypes.Buil
 		frontendAttrs["platform"] = strings.Join(req.Platforms, ",")
 	}
 	for key, val := range req.BuildArgs {
-		frontendAttrs[fmt.Sprintf("build-arg:%s", key)] = val
+		frontendAttrs["build-arg:"+key] = val
 	}
 	for key, val := range req.Labels {
 		k := strings.TrimSpace(key)
 		if k == "" {
 			continue
 		}
-		frontendAttrs[fmt.Sprintf("label:%s", k)] = val
+		frontendAttrs["label:"+k] = val
 	}
 
 	solveOpt := buildkit.SolveOpt{

--- a/backend/pkg/libarcane/libbuild/builder_buildkit_local.go
+++ b/backend/pkg/libarcane/libbuild/builder_buildkit_local.go
@@ -3,6 +3,7 @@ package libbuild
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -15,7 +16,7 @@ import (
 
 func (b *builder) newLocalBuildkitSessionInternal(ctx context.Context) (*buildSession, error) {
 	if b.dockerClientProvider == nil {
-		return nil, fmt.Errorf("docker service not available")
+		return nil, errors.New("docker service not available")
 	}
 
 	dockerClient, err := b.dockerClientProvider.GetClient(ctx)

--- a/backend/pkg/libarcane/libbuild/builder_docker.go
+++ b/backend/pkg/libarcane/libbuild/builder_docker.go
@@ -25,6 +25,7 @@ import (
 
 type dockerBuildInput struct {
 	buildFilesystemInput
+
 	platform    string
 	buildArgs   map[string]*string
 	labels      map[string]string
@@ -140,7 +141,7 @@ func prepareDockerBuildInputInternal(req imagetypes.BuildRequest) (dockerBuildIn
 	}
 
 	if len(req.Platforms) > 1 {
-		return dockerBuildInput{}, true, fmt.Errorf("docker build fallback does not support multi-platform builds")
+		return dockerBuildInput{}, true, errors.New("docker build fallback does not support multi-platform builds")
 	}
 
 	platform := ""
@@ -360,7 +361,7 @@ func (b *builder) pushDockerImagesInternal(
 		writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
 			Type:    "build",
 			Service: serviceName,
-			Status:  fmt.Sprintf("pushing %s", tag),
+			Status:  "pushing " + tag,
 		})
 		pushOptions := dockerclient.ImagePushOptions{}
 		if b.registryAuthProvider != nil {
@@ -369,7 +370,7 @@ func (b *builder) pushDockerImagesInternal(
 				writeProgressEventInternal(progressWriter, imagetypes.ProgressEvent{
 					Type:    "build",
 					Service: serviceName,
-					Status:  fmt.Sprintf("registry auth unavailable for %s", tag),
+					Status:  "registry auth unavailable for " + tag,
 				})
 			} else if authHeader != "" {
 				pushOptions.RegistryAuth = authHeader

--- a/backend/pkg/libarcane/registryauth/helpers.go
+++ b/backend/pkg/libarcane/registryauth/helpers.go
@@ -95,7 +95,7 @@ func DecodeAuthHeader(authEncoded string) (dockerregistry.AuthConfig, error) {
 	return *cfg, nil
 }
 
-func RegistryAuthLookupKeys(url string) []string {
+func LookupKeys(url string) []string {
 	normalizedHost := NormalizeRegistryForComparison(url)
 	if normalizedHost == "" {
 		return nil

--- a/backend/pkg/libarcane/registryauth/helpers_test.go
+++ b/backend/pkg/libarcane/registryauth/helpers_test.go
@@ -81,7 +81,7 @@ func TestDecodeAuthHeader_InvalidInput(t *testing.T) {
 }
 
 func TestRegistryAuthLookupKeys(t *testing.T) {
-	assert.Equal(t, []string{"ghcr.io"}, RegistryAuthLookupKeys("https://GHCR.IO/"))
-	assert.Equal(t, []string{"docker.io", "index.docker.io", "registry-1.docker.io"}, RegistryAuthLookupKeys("https://index.docker.io/v1/"))
-	assert.Nil(t, RegistryAuthLookupKeys("   "))
+	assert.Equal(t, []string{"ghcr.io"}, LookupKeys("https://GHCR.IO/"))
+	assert.Equal(t, []string{"docker.io", "index.docker.io", "registry-1.docker.io"}, LookupKeys("https://index.docker.io/v1/"))
+	assert.Nil(t, LookupKeys("   "))
 }

--- a/backend/pkg/libarcane/startup/runtime_identity.go
+++ b/backend/pkg/libarcane/startup/runtime_identity.go
@@ -320,12 +320,12 @@ func ensureSQLiteFilesExistInternal(databaseURL string) error {
 	// prepareWritablePathsInternal is not called.
 	dir := filepath.Dir(sqlitePath)
 	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, pkgutils.DirPerm); err != nil { //nolint:gosec // path is derived from the configured SQLite DSN, not user input
+		if err := os.MkdirAll(dir, pkgutils.DirPerm); err != nil {
 			return fmt.Errorf("create sqlite directory %s: %w", dir, err)
 		}
 	}
 
-	file, err := os.OpenFile(sqlitePath, os.O_CREATE|os.O_RDWR, pkgutils.FilePerm) //nolint:gosec // path is derived from the configured SQLite DSN
+	file, err := os.OpenFile(sqlitePath, os.O_CREATE|os.O_RDWR, pkgutils.FilePerm)
 	if err != nil {
 		return fmt.Errorf("create sqlite file %s: %w", sqlitePath, err)
 	}
@@ -385,7 +385,7 @@ func chownRecursiveInternal(path string, uid int, gid int, mountpoints map[strin
 			}
 			return filepath.SkipDir
 		}
-		//nolint:gosec // currentPath comes from fixed container paths under /app/data or /builds
+
 		return lchownFn(currentPath, uid, gid)
 	})
 }

--- a/backend/pkg/libarcane/swarm/stack_deploy_engine.go
+++ b/backend/pkg/libarcane/swarm/stack_deploy_engine.go
@@ -188,10 +188,7 @@ func reconcileStackServices(
 		if service.Name == "" {
 			service.Name = key
 		}
-		spec, err := buildServiceSpec(service, stackName, stackLabels, networkNameByKey, configMetaByKey, secretMetaByKey, project.Volumes)
-		if err != nil {
-			return nil, err
-		}
+		spec := buildServiceSpec(service, stackName, stackLabels, networkNameByKey, configMetaByKey, secretMetaByKey, project.Volumes)
 		desiredServices[spec.Name] = struct{}{}
 
 		if existing, ok := existingServices[spec.Name]; ok {
@@ -613,7 +610,7 @@ func buildServiceSpec(
 	configMetaByKey map[string]resourceMeta,
 	secretMetaByKey map[string]resourceMeta,
 	projectVolumes composegotypes.Volumes,
-) (swarm.ServiceSpec, error) {
+) swarm.ServiceSpec {
 	serviceName := stackScopedName(stackName, service.Name)
 	serviceLabels := mergeLabels(nil, stackLabels)
 	if service.Deploy != nil {
@@ -668,7 +665,7 @@ func buildServiceSpec(
 	applyDeployConfig(&spec, service.Deploy, service.Scale)
 	applyServicePorts(&spec, service.Ports)
 
-	return spec, nil
+	return spec
 }
 
 func createSwarmService(
@@ -1082,8 +1079,8 @@ func convertIPAM(cfg composegotypes.IPAMConfig) *network.IPAM {
 			if pool == nil {
 				continue
 			}
-			subnet, _ := parsePrefix(pool.Subnet)
-			ipRange, _ := parsePrefix(pool.IPRange)
+			subnet := parsePrefix(pool.Subnet)
+			ipRange := parsePrefix(pool.IPRange)
 			gateway, _ := parseAddr(pool.Gateway)
 			pools = append(pools, network.IPAMConfig{
 				Subnet:     subnet,
@@ -1123,16 +1120,16 @@ func parseAddr(value string) (netip.Addr, bool) {
 	return addr, true
 }
 
-func parsePrefix(value string) (netip.Prefix, bool) {
+func parsePrefix(value string) netip.Prefix {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return netip.Prefix{}, false
+		return netip.Prefix{}
 	}
 	prefix, err := netip.ParsePrefix(value)
 	if err != nil {
-		return netip.Prefix{}, false
+		return netip.Prefix{}
 	}
-	return prefix, true
+	return prefix
 }
 
 func parseAuxAddresses(values map[string]string) map[string]netip.Addr {

--- a/backend/pkg/libarcane/system/gpu.go
+++ b/backend/pkg/libarcane/system/gpu.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -81,7 +82,7 @@ func (m *GPUMonitor) Stats(ctx context.Context) ([]systemtypes.GPUStats, error) 
 	t := m.gpuType
 	m.cacheMu.RUnlock()
 	if t == "" {
-		return nil, fmt.Errorf("no supported GPU found")
+		return nil, errors.New("no supported GPU found")
 	}
 	return m.statsForTypeInternal(ctx, t)
 }
@@ -95,7 +96,7 @@ func (m *GPUMonitor) statsForTypeInternal(ctx context.Context, gpuType string) (
 	case "intel":
 		return getIntelStatsInternal(ctx)
 	default:
-		return nil, fmt.Errorf("no supported GPU found")
+		return nil, errors.New("no supported GPU found")
 	}
 }
 
@@ -124,21 +125,21 @@ func (m *GPUMonitor) detectInternal(ctx context.Context) error {
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "nvidia")
 				return nil
 			}
-			return fmt.Errorf("nvidia-smi not found but GPU_TYPE set to nvidia")
+			return errors.New("nvidia-smi not found but GPU_TYPE set to nvidia")
 		case "amd":
 			if HasAMDGPU() {
 				m.markDetectedInternal("amd", AMDGPUSysfsPath)
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "amd")
 				return nil
 			}
-			return fmt.Errorf("AMD GPU not found in sysfs but GPU_TYPE set to amd")
+			return errors.New("AMD GPU not found in sysfs but GPU_TYPE set to amd")
 		case "intel":
 			if path, err := exec.LookPath("intel_gpu_top"); err == nil {
 				m.markDetectedInternal("intel", path)
 				slog.InfoContext(ctx, "Using configured GPU type", "type", "intel")
 				return nil
 			}
-			return fmt.Errorf("intel_gpu_top not found but GPU_TYPE set to intel")
+			return errors.New("intel_gpu_top not found but GPU_TYPE set to intel")
 		default:
 			slog.WarnContext(ctx, "Invalid GPU_TYPE specified, falling back to auto-detection", "gpu_type", t)
 		}
@@ -161,7 +162,7 @@ func (m *GPUMonitor) detectInternal(ctx context.Context) error {
 	}
 
 	m.detectionDone = true
-	return fmt.Errorf("no supported GPU found")
+	return errors.New("no supported GPU found")
 }
 
 // HasAMDGPU reports whether a card with mem_info_vram_total exists under AMDGPUSysfsPath.
@@ -242,7 +243,7 @@ func getNvidiaStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error)
 	}
 
 	if len(stats) == 0 {
-		return nil, fmt.Errorf("no GPU data parsed from nvidia-smi")
+		return nil, errors.New("no GPU data parsed from nvidia-smi")
 	}
 
 	slog.DebugContext(ctx, "Collected NVIDIA GPU stats", "gpu_count", len(stats))
@@ -265,11 +266,11 @@ func getAMDStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
 		}
 
 		devicePath := fmt.Sprintf("%s/%s/device", AMDGPUSysfsPath, name)
-		memTotalBytes, err := readSysfsValueInternal(fmt.Sprintf("%s/mem_info_vram_total", devicePath))
+		memTotalBytes, err := readSysfsValueInternal(devicePath + "/mem_info_vram_total")
 		if err != nil {
 			continue
 		}
-		memUsedBytes, err := readSysfsValueInternal(fmt.Sprintf("%s/mem_info_vram_used", devicePath))
+		memUsedBytes, err := readSysfsValueInternal(devicePath + "/mem_info_vram_used")
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to read AMD GPU memory used", "card", name, "error", err)
 			continue
@@ -285,7 +286,7 @@ func getAMDStatsInternal(ctx context.Context) ([]systemtypes.GPUStats, error) {
 	}
 
 	if len(stats) == 0 {
-		return nil, fmt.Errorf("no AMD GPU data found in sysfs")
+		return nil, errors.New("no AMD GPU data found in sysfs")
 	}
 
 	slog.DebugContext(ctx, "Collected AMD GPU stats", "gpu_count", len(stats))

--- a/backend/pkg/libarcane/timeouts/timeouts.go
+++ b/backend/pkg/libarcane/timeouts/timeouts.go
@@ -23,6 +23,6 @@ func GetDuration(settingSeconds int, defaultDuration time.Duration) time.Duratio
 	return defaultDuration
 }
 
-func WithTimeout(ctx context.Context, settingSeconds int, defaultDuration time.Duration) (context.Context, context.CancelFunc) { //nolint:gosec // helper intentionally returns the cancel func to callers.
-	return context.WithTimeout(ctx, GetDuration(settingSeconds, defaultDuration)) //nolint:gosec // helper intentionally returns the cancel func to callers.
+func WithTimeout(ctx context.Context, settingSeconds int, defaultDuration time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, GetDuration(settingSeconds, defaultDuration))
 }

--- a/backend/pkg/libarcane/ws/diagnostics.go
+++ b/backend/pkg/libarcane/ws/diagnostics.go
@@ -13,6 +13,7 @@ const workerGoroutineCountTTL = 5 * time.Second
 
 var workerGoroutineCountCache struct {
 	sync.Mutex
+
 	value int
 	at    time.Time
 }

--- a/backend/pkg/pagination/filters.go
+++ b/backend/pkg/pagination/filters.go
@@ -27,7 +27,7 @@ func SearchOrderAndPaginate[T any](items []T, params QueryParams, searchConfig C
 	items = sortFunction(items, params.SortParams, searchConfig.SortBindings)
 
 	totalCount := len(items)
-	items = paginateItemsFunction(items, params.PaginationParams)
+	items = paginateItemsFunction(items, params.Params)
 
 	return FilterResult[T]{
 		Items:          items,

--- a/backend/pkg/pagination/pagination.go
+++ b/backend/pkg/pagination/pagination.go
@@ -1,6 +1,6 @@
 package pagination
 
-type PaginationParams struct {
+type Params struct {
 	Start int
 	Limit int
 	// SkipCount opts out of the COUNT(*) query that backs TotalItems/TotalPages.
@@ -13,7 +13,7 @@ type PaginationParams struct {
 // UnknownTotal is the sentinel returned in TotalItems/TotalPages when SkipCount is set.
 const UnknownTotal int64 = -1
 
-func paginateItemsFunction[T any](items []T, params PaginationParams) []T {
+func paginateItemsFunction[T any](items []T, params Params) []T {
 	if params.Limit <= 0 {
 		return items
 	}

--- a/backend/pkg/pagination/pagination_test.go
+++ b/backend/pkg/pagination/pagination_test.go
@@ -21,7 +21,7 @@ func TestBuildResponseFromFilterResult(t *testing.T) {
 				TotalAvailable: 10,
 			},
 			params: QueryParams{
-				PaginationParams: PaginationParams{
+				Params: Params{
 					Start: 0,
 					Limit: -1,
 				},
@@ -42,7 +42,7 @@ func TestBuildResponseFromFilterResult(t *testing.T) {
 				TotalAvailable: 0,
 			},
 			params: QueryParams{
-				PaginationParams: PaginationParams{
+				Params: Params{
 					Start: 0,
 					Limit: -1,
 				},
@@ -63,7 +63,7 @@ func TestBuildResponseFromFilterResult(t *testing.T) {
 				TotalAvailable: 100,
 			},
 			params: QueryParams{
-				PaginationParams: PaginationParams{
+				Params: Params{
 					Start: 0,
 					Limit: 10,
 				},
@@ -84,7 +84,7 @@ func TestBuildResponseFromFilterResult(t *testing.T) {
 				TotalAvailable: 100,
 			},
 			params: QueryParams{
-				PaginationParams: PaginationParams{
+				Params: Params{
 					Start: 10,
 					Limit: 10,
 				},
@@ -105,7 +105,7 @@ func TestBuildResponseFromFilterResult(t *testing.T) {
 				TotalAvailable: 3,
 			},
 			params: QueryParams{
-				PaginationParams: PaginationParams{
+				Params: Params{
 					Start: 0,
 					Limit: 0,
 				},
@@ -133,32 +133,32 @@ func TestPaginateItemsFunction(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		params   PaginationParams
+		params   Params
 		expected []int
 	}{
 		{
 			name:     "show all mode (limit = -1)",
-			params:   PaginationParams{Start: 0, Limit: -1},
+			params:   Params{Start: 0, Limit: -1},
 			expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 		{
 			name:     "show all mode (limit = 0)",
-			params:   PaginationParams{Start: 0, Limit: 0},
+			params:   Params{Start: 0, Limit: 0},
 			expected: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		},
 		{
 			name:     "normal pagination first page",
-			params:   PaginationParams{Start: 0, Limit: 3},
+			params:   Params{Start: 0, Limit: 3},
 			expected: []int{1, 2, 3},
 		},
 		{
 			name:     "normal pagination second page",
-			params:   PaginationParams{Start: 3, Limit: 3},
+			params:   Params{Start: 3, Limit: 3},
 			expected: []int{4, 5, 6},
 		},
 		{
 			name:     "pagination at end of list",
-			params:   PaginationParams{Start: 8, Limit: 5},
+			params:   Params{Start: 8, Limit: 5},
 			expected: []int{9, 10},
 		},
 	}

--- a/backend/pkg/pagination/params.go
+++ b/backend/pkg/pagination/params.go
@@ -3,6 +3,7 @@ package pagination
 type QueryParams struct {
 	SearchQuery
 	SortParams
-	PaginationParams
+	Params
+
 	Filters map[string]string
 }

--- a/backend/pkg/pagination/search.go
+++ b/backend/pkg/pagination/search.go
@@ -4,7 +4,8 @@ import (
 	"strings"
 )
 
-// Return any error to skip the field (for  when matching an unknown state on an enum)
+// SearchAccessor extracts a searchable string from T. Return any error to skip
+// the field (e.g. when matching an unknown enum state).
 //
 // Note: returning ("", nil) will match!
 type SearchAccessor[T any] = func(T) (string, error)

--- a/backend/pkg/pagination/skipcount_test.go
+++ b/backend/pkg/pagination/skipcount_test.go
@@ -30,8 +30,8 @@ func TestPaginateAndSortDB_SkipCountReturnsUnknownTotals(t *testing.T) {
 
 	var got []widget
 	resp, err := PaginateAndSortDB(QueryParams{
-		PaginationParams: PaginationParams{Start: 0, Limit: 2, SkipCount: true},
-		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+		Params:     Params{Start: 0, Limit: 2, SkipCount: true},
+		SortParams: SortParams{Sort: "Name", Order: SortOrder("asc")},
 	}, db.Model(&widget{}), &got)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
@@ -46,8 +46,8 @@ func TestPaginateAndSortDB_DefaultStillCounts(t *testing.T) {
 
 	var got []widget
 	resp, err := PaginateAndSortDB(QueryParams{
-		PaginationParams: PaginationParams{Start: 0, Limit: 2},
-		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+		Params:     Params{Start: 0, Limit: 2},
+		SortParams: SortParams{Sort: "Name", Order: SortOrder("asc")},
 	}, db.Model(&widget{}), &got)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
@@ -60,8 +60,8 @@ func TestPaginateAndSortDB_SkipCountShowAll(t *testing.T) {
 
 	var got []widget
 	resp, err := PaginateAndSortDB(QueryParams{
-		PaginationParams: PaginationParams{Start: 0, Limit: -1, SkipCount: true},
-		SortParams:       SortParams{Sort: "Name", Order: SortOrder("asc")},
+		Params:     Params{Start: 0, Limit: -1, SkipCount: true},
+		SortParams: SortParams{Sort: "Name", Order: SortOrder("asc")},
 	}, db.Model(&widget{}), &got)
 	require.NoError(t, err)
 	require.Len(t, got, 5)

--- a/backend/pkg/projects/compose.go
+++ b/backend/pkg/projects/compose.go
@@ -41,6 +41,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 
 type inspectCompatibleDockerCli struct {
 	command.Cli
+
 	apiClient client.APIClient
 }
 

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -137,7 +138,7 @@ func (l *EnvLoader) loadAndMergeGlobalEnv(ctx context.Context, path string, envM
 }
 
 func (l *EnvLoader) loadAndMergeProjectEnv(ctx context.Context, path string, envMap, injectionVars EnvMap) error {
-	key := strings.Join([]string{path, l.projectsDir, fmt.Sprint(l.autoInjectEnv), envContextFingerprintInternal(envMap)}, "\x00")
+	key := strings.Join([]string{path, l.projectsDir, strconv.FormatBool(l.autoInjectEnv), envContextFingerprintInternal(envMap)}, "\x00")
 	entry, err := loadCachedEnvFileInternal(ctx, projectEnvFileCache, key, path, envMap)
 	if err != nil {
 		return err
@@ -400,7 +401,7 @@ func parseEnvWithContext(r io.Reader, contextEnv EnvMap) (EnvMap, error) {
 		return nil, fmt.Errorf("parse env: %w", err)
 	}
 
-	return EnvMap(envMap), nil
+	return envMap, nil
 }
 
 func readOptionalProjectFileInternal(projectPath, fileName string) (string, bool, error) {

--- a/backend/pkg/projects/fs_templates.go
+++ b/backend/pkg/projects/fs_templates.go
@@ -36,7 +36,7 @@ func ReadFolderComposeTemplate(baseDir, folder string) (string, *string, string,
 		}
 	}
 
-	desc := fmt.Sprintf("Imported from %s", composePath)
+	desc := "Imported from " + composePath
 	return string(b), envPtr, desc, true, nil
 }
 

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -458,7 +459,7 @@ func CreateUniqueDir(projectsRoot, basePath, name string, perm os.FileMode) (pat
 
 	// Reject empty or invalid sanitized names
 	if sanitized == "" || strings.Trim(sanitized, "_") == "" {
-		return "", "", fmt.Errorf("invalid project name: results in empty directory name")
+		return "", "", errors.New("invalid project name: results in empty directory name")
 	}
 
 	// Get absolute path of the true projects root for validation
@@ -481,7 +482,7 @@ func CreateUniqueDir(projectsRoot, basePath, name string, perm os.FileMode) (pat
 
 		// Security check: ensure candidate is a subdirectory of projectsRoot
 		if !IsSafeSubdirectory(projectsRootAbs, candidateAbs) {
-			return "", "", fmt.Errorf("project directory would be outside allowed projects root")
+			return "", "", errors.New("project directory would be outside allowed projects root")
 		}
 
 		if mkErr := os.Mkdir(candidate, perm); mkErr == nil {
@@ -493,7 +494,7 @@ func CreateUniqueDir(projectsRoot, basePath, name string, perm os.FileMode) (pat
 				if strings.HasPrefix(candidateAbs, projectsRootAbs+string(filepath.Separator)) {
 					_ = os.Remove(candidateAbs)
 				}
-				return "", "", fmt.Errorf("created directory is outside allowed projects root")
+				return "", "", errors.New("created directory is outside allowed projects root")
 			}
 
 			return candidate, folderName, nil

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -55,7 +55,7 @@ func WriteComposeFile(projectsRoot, dirPath, content string) error {
 	rootAbs = filepath.Clean(rootAbs)
 
 	if !IsSafeSubdirectory(rootAbs, dirPath) {
-		return fmt.Errorf("refusing to write compose file: path outside projects root")
+		return errors.New("refusing to write compose file: path outside projects root")
 	}
 
 	if err := os.MkdirAll(dirPath, pkgutils.DirPerm); err != nil {
@@ -92,7 +92,7 @@ func WriteProjectFile(projectsRoot, dirPath, fileName, content string) error {
 	rootAbs = filepath.Clean(rootAbs)
 
 	if !IsSafeSubdirectory(rootAbs, dirPath) {
-		return fmt.Errorf("refusing to write project file: path outside projects root")
+		return errors.New("refusing to write project file: path outside projects root")
 	}
 
 	if err := os.MkdirAll(dirPath, pkgutils.DirPerm); err != nil {
@@ -125,7 +125,7 @@ func RemoveProjectFile(projectsRoot, dirPath, fileName string) error {
 	rootAbs = filepath.Clean(rootAbs)
 
 	if !IsSafeSubdirectory(rootAbs, dirPath) {
-		return fmt.Errorf("refusing to remove project file: path outside projects root")
+		return errors.New("refusing to remove project file: path outside projects root")
 	}
 
 	if fileName == "" || filepath.Base(fileName) != fileName || strings.Contains(fileName, string(filepath.Separator)) {
@@ -234,7 +234,7 @@ func WriteSyncedDirectory(projectsRoot, projectPath string, files []SyncFile) ([
 	projectAbs = filepath.Clean(projectAbs)
 
 	if !IsSafeSubdirectory(rootAbs, projectAbs) {
-		return nil, fmt.Errorf("project path is outside projects root")
+		return nil, errors.New("project path is outside projects root")
 	}
 
 	// Ensure project directory exists
@@ -298,7 +298,7 @@ func CleanupRemovedFiles(projectsRoot, projectPath string, oldFiles, newFiles []
 	projectAbs = filepath.Clean(projectAbs)
 
 	if !IsSafeSubdirectory(rootAbs, projectAbs) {
-		return fmt.Errorf("project path is outside projects root")
+		return errors.New("project path is outside projects root")
 	}
 
 	// Build set of new files for quick lookup

--- a/backend/pkg/projects/includes.go
+++ b/backend/pkg/projects/includes.go
@@ -81,7 +81,7 @@ func ParseIncludesFromContent(composeFilePath string, content []byte, envMap Env
 		// `include:` key present but null (e.g. `include: ~`) — treat as empty.
 		return []IncludeFile{}, nil
 	default:
-		return nil, fmt.Errorf("invalid include type")
+		return nil, errors.New("invalid include type")
 	}
 
 	return includeFiles, nil
@@ -111,7 +111,7 @@ func extractIncludePathsInternal(item any) ([]string, error) {
 	case map[string]any:
 		return extractIncludePathsFromMapInternal(v)
 	default:
-		return nil, fmt.Errorf("invalid include item type")
+		return nil, errors.New("invalid include item type")
 	}
 }
 
@@ -137,7 +137,7 @@ func extractIncludePathsFromMapInternal(v map[string]any) ([]string, error) {
 
 func resolveIncludeFileInternal(includePath, baseDir string, envMap EnvMap, includeContent bool) (IncludeFile, error) {
 	if includePath == "" {
-		return IncludeFile{}, fmt.Errorf("empty include path")
+		return IncludeFile{}, errors.New("empty include path")
 	}
 
 	// Expand environment variables in the include path (e.g., ${PROJECT_STACK_DIR})
@@ -194,7 +194,7 @@ func readIncludeContentInternal(fullPath, includePath string, includeContent boo
 // Only allows writing within the project directory
 func ValidateIncludePathForWrite(projectDir, includePath string) (string, error) {
 	if includePath == "" {
-		return "", fmt.Errorf("include path cannot be empty")
+		return "", errors.New("include path cannot be empty")
 	}
 
 	// Resolve project directory to absolute path and evaluate symlinks
@@ -239,7 +239,7 @@ func ValidateIncludePathForWrite(projectDir, includePath string) (string, error)
 
 	// Prevent targeting the project directory itself
 	if evalPath == absProjectDir {
-		return "", fmt.Errorf("include path cannot be the project directory itself")
+		return "", errors.New("include path cannot be the project directory itself")
 	}
 
 	// Check if resolved path is within project directory
@@ -247,7 +247,7 @@ func ValidateIncludePathForWrite(projectDir, includePath string) (string, error)
 	isWithinProject := strings.HasPrefix(evalPath+string(filepath.Separator), projectPrefix)
 
 	if !isWithinProject {
-		return "", fmt.Errorf("write access denied: path is outside project directory")
+		return "", errors.New("write access denied: path is outside project directory")
 	}
 
 	return absFullPath, nil

--- a/backend/pkg/remenv/client.go
+++ b/backend/pkg/remenv/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	HeaderAPIKey        = "X-API-Key"            // #nosec G101: header name, not a credential
+	HeaderAPIKey        = "X-Api-Key"            // #nosec G101: header name, not a credential
 	HeaderAgentToken    = "X-Arcane-Agent-Token" // #nosec G101: header name, not a credential
 	HeaderAuthorization = "Authorization"
 	bearerScheme        = "Bearer "
@@ -72,14 +73,14 @@ type TunnelTransportFuncs struct {
 
 func (t TunnelTransportFuncs) EnsureAvailable(ctx context.Context, envID string) error {
 	if t.EnsureAvailableFunc == nil {
-		return fmt.Errorf("edge transport unavailable")
+		return errors.New("edge transport unavailable")
 	}
 	return t.EnsureAvailableFunc(ctx, envID)
 }
 
 func (t TunnelTransportFuncs) Do(ctx context.Context, envID, method, path string, headers map[string]string, body []byte) (*Response, error) {
 	if t.DoFunc == nil {
-		return nil, fmt.Errorf("edge transport unavailable")
+		return nil, errors.New("edge transport unavailable")
 	}
 	return t.DoFunc(ctx, envID, method, path, headers, body)
 }
@@ -123,7 +124,7 @@ func (c *Client) DoJSON(ctx context.Context, req Request, out any) error {
 
 func (c *Client) doViaTunnelInternal(ctx context.Context, req Request) (*Response, error) {
 	if c.tunnel == nil {
-		return nil, &TransportError{Err: fmt.Errorf("edge transport unavailable")}
+		return nil, &TransportError{Err: errors.New("edge transport unavailable")}
 	}
 
 	if err := c.tunnel.EnsureAvailable(ctx, req.EnvironmentID); err != nil {
@@ -153,7 +154,7 @@ func (c *Client) doDirectHTTPInternal(ctx context.Context, req Request) (*Respon
 		httpReq.Header.Set(key, value)
 	}
 
-	resp, err := c.httpClient.Do(httpReq) //nolint:gosec // intentional request to configured remote environment URL
+	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, &TransportError{Err: err}
 	}
@@ -191,7 +192,7 @@ func (r *Response) DecodeJSON(out any) error {
 		return nil
 	}
 	if r == nil {
-		return &DecodeError{Err: fmt.Errorf("response is nil")}
+		return &DecodeError{Err: errors.New("response is nil")}
 	}
 	if err := json.Unmarshal(r.Body, out); err != nil {
 		return &DecodeError{Err: err}

--- a/backend/pkg/scheduler/analytics_job.go
+++ b/backend/pkg/scheduler/analytics_job.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -133,7 +134,7 @@ func (j *AnalyticsJob) Run(ctx context.Context) {
 			}
 			req.Header.Set("Content-Type", "application/json")
 
-			resp, err := j.httpClient.Do(req) //nolint:gosec // intentional request to configured analytics heartbeat endpoint
+			resp, err := j.httpClient.Do(req)
 			if err != nil {
 				return struct{}{}, fmt.Errorf("failed to send request: %w", err)
 			}
@@ -193,7 +194,7 @@ func (j *AnalyticsJob) Reschedule(ctx context.Context) error {
 
 func (j *AnalyticsJob) claimHeartbeatAttemptWindowInternal(ctx context.Context) (bool, error) {
 	if j.kvService == nil {
-		return false, fmt.Errorf("analytics heartbeat kv service is not configured")
+		return false, errors.New("analytics heartbeat kv service is not configured")
 	}
 
 	j.runMu.Lock()

--- a/backend/pkg/utils/auth.go
+++ b/backend/pkg/utils/auth.go
@@ -6,6 +6,6 @@ package utils
 const (
 	HeaderAgentBootstrap = "X-Arcane-Agent-Bootstrap"
 	HeaderAgentToken     = "X-Arcane-Agent-Token" // #nosec G101: header name, not a credential
-	HeaderApiKey         = "X-API-Key"            // #nosec G101: header name, not a credential
+	HeaderApiKey         = "X-Api-Key"            // #nosec G101: header name, not a credential
 	AgentPairingPrefix   = "/api/environments/0/agent/pair"
 )

--- a/backend/pkg/utils/cache/cache_util.go
+++ b/backend/pkg/utils/cache/cache_util.go
@@ -9,12 +9,12 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-type ErrStale struct {
+type StaleError struct {
 	Err error
 }
 
-func (e *ErrStale) Error() string { return "stale cache value: " + e.Err.Error() }
-func (e *ErrStale) Unwrap() error { return e.Err }
+func (e *StaleError) Error() string { return "stale cache value: " + e.Err.Error() }
+func (e *StaleError) Unwrap() error { return e.Err }
 
 type Cache[T any] struct {
 	ttl time.Duration
@@ -125,7 +125,7 @@ func (c *Cache[T]) GetOrFetch(ctx context.Context, fetch func(ctx context.Contex
 	})
 	if err != nil {
 		if hasStale {
-			return stale, &ErrStale{Err: err}
+			return stale, &StaleError{Err: err}
 		}
 		var zero T
 		return zero, err

--- a/backend/pkg/utils/httpx/outbound_url.go
+++ b/backend/pkg/utils/httpx/outbound_url.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -13,7 +14,7 @@ import (
 func ValidateOutboundHTTPURL(rawURL string) (*url.URL, error) {
 	trimmed := strings.TrimSpace(rawURL)
 	if trimmed == "" {
-		return nil, fmt.Errorf("URL is required")
+		return nil, errors.New("URL is required")
 	}
 
 	parsed, err := url.Parse(trimmed)
@@ -27,11 +28,11 @@ func ValidateOutboundHTTPURL(rawURL string) (*url.URL, error) {
 	}
 
 	if parsed.User != nil {
-		return nil, fmt.Errorf("embedded credentials are not allowed")
+		return nil, errors.New("embedded credentials are not allowed")
 	}
 
 	if parsed.Host == "" || parsed.Hostname() == "" {
-		return nil, fmt.Errorf("URL host is required")
+		return nil, errors.New("URL host is required")
 	}
 
 	return parsed, nil

--- a/backend/pkg/utils/httpx/safe_remote.go
+++ b/backend/pkg/utils/httpx/safe_remote.go
@@ -126,7 +126,7 @@ func NewSafeOutboundHTTPClient(base *http.Client, lookupIP LookupIPFunc) (*http.
 		if lastErr != nil {
 			return nil, lastErr
 		}
-		return nil, fmt.Errorf("failed to resolve remote host")
+		return nil, errors.New("failed to resolve remote host")
 	}
 
 	client := *base
@@ -150,7 +150,11 @@ func NewSafeOutboundHTTPClient(base *http.Client, lookupIP LookupIPFunc) (*http.
 func cloneHTTPTransportInternal(base http.RoundTripper) (*http.Transport, error) {
 	switch t := base.(type) {
 	case nil:
-		return http.DefaultTransport.(*http.Transport).Clone(), nil
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, &common.DefaultTransportTypeError{}
+		}
+		return defaultTransport.Clone(), nil
 	case *http.Transport:
 		return t.Clone(), nil
 	default:

--- a/backend/pkg/utils/jwtclaims/jwt.go
+++ b/backend/pkg/utils/jwtclaims/jwt.go
@@ -85,15 +85,12 @@ func GetStringSliceClaim(m map[string]any, key string) []string {
 
 // CheckOrGenerateJwtSecret verifies a secret exists or generates a random one
 func CheckOrGenerateJwtSecret(jwtSecret string) []byte {
-	var secretBytes []byte
 	if jwtSecret != "" {
-		secretBytes = []byte(jwtSecret)
-		return secretBytes
-	} else {
-		secretBytes = make([]byte, 32)
-		if _, err := rand.Read(secretBytes); err != nil {
-			panic(fmt.Errorf("failed to generate random JWT secret: %w", err))
-		}
+		return []byte(jwtSecret)
+	}
+	secretBytes := make([]byte, 32)
+	if _, err := rand.Read(secretBytes); err != nil {
+		panic(fmt.Errorf("failed to generate random JWT secret: %w", err))
 	}
 	return secretBytes
 }

--- a/backend/pkg/utils/notifications/discord_sender.go
+++ b/backend/pkg/utils/notifications/discord_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -25,10 +26,10 @@ func BuildDiscordURL(config models.DiscordConfig) (string, error) {
 // SendDiscord sends a message via Shoutrrr Discord using proper service configuration
 func SendDiscord(ctx context.Context, config models.DiscordConfig, message string) error {
 	if config.WebhookID == "" {
-		return fmt.Errorf("discord webhook ID is empty")
+		return errors.New("discord webhook ID is empty")
 	}
 	if config.Token == "" {
-		return fmt.Errorf("discord token is empty")
+		return errors.New("discord token is empty")
 	}
 
 	shoutrrrURL, err := BuildDiscordURL(config)

--- a/backend/pkg/utils/notifications/email_sender.go
+++ b/backend/pkg/utils/notifications/email_sender.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
@@ -61,7 +62,7 @@ func smtpAuthTypeFromModeInternal(mode models.EmailAuthMode) mail.SMTPAuthType {
 
 func buildMailClientInternal(config models.EmailConfig, options smtpBuildOptions) (*mail.Client, error) {
 	if config.SMTPHost == "" {
-		return nil, fmt.Errorf("SMTP host is empty")
+		return nil, errors.New("SMTP host is empty")
 	}
 	if config.SMTPPort < 1 || config.SMTPPort > 65535 {
 		return nil, fmt.Errorf("invalid SMTP port: %d", config.SMTPPort)
@@ -113,17 +114,17 @@ func SendEmail(ctx context.Context, config models.EmailConfig, subject, htmlBody
 
 func sendEmailInternal(ctx context.Context, config models.EmailConfig, subject, htmlBody string, options smtpBuildOptions) error {
 	if ctx == nil {
-		return fmt.Errorf("email send context is required")
+		return errors.New("email send context is required")
 	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("email send canceled: %w", err)
 	}
 
 	if config.FromAddress == "" {
-		return fmt.Errorf("from address is required")
+		return errors.New("from address is required")
 	}
 	if len(config.ToAddresses) == 0 {
-		return fmt.Errorf("at least one recipient is required")
+		return errors.New("at least one recipient is required")
 	}
 
 	client, err := buildMailClientInternal(config, options)

--- a/backend/pkg/utils/notifications/generic_sender.go
+++ b/backend/pkg/utils/notifications/generic_sender.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +22,7 @@ import (
 // BuildGenericURL and sendGenericDirectInternal.
 func resolveWebhookURLInternal(config models.GenericConfig) (*url.URL, error) {
 	if config.WebhookURL == "" {
-		return nil, fmt.Errorf("webhook URL is empty")
+		return nil, errors.New("webhook URL is empty")
 	}
 
 	parsed, err := url.Parse(config.WebhookURL)
@@ -43,7 +44,7 @@ func resolveWebhookURLInternal(config models.GenericConfig) (*url.URL, error) {
 	}
 
 	if parsed.Host == "" {
-		return nil, fmt.Errorf("invalid webhook URL: missing host")
+		return nil, errors.New("invalid webhook URL: missing host")
 	}
 
 	switch strings.ToLower(parsed.Scheme) {
@@ -128,7 +129,7 @@ func BuildGenericURL(config models.GenericConfig) (string, error) {
 // but embed a success/failure indicator inside the JSON body.
 func SendGenericWithTitle(ctx context.Context, config models.GenericConfig, title, message string) error {
 	if config.WebhookURL == "" {
-		return fmt.Errorf("webhook URL is empty")
+		return errors.New("webhook URL is empty")
 	}
 
 	// When the caller needs response-body validation we make the HTTP request

--- a/backend/pkg/utils/notifications/gotify_sender.go
+++ b/backend/pkg/utils/notifications/gotify_sender.go
@@ -2,8 +2,10 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -15,11 +17,11 @@ import (
 // URL example: gotify://host[:port][/path]/token[?query]
 func BuildGotifyURL(config models.GotifyConfig) (string, error) {
 	if config.Host == "" {
-		return "", fmt.Errorf("gotify host is required")
+		return "", errors.New("gotify host is required")
 	}
 
 	if config.Token == "" {
-		return "", fmt.Errorf("gotify token is required")
+		return "", errors.New("gotify token is required")
 	}
 
 	u := &url.URL{
@@ -42,7 +44,7 @@ func BuildGotifyURL(config models.GotifyConfig) (string, error) {
 
 	q := u.Query()
 	// Always set priority if it's within valid range, 0 is a valid priority
-	q.Set("priority", fmt.Sprintf("%d", config.Priority))
+	q.Set("priority", strconv.Itoa(config.Priority))
 
 	if config.Title != "" {
 		q.Set("title", config.Title)

--- a/backend/pkg/utils/notifications/matrix_sender.go
+++ b/backend/pkg/utils/notifications/matrix_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -15,7 +16,7 @@ import (
 // URL example: matrix://user:password@host[:port]/[?rooms=!roomID1[,roomAlias2]][&disableTLS=yes]
 func BuildMatrixURL(config models.MatrixConfig) (string, error) {
 	if config.Host == "" {
-		return "", fmt.Errorf("matrix host is required")
+		return "", errors.New("matrix host is required")
 	}
 
 	// Build the base URL

--- a/backend/pkg/utils/notifications/ntfy_sender.go
+++ b/backend/pkg/utils/notifications/ntfy_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -15,7 +16,7 @@ import (
 // URL example: ntfy://[user:password@]host[:port]/topic[?query]
 func BuildNtfyURL(config models.NtfyConfig) (string, error) {
 	if config.Topic == "" {
-		return "", fmt.Errorf("ntfy topic is required")
+		return "", errors.New("ntfy topic is required")
 	}
 
 	// Default host to ntfy.sh if not specified
@@ -87,7 +88,7 @@ func BuildNtfyURL(config models.NtfyConfig) (string, error) {
 // SendNtfy sends a message via Shoutrrr Ntfy using proper service configuration
 func SendNtfy(ctx context.Context, config models.NtfyConfig, message string) error {
 	if config.Topic == "" {
-		return fmt.Errorf("ntfy topic is required")
+		return errors.New("ntfy topic is required")
 	}
 
 	shoutrrrURL, err := BuildNtfyURL(config)

--- a/backend/pkg/utils/notifications/pushover_sender.go
+++ b/backend/pkg/utils/notifications/pushover_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -18,13 +19,13 @@ func BuildPushoverURL(config models.PushoverConfig) (string, error) {
 	token := strings.TrimSpace(config.Token)
 
 	if user == "" {
-		return "", fmt.Errorf("pushover user key is required")
+		return "", errors.New("pushover user key is required")
 	}
 	if token == "" {
-		return "", fmt.Errorf("pushover token is required")
+		return "", errors.New("pushover token is required")
 	}
 	if config.Priority < -2 || config.Priority > 2 {
-		return "", fmt.Errorf("pushover priority must be between -2 and 2")
+		return "", errors.New("pushover priority must be between -2 and 2")
 	}
 
 	u := &url.URL{
@@ -58,13 +59,13 @@ func BuildPushoverURL(config models.PushoverConfig) (string, error) {
 // SendPushover sends a message via Shoutrrr Pushover using proper service configuration.
 func SendPushover(ctx context.Context, config models.PushoverConfig, message string) error {
 	if strings.TrimSpace(config.Token) == "" {
-		return fmt.Errorf("pushover token is empty")
+		return errors.New("pushover token is empty")
 	}
 	if strings.TrimSpace(config.User) == "" {
-		return fmt.Errorf("pushover user key is empty")
+		return errors.New("pushover user key is empty")
 	}
 	if config.Priority < -2 || config.Priority > 2 {
-		return fmt.Errorf("pushover priority must be between -2 and 2")
+		return errors.New("pushover priority must be between -2 and 2")
 	}
 
 	shoutrrrURL, err := BuildPushoverURL(config)

--- a/backend/pkg/utils/notifications/signal_sender.go
+++ b/backend/pkg/utils/notifications/signal_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -29,26 +30,26 @@ func BuildSignalURL(config models.SignalConfig) (string, error) {
 // SendSignal sends a message via Shoutrrr Signal using proper service configuration
 func SendSignal(ctx context.Context, config models.SignalConfig, message string) error {
 	if config.Host == "" {
-		return fmt.Errorf("signal host is empty")
+		return errors.New("signal host is empty")
 	}
 	if config.Port == 0 {
-		return fmt.Errorf("signal port is not set")
+		return errors.New("signal port is not set")
 	}
 	if config.Source == "" {
-		return fmt.Errorf("signal source phone number is empty")
+		return errors.New("signal source phone number is empty")
 	}
 	if len(config.Recipients) == 0 {
-		return fmt.Errorf("no signal recipients configured")
+		return errors.New("no signal recipients configured")
 	}
 
 	// Validate authentication
 	hasBasicAuth := config.User != "" && config.Password != ""
 	hasTokenAuth := config.Token != ""
 	if !hasBasicAuth && !hasTokenAuth {
-		return fmt.Errorf("signal requires either basic auth (user/password) or token authentication")
+		return errors.New("signal requires either basic auth (user/password) or token authentication")
 	}
 	if hasBasicAuth && hasTokenAuth {
-		return fmt.Errorf("signal cannot use both basic auth and token authentication simultaneously")
+		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
 	shoutrrrURL, err := BuildSignalURL(config)

--- a/backend/pkg/utils/notifications/slack_sender.go
+++ b/backend/pkg/utils/notifications/slack_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -12,7 +13,7 @@ import (
 // BuildSlackURL converts SlackConfig to Shoutrrr URL format using shoutrrr's Config
 func BuildSlackURL(config models.SlackConfig) (string, error) {
 	if config.Token == "" {
-		return "", fmt.Errorf("slack token is required")
+		return "", errors.New("slack token is required")
 	}
 
 	// Parse the token to get the token object
@@ -38,7 +39,7 @@ func BuildSlackURL(config models.SlackConfig) (string, error) {
 // SendSlack sends a message via Shoutrrr Slack using proper service configuration
 func SendSlack(ctx context.Context, config models.SlackConfig, message string) error {
 	if config.Token == "" {
-		return fmt.Errorf("slack token is empty")
+		return errors.New("slack token is empty")
 	}
 
 	shoutrrrURL, err := BuildSlackURL(config)

--- a/backend/pkg/utils/notifications/telegram_sender.go
+++ b/backend/pkg/utils/notifications/telegram_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
@@ -40,10 +41,10 @@ func BuildTelegramURL(config models.TelegramConfig) (string, error) {
 // SendTelegram sends a message via Shoutrrr Telegram using proper service configuration
 func SendTelegram(ctx context.Context, config models.TelegramConfig, message string) error {
 	if config.BotToken == "" {
-		return fmt.Errorf("telegram bot token is empty")
+		return errors.New("telegram bot token is empty")
 	}
 	if len(config.ChatIDs) == 0 {
-		return fmt.Errorf("no telegram chat IDs configured")
+		return errors.New("no telegram chat IDs configured")
 	}
 
 	shoutrrrURL, err := BuildTelegramURL(config)

--- a/backend/pkg/utils/signals/signals.go
+++ b/backend/pkg/utils/signals/signals.go
@@ -24,7 +24,7 @@ var onlyOneSignalHandler = make(chan struct{})
 func SignalContext(parentCtx context.Context) context.Context {
 	close(onlyOneSignalHandler) // Panics when called twice
 
-	ctx, cancel := context.WithCancel(parentCtx) //nolint:gosec // cancel is intentionally triggered by the signal handler goroutine below.
+	ctx, cancel := context.WithCancel(parentCtx)
 
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)

--- a/cli/internal/ci/ci_detect.go
+++ b/cli/internal/ci/ci_detect.go
@@ -3,6 +3,7 @@ package ci
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,7 +37,7 @@ func DetectToken(ctx context.Context, provider string, audience string, getenv f
 		if token := strings.TrimSpace(getenv("CI_JOB_JWT_V2")); token != "" {
 			return token, ProviderGitLab, nil
 		}
-		return "", "", fmt.Errorf("no supported CI OIDC token source detected")
+		return "", "", errors.New("no supported CI OIDC token source detected")
 	case ProviderGitHub:
 		token, err := mintGitHubActionsTokenInternal(ctx, audience, getenv, httpClient)
 		if err != nil {
@@ -46,11 +47,11 @@ func DetectToken(ctx context.Context, provider string, audience string, getenv f
 	case ProviderGitLab:
 		token := strings.TrimSpace(getenv("CI_JOB_JWT_V2"))
 		if token == "" {
-			return "", "", fmt.Errorf("CI_JOB_JWT_V2 is not set; pass a GitLab id_tokens value with --token")
+			return "", "", errors.New("CI_JOB_JWT_V2 is not set; pass a GitLab id_tokens value with --token")
 		}
 		return token, ProviderGitLab, nil
 	case ProviderGeneric:
-		return "", "", fmt.Errorf("generic provider requires --token, --token-file, or --token-stdin")
+		return "", "", errors.New("generic provider requires --token, --token-file, or --token-stdin")
 	default:
 		return "", "", fmt.Errorf("unsupported federated provider %q", provider)
 	}
@@ -60,7 +61,7 @@ func mintGitHubActionsTokenInternal(ctx context.Context, audience string, getenv
 	requestURL := strings.TrimSpace(getenv("ACTIONS_ID_TOKEN_REQUEST_URL"))
 	requestToken := strings.TrimSpace(getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
 	if requestURL == "" || requestToken == "" {
-		return "", fmt.Errorf("GitHub Actions OIDC request environment is not set")
+		return "", errors.New("GitHub Actions OIDC request environment is not set")
 	}
 
 	parsedURL, err := url.Parse(requestURL)
@@ -102,7 +103,7 @@ func mintGitHubActionsTokenInternal(ctx context.Context, audience string, getenv
 	}
 	token := strings.TrimSpace(payload.Value)
 	if token == "" {
-		return "", fmt.Errorf("GitHub Actions OIDC response did not include a token")
+		return "", errors.New("GitHub Actions OIDC response did not include a token")
 	}
 	return token, nil
 }

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	headerAPIKey   = "X-API-KEY" //nolint:gosec
+	headerAPIKey   = "X-Api-Key" // #nosec G101 -- HTTP header name, not a credential
 	defaultTimeout = 10 * time.Minute
 	defaultEnvID   = "0"
 	maxErrorBody   = 4096
@@ -280,7 +280,7 @@ func (c *Client) Request(ctx context.Context, method, path string, body any) (*h
 			req.Header.Set("Accept", "application/json")
 			start := time.Now()
 			logger.GetLogger().Debug("Sending request", "method", method, "url", fullURL, "env_id", c.envID, "streaming_body", true)
-			resp, err := c.httpClient.Do(req) //nolint:gosec // intentional request to configured Arcane server URL
+			resp, err := c.httpClient.Do(req)
 			if err != nil {
 				logger.GetLogger().Debug("Request failed", "method", method, "url", fullURL, "env_id", c.envID, "duration", time.Since(start).String(), "error", err)
 				return nil, fmt.Errorf("request failed: %w", err)
@@ -323,7 +323,7 @@ func (c *Client) RequestRaw(ctx context.Context, method, path string, body io.Re
 
 	start := time.Now()
 	logger.GetLogger().Debug("Sending raw request", "method", method, "url", fullURL, "env_id", c.envID)
-	resp, err := c.httpClient.Do(req) //nolint:gosec // intentional request to configured Arcane server URL
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		logger.GetLogger().Debug("Raw request failed", "method", method, "url", fullURL, "env_id", c.envID, "duration", time.Since(start).String(), "error", err)
 		return nil, fmt.Errorf("request failed: %w", err)
@@ -335,7 +335,7 @@ func (c *Client) RequestRaw(ctx context.Context, method, path string, body io.Re
 
 func (c *Client) resolveURL(path string) (string, error) {
 	if strings.TrimSpace(path) == "" {
-		return "", fmt.Errorf("invalid path: empty")
+		return "", errors.New("invalid path: empty")
 	}
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
 		if _, err := url.Parse(path); err != nil {
@@ -348,7 +348,7 @@ func (c *Client) resolveURL(path string) (string, error) {
 		return "", fmt.Errorf("invalid path: %w", err)
 	}
 	if c.baseURLParsed == nil {
-		return "", fmt.Errorf("invalid base URL")
+		return "", errors.New("invalid base URL")
 	}
 	return c.baseURLParsed.ResolveReference(rel).String(), nil
 }
@@ -373,7 +373,7 @@ func (c *Client) doRequest(ctx context.Context, method, fullURL string, bodyByte
 
 		start := time.Now()
 		logger.GetLogger().Debug("Sending request", "method", method, "url", fullURL, "env_id", c.envID, "attempt", attempt, "max_attempts", attempts, "body_bytes", len(bodyBytes))
-		resp, err := c.httpClient.Do(req) //nolint:gosec // intentional request to configured Arcane server URL
+		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			logger.GetLogger().Debug("Request failed", "method", method, "url", fullURL, "env_id", c.envID, "attempt", attempt, "duration", time.Since(start).String(), "error", err)
 			if attempt < attempts && c.shouldRetry(method, 0, err) {
@@ -478,7 +478,7 @@ func (c *Client) applyAuth(req *http.Request) {
 
 func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.refreshToken == "" {
-		return fmt.Errorf("refresh token not configured; run `arcane auth login`")
+		return errors.New("refresh token not configured; run `arcane auth login`")
 	}
 
 	bodyBytes, err := json.Marshal(map[string]string{"refreshToken": c.refreshToken})
@@ -487,7 +487,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	}
 
 	if c.baseURLParsed == nil {
-		return fmt.Errorf("invalid base URL")
+		return errors.New("invalid base URL")
 	}
 	refreshURL := c.baseURLParsed.ResolveReference(&url.URL{Path: types.Endpoints.AuthRefresh()}).String()
 	logger.GetLogger().Debug("Sending token refresh request", "url", refreshURL)
@@ -500,7 +500,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	req.Header.Set("Accept", "application/json")
 
 	start := time.Now()
-	resp, err := c.httpClient.Do(req) //nolint:gosec // intentional request to configured Arcane server URL
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		logger.GetLogger().Debug("Token refresh request failed", "url", refreshURL, "duration", time.Since(start).String(), "error", err)
 		return fmt.Errorf("token refresh failed: %w", err)
@@ -522,7 +522,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 		return fmt.Errorf("failed to parse refresh response: %w", err)
 	}
 	if !result.Success || result.Data.Token == "" {
-		return fmt.Errorf("token refresh failed: unexpected response from server")
+		return errors.New("token refresh failed: unexpected response from server")
 	}
 
 	newRefresh := result.Data.RefreshToken
@@ -658,7 +658,7 @@ func DecodeResponseStrict[T any](resp *http.Response) (*APIResponse[T], error) {
 		if strings.TrimSpace(result.Error) != "" {
 			return &result, fmt.Errorf("API error: %s", result.Error)
 		}
-		return &result, fmt.Errorf("API error: request was not successful")
+		return &result, errors.New("API error: request was not successful")
 	}
 
 	return &result, nil

--- a/cli/internal/cmdutil/context.go
+++ b/cli/internal/cmdutil/context.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -12,7 +13,7 @@ import (
 // ClientFromCommand returns a configured authenticated client for the command.
 func ClientFromCommand(cmd *cobra.Command) (*client.Client, error) {
 	if cmd == nil {
-		return nil, fmt.Errorf("nil command")
+		return nil, errors.New("nil command")
 	}
 	if app, ok := runtimectx.From(cmd.Context()); ok {
 		return app.Client()
@@ -23,7 +24,7 @@ func ClientFromCommand(cmd *cobra.Command) (*client.Client, error) {
 // UnauthClientFromCommand returns a configured unauthenticated client for the command.
 func UnauthClientFromCommand(cmd *cobra.Command) (*client.Client, error) {
 	if cmd == nil {
-		return nil, fmt.Errorf("nil command")
+		return nil, errors.New("nil command")
 	}
 	if app, ok := runtimectx.From(cmd.Context()); ok {
 		return app.UnauthClient()

--- a/cli/internal/cmdutil/response.go
+++ b/cli/internal/cmdutil/response.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +28,7 @@ func (e *HTTPStatusError) Error() string {
 // EnsureSuccessStatus returns an error for non-2xx responses.
 func EnsureSuccessStatus(resp *http.Response) error {
 	if resp == nil {
-		return fmt.Errorf("nil HTTP response")
+		return errors.New("nil HTTP response")
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
@@ -45,7 +46,7 @@ func DecodeJSON[T any](resp *http.Response, out *T) error {
 		return err
 	}
 	if out == nil {
-		return fmt.Errorf("nil decode target")
+		return errors.New("nil decode target")
 	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -102,6 +102,8 @@ func SetColorEnabled(enabled bool) {
 // Success prints a success message in green.
 // The message is prefixed with a newline for visual separation.
 // Format specifiers and arguments work like fmt.Printf.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Success(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("\n%s\n", render(successStyle, msg))
@@ -110,6 +112,8 @@ func Success(format string, a ...any) {
 // Error prints an error message in red.
 // The message is prefixed with a newline for visual separation.
 // Format specifiers and arguments work like fmt.Printf.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Error(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("\n%s\n", render(errorStyle, msg))
@@ -118,6 +122,8 @@ func Error(format string, a ...any) {
 // Warning prints a warning message in yellow.
 // The message is prefixed with a newline for visual separation.
 // Format specifiers and arguments work like fmt.Printf.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Warning(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("\n%s\n", render(warnStyle, msg))
@@ -126,6 +132,8 @@ func Warning(format string, a ...any) {
 // Info prints an info message in cyan.
 // The message is prefixed with a newline for visual separation.
 // Format specifiers and arguments work like fmt.Printf.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Info(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("\n%s\n", render(infoStyle, msg))
@@ -134,6 +142,8 @@ func Info(format string, a ...any) {
 // Header prints a header message in bold white.
 // Use this to introduce sections of output. The message is prefixed
 // with a newline for visual separation.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Header(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("\n%s\n", render(headerStyle, msg))
@@ -141,6 +151,8 @@ func Header(format string, a ...any) {
 
 // Print prints a standard message without color formatting.
 // Use this for regular output that doesn't need status indication.
+//
+//nolint:goprintffuncname // printf-style output helper; *f rename across call sites tracked separately
 func Print(format string, a ...any) {
 	fmt.Printf(format+"\n", a...)
 }

--- a/cli/internal/prompt/prompt.go
+++ b/cli/internal/prompt/prompt.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,7 +21,7 @@ func Select(label string, options []string) (int, error) {
 		return -1, fmt.Errorf("no %s options available", label)
 	}
 	if !IsInteractive() {
-		return -1, fmt.Errorf("interactive terminal required")
+		return -1, errors.New("interactive terminal required")
 	}
 
 	items := make([]list.Item, len(options))
@@ -37,16 +38,16 @@ func Select(label string, options []string) (int, error) {
 
 	result, ok := finalModel.(selectModel)
 	if !ok {
-		return -1, fmt.Errorf("failed to read selection")
+		return -1, errors.New("failed to read selection")
 	}
 	if result.canceled {
-		return -1, fmt.Errorf("selection canceled")
+		return -1, errors.New("selection canceled")
 	}
 	if result.choice < 0 {
-		return -1, fmt.Errorf("selection required")
+		return -1, errors.New("selection required")
 	}
 	if result.choice >= len(options) {
-		return -1, fmt.Errorf("selection out of range")
+		return -1, errors.New("selection out of range")
 	}
 
 	clearScreenAndShowSelection(label, options[result.choice])

--- a/cli/internal/types/config.go
+++ b/cli/internal/types/config.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"fmt"
+	"errors"
 	"maps"
 	"strings"
 )
@@ -81,11 +81,11 @@ type Config struct {
 	// ServerURL is the base URL of the Arcane server (e.g., http://localhost:3552)
 	ServerURL string `yaml:"server_url" mapstructure:"server_url"`
 	// APIKey is the API key for authentication (sent as X-API-KEY)
-	APIKey string `yaml:"api_key,omitempty" mapstructure:"api_key"` //nolint:gosec // persisted config schema requires this field name
+	APIKey string `yaml:"api_key,omitempty" mapstructure:"api_key"`
 	// JWTToken is the JWT access token for authentication (sent as Authorization: Bearer)
-	JWTToken string `yaml:"jwt_token,omitempty" mapstructure:"jwt_token"` //nolint:gosec // persisted config schema requires this field name
+	JWTToken string `yaml:"jwt_token,omitempty" mapstructure:"jwt_token"`
 	// RefreshToken is the refresh token for obtaining new access tokens
-	RefreshToken string `yaml:"refresh_token,omitempty" mapstructure:"refresh_token"` //nolint:gosec // persisted config schema requires this field name
+	RefreshToken string `yaml:"refresh_token,omitempty" mapstructure:"refresh_token"`
 	// DefaultEnvironment is the default environment ID to use
 	DefaultEnvironment string `yaml:"default_environment,omitempty" mapstructure:"default_environment"`
 	// FederatedAudience is the default token audience for `arcane-cli auth federated`
@@ -107,7 +107,7 @@ func (c *Config) HasAuth() bool {
 // This is useful for commands like `auth login` that do not require prior authentication.
 func (c *Config) ValidateServerURL() error {
 	if c.ServerURL == "" {
-		return fmt.Errorf("server_url is not configured. Run: arcane config set --server-url <url>")
+		return errors.New("server_url is not configured. Run: arcane config set --server-url <url>")
 	}
 	return nil
 }
@@ -120,7 +120,7 @@ func (c *Config) Validate() error {
 		return err
 	}
 	if !c.HasAuth() {
-		return fmt.Errorf("authentication is not configured. Run: arcane config set --api-key <key> OR arcane auth login")
+		return errors.New("authentication is not configured. Run: arcane config set --api-key <key> OR arcane auth login")
 	}
 	return nil
 }

--- a/cli/internal/types/endpoints.go
+++ b/cli/internal/types/endpoints.go
@@ -344,6 +344,7 @@ var Endpoints = ArcaneApiEndpoints{ //nolint:gosec // static endpoint paths; aut
 }
 
 // Auth endpoints
+
 func (e ArcaneApiEndpoints) AuthLogout() string    { return e.AuthLogoutEndpoint }
 func (e ArcaneApiEndpoints) AuthMe() string        { return e.AuthMeEndpoint }
 func (e ArcaneApiEndpoints) AuthPassword() string  { return e.AuthPasswordEndpoint }
@@ -351,15 +352,18 @@ func (e ArcaneApiEndpoints) AuthRefresh() string   { return e.AuthRefreshEndpoin
 func (e ArcaneApiEndpoints) AuthFederated() string { return e.AuthFederatedEndpoint }
 
 // OIDC endpoints
+
 func (e ArcaneApiEndpoints) OIDCDeviceCode() string  { return e.OIDCDeviceCodeEndpoint }
 func (e ArcaneApiEndpoints) OIDCDeviceToken() string { return e.OIDCDeviceTokenEndpoint }
 func (e ArcaneApiEndpoints) OIDCStatus() string      { return e.OIDCStatusEndpoint }
 
 // API Key endpoints
+
 func (e ArcaneApiEndpoints) ApiKeys() string         { return e.ApiKeysEndpoint }
 func (e ArcaneApiEndpoints) ApiKey(id string) string { return fmt.Sprintf(e.ApiKeyEndpoint, id) }
 
 // User endpoints
+
 func (e ArcaneApiEndpoints) Users() string         { return e.UsersEndpoint }
 func (e ArcaneApiEndpoints) User(id string) string { return fmt.Sprintf(e.UserEndpoint, id) }
 func (e ArcaneApiEndpoints) UserRoleAssignments(userID string) string {
@@ -367,6 +371,7 @@ func (e ArcaneApiEndpoints) UserRoleAssignments(userID string) string {
 }
 
 // Role (RBAC) endpoints
+
 func (e ArcaneApiEndpoints) Roles() string         { return e.RolesEndpoint }
 func (e ArcaneApiEndpoints) Role(id string) string { return fmt.Sprintf(e.RoleEndpoint, id) }
 func (e ArcaneApiEndpoints) RolesAvailablePermissions() string {
@@ -374,12 +379,14 @@ func (e ArcaneApiEndpoints) RolesAvailablePermissions() string {
 }
 
 // OIDC role mapping endpoints
+
 func (e ArcaneApiEndpoints) OidcRoleMappings() string { return e.OidcRoleMappingsEndpoint }
 func (e ArcaneApiEndpoints) OidcRoleMapping(id string) string {
 	return fmt.Sprintf(e.OidcRoleMappingEndpoint, id)
 }
 
 // Environment endpoints
+
 func (e ArcaneApiEndpoints) Environments() string { return e.EnvironmentsEndpoint }
 
 func (e ArcaneApiEndpoints) Environment(id string) string {
@@ -395,6 +402,7 @@ func (e ArcaneApiEndpoints) EnvironmentVersion(envID string) string {
 }
 
 // Container endpoints
+
 func (e ArcaneApiEndpoints) Containers(envID string) string {
 	return fmt.Sprintf(e.ContainersEndpoint, envID)
 }
@@ -428,6 +436,7 @@ func (e ArcaneApiEndpoints) ContainersCounts(envID string) string {
 }
 
 // Image endpoints
+
 func (e ArcaneApiEndpoints) Images(envID string) string { return fmt.Sprintf(e.ImagesEndpoint, envID) }
 
 func (e ArcaneApiEndpoints) Image(envID, imageID string) string {
@@ -451,6 +460,7 @@ func (e ArcaneApiEndpoints) ImagesUpload(envID string) string {
 }
 
 // Image Update endpoints
+
 func (e ArcaneApiEndpoints) ImageUpdatesCheck(envID string) string {
 	return fmt.Sprintf(e.ImageUpdatesCheckEndpoint, envID)
 }
@@ -468,6 +478,7 @@ func (e ArcaneApiEndpoints) ImageUpdatesSummary(envID string) string {
 }
 
 // Network endpoints
+
 func (e ArcaneApiEndpoints) Networks(envID string) string {
 	return fmt.Sprintf(e.NetworksEndpoint, envID)
 }
@@ -485,6 +496,7 @@ func (e ArcaneApiEndpoints) NetworksPrune(envID string) string {
 }
 
 // Volume endpoints
+
 func (e ArcaneApiEndpoints) Volumes(envID string) string {
 	return fmt.Sprintf(e.VolumesEndpoint, envID)
 }
@@ -510,6 +522,7 @@ func (e ArcaneApiEndpoints) VolumeUsage(envID, volumeName string) string {
 }
 
 // Project endpoints
+
 func (e ArcaneApiEndpoints) Projects(envID string) string {
 	return fmt.Sprintf(e.ProjectsEndpoint, envID)
 }
@@ -551,6 +564,7 @@ func (e ArcaneApiEndpoints) ProjectIncludes(envID, projectID string) string {
 }
 
 // System endpoints
+
 func (e ArcaneApiEndpoints) SystemPrune(envID string) string {
 	return fmt.Sprintf(e.SystemPruneEndpoint, envID)
 }
@@ -584,6 +598,7 @@ func (e ArcaneApiEndpoints) SystemUpgradeCheck(envID string) string {
 }
 
 // Updater endpoints
+
 func (e ArcaneApiEndpoints) UpdaterStatus(envID string) string {
 	return fmt.Sprintf(e.UpdaterStatusEndpoint, envID)
 }
@@ -597,11 +612,13 @@ func (e ArcaneApiEndpoints) UpdaterHistory(envID string) string {
 }
 
 // Job schedule endpoints
+
 func (e ArcaneApiEndpoints) JobSchedules(envID string) string {
 	return fmt.Sprintf(e.JobSchedulesEndpoint, envID)
 }
 
 // Settings endpoints
+
 func (e ArcaneApiEndpoints) Settings(envID string) string {
 	return fmt.Sprintf(e.SettingsEndpoint, envID)
 }
@@ -611,6 +628,7 @@ func (e ArcaneApiEndpoints) SettingsPublic(envID string) string {
 }
 
 // Notification endpoints
+
 func (e ArcaneApiEndpoints) NotificationsSettings(envID string) string {
 	return fmt.Sprintf(e.NotificationsSettingsEndpoint, envID)
 }
@@ -624,6 +642,7 @@ func (e ArcaneApiEndpoints) NotificationsTestProvider(envID, provider string) st
 }
 
 // Container Registry endpoints
+
 func (e ArcaneApiEndpoints) ContainerRegistries() string { return e.ContainerRegistriesEndpoint }
 
 func (e ArcaneApiEndpoints) ContainerRegistry(id string) string {
@@ -635,6 +654,7 @@ func (e ArcaneApiEndpoints) ContainerRegistryTest(id string) string {
 }
 
 // Event endpoints
+
 func (e ArcaneApiEndpoints) Events() string         { return e.EventsEndpoint }
 func (e ArcaneApiEndpoints) Event(id string) string { return fmt.Sprintf(e.EventEndpoint, id) }
 func (e ArcaneApiEndpoints) EventsEnvironment(envID string) string {
@@ -642,6 +662,7 @@ func (e ArcaneApiEndpoints) EventsEnvironment(envID string) string {
 }
 
 // Template endpoints
+
 func (e ArcaneApiEndpoints) Templates() string           { return e.TemplatesEndpoint }
 func (e ArcaneApiEndpoints) Template(id string) string   { return fmt.Sprintf(e.TemplateEndpoint, id) }
 func (e ArcaneApiEndpoints) TemplatesAll() string        { return e.TemplatesAllEndpoint }
@@ -660,11 +681,13 @@ func (e ArcaneApiEndpoints) TemplateDownload(id string) string {
 func (e ArcaneApiEndpoints) TemplateFetch() string { return e.TemplateFetchEndpoint }
 
 // Dashboard endpoints
+
 func (e ArcaneApiEndpoints) Dashboard(envID string) string {
 	return fmt.Sprintf(e.DashboardEndpoint, envID)
 }
 
 // GitOps Sync endpoints
+
 func (e ArcaneApiEndpoints) GitOpsSyncs(envID string) string {
 	return fmt.Sprintf(e.GitOpsSyncsEndpoint, envID)
 }
@@ -685,6 +708,7 @@ func (e ArcaneApiEndpoints) GitOpsSyncsImport(envID string) string {
 }
 
 // Git Repository endpoints
+
 func (e ArcaneApiEndpoints) GitRepositories() string { return e.GitRepositoriesEndpoint }
 func (e ArcaneApiEndpoints) GitRepository(id string) string {
 	return fmt.Sprintf(e.GitRepositoryEndpoint, id)

--- a/cli/pkg/admin/apikeys/cmd.go
+++ b/cli/pkg/admin/apikeys/cmd.go
@@ -1,7 +1,9 @@
 package apikeys
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -116,7 +118,7 @@ var listCmd = &cobra.Command{
 				key.ID,
 				key.Name,
 				description,
-				fmt.Sprintf("%d", len(key.Permissions)),
+				strconv.Itoa(len(key.Permissions)),
 				key.CreatedAt.Format("2006-01-02 15:04"),
 				lastUsed,
 			}
@@ -146,7 +148,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 		if len(grants) == 0 {
-			return fmt.Errorf("at least one --permission is required (e.g. --permission containers:list)")
+			return errors.New("at least one --permission is required (e.g. --permission containers:list)")
 		}
 		createReq := apikey.CreateApiKey{
 			Name:        args[0],
@@ -274,7 +276,7 @@ var getCmd = &cobra.Command{
 		if result.Data.ExpiresAt != nil {
 			output.KeyValue("Expires", result.Data.ExpiresAt.Format("2006-01-02 15:04"))
 		}
-		output.KeyValue("Permissions", fmt.Sprintf("%d", len(result.Data.Permissions)))
+		output.KeyValue("Permissions", strconv.Itoa(len(result.Data.Permissions)))
 		if len(result.Data.Permissions) > 0 {
 			rows := make([][]string, len(result.Data.Permissions))
 			for i, g := range result.Data.Permissions {

--- a/cli/pkg/admin/notifications/cmd.go
+++ b/cli/pkg/admin/notifications/cmd.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
 	"github.com/getarcaneapp/arcane/cli/internal/cmdutil"
@@ -64,9 +65,9 @@ var settingsGetCmd = &cobra.Command{
 		rows := make([][]string, len(result))
 		for i, setting := range result {
 			rows[i] = []string{
-				fmt.Sprintf("%d", setting.ID),
+				strconv.FormatUint(uint64(setting.ID), 10),
 				string(setting.Provider),
-				fmt.Sprintf("%t", setting.Enabled),
+				strconv.FormatBool(setting.Enabled),
 			}
 		}
 

--- a/cli/pkg/admin/roles/cmd.go
+++ b/cli/pkg/admin/roles/cmd.go
@@ -6,7 +6,9 @@
 package roles
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/getarcaneapp/arcane/cli/internal/cmdutil"
@@ -94,8 +96,8 @@ var listCmd = &cobra.Command{
 				r.ID,
 				r.Name,
 				roleType,
-				fmt.Sprintf("%d", r.AssignedUserCount),
-				fmt.Sprintf("%d", len(r.Permissions)),
+				strconv.Itoa(r.AssignedUserCount),
+				strconv.Itoa(len(r.Permissions)),
 			}
 		}
 		output.Table(headers, rows)
@@ -135,9 +137,9 @@ var getCmd = &cobra.Command{
 		if result.Data.Description != nil {
 			output.KeyValue("Description", *result.Data.Description)
 		}
-		output.KeyValue("Built-in", fmt.Sprintf("%t", result.Data.BuiltIn))
-		output.KeyValue("Assigned users", fmt.Sprintf("%d", result.Data.AssignedUserCount))
-		output.KeyValue("Permissions", fmt.Sprintf("%d", len(result.Data.Permissions)))
+		output.KeyValue("Built-in", strconv.FormatBool(result.Data.BuiltIn))
+		output.KeyValue("Assigned users", strconv.Itoa(result.Data.AssignedUserCount))
+		output.KeyValue("Permissions", strconv.Itoa(len(result.Data.Permissions)))
 		if len(result.Data.Permissions) > 0 {
 			rows := make([][]string, len(result.Data.Permissions))
 			for i, p := range result.Data.Permissions {
@@ -155,10 +157,10 @@ var createCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if roleCreateName == "" {
-			return fmt.Errorf("--name is required")
+			return errors.New("--name is required")
 		}
 		if len(roleCreatePermissions) == 0 {
-			return fmt.Errorf("at least one --permission is required")
+			return errors.New("at least one --permission is required")
 		}
 		c, err := cmdutil.ClientFromCommand(cmd)
 		if err != nil {
@@ -188,7 +190,7 @@ var createCmd = &cobra.Command{
 		}
 		output.Success("Role %s created", result.Data.Name)
 		output.KeyValue("ID", result.Data.ID)
-		output.KeyValue("Permissions", fmt.Sprintf("%d", len(result.Data.Permissions)))
+		output.KeyValue("Permissions", strconv.Itoa(len(result.Data.Permissions)))
 		return nil
 	},
 }

--- a/cli/pkg/admin/users/cmd.go
+++ b/cli/pkg/admin/users/cmd.go
@@ -77,11 +77,11 @@ func summarizeRoleAssignments(assignments []user.RoleAssignmentSummary) string {
 		b := buckets[roleID]
 		switch {
 		case b.hasGlobal && b.envScoped == 0:
-			parts = append(parts, fmt.Sprintf("%s (global)", roleID))
+			parts = append(parts, roleID+" (global)")
 		case b.hasGlobal && b.envScoped > 0:
 			parts = append(parts, fmt.Sprintf("%s (global +%d envs)", roleID, b.envScoped))
 		case b.envScoped == 1:
-			parts = append(parts, fmt.Sprintf("%s on 1 env", roleID))
+			parts = append(parts, roleID+" on 1 env")
 		default:
 			parts = append(parts, fmt.Sprintf("%s on %d envs", roleID, b.envScoped))
 		}

--- a/cli/pkg/auth/cmd.go
+++ b/cli/pkg/auth/cmd.go
@@ -2,9 +2,11 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -86,7 +88,7 @@ var loginCmd = &cobra.Command{
 
 		for {
 			if time.Now().After(expiresAt) {
-				return fmt.Errorf("device authorization expired; run login again")
+				return errors.New("device authorization expired; run login again")
 			}
 
 			select {
@@ -116,9 +118,9 @@ var loginCmd = &cobra.Command{
 					ticker.Reset(pollInterval)
 					continue
 				case "expired_token":
-					return fmt.Errorf("device authorization expired; run login again")
+					return errors.New("device authorization expired; run login again")
 				case "access_denied":
-					return fmt.Errorf("device authorization denied")
+					return errors.New("device authorization denied")
 				default:
 					return fmt.Errorf("device token exchange failed (status %d): %s", tokenResp.StatusCode, strings.TrimSpace(string(tokenBody)))
 				}
@@ -129,7 +131,7 @@ var loginCmd = &cobra.Command{
 				return fmt.Errorf("failed to parse token response: %w", err)
 			}
 			if !tokenResult.Success || tokenResult.Token == "" {
-				return fmt.Errorf("device token exchange failed: unexpected response from server")
+				return errors.New("device token exchange failed: unexpected response from server")
 			}
 
 			if cmdutil.JSONOutputEnabled(cmd) || jsonOutput {
@@ -437,9 +439,9 @@ var oidcStatusCmd = &cobra.Command{
 		}
 
 		output.Header("OIDC Status")
-		output.KeyValue("Environment Forced", fmt.Sprintf("%t", result.EnvForced))
-		output.KeyValue("Environment Configured", fmt.Sprintf("%t", result.EnvConfigured))
-		output.KeyValue("Merge Accounts", fmt.Sprintf("%t", result.MergeAccounts))
+		output.KeyValue("Environment Forced", strconv.FormatBool(result.EnvForced))
+		output.KeyValue("Environment Configured", strconv.FormatBool(result.EnvConfigured))
+		output.KeyValue("Merge Accounts", strconv.FormatBool(result.MergeAccounts))
 		return nil
 	},
 }

--- a/cli/pkg/auth/federated.go
+++ b/cli/pkg/auth/federated.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,7 +45,7 @@ GitHub Actions example:
 		exportOutput, _ := cmd.Flags().GetBool("export")
 
 		if cmdutil.JSONOutputEnabled(cmd) && exportOutput {
-			return fmt.Errorf("--json and --export cannot be used together")
+			return errors.New("--json and --export cannot be used together")
 		}
 
 		cfg, err := config.Load()
@@ -73,7 +74,7 @@ GitHub Actions example:
 			return err
 		}
 		if tokenResp.AccessToken == "" {
-			return fmt.Errorf("federated token exchange failed: empty access token")
+			return errors.New("federated token exchange failed: empty access token")
 		}
 
 		expiresAt := time.Now().UTC().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
@@ -149,7 +150,7 @@ func resolveFederatedSubjectTokenInternal(cmd *cobra.Command, provider string, a
 		}
 		token = strings.TrimSpace(string(data))
 		if token == "" {
-			return "", "", fmt.Errorf("token file is empty")
+			return "", "", errors.New("token file is empty")
 		}
 		return token, "file", nil
 	}
@@ -162,7 +163,7 @@ func resolveFederatedSubjectTokenInternal(cmd *cobra.Command, provider string, a
 		}
 		token = strings.TrimSpace(string(data))
 		if token == "" {
-			return "", "", fmt.Errorf("stdin token is empty")
+			return "", "", errors.New("stdin token is empty")
 		}
 		return token, "stdin", nil
 	}

--- a/cli/pkg/config/cmd.go
+++ b/cli/pkg/config/cmd.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -134,7 +135,7 @@ Legacy flag syntax (flags shown below) is still supported:
 		updated = updated || updatedByFlags
 
 		if !updated {
-			return fmt.Errorf("no configuration values provided. Use `arcane config set <key> <value>` (e.g. `arcane config set server-url http://localhost:3552`) or legacy flags (--server-url, --api-key, --jwt-token, --environment, --log-level, --default-limit, --resource-limit)")
+			return errors.New("no configuration values provided. Use `arcane config set <key> <value>` (e.g. `arcane config set server-url http://localhost:3552`) or legacy flags (--server-url, --api-key, --jwt-token, --environment, --log-level, --default-limit, --resource-limit)")
 		}
 
 		if err := config.Save(cfg); err != nil {
@@ -186,7 +187,7 @@ var configTestCmd = &cobra.Command{
 		if cfg.JWTToken != "" {
 			req.Header.Set("Authorization", "Bearer "+cfg.JWTToken)
 		} else {
-			req.Header.Set("X-API-KEY", cfg.APIKey)
+			req.Header.Set("X-Api-Key", cfg.APIKey)
 		}
 
 		resp, err := httpClient.Do(req)
@@ -365,7 +366,7 @@ func applyConfigSetFlags(cmd *cobra.Command, cfg *clitypes.Config) (bool, error)
 
 	if cmd.Flags().Changed("default-limit") {
 		if setDefaultLimit < 0 {
-			return false, fmt.Errorf("--default-limit must be >= 0")
+			return false, errors.New("--default-limit must be >= 0")
 		}
 		cfg.SetDefaultLimit(setDefaultLimit)
 		if setDefaultLimit == 0 {

--- a/cli/pkg/containers/cmd.go
+++ b/cli/pkg/containers/cmd.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -150,7 +151,7 @@ func buildContainersListPath(cmd *cobra.Command, c *client.Client, forceHasUpdat
 	path := types.Endpoints.Containers(c.EnvID())
 	if containersAll {
 		if cmd != nil && (cmd.Flags().Changed("limit") || cmd.Flags().Changed("start")) {
-			return "", fmt.Errorf("--all cannot be combined with explicit pagination flags")
+			return "", errors.New("--all cannot be combined with explicit pagination flags")
 		}
 	} else {
 		var err error
@@ -570,10 +571,10 @@ var containersCreateCmd = &cobra.Command{
 
 		// Validate required fields
 		if req.Name == "" {
-			return fmt.Errorf("--name is required")
+			return errors.New("--name is required")
 		}
 		if req.Image == "" {
-			return fmt.Errorf("--image is required")
+			return errors.New("--image is required")
 		}
 
 		path := types.Endpoints.Containers(c.EnvID())
@@ -689,7 +690,7 @@ func containerDisplayName(details *container.Details) string {
 func resolveContainer(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (*container.Details, bool, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, false, fmt.Errorf("container identifier is required")
+		return nil, false, errors.New("container identifier is required")
 	}
 
 	details, complete, found, err := fetchContainerByIdentifier(ctx, c, trimmed)

--- a/cli/pkg/doctor/cmd.go
+++ b/cli/pkg/doctor/cmd.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,7 +42,7 @@ var DoctorCmd = &cobra.Command{
 
 		cfg := app.Config()
 		if cfg == nil {
-			return fmt.Errorf("configuration unavailable")
+			return errors.New("configuration unavailable")
 		}
 
 		rep := report{Healthy: true}
@@ -123,7 +124,7 @@ var DoctorCmd = &cobra.Command{
 		}
 
 		if !rep.Healthy {
-			return fmt.Errorf("diagnostics failed")
+			return errors.New("diagnostics failed")
 		}
 		return nil
 	},

--- a/cli/pkg/environments/cmd.go
+++ b/cli/pkg/environments/cmd.go
@@ -2,8 +2,10 @@ package environments
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -225,7 +227,7 @@ var switchCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !prompt.IsInteractive() {
-			return fmt.Errorf("interactive terminal required; run `arcane config set environment <id>` instead")
+			return errors.New("interactive terminal required; run `arcane config set environment <id>` instead")
 		}
 
 		cfg, err := config.Load()
@@ -251,7 +253,7 @@ var switchCmd = &cobra.Command{
 		}
 
 		if len(result.Data) == 0 {
-			return fmt.Errorf("no environments available")
+			return errors.New("no environments available")
 		}
 
 		currentEnv := cfg.DefaultEnvironment
@@ -344,7 +346,7 @@ var updateCmd = &cobra.Command{
 
 		var req environment.Update
 		if cmd.Flags().Changed("enabled") && cmd.Flags().Changed("disabled") {
-			return fmt.Errorf("--enabled and --disabled are mutually exclusive")
+			return errors.New("--enabled and --disabled are mutually exclusive")
 		}
 		if cmd.Flags().Changed("name") {
 			req.Name = &envUpdateName
@@ -441,7 +443,7 @@ var versionCmd = &cobra.Command{
 		output.KeyValue("Revision", result.ShortRevision)
 		output.KeyValue("Go Version", result.GoVersion)
 		output.KeyValue("Build Time", result.BuildTime)
-		output.KeyValue("Update Available", fmt.Sprintf("%t", result.UpdateAvailable))
+		output.KeyValue("Update Available", strconv.FormatBool(result.UpdateAvailable))
 		return nil
 	},
 }

--- a/cli/pkg/generate/certs.go
+++ b/cli/pkg/generate/certs.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -126,7 +127,7 @@ type serverTLSPaths struct {
 
 func generateEdgeMTLSBundleInternal(outDir, envID string, appURL string) (*edgeMTLSPaths, error) {
 	if envID == "" {
-		return nil, fmt.Errorf("env ID is required")
+		return nil, errors.New("env ID is required")
 	}
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
@@ -155,7 +156,7 @@ func generateEdgeMTLSBundleInternal(outDir, envID string, appURL string) (*edgeM
 	if trustDomain != "" {
 		dnsSANs = append(dnsSANs, "arcane-agent."+trustDomain)
 	}
-	clientTemplate, err := NewEdgeMTLSClientTemplate(fmt.Sprintf("arcane-edge-%s", envID), BuildEdgeMTLSURISAN(appURL, envID), dnsSANs)
+	clientTemplate, err := NewEdgeMTLSClientTemplate("arcane-edge-"+envID, BuildEdgeMTLSURISAN(appURL, envID), dnsSANs)
 	if err != nil {
 		return nil, err
 	}
@@ -187,15 +188,15 @@ func generateEdgeMTLSBundleInternal(outDir, envID string, appURL string) (*edgeM
 
 func generateServerTLSBundleInternal(outDir, commonName string, hosts []string, certName string, keyName string) (*serverTLSPaths, error) {
 	if commonName == "" {
-		return nil, fmt.Errorf("common name is required")
+		return nil, errors.New("common name is required")
 	}
 	certName = filepath.Base(strings.TrimSpace(certName))
 	if certName == "." || certName == "" {
-		return nil, fmt.Errorf("certificate file name is required")
+		return nil, errors.New("certificate file name is required")
 	}
 	keyName = filepath.Base(strings.TrimSpace(keyName))
 	if keyName == "." || keyName == "" {
-		return nil, fmt.Errorf("key file name is required")
+		return nil, errors.New("key file name is required")
 	}
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
@@ -249,7 +250,7 @@ func NewEdgeMTLSCATemplate() (*x509.Certificate, error) {
 func NewEdgeMTLSClientTemplate(commonName string, uriSAN *url.URL, dnsSANs []string) (*x509.Certificate, error) {
 	commonName = strings.TrimSpace(commonName)
 	if commonName == "" {
-		return nil, fmt.Errorf("common name is required")
+		return nil, errors.New("common name is required")
 	}
 	template, err := newCertificateTemplateInternal(commonName)
 	if err != nil {
@@ -278,7 +279,7 @@ func NewEdgeMTLSClientTemplate(commonName string, uriSAN *url.URL, dnsSANs []str
 func NewServerTLSTemplate(commonName string, hosts []string) (*x509.Certificate, error) {
 	commonName = strings.TrimSpace(commonName)
 	if commonName == "" {
-		return nil, fmt.Errorf("common name is required")
+		return nil, errors.New("common name is required")
 	}
 	template, err := newCertificateTemplateInternal(commonName)
 	if err != nil {

--- a/cli/pkg/gitops/cmd.go
+++ b/cli/pkg/gitops/cmd.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -619,7 +620,7 @@ func init() {
 func resolveGitOpsSync(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (*gitops.GitOpsSync, bool, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, false, fmt.Errorf("gitops sync identifier is required")
+		return nil, false, errors.New("gitops sync identifier is required")
 	}
 
 	resp, err := c.Get(ctx, types.Endpoints.GitOpsSync(c.EnvID(), trimmed))

--- a/cli/pkg/images/cmd.go
+++ b/cli/pkg/images/cmd.go
@@ -33,6 +33,7 @@ package images
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -88,7 +89,7 @@ var imagesListCmd = &cobra.Command{
 			return err
 		}
 		if imagesInUseOnly && imagesUnusedOnly {
-			return fmt.Errorf("--inuse and --unused cannot be used together")
+			return errors.New("--inuse and --unused cannot be used together")
 		}
 
 		path := types.Endpoints.Images(c.EnvID())
@@ -431,7 +432,7 @@ var imagesPullCmd = &cobra.Command{
 				}
 				if currentID != event.ID {
 					currentID = event.ID
-					progressUI.SetLabel(fmt.Sprintf("Downloading %s", event.ID))
+					progressUI.SetLabel("Downloading " + event.ID)
 					progressUI.SetTotal(event.ProgressDetail.Total)
 				}
 				progressUI.SetCurrent(event.ProgressDetail.Current)
@@ -732,7 +733,7 @@ func init() {
 func resolveImageID(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (string, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return "", fmt.Errorf("image identifier is required")
+		return "", errors.New("image identifier is required")
 	}
 
 	resolvedID, found, err := resolveImageByID(ctx, c, trimmed)

--- a/cli/pkg/images/updates/cmd.go
+++ b/cli/pkg/images/updates/cmd.go
@@ -3,6 +3,7 @@ package updates
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
 	"github.com/getarcaneapp/arcane/cli/internal/output"
@@ -140,7 +141,7 @@ var checkImageCmd = &cobra.Command{
 		}
 
 		output.Header("Image Update Status")
-		output.KeyValue("Has Update", fmt.Sprintf("%t", result.Data.HasUpdate))
+		output.KeyValue("Has Update", strconv.FormatBool(result.Data.HasUpdate))
 		if result.Data.HasUpdate {
 			output.KeyValue("Update Type", result.Data.UpdateType)
 			output.KeyValue("Current Version", result.Data.CurrentVersion)
@@ -183,10 +184,10 @@ var summaryCmd = &cobra.Command{
 		}
 
 		output.Header("Image Updates Summary")
-		output.KeyValue("Total Images", fmt.Sprintf("%d", result.Data.TotalImages))
-		output.KeyValue("Images with Updates", fmt.Sprintf("%d", result.Data.ImagesWithUpdates))
-		output.KeyValue("Digest Updates", fmt.Sprintf("%d", result.Data.DigestUpdates))
-		output.KeyValue("Errors", fmt.Sprintf("%d", result.Data.ErrorsCount))
+		output.KeyValue("Total Images", strconv.Itoa(result.Data.TotalImages))
+		output.KeyValue("Images with Updates", strconv.Itoa(result.Data.ImagesWithUpdates))
+		output.KeyValue("Digest Updates", strconv.Itoa(result.Data.DigestUpdates))
+		output.KeyValue("Errors", strconv.Itoa(result.Data.ErrorsCount))
 		return nil
 	},
 }

--- a/cli/pkg/jobs/cmd.go
+++ b/cli/pkg/jobs/cmd.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
@@ -91,7 +92,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if req.EnvironmentHealthInterval == nil && req.EventCleanupInterval == nil && req.ExpiredSessionsCleanupInterval == nil {
-			return fmt.Errorf("no updates provided (set at least one interval flag)")
+			return errors.New("no updates provided (set at least one interval flag)")
 		}
 
 		resp, err := c.Put(cmd.Context(), types.Endpoints.JobSchedules(c.EnvID()), req)

--- a/cli/pkg/networks/cmd.go
+++ b/cli/pkg/networks/cmd.go
@@ -3,6 +3,7 @@ package networks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,7 +45,7 @@ var listCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if inUseOnlyFlag && unusedOnlyFlag {
-			return fmt.Errorf("--inuse and --unused cannot be used together")
+			return errors.New("--inuse and --unused cannot be used together")
 		}
 		c, err := client.NewFromConfig()
 		if err != nil {
@@ -345,7 +346,7 @@ func shortID(id string) string {
 func resolveNetworkID(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (string, string, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return "", "", fmt.Errorf("network identifier is required")
+		return "", "", errors.New("network identifier is required")
 	}
 
 	resp, err := c.Get(ctx, types.Endpoints.Network(c.EnvID(), trimmed))

--- a/cli/pkg/projects/cmd.go
+++ b/cli/pkg/projects/cmd.go
@@ -3,12 +3,14 @@ package projects
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -116,8 +118,8 @@ func runProjectsList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 				proj.Name,
 				proj.Status,
 				projectUpdateStatus(proj),
-				fmt.Sprintf("%d", imageCount),
-				fmt.Sprintf("%d", updatedCount),
+				strconv.Itoa(imageCount),
+				strconv.Itoa(updatedCount),
 			}
 		}
 		output.Table(headers, rows)
@@ -132,8 +134,8 @@ func runProjectsList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 			proj.ID,
 			proj.Name,
 			proj.Status,
-			fmt.Sprintf("%d", proj.ServiceCount),
-			fmt.Sprintf("%d", proj.RunningCount),
+			strconv.Itoa(proj.ServiceCount),
+			strconv.Itoa(proj.RunningCount),
 			proj.CreatedAt,
 		}
 	}
@@ -656,7 +658,7 @@ func init() {
 func resolveProject(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (*project.Details, bool, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, false, fmt.Errorf("project identifier is required")
+		return nil, false, errors.New("project identifier is required")
 	}
 
 	resp, err := c.Get(ctx, types.Endpoints.Project(c.EnvID(), trimmed))

--- a/cli/pkg/registries/cmd.go
+++ b/cli/pkg/registries/cmd.go
@@ -2,6 +2,7 @@ package registries
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
@@ -220,7 +221,7 @@ var updateCmd = &cobra.Command{
 
 		req := make(map[string]any)
 		if cmd.Flags().Changed("enabled") && cmd.Flags().Changed("disabled") {
-			return fmt.Errorf("--enabled and --disabled are mutually exclusive")
+			return errors.New("--enabled and --disabled are mutually exclusive")
 		}
 		if cmd.Flags().Changed("url") {
 			req["url"] = registryUpdateURL
@@ -239,7 +240,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		if len(req) == 0 {
-			return fmt.Errorf("no updates provided; use --url, --username, --password, --enabled, or --disabled")
+			return errors.New("no updates provided; use --url, --username, --password, --enabled, or --disabled")
 		}
 
 		resp, err := c.Put(cmd.Context(), types.Endpoints.ContainerRegistry(args[0]), req)

--- a/cli/pkg/repos/cmd.go
+++ b/cli/pkg/repos/cmd.go
@@ -3,11 +3,13 @@ package repos
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
@@ -524,7 +526,7 @@ var filesCmd = &cobra.Command{
 		for i, node := range files {
 			size := ""
 			if node.Type == gitops.FileTreeNodeTypeFile {
-				size = fmt.Sprintf("%d", node.Size)
+				size = strconv.FormatInt(node.Size, 10)
 			}
 			rows[i] = []string{
 				node.Name,
@@ -580,7 +582,7 @@ var syncCmd = &cobra.Command{
 func resolveGitRepository(ctx context.Context, c *client.Client, identifier string) (*gitops.GitRepository, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, fmt.Errorf("repository identifier is required")
+		return nil, errors.New("repository identifier is required")
 	}
 
 	// Try direct GET by ID.
@@ -598,7 +600,7 @@ func resolveGitRepository(ctx context.Context, c *client.Client, identifier stri
 	}
 
 	// Fallback: search via list endpoint.
-	listPath := fmt.Sprintf("%s?limit=200", types.Endpoints.GitRepositories())
+	listPath := types.Endpoints.GitRepositories() + "?limit=200"
 	listResp, err := c.Get(ctx, listPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search repositories: %w", err)

--- a/cli/pkg/selfupdate/cmd.go
+++ b/cli/pkg/selfupdate/cmd.go
@@ -636,6 +636,7 @@ func downloadFileInternal(ctx context.Context, url, outputPath string) error {
 	return nil
 }
 
+//nolint:goprintffuncname // internal verbose-logging helper; printf-style by design
 func verboseCLIUpdateInternal(format string, args ...any) {
 	if !cliUpdateVerbose {
 		return
@@ -666,7 +667,7 @@ func findChecksumInternal(checksums string, artifactNames ...string) (string, er
 		}
 	}
 
-	for _, line := range strings.Split(checksums, "\n") {
+	for line := range strings.SplitSeq(checksums, "\n") {
 		fields := strings.Fields(strings.TrimSpace(line))
 		if len(fields) < 2 {
 			continue
@@ -681,7 +682,7 @@ func findChecksumInternal(checksums string, artifactNames ...string) (string, er
 
 func checksumEntryNamesInternal(checksums string) []string {
 	names := make([]string, 0)
-	for _, line := range strings.Split(checksums, "\n") {
+	for line := range strings.SplitSeq(checksums, "\n") {
 		fields := strings.Fields(strings.TrimSpace(line))
 		if len(fields) < 2 {
 			continue

--- a/cli/pkg/system/cmd.go
+++ b/cli/pkg/system/cmd.go
@@ -3,6 +3,7 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
 	"github.com/getarcaneapp/arcane/cli/internal/cmdutil"
@@ -327,7 +328,7 @@ var upgradeCheckCmd = &cobra.Command{
 		}
 
 		output.Header("Upgrade Check")
-		output.KeyValue("Can Upgrade", fmt.Sprintf("%t", result.CanUpgrade))
+		output.KeyValue("Can Upgrade", strconv.FormatBool(result.CanUpgrade))
 		output.KeyValue("Message", result.Message)
 		if result.Error {
 			output.KeyValue("Error", "true")

--- a/cli/pkg/templates/cmd.go
+++ b/cli/pkg/templates/cmd.go
@@ -3,12 +3,14 @@ package templates
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -78,7 +80,7 @@ var listCmd = &cobra.Command{
 
 		if templateListAll {
 			if cmd.Flags().Changed("limit") || cmd.Flags().Changed("start") {
-				return fmt.Errorf("--all cannot be combined with explicit pagination flags")
+				return errors.New("--all cannot be combined with explicit pagination flags")
 			}
 			path = types.Endpoints.TemplatesAll()
 			resp, err := c.Get(cmd.Context(), path)
@@ -223,8 +225,8 @@ var contentCmd = &cobra.Command{
 		output.Header("Template Content")
 		output.KeyValue("Name", result.Data.Template.Name)
 		output.KeyValue("Description", result.Data.Template.Description)
-		output.KeyValue("Services", fmt.Sprintf("%d", len(result.Data.Services)))
-		output.KeyValue("Env Variables", fmt.Sprintf("%d", len(result.Data.EnvVariables)))
+		output.KeyValue("Services", strconv.Itoa(len(result.Data.Services)))
+		output.KeyValue("Env Variables", strconv.Itoa(len(result.Data.EnvVariables)))
 		fmt.Println("\n--- Compose Content ---")
 		fmt.Println(result.Data.Content)
 		if result.Data.EnvContent != "" {
@@ -455,7 +457,7 @@ var getCmd = &cobra.Command{
 func resolveTemplate(ctx context.Context, c *client.Client, identifier string) (*template.Template, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, fmt.Errorf("template identifier is required")
+		return nil, errors.New("template identifier is required")
 	}
 
 	resp, err := c.Get(ctx, types.Endpoints.Template(trimmed))
@@ -760,7 +762,7 @@ func topTemplatesFromRankedMatches(matches []rankedTemplateMatch, limit int) []t
 	}
 
 	result := make([]template.Template, 0, limit)
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		result = append(result, matches[i].template)
 	}
 	return result
@@ -770,13 +772,13 @@ func minInt(values ...int) int {
 	if len(values) == 0 {
 		return 0
 	}
-	min := values[0]
+	result := values[0]
 	for _, value := range values[1:] {
-		if value < min {
-			min = value
+		if value < result {
+			result = value
 		}
 	}
-	return min
+	return result
 }
 
 func maxInt(a, b int) int {

--- a/cli/pkg/updater/cmd.go
+++ b/cli/pkg/updater/cmd.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/getarcaneapp/arcane/cli/internal/client"
@@ -53,8 +54,8 @@ var statusCmd = &cobra.Command{
 		}
 
 		output.Header("Updater Status")
-		output.KeyValue("Updating Containers", fmt.Sprintf("%d", result.Data.UpdatingContainers))
-		output.KeyValue("Updating Projects", fmt.Sprintf("%d", result.Data.UpdatingProjects))
+		output.KeyValue("Updating Containers", strconv.Itoa(result.Data.UpdatingContainers))
+		output.KeyValue("Updating Projects", strconv.Itoa(result.Data.UpdatingProjects))
 		return nil
 	},
 }
@@ -93,10 +94,10 @@ var runCmd = &cobra.Command{
 		}
 
 		output.Header("Updater Results")
-		output.KeyValue("Checked", fmt.Sprintf("%d", result.Data.Checked))
-		output.KeyValue("Updated", fmt.Sprintf("%d", result.Data.Updated))
-		output.KeyValue("Skipped", fmt.Sprintf("%d", result.Data.Skipped))
-		output.KeyValue("Failed", fmt.Sprintf("%d", result.Data.Failed))
+		output.KeyValue("Checked", strconv.Itoa(result.Data.Checked))
+		output.KeyValue("Updated", strconv.Itoa(result.Data.Updated))
+		output.KeyValue("Skipped", strconv.Itoa(result.Data.Skipped))
+		output.KeyValue("Failed", strconv.Itoa(result.Data.Failed))
 		output.KeyValue("Duration", result.Data.Duration)
 		return nil
 	},
@@ -136,9 +137,9 @@ var historyCmd = &cobra.Command{
 		rows := make([][]string, len(result.Data))
 		for i, h := range result.Data {
 			rows[i] = []string{
-				fmt.Sprintf("%d", h.Checked),
-				fmt.Sprintf("%d", h.Updated),
-				fmt.Sprintf("%d", h.Failed),
+				strconv.Itoa(h.Checked),
+				strconv.Itoa(h.Updated),
+				strconv.Itoa(h.Failed),
 				h.Duration,
 			}
 		}

--- a/cli/pkg/volumes/cmd.go
+++ b/cli/pkg/volumes/cmd.go
@@ -3,6 +3,7 @@ package volumes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -51,7 +52,7 @@ var listCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if inUseOnlyFlag && unusedOnlyFlag {
-			return fmt.Errorf("--inuse and --unused cannot be used together")
+			return errors.New("--inuse and --unused cannot be used together")
 		}
 		c, err := client.NewFromConfig()
 		if err != nil {
@@ -469,7 +470,7 @@ func init() {
 func resolveVolume(ctx context.Context, c *client.Client, identifier string, allowPrompt bool) (*volume.Volume, error) {
 	trimmed := strings.TrimSpace(identifier)
 	if trimmed == "" {
-		return nil, fmt.Errorf("volume identifier is required")
+		return nil, errors.New("volume identifier is required")
 	}
 
 	resp, err := c.Get(ctx, types.Endpoints.Volume(c.EnvID(), trimmed))

--- a/types/apikey/apikey.go
+++ b/types/apikey/apikey.go
@@ -9,7 +9,7 @@ type PermissionGrant struct {
 	EnvironmentID *string `json:"environmentId,omitempty" doc:"Environment ID to scope the grant to; omit for a global grant"`
 }
 
-// Create represents the request body for creating an API key.
+// CreateApiKey represents the request body for creating an API key.
 type CreateApiKey struct {
 	Name        string            `json:"name" minLength:"1" maxLength:"255" doc:"Name of the API key" example:"My API Key"`
 	Description *string           `json:"description,omitempty" maxLength:"1000" doc:"Optional description of the API key"`
@@ -36,10 +36,11 @@ type ApiKey struct {
 // ApiKeyCreatedDto represents a newly created API key with the full secret.
 type ApiKeyCreatedDto struct {
 	ApiKey
+
 	Key string `json:"key" doc:"The full API key secret (only shown once)"`
 }
 
-// Update represents the request body for updating an API key.
+// UpdateApiKey represents the request body for updating an API key.
 type UpdateApiKey struct {
 	Name        *string           `json:"name,omitempty" maxLength:"255" doc:"New name for the API key"`
 	Description *string           `json:"description,omitempty" maxLength:"1000" doc:"New description for the API key"`

--- a/types/auth/auth.go
+++ b/types/auth/auth.go
@@ -9,12 +9,12 @@ import (
 // Login represents the login request body.
 type Login struct {
 	Username string `json:"username" minLength:"1" maxLength:"255" doc:"Username of the user" example:"admin"`
-	Password string `json:"password" minLength:"1" doc:"Password of the user"` //nolint:gosec // API schema requires password field name
+	Password string `json:"password" minLength:"1" doc:"Password of the user"`
 }
 
 // Refresh represents the token refresh request body.
 type Refresh struct {
-	RefreshToken string `json:"refreshToken" minLength:"1" doc:"Refresh token used to obtain a new access token"` //nolint:gosec // API schema requires refreshToken field name
+	RefreshToken string `json:"refreshToken" minLength:"1" doc:"Refresh token used to obtain a new access token"`
 }
 
 // PasswordChange represents the password change request body.
@@ -32,7 +32,7 @@ type SessionMeta struct {
 // LoginResponse represents the successful login response data.
 type LoginResponse struct {
 	Token        string    `json:"token" doc:"JWT access token"`
-	RefreshToken string    `json:"refreshToken" doc:"Refresh token for obtaining new access tokens"` //nolint:gosec // API schema requires refreshToken field name
+	RefreshToken string    `json:"refreshToken" doc:"Refresh token for obtaining new access tokens"`
 	ExpiresAt    time.Time `json:"expiresAt" doc:"Expiration time of the access token"`
 	User         user.User `json:"user" doc:"Authenticated user information"`
 }
@@ -40,7 +40,7 @@ type LoginResponse struct {
 // TokenRefreshResponse represents the successful token refresh response data.
 type TokenRefreshResponse struct {
 	Token        string    `json:"token" doc:"New JWT access token"`
-	RefreshToken string    `json:"refreshToken" doc:"New refresh token"` //nolint:gosec // API schema requires refreshToken field name
+	RefreshToken string    `json:"refreshToken" doc:"New refresh token"`
 	ExpiresAt    time.Time `json:"expiresAt" doc:"Expiration time of the new access token"`
 }
 

--- a/types/auth/oidc.go
+++ b/types/auth/oidc.go
@@ -70,7 +70,7 @@ type OidcTokenResponse struct {
 	// AccessToken is the OAuth 2.0 access token.
 	//
 	// Required: true
-	AccessToken string `json:"access_token"` //nolint:gosec // OAuth/OIDC schema requires access_token field name
+	AccessToken string `json:"access_token"`
 
 	// TokenType specifies the type of the access token (typically "Bearer").
 	//
@@ -80,7 +80,7 @@ type OidcTokenResponse struct {
 	// RefreshToken is the OAuth 2.0 refresh token.
 	//
 	// Required: false
-	RefreshToken string `json:"refresh_token,omitempty"` //nolint:gosec // OAuth/OIDC schema requires refresh_token field name
+	RefreshToken string `json:"refresh_token,omitempty"`
 
 	// ExpiresIn is the lifetime of the access token in seconds.
 	//
@@ -223,7 +223,7 @@ type OidcCallbackResponse struct {
 	// RefreshToken is the refresh token for obtaining new access tokens.
 	//
 	// Required: true
-	RefreshToken string `json:"refreshToken"` //nolint:gosec // API schema requires refreshToken field name
+	RefreshToken string `json:"refreshToken"`
 
 	// ExpiresAt is the expiration time of the access token.
 	//
@@ -300,7 +300,7 @@ type OidcDeviceTokenResponse struct {
 	// RefreshToken is the refresh token for obtaining new access tokens.
 	//
 	// Required: true
-	RefreshToken string `json:"refreshToken"` //nolint:gosec // API schema requires refreshToken field name
+	RefreshToken string `json:"refreshToken"`
 
 	// ExpiresAt is the expiration time of the access token.
 	//

--- a/types/base/json.go
+++ b/types/base/json.go
@@ -9,7 +9,7 @@ import (
 // in a database. It implements the sql.Valuer and sql.Scanner interfaces for
 // seamless database integration.
 //
-// nolint:recvcheck
+//nolint:recvcheck
 type JsonObject map[string]any
 
 // Value implements the driver.Valuer interface for database storage.

--- a/types/container/history.go
+++ b/types/container/history.go
@@ -12,6 +12,7 @@ type StatsHistorySample struct {
 // StatsStreamPayload is the container stats websocket payload.
 type StatsStreamPayload struct {
 	dockercontainer.StatsResponse
+
 	StatsHistory         []StatsHistorySample `json:"statsHistory,omitempty"`
 	CurrentHistorySample StatsHistorySample   `json:"currentHistorySample"`
 }

--- a/types/containerregistry/container_registry.go
+++ b/types/containerregistry/container_registry.go
@@ -2,7 +2,7 @@ package containerregistry
 
 import "time"
 
-// Registry represents a container registry in API responses.
+// ContainerRegistry represents a container registry in API responses.
 type ContainerRegistry struct {
 	// ID of the container registry.
 	//

--- a/types/dockerinfo/docker_info.go
+++ b/types/dockerinfo/docker_info.go
@@ -3,6 +3,11 @@ package dockerinfo
 import "github.com/moby/moby/api/types/system"
 
 type Info struct {
+	// Embedded system.Info from the Docker daemon.
+	//
+	// Required: true
+	system.Info
+
 	// Success indicates if the Docker daemon information was successfully retrieved.
 	//
 	// Required: true
@@ -37,9 +42,4 @@ type Info struct {
 	//
 	// Required: true
 	BuildTime string `json:"buildTime"`
-
-	// Embedded system.Info from the Docker daemon.
-	//
-	// Required: true
-	system.Info
 }

--- a/types/environment/environment.go
+++ b/types/environment/environment.go
@@ -21,7 +21,7 @@ type Create struct {
 	// AccessToken for authentication with the environment.
 	//
 	// Required: false
-	AccessToken *string `json:"accessToken,omitempty"` //nolint:gosec // API schema requires accessToken field name
+	AccessToken *string `json:"accessToken,omitempty"`
 
 	// UseApiKey indicates if an API key should be generated for pairing.
 	//
@@ -53,7 +53,7 @@ type Update struct {
 	// AccessToken for authentication with the environment.
 	//
 	// Required: false
-	AccessToken *string `json:"accessToken,omitempty"` //nolint:gosec // API schema requires accessToken field name
+	AccessToken *string `json:"accessToken,omitempty"`
 
 	// RegenerateApiKey indicates whether to regenerate the API key.
 	//
@@ -202,7 +202,7 @@ type Environment struct {
 	// ApiKey is returned only when creating or regenerating
 	//
 	// Required: false
-	ApiKey *string `json:"apiKey,omitempty"` //nolint:gosec // API schema requires apiKey field name
+	ApiKey *string `json:"apiKey,omitempty"`
 }
 
 // AgentPairRequest is the request body for pairing with an agent.

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -178,7 +178,7 @@ type PruneReport struct {
 // combining both types into a single list and converting space reclaimed to int64.
 func NewPruneReport(src image.PruneReport) PruneReport {
 	// Safely convert uint64 to int64, capping at MaxInt64 to prevent overflow
-	spaceReclaimed := int64(0)
+	var spaceReclaimed int64
 	if src.SpaceReclaimed > uint64(math.MaxInt64) {
 		spaceReclaimed = math.MaxInt64
 	} else {
@@ -537,7 +537,7 @@ func NewDetailSummary(src *image.InspectResponse) DetailSummary {
 		if len(src.Config.ExposedPorts) > 0 {
 			out.Config.ExposedPorts = make(map[string]struct{}, len(src.Config.ExposedPorts))
 			for p := range src.Config.ExposedPorts {
-				out.Config.ExposedPorts[string(p)] = struct{}{}
+				out.Config.ExposedPorts[p] = struct{}{}
 			}
 		}
 		if len(src.Config.Env) > 0 {
@@ -553,7 +553,8 @@ func NewDetailSummary(src *image.InspectResponse) DetailSummary {
 			}
 		}
 		out.Config.WorkingDir = src.Config.WorkingDir
-		out.Config.ArgsEscaped = src.Config.ArgsEscaped //nolint:staticcheck // Required for Docker Windows image compatibility
+		//nolint:staticcheck // SA1019: deprecated field intentionally copied for Docker Windows image compatibility
+		out.Config.ArgsEscaped = src.Config.ArgsEscaped
 	}
 
 	out.Architecture = src.Architecture

--- a/types/meta/template_meta.go
+++ b/types/meta/template_meta.go
@@ -1,6 +1,6 @@
 package meta
 
-// Template represents metadata about a template.
+// TemplateMeta represents metadata about a template.
 type TemplateMeta struct {
 	// Version of the template.
 	//

--- a/types/project/marshal_utils.go
+++ b/types/project/marshal_utils.go
@@ -21,6 +21,7 @@ var unitBytesType = reflect.TypeFor[composetypes.UnitBytes]()
 // handle serviceConfig separately from the rest of the payload.
 type runtimeServiceJSON struct {
 	runtimeServiceAlias
+
 	ServiceConfig json.RawMessage `json:"serviceConfig,omitempty"`
 }
 
@@ -32,6 +33,7 @@ type runtimeServiceAlias RuntimeService
 // services array while still decoding the rest of the struct normally.
 type detailsJSON struct {
 	detailsAlias
+
 	Services        []json.RawMessage `json:"services,omitempty"`
 	RuntimeServices []RuntimeService  `json:"runtimeServices,omitempty"`
 }

--- a/types/swarm/service.go
+++ b/types/swarm/service.go
@@ -354,11 +354,11 @@ func NewServiceSummary(service swarm.Service, nodeNames []string, networkNameByI
 		image = spec.TaskTemplate.ContainerSpec.Image
 	}
 
-	ports := make([]ServicePort, 0)
 	portSpecs := service.Endpoint.Spec.Ports
 	if len(portSpecs) == 0 {
 		portSpecs = service.Endpoint.Ports
 	}
+	ports := make([]ServicePort, 0, len(portSpecs))
 	for _, port := range portSpecs {
 		ports = append(ports, ServicePort{
 			Protocol:      string(port.Protocol),

--- a/types/template/template.go
+++ b/types/template/template.go
@@ -101,7 +101,7 @@ type RemoteRegistry struct {
 	Templates []RemoteTemplate `json:"templates"`
 }
 
-// Registry represents a local registry configuration.
+// TemplateRegistry represents a local registry configuration.
 type TemplateRegistry struct {
 	BaseRegistry
 

--- a/types/user/user.go
+++ b/types/user/user.go
@@ -4,7 +4,7 @@ package user
 // Role assignments are managed separately via PUT /users/{userId}/role-assignments.
 type CreateUser struct {
 	Username    string  `json:"username" minLength:"1" maxLength:"255" doc:"Username of the user" example:"johndoe"`
-	Password    string  `json:"password" minLength:"8" doc:"Password of the user"` //nolint:gosec // API schema requires password field name
+	Password    string  `json:"password" minLength:"8" doc:"Password of the user"`
 	DisplayName *string `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user" example:"John Doe"`
 	Email       *string `json:"email,omitempty" doc:"Email address of the user" example:"john@example.com"`
 	Locale      *string `json:"locale,omitempty" doc:"Locale preference of the user" example:"en-US"`
@@ -17,7 +17,7 @@ type UpdateUser struct {
 	DisplayName *string `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user"`
 	Email       *string `json:"email,omitempty" doc:"Email address of the user"`
 	Locale      *string `json:"locale,omitempty" doc:"Locale preference of the user"`
-	Password    *string `json:"password,omitempty" minLength:"8" doc:"New password for the user"` //nolint:gosec // API schema requires password field name
+	Password    *string `json:"password,omitempty" minLength:"8" doc:"New password for the user"`
 }
 
 // RoleAssignmentSummary is a compact form of a user's role assignment used

--- a/types/volume/browse.go
+++ b/types/volume/browse.go
@@ -15,6 +15,7 @@ type FileEntry struct {
 
 type FileMetadata struct {
 	FileEntry
+
 	MimeType string `json:"mimeType" doc:"MIME type of the file"`
 	IsText   bool   `json:"isText" doc:"Whether the file is a text file"`
 	IsBinary bool   `json:"isBinary" doc:"Whether the file is a binary file"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds new golangci-lint linters to `.github/.golangci.yml` and refactors a large portion of the Go backend to satisfy them: unexported functions gain the `Internal` suffix, forced type assertions (`.(T)`) are replaced with checked form (`.(T), ok`), static `fmt.Errorf` calls become `errors.New`, simple `fmt.Sprintf` string joins become concatenation, and a stray `fmt.Printf` pair is promoted to `slog.WarnContext`. Also renames the `pagination.PaginationParams` type to `pagination.Params` and removes the always-`false` `pairingSucceeded` dead-code path from `UpdateEnvironment`.

- **214 files touched** — nearly all changes are mechanical search-and-replace driven by the new linter set; the only non-mechanical logic edits are the defensive type-assertion fixes in `ws/handler.go`, `edge/client.go`, `edge/server.go`, and the `handleCommandComplete` simplification in `edge/proxy.go`.
- **`.github/.golangci.yml`**: adds ~45 linters including `arangolint` and `clickhouselint`, which are database-driver-specific linters for ArangoDB and ClickHouse — neither of which this codebase uses; also enables `forbidigo` without any `patterns` configuration, making it a no-op until patterns are specified.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a large but almost entirely mechanical refactoring; all logic paths that existed before still exist, and the two real behavior changes (guarding type assertions, removing a dead always-false flag) are correct improvements with no regression risk.

Every code change is either a compile-time-equivalent rename, a safe conversion from a panicking type assertion to a checked one, or removal of dead code that was never reachable. The new linter configuration is additive and the two no-op linters produce no findings rather than false positives.

.github/.golangci.yml deserves a second look to confirm whether arangolint, clickhouselint, and an unconfigured forbidigo are intentional.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/api/handlers/environments.go`, line 861-897 ([link](https://github.com/getarcaneapp/arcane/blob/50825ab6bd2b816718841adfa674792f00ab9135/backend/api/handlers/environments.go#L861-L897)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unexported methods missing required "Internal" suffix**

   The team rule requires all unexported functions/methods to carry an `Internal` suffix. This PR modifies the signatures of `handleEnvironmentPairing`, `triggerPostUpdateTasks`, and `triggerEnvironmentResourceSync` — all three are unexported and lack the suffix. The same pattern appears on `buildUpdateMap` in this file and on `runServices` in `backend/internal/bootstrap/bootstrap.go` (whose signature formatting was also touched by this PR).

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/api/handlers/environments.go
   Line: 861-897
   
   Comment:
   **Unexported methods missing required "Internal" suffix**
   
   The team rule requires all unexported functions/methods to carry an `Internal` suffix. This PR modifies the signatures of `handleEnvironmentPairing`, `triggerPostUpdateTasks`, and `triggerEnvironmentResourceSync` — all three are unexported and lack the suffix. The same pattern appears on `buildUpdateMap` in this file and on `runServices` in `backend/internal/bootstrap/bootstrap.go` (whose signature formatting was also touched by this PR).
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Flinters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Flinters%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fenvironments.go%0ALine%3A%20861-897%0A%0AComment%3A%0A**Unexported%20methods%20missing%20required%20%22Internal%22%20suffix**%0A%0AThe%20team%20rule%20requires%20all%20unexported%20functions%2Fmethods%20to%20carry%20an%20%60Internal%60%20suffix.%20This%20PR%20modifies%20the%20signatures%20of%20%60handleEnvironmentPairing%60%2C%20%60triggerPostUpdateTasks%60%2C%20and%20%60triggerEnvironmentResourceSync%60%20%E2%80%94%20all%20three%20are%20unexported%20and%20lack%20the%20suffix.%20The%20same%20pattern%20appears%20on%20%60buildUpdateMap%60%20in%20this%20file%20and%20on%20%60runServices%60%20in%20%60backend%2Finternal%2Fbootstrap%2Fbootstrap.go%60%20%28whose%20signature%20formatting%20was%20also%20touched%20by%20this%20PR%29.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fenvironments.go%0ALine%3A%20861-897%0A%0AComment%3A%0A**Unexported%20methods%20missing%20required%20%22Internal%22%20suffix**%0A%0AThe%20team%20rule%20requires%20all%20unexported%20functions%2Fmethods%20to%20carry%20an%20%60Internal%60%20suffix.%20This%20PR%20modifies%20the%20signatures%20of%20%60handleEnvironmentPairing%60%2C%20%60triggerPostUpdateTasks%60%2C%20and%20%60triggerEnvironmentResourceSync%60%20%E2%80%94%20all%20three%20are%20unexported%20and%20lack%20the%20suffix.%20The%20same%20pattern%20appears%20on%20%60buildUpdateMap%60%20in%20this%20file%20and%20on%20%60runServices%60%20in%20%60backend%2Finternal%2Fbootstrap%2Fbootstrap.go%60%20%28whose%20signature%20formatting%20was%20also%20touched%20by%20this%20PR%29.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Flinters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Flinters%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2F.golangci.yml%3A8-10%0A**Database-driver%20linters%20unrelated%20to%20this%20project**%0A%0A%60arangolint%60%20and%20%60clickhouselint%60%20are%20opinionated%20linters%20for%20the%20ArangoDB%20Go%20driver%20and%20the%20ClickHouse%20native%20Go%20driver%20respectively.%20This%20codebase%20uses%20neither.%20They%20will%20never%20fire%20any%20findings%2C%20add%20binary%20size%20to%20the%20linter%20runner%2C%20and%20may%20confuse%20future%20contributors%20who%20wonder%20why%20an%20ArangoDB%2FClickHouse%20linter%20is%20enforced%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2F.golangci.yml%3A24%0A**%60forbidigo%60%20enabled%20without%20any%20patterns**%0A%0A%60forbidigo%60%20only%20enforces%20what%20you%20explicitly%20forbid%20via%20a%20%60patterns%60%20list.%20Without%20patterns%20the%20linter%20is%20a%20no-op%20%E2%80%94%20it%20will%20never%20flag%20anything%20and%20just%20adds%20overhead%20to%20every%20linter%20run.%20Either%20add%20the%20desired%20patterns%20%28e.g.%2C%20%60fmt.Printf%60%2C%20%60fmt.Println%60%29%20under%20%60settings.forbidigo%60%2C%20or%20remove%20the%20entry%20until%20it%20is%20configured.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2F.golangci.yml%3A8-10%0A**Database-driver%20linters%20unrelated%20to%20this%20project**%0A%0A%60arangolint%60%20and%20%60clickhouselint%60%20are%20opinionated%20linters%20for%20the%20ArangoDB%20Go%20driver%20and%20the%20ClickHouse%20native%20Go%20driver%20respectively.%20This%20codebase%20uses%20neither.%20They%20will%20never%20fire%20any%20findings%2C%20add%20binary%20size%20to%20the%20linter%20runner%2C%20and%20may%20confuse%20future%20contributors%20who%20wonder%20why%20an%20ArangoDB%2FClickHouse%20linter%20is%20enforced%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2F.golangci.yml%3A24%0A**%60forbidigo%60%20enabled%20without%20any%20patterns**%0A%0A%60forbidigo%60%20only%20enforces%20what%20you%20explicitly%20forbid%20via%20a%20%60patterns%60%20list.%20Without%20patterns%20the%20linter%20is%20a%20no-op%20%E2%80%94%20it%20will%20never%20flag%20anything%20and%20just%20adds%20overhead%20to%20every%20linter%20run.%20Either%20add%20the%20desired%20patterns%20%28e.g.%2C%20%60fmt.Printf%60%2C%20%60fmt.Println%60%29%20under%20%60settings.forbidigo%60%2C%20or%20remove%20the%20entry%20until%20it%20is%20configured.%0A%0A&repo=getarcaneapp%2Farcane&pr=2772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/.golangci.yml:8-10
**Database-driver linters unrelated to this project**

`arangolint` and `clickhouselint` are opinionated linters for the ArangoDB Go driver and the ClickHouse native Go driver respectively. This codebase uses neither. They will never fire any findings, add binary size to the linter runner, and may confuse future contributors who wonder why an ArangoDB/ClickHouse linter is enforced here.

### Issue 2 of 2
.github/.golangci.yml:24
**`forbidigo` enabled without any patterns**

`forbidigo` only enforces what you explicitly forbid via a `patterns` list. Without patterns the linter is a no-op — it will never flag anything and just adds overhead to every linter run. Either add the desired patterns (e.g., `fmt.Printf`, `fmt.Println`) under `settings.forbidigo`, or remove the entry until it is configured.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: add new go linters and refacto..."](https://github.com/getarcaneapp/arcane/commit/04c17b9f4118354b5cbf92a410e4bbe4c52d6e6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34756027)</sub>

<!-- /greptile_comment -->