### PR TITLE
fix: make updater service skip swarm containers and make checks more robust

### DIFF
--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -87,8 +87,8 @@ func provideResourcesFSInternal() embed.FS {
 // wire_gen.go call them in a normal build.
 
 // provideVersionServiceInternal supplies the bool/string scalars wire can't inject by type.
-func provideVersionServiceInternal(httpClient *http.Client, cfg *config.Config, registry *services.ContainerRegistryService, docker *services.DockerClientService) *services.VersionService {
-	return services.NewVersionService(httpClient, cfg.UpdateCheckDisabled, config.Version, config.Revision, registry, docker)
+func provideVersionServiceInternal(httpClient *http.Client, cfg *config.Config, registry *services.ContainerRegistryService, docker *services.DockerClientService, imageUpdate *services.ImageUpdateService) *services.VersionService {
+	return services.NewVersionService(httpClient, cfg.UpdateCheckDisabled, config.Version, config.Revision, registry, docker, imageUpdate)
 }
 
 // provideGitRepositoryServiceInternal supplies cfg.GitWorkDir (bare string).

--- a/backend/internal/di/wire_gen.go
+++ b/backend/internal/di/wire_gen.go
@@ -58,7 +58,7 @@ func InitializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	oidcService := services.NewOidcService(authService, settingsService, cfg, httpClient)
 	templateService := services.NewTemplateService(ctx, db, httpClient, settingsService)
 	systemService := services.NewSystemService(db, dockerClientService, containerService, imageService, volumeService, networkService, settingsService, activityService)
-	versionService := provideVersionServiceInternal(httpClient, cfg, containerRegistryService, dockerClientService)
+	versionService := provideVersionServiceInternal(httpClient, cfg, containerRegistryService, dockerClientService, imageUpdateService)
 	systemUpgradeService := services.NewSystemUpgradeService(dockerClientService, versionService, eventService, settingsService)
 	diagnosticsService := services.NewDiagnosticsService()
 	updaterService := provideUpdaterServiceInternal(db, settingsService, dockerClientService, projectService, imageUpdateService, containerRegistryService, eventService, imageService, notificationService, systemUpgradeService, activityService)

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -804,6 +804,23 @@ func (s *ImageUpdateService) MarkImageRefUpToDateAfterPull(ctx context.Context, 
 	})
 }
 
+func (s *ImageUpdateService) getStoredUpdateByImageIDInternal(ctx context.Context, imageID string) (*models.ImageUpdateRecord, bool, error) {
+	imageID = strings.TrimSpace(imageID)
+	if s == nil || s.db == nil || imageID == "" {
+		return nil, false, nil
+	}
+
+	var record models.ImageUpdateRecord
+	if err := s.db.WithContext(ctx).Where("id = ?", imageID).First(&record).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get stored image update by image id: %w", err)
+	}
+
+	return &record, true, nil
+}
+
 // GetUnnotifiedUpdates returns a map of image IDs that have updates but haven't been notified yet
 func (s *ImageUpdateService) GetUnnotifiedUpdates(ctx context.Context) (map[string]*models.ImageUpdateRecord, error) {
 	var records []models.ImageUpdateRecord

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -202,7 +202,11 @@ const (
 	imagePullModeAlways
 )
 
-var composePullProjectServicesInternal = projects.ComposePull
+var (
+	composePullProjectServicesInternal = projects.ComposePull
+	composeStopProjectServicesInternal = projects.ComposeStop
+	composeUpProjectServicesInternal   = projects.ComposeUp
+)
 
 func resolveServiceImagePullMode(svc composetypes.ServiceConfig) imagePullMode {
 	rawPolicy := strings.ToLower(strings.TrimSpace(svc.PullPolicy))
@@ -744,6 +748,7 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 	if err != nil {
 		return err
 	}
+	previousStatus := projectFromDb.Status
 
 	// 1. Load project
 	compProj, _, err := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
@@ -759,21 +764,22 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 	// 3. Pull images for specific services
 	writeProjectProgressInternal(ctx, "Pulling updated service images", 20, "pull")
 	if err := s.composePullSelectedServicesInternal(ctx, compProj, servicesToUpdate); err != nil {
-		slog.WarnContext(ctx, "compose pull failed, continuing", "error", err)
+		if statusErr := s.updateProjectStatusInternal(ctx, projectID, previousStatus); statusErr != nil {
+			slog.ErrorContext(ctx, "UpdateProjectServices: failed to restore project status after compose pull failure", "projectID", projectID, "error", statusErr)
+		}
+		return fmt.Errorf("pull updated service images: %w", err)
 	}
 
 	// 4. Stop specific services
 	writeProjectProgressInternal(ctx, "Stopping selected services", 45, "stop")
-	if err := projects.ComposeStop(ctx, compProj, servicesToUpdate); err != nil {
+	if err := composeStopProjectServicesInternal(ctx, compProj, servicesToUpdate); err != nil {
 		slog.WarnContext(ctx, "compose stop failed, continuing", "error", err)
 	}
 
 	// 5. Up specific services
 	writeProjectProgressInternal(ctx, "Starting selected services", 70, "up")
-	if err := projects.ComposeUp(ctx, compProj, servicesToUpdate, false, false); err != nil {
-		if statusErr := s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusStopped); statusErr != nil {
-			slog.ErrorContext(ctx, "UpdateProjectServices: failed to set stopped status after compose up failure", "projectID", projectID, "error", statusErr)
-		}
+	if err := composeUpProjectServicesInternal(ctx, compProj, servicesToUpdate, false, true); err != nil {
+		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return fmt.Errorf("failed to up services: %w", err)
 	}
 

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -895,6 +895,122 @@ func TestProjectService_ComposePullSelectedServicesInternal_LeavesRecordsWhenPul
 	assert.Zero(t, count)
 }
 
+func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	projectPath := createComposeProjectDir(t, projectsDir, "compose-update-pull-fail")
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: registry.example.com/team/app:9.9.9\n"), 0o644))
+
+	projectRecord := &models.Project{
+		BaseModel: models.BaseModel{ID: "project-update-pull-fail"},
+		Name:      "compose-update-pull-fail",
+		DirName:   ptr("compose-update-pull-fail"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusRunning,
+	}
+	require.NoError(t, db.Create(projectRecord).Error)
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             "sha256:selected-old",
+		Repository:     "registry.example.com/team/app",
+		Tag:            "9.9.9",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "9.9.9",
+		CheckTime:      time.Now().UTC().Add(-time.Hour),
+	}).Error)
+
+	originalComposePull := composePullProjectServicesInternal
+	originalComposeUp := composeUpProjectServicesInternal
+	t.Cleanup(func() {
+		composePullProjectServicesInternal = originalComposePull
+		composeUpProjectServicesInternal = originalComposeUp
+	})
+
+	composePullProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
+		return errors.New("compose pull failed")
+	}
+	upCalled := false
+	composeUpProjectServicesInternal = func(context.Context, *composetypes.Project, []string, bool, bool) error {
+		upCalled = true
+		return errors.New("compose up should not run")
+	}
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "pull updated service images")
+	assert.False(t, upCalled, "compose up must not run after a pull failure")
+
+	var persistedProject models.Project
+	require.NoError(t, db.WithContext(ctx).Where("id = ?", projectRecord.ID).First(&persistedProject).Error)
+	assert.Equal(t, models.ProjectStatusRunning, persistedProject.Status)
+
+	var persistedRecord models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:selected-old").First(&persistedRecord).Error)
+	assert.True(t, persistedRecord.HasUpdate)
+}
+
+func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	projectPath := createComposeProjectDir(t, projectsDir, "compose-update-force")
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: registry.example.com/team/app:9.9.9\n"), 0o644))
+
+	projectRecord := &models.Project{
+		BaseModel: models.BaseModel{ID: "project-update-force"},
+		Name:      "compose-update-force",
+		DirName:   ptr("compose-update-force"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusRunning,
+	}
+	require.NoError(t, db.Create(projectRecord).Error)
+
+	originalComposePull := composePullProjectServicesInternal
+	originalComposeStop := composeStopProjectServicesInternal
+	originalComposeUp := composeUpProjectServicesInternal
+	t.Cleanup(func() {
+		composePullProjectServicesInternal = originalComposePull
+		composeStopProjectServicesInternal = originalComposeStop
+		composeUpProjectServicesInternal = originalComposeUp
+	})
+
+	composePullProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
+		return nil
+	}
+	composeStopProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
+		return nil
+	}
+	upCalled := false
+	forceRecreate := false
+	composeUpProjectServicesInternal = func(_ context.Context, _ *composetypes.Project, services []string, removeOrphans bool, force bool) error {
+		upCalled = true
+		forceRecreate = force
+		assert.Equal(t, []string{"app"}, services)
+		assert.False(t, removeOrphans)
+		return errors.New("compose up failed after assertion")
+	}
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
+	require.Error(t, err)
+	assert.True(t, upCalled)
+	assert.True(t, forceRecreate, "service updates must force recreate after pulling the updated image")
+}
+
 func TestProjectService_UpdateProject_RenamesDirectoryWhenNameChanges(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/moby/moby/client"
 )
 
-var ArcaneUpgraderImage = "ghcr.io/getarcaneapp/arcane:latest"
+const defaultArcaneUpgraderImageInternal = "ghcr.io/getarcaneapp/arcane:latest"
 
 type SystemUpgradeService struct {
 	upgrading       atomic.Bool
@@ -114,14 +114,15 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 
 	// Use the same image reference as the currently running Arcane container for the upgrader.
 	// This avoids mismatches where a newer/older upgrader CLI expects different behavior.
+	upgraderImage := defaultArcaneUpgraderImageInternal
 	if currentContainer.Config != nil {
 		if img := strings.TrimSpace(currentContainer.Config.Image); img != "" {
-			ArcaneUpgraderImage = img
+			upgraderImage = img
 		}
 	}
-	slog.Debug("Using upgrader image", "image", ArcaneUpgraderImage)
+	slog.Debug("Using upgrader image", "image", upgraderImage)
 
-	slog.Info("Spawning upgrade CLI command", "containerName", containerName, "upgraderImage", ArcaneUpgraderImage)
+	slog.Info("Spawning upgrade CLI command", "containerName", containerName, "upgraderImage", upgraderImage)
 
 	// Spawn the upgrade command in a detached container
 	// This will run independently of the current container
@@ -131,16 +132,16 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	}
 
 	// Pull the upgrader image first to ensure it exists
-	slog.Info("Pulling upgrader image", "image", ArcaneUpgraderImage)
+	slog.Info("Pulling upgrader image", "image", upgraderImage)
 
 	settings := s.settingsService.GetSettingsConfig()
 	pullCtx, pullCancel := timeouts.WithTimeout(ctx, settings.DockerImagePullTimeout.AsInt(), timeouts.DefaultDockerImagePull)
 	defer pullCancel()
 
-	pullReader, err := dockerClient.ImagePull(pullCtx, ArcaneUpgraderImage, client.ImagePullOptions{})
+	pullReader, err := dockerClient.ImagePull(pullCtx, upgraderImage, client.ImagePullOptions{})
 	if err != nil {
 		if errors.Is(pullCtx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("upgrader image pull timed out for %s (increase DOCKER_IMAGE_PULL_TIMEOUT or setting)", ArcaneUpgraderImage)
+			return fmt.Errorf("upgrader image pull timed out for %s (increase DOCKER_IMAGE_PULL_TIMEOUT or setting)", upgraderImage)
 		}
 		return fmt.Errorf("pull upgrader image: %w", err)
 	}
@@ -152,7 +153,7 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	if closeErr := pullReader.Close(); closeErr != nil {
 		slog.Warn("Failed to close upgrader image pull reader", "error", closeErr)
 	}
-	slog.Info("Upgrader image pulled successfully", "image", ArcaneUpgraderImage)
+	slog.Info("Upgrader image pulled successfully", "image", upgraderImage)
 
 	// Try to get the /app/data mount from current container so upgrade logs persist.
 	appDataMount := dockerutils.MountForDestination(currentContainer.Mounts, "/app/data", "/app/data")
@@ -180,7 +181,7 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 	}
 
 	config := &containertypes.Config{
-		Image: ArcaneUpgraderImage,
+		Image: upgraderImage,
 		Cmd:   []string{binaryPath, "upgrade", "--container", containerName},
 		Env:   runtimeOptions.ContainerEnv,
 		Labels: map[string]string{

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -589,6 +589,21 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 		return out, nil
 	}
 
+	if libupdater.IsSwarmTask(labels) && !isArcaneContainer {
+		slog.InfoContext(ctx, "UpdateSingleContainer: skipping swarm task container", "containerID", containerID)
+		out.Items = append(out.Items, updater.ResourceResult{
+			ResourceID:   targetContainer.ID,
+			ResourceType: "container",
+			ResourceName: containerName,
+			Status:       "skipped",
+			Error:        "swarm service; update at the service level",
+		})
+		out.Skipped++
+		out.Checked = 1
+		out.Duration = time.Since(start).String()
+		return out, nil
+	}
+
 	// Resolve the best pullable image reference for this container.
 	configImageRef := ""
 	if inspectBefore.Config != nil {
@@ -1416,6 +1431,11 @@ func (s *UpdaterService) restartContainersUsingOldIDs(ctx context.Context, oldID
 
 		// Skip containers with opt-out label
 		if libupdater.IsUpdateDisabled(c.Labels) {
+			continue
+		}
+
+		if libupdater.IsSwarmTask(c.Labels) && !libupdater.IsArcaneContainer(c.Labels) {
+			slog.DebugContext(ctx, "restartContainersUsingOldIDs: skipping swarm task container", "containerId", c.ID, "names", c.Names)
 			continue
 		}
 

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -270,6 +270,124 @@ func TestUpdaterService_CLICalledWithSystemUser(t *testing.T) {
 	assert.Equal(t, systemUser.Username, mockUpgrade.capturedUser.Username)
 }
 
+func TestUpdaterService_UpdateSingleContainerSkipsSwarmTaskInternal(t *testing.T) {
+	ctx := context.Background()
+	const containerID = "swarm-task-1"
+	labels := map[string]string{
+		libupdater.LabelSwarmServiceID:   "service-1",
+		libupdater.LabelSwarmServiceName: "web",
+	}
+	pullCalled := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]container.Summary{
+				{
+					ID:      containerID,
+					Names:   []string{"/web.1.task"},
+					Image:   "nginx:latest",
+					ImageID: "sha256:old-image",
+					Labels:  labels,
+				},
+			}))
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(container.InspectResponse{
+				ID:    containerID,
+				Image: "sha256:old-image",
+				Config: &container.Config{
+					Image:  "nginx:latest",
+					Labels: labels,
+				},
+			}))
+		case strings.HasSuffix(r.URL.Path, "/images/create"):
+			pullCalled = true
+			http.Error(w, "unexpected pull", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dcli, err := dockerclient.NewClientWithOpts(
+		dockerclient.WithHost("tcp://"+srv.Listener.Addr().String()),
+		dockerclient.WithVersion("1.46"),
+	)
+	require.NoError(t, err)
+
+	db := setupActivityServiceTestDBInternal(t)
+	svc := NewUpdaterService(nil, nil, &DockerClientService{client: dcli, config: &config.Config{}}, nil, nil, nil, nil, nil, nil, nil, NewActivityService(db))
+
+	out, err := svc.UpdateSingleContainer(ctx, containerID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Len(t, out.Items, 1)
+	assert.Equal(t, "skipped", out.Items[0].Status)
+	assert.Contains(t, out.Items[0].Error, "swarm service")
+	assert.False(t, pullCalled, "swarm task update must not pull or recreate the task container")
+}
+
+func TestUpdaterService_RestartContainersUsingOldIDsSkipsSwarmTaskInternal(t *testing.T) {
+	ctx := context.Background()
+	const containerID = "swarm-task-1"
+	labels := map[string]string{
+		libupdater.LabelSwarmServiceID:   "service-1",
+		libupdater.LabelSwarmServiceName: "web",
+	}
+	stopCalled := false
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]container.Summary{
+				{
+					ID:      containerID,
+					Names:   []string{"/web.1.task"},
+					Image:   "nginx:latest",
+					ImageID: "sha256:old-image",
+					Labels:  labels,
+				},
+			}))
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(container.InspectResponse{
+				ID:    containerID,
+				Name:  "/web.1.task",
+				Image: "sha256:old-image",
+				Config: &container.Config{
+					Image:  "nginx:latest",
+					Labels: labels,
+				},
+			}))
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/stop"):
+			stopCalled = true
+			http.Error(w, "unexpected stop", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	dcli, err := dockerclient.NewClientWithOpts(
+		dockerclient.WithHost("tcp://"+srv.Listener.Addr().String()),
+		dockerclient.WithVersion("1.46"),
+	)
+	require.NoError(t, err)
+
+	settingsDB := setupUpdaterServiceSettingsDB(t)
+	settings, err := NewSettingsService(ctx, settingsDB)
+	require.NoError(t, err)
+	svc := NewUpdaterService(nil, settings, &DockerClientService{client: dcli, config: &config.Config{}}, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	results, err := svc.restartContainersUsingOldIDs(ctx, map[string]string{"sha256:old-image": "nginx:latest"}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.False(t, stopCalled, "swarm task update must not stop the orchestrator-owned task container")
+}
+
 // TestUpdaterService_UpgradeServiceNotNilCheck verifies the nil check logic
 func TestUpdaterService_UpgradeServiceNotNilCheck(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/services/version_service.go
+++ b/backend/internal/services/version_service.go
@@ -43,9 +43,10 @@ type VersionService struct {
 	revision                 string
 	containerRegistryService *ContainerRegistryService
 	dockerService            *DockerClientService
+	imageUpdateService       *ImageUpdateService
 }
 
-func NewVersionService(httpClient *http.Client, disabled bool, version string, revision string, containerRegistryService *ContainerRegistryService, dockerService *DockerClientService) *VersionService {
+func NewVersionService(httpClient *http.Client, disabled bool, version string, revision string, containerRegistryService *ContainerRegistryService, dockerService *DockerClientService, imageUpdateService *ImageUpdateService) *VersionService {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
@@ -57,6 +58,7 @@ func NewVersionService(httpClient *http.Client, disabled bool, version string, r
 		revision:                 revision,
 		containerRegistryService: containerRegistryService,
 		dockerService:            dockerService,
+		imageUpdateService:       imageUpdateService,
 	}
 }
 
@@ -221,7 +223,7 @@ func (s *VersionService) GetAppVersionInfo(ctx context.Context) *version.Info {
 	ver := s.normalizeVersion(s.version)
 
 	// Always detect current image info
-	currentTag, currentDigest, currentImageRef := s.detectCurrentImageInfo(ctx)
+	currentTag, currentDigest, currentImageRef, currentImageID := s.detectCurrentImageInfo(ctx)
 
 	// Build base info struct (always populated)
 	info := &version.Info{
@@ -243,6 +245,8 @@ func (s *VersionService) GetAppVersionInfo(ctx context.Context) *version.Info {
 		return info
 	}
 
+	semverUpdateAvailable := false
+
 	// For semver versions, check GitHub releases
 	if isSemver {
 		rel, err := s.getLatestReleaseInternal(ctx)
@@ -250,19 +254,16 @@ func (s *VersionService) GetAppVersionInfo(ctx context.Context) *version.Info {
 		if err == nil || errors.As(err, &staleErr) {
 			if rel.TagName != "" {
 				info.NewestVersion = rel.TagName
-				info.UpdateAvailable = s.IsNewer(rel.TagName, ver)
+				semverUpdateAvailable = s.IsNewer(rel.TagName, ver)
 				info.ReleaseURL = s.ReleaseURL(rel.TagName)
 				info.ReleaseNotes = rel.Body
 				info.ReleasedAt = rel.PublishedAt
 			}
 		}
-		return info
 	}
 
-	// For non-semver versions (like "next"), check digest-based updates
-	if currentTag != "" && currentDigest != "" && currentImageRef != "" && s.containerRegistryService != nil {
-		updateAvailable, latestDigest := s.checkDigestBasedUpdate(ctx, currentTag, currentDigest, currentImageRef)
-		info.UpdateAvailable = updateAvailable
+	digestUpdateAvailable, latestDigest := s.storedOrDigestBasedUpdateInternal(ctx, currentImageID, currentTag, currentDigest, currentImageRef)
+	if latestDigest != "" {
 		info.NewestDigest = latestDigest
 	}
 
@@ -278,7 +279,25 @@ func (s *VersionService) GetAppVersionInfo(ctx context.Context) *version.Info {
 		}
 	}
 
+	info.UpdateAvailable = semverUpdateAvailable || (!isSemver && digestUpdateAvailable)
 	return info
+}
+
+func (s *VersionService) storedOrDigestBasedUpdateInternal(ctx context.Context, currentImageID, currentTag, currentDigest, currentImageRef string) (bool, string) {
+	if s.imageUpdateService != nil && strings.TrimSpace(currentImageID) != "" {
+		record, found, err := s.imageUpdateService.getStoredUpdateByImageIDInternal(ctx, currentImageID)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to read stored Arcane image update state", "imageID", currentImageID, "error", err)
+		} else if found {
+			return record.HasUpdate, stringPtrToString(record.LatestDigest)
+		}
+	}
+
+	if currentTag != "" && currentDigest != "" && currentImageRef != "" && s.containerRegistryService != nil {
+		return s.checkDigestBasedUpdate(ctx, currentTag, currentDigest, currentImageRef)
+	}
+
+	return false, ""
 }
 
 func parseEnabledFeatures() []string {
@@ -304,44 +323,50 @@ func parseEnabledFeatures() []string {
 }
 
 // detectCurrentImageInfo attempts to detect the current container's image tag and digest
-func (s *VersionService) detectCurrentImageInfo(ctx context.Context) (tag string, digest string, imageRef string) {
+func (s *VersionService) detectCurrentImageInfo(ctx context.Context) (tag string, digest string, imageRef string, imageID string) {
 	if s.dockerService == nil {
 		slog.Debug("detectCurrentImageInfo: dockerService is nil")
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		slog.Debug("detectCurrentImageInfo: failed to get docker client", "error", err)
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	containerId := s.detectContainerID(ctx, dockerClient)
 	if containerId == "" {
 		slog.Debug("detectCurrentImageInfo: could not detect container ID")
-		return "", "", ""
+		return "", "", "", ""
 	}
 	slog.Debug("detectCurrentImageInfo: detected container", "containerId", containerId)
 
 	inspectResult, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, containerId, client.ContainerInspectOptions{})
 	if err != nil {
 		slog.Debug("detectCurrentImageInfo: failed to inspect container", "containerId", containerId, "error", err)
-		return "", "", ""
+		return "", "", "", ""
 	}
 	container := inspectResult.Container
+	imageID = container.Image
+
+	configImage := ""
+	if container.Config != nil {
+		configImage = container.Config.Image
+	}
 
 	// Parse tag from container config image (user-specified reference)
-	tag = s.extractTagFromImageRef(container.Config.Image)
+	tag = s.extractTagFromImageRef(configImage)
 
 	// Get digest and normalized imageRef from container image
 	imageRef, digest = s.extractImageDetails(ctx, dockerClient, container)
 
 	// Fallback to container config image if RepoDigests didn't provide imageRef
 	if imageRef == "" {
-		imageRef = s.normalizeImageRef(container.Config.Image)
+		imageRef = s.normalizeImageRef(configImage)
 	}
 
-	return tag, digest, imageRef
+	return tag, digest, imageRef, imageID
 }
 
 // detectContainerID tries to get the current container ID, falling back to label-based detection

--- a/backend/internal/services/version_service_test.go
+++ b/backend/internal/services/version_service_test.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	libupdater "github.com/getarcaneapp/arcane/backend/pkg/libarcane/imageupdate"
+	"github.com/moby/moby/api/types/container"
+	dockertypesimage "github.com/moby/moby/api/types/image"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionService_GetAppVersionInfoDoesNotUseStoredDigestUpdateForSemverBuildInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupImageUpdateTestDB(t)
+
+	const (
+		containerID = "arcane-container-1234567890"
+		imageID     = "sha256:arcane-image"
+		imageRef    = "ghcr.io/getarcaneapp/arcane:latest"
+	)
+	currentDigest := digest.FromString("current-arcane").String()
+	latestDigest := digest.FromString("latest-arcane").String()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]container.Summary{
+				{
+					ID:    containerID,
+					State: container.StateRunning,
+					Labels: map[string]string{
+						libupdater.LabelArcane: "true",
+					},
+				},
+			}))
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(container.InspectResponse{
+				ID:    containerID,
+				Image: imageID,
+				Config: &container.Config{
+					Image: imageRef,
+					Labels: map[string]string{
+						libupdater.LabelArcane: "true",
+					},
+				},
+			}))
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			encodedRef := strings.TrimSuffix(r.URL.Path[strings.LastIndex(r.URL.Path, "/images/")+len("/images/"):], "/json")
+			_, err := url.PathUnescape(encodedRef)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:          imageID,
+				RepoTags:    []string{imageRef},
+				RepoDigests: []string{"ghcr.io/getarcaneapp/arcane@" + currentDigest},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	require.NoError(t, db.WithContext(ctx).Create(&models.ImageUpdateRecord{
+		ID:             imageID,
+		Repository:     "ghcr.io/getarcaneapp/arcane",
+		Tag:            "latest",
+		HasUpdate:      true,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: "latest",
+		CurrentDigest:  &currentDigest,
+		LatestDigest:   &latestDigest,
+		CheckTime:      time.Now().UTC(),
+	}).Error)
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("unavailable")),
+			Request:    req,
+		}, nil
+	})}
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
+	svc := NewVersionService(httpClient, false, "1.2.3", "revision", nil, dockerService, imageUpdateService)
+
+	info := svc.GetAppVersionInfo(ctx)
+
+	require.NotNil(t, info)
+	assert.True(t, info.IsSemverVersion)
+	assert.False(t, info.UpdateAvailable)
+	assert.Equal(t, latestDigest, info.NewestDigest)
+	assert.Equal(t, currentDigest, info.CurrentDigest)
+}

--- a/backend/pkg/libarcane/imageupdate/labels.go
+++ b/backend/pkg/libarcane/imageupdate/labels.go
@@ -8,6 +8,10 @@ const (
 	LabelArcaneAgent = "com.getarcaneapp.arcane.agent"   // Identifies an Arcane agent container
 	LabelUpdater     = "com.getarcaneapp.arcane.updater" // Enable/disable updates (true/false)
 
+	// LabelSwarmServiceID and LabelSwarmServiceName identify Docker Swarm task containers.
+	LabelSwarmServiceID   = "com.docker.swarm.service.id"
+	LabelSwarmServiceName = "com.docker.swarm.service.name"
+
 	// LabelDependsOn and the constants below are update-dependency labels.
 	LabelDependsOn  = "com.getarcaneapp.arcane.depends-on"  // Comma-separated list of container names this depends on
 	LabelStopSignal = "com.getarcaneapp.arcane.stop-signal" // Custom stop signal (e.g., SIGINT)
@@ -62,6 +66,11 @@ func IsUpdateDisabled(labels map[string]string) bool {
 	return false
 }
 
+// IsSwarmTask checks if the labels identify a Docker Swarm task container.
+func IsSwarmTask(labels map[string]string) bool {
+	return hasNonEmptyLabelInternal(labels, LabelSwarmServiceID) || hasNonEmptyLabelInternal(labels, LabelSwarmServiceName)
+}
+
 // GetStopSignal returns the custom stop signal if set, otherwise empty string
 func GetStopSignal(labels map[string]string) string {
 	if labels == nil {
@@ -82,6 +91,20 @@ func hasTruthyLabelInternal(labels map[string]string, target string) bool {
 
 	for k, v := range labels {
 		if strings.EqualFold(k, target) && isTruthyLabelValueInternal(v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasNonEmptyLabelInternal(labels map[string]string, target string) bool {
+	if labels == nil {
+		return false
+	}
+
+	for k, v := range labels {
+		if strings.EqualFold(k, target) && strings.TrimSpace(v) != "" {
 			return true
 		}
 	}

--- a/backend/pkg/libarcane/imageupdate/labels_test.go
+++ b/backend/pkg/libarcane/imageupdate/labels_test.go
@@ -259,6 +259,58 @@ func TestIsUpdateDisabled(t *testing.T) {
 	}
 }
 
+func TestIsSwarmTask(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   false,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+			want:   false,
+		},
+		{
+			name:   "unrelated labels",
+			labels: map[string]string{"com.example.service": "api"},
+			want:   false,
+		},
+		{
+			name:   "swarm service id",
+			labels: map[string]string{LabelSwarmServiceID: "service-id"},
+			want:   true,
+		},
+		{
+			name:   "swarm service name",
+			labels: map[string]string{LabelSwarmServiceName: "web"},
+			want:   true,
+		},
+		{
+			name:   "case insensitive label key",
+			labels: map[string]string{"COM.DOCKER.SWARM.SERVICE.ID": "service-id"},
+			want:   true,
+		},
+		{
+			name:   "empty swarm label value",
+			labels: map[string]string{LabelSwarmServiceID: "   "},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSwarmTask(tt.labels); got != tt.want {
+				t.Errorf("IsSwarmTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldDisableArcaneServerRedeploy(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/go.work.sum
+++ b/go.work.sum
@@ -604,10 +604,13 @@ github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8I
 github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6/go.mod h1:I6V7YzU0XDpsHqbsyrghnFZLO1gwK6NPTNvmetQIk9U=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/trillian v1.7.2 h1:EPBxc4YWY4Ak8tcuhyFleY+zYlbCDCa4Sn24e1Ka8Js=
 github.com/google/trillian v1.7.2/go.mod h1:mfQJW4qRH6/ilABtPYNBerVJAJ/upxHLX81zxNQw05s=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=
+github.com/google/wire v0.7.0/go.mod h1:n6YbUQD9cPKTnHXEBN2DXlOp/mVADhVErcMFb0v3J18=
 github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU9uHLo7OnF5tL52HFAgMmyrf4=
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
@@ -1151,7 +1154,6 @@ go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJ
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
-go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
 go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.37.0/go.mod h1:VredYzxUvuo2q3WRcDnKDjbdvmO0sCzOvVAiY+yUkAg=
 go.opentelemetry.io/otel/sdk v1.38.0/go.mod h1:ghmNdGlVemJI3+ZB5iDEuk4bWA3GkTpW+DOoZMYBVVg=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the updater service skip Docker Swarm task containers (delegating updates to the service level), hardens `GetAppVersionInfo` to consult stored `ImageUpdateRecord` entries before doing a live registry call, fixes a nil-pointer risk in `detectCurrentImageInfo` when `container.Config` is nil, and changes project-service pull failures from a logged warning to a hard error that restores project status.

- Adds `IsSwarmTask` label helper and gates both `UpdateSingleContainer` and `restartContainersUsingOldIDs` behind it so swarm-managed task containers are never stopped/recreated by Arcane.
- Replaces the exported mutable `ArcaneUpgraderImage` global with a local variable initialised from an unexported constant, eliminating a concurrent-mutation hazard.
- Makes `composeUp` pass `forceRecreate=true` so containers are always recreated after a successful image pull during service updates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are well-guarded and covered by new tests; no path introduces incorrect data or unsafe state transitions.

Each of the three main logic paths — swarm skipping, stored-record version check, and pull-failure hard-stop — is validated by targeted unit tests. The UpdateAvailable flag is correctly gated so stored digest updates never surface as an update banner for semver builds. The system_upgrade_service.go refactor removes a shared mutable global without changing the effective fallback value. The forceRecreate=true fix in UpdateProjectServices is the correct default for image-update deployments and is directly asserted in a new test.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: make updater service skip swarm con..."](https://github.com/getarcaneapp/arcane/commit/11558b92cc535513f2a3e27a61a436160234c3d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34816144)</sub>

<!-- /greptile_comment -->