### PR TITLE
fix: add global csrf middleware

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -141,6 +141,7 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *di.Servic
 
 	authMiddleware := appServices.AuthMiddleware
 	e.Use(middleware.NewCORSMiddleware(cfg).Add())
+	e.Use(middleware.NewCSRFMiddleware(cfg).Add()) //nolint:contextcheck // Echo middleware uses request context from echo.Context, not the app lifecycle context.
 
 	apiGroup := e.Group("/api")
 

--- a/backend/internal/middleware/csrf_middleware.go
+++ b/backend/internal/middleware/csrf_middleware.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
+	"github.com/labstack/echo/v4"
+)
+
+// publicCrossOriginBypassPaths are endpoints intentionally reachable cross-origin
+// by non-browser callers that authenticate with their OWN token carried in the
+// path or request body (not the session cookie). Cross-origin protection must not
+// block them, since a legitimate external caller (CI, webhook source) may attach
+// an Origin header. Patterns use net/http ServeMux syntax, matched against URL path.
+var publicCrossOriginBypassPaths = []string{
+	"/api/webhooks/trigger/{token}",
+	"/api/auth/federated/token",
+}
+
+// CSRFMiddleware rejects cross-origin state-changing requests to the cookie-backed
+// API. It complements the SameSite=Lax session cookie with server-side origin
+// verification (Sec-Fetch-Site, with an Origin/Host fallback) via the standard
+// library's net/http.CrossOriginProtection.
+//
+// Header-credentialed requests (Bearer / X-API-Key / agent token) are not CSRF-able
+// — a browser cannot attach those headers to a forged cross-origin request — so they
+// are left untouched, as are non-browser clients that send no Origin header.
+type CSRFMiddleware struct {
+	cfg *config.Config
+}
+
+func NewCSRFMiddleware(cfg *config.Config) *CSRFMiddleware {
+	return &CSRFMiddleware{cfg: cfg}
+}
+
+func (m *CSRFMiddleware) Add() echo.MiddlewareFunc {
+	// Edge Agent mode: skip. The agent only receives server-to-server requests
+	// through the edge tunnel from the manager — never from browsers. Mirrors CORSMiddleware.
+	if m.cfg != nil && m.cfg.EdgeAgent {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error { return next(c) }
+		}
+	}
+
+	cop := http.NewCrossOriginProtection()
+	for _, origin := range deriveAllowedOriginsInternal(m.cfg, nil) {
+		// AddTrustedOrigin expects scheme://host[:port]; deriveAllowedOriginsInternal
+		// already produces that form (shared with CORS). Skip anything malformed.
+		if err := cop.AddTrustedOrigin(origin); err != nil {
+			slog.Warn("CSRF: ignoring invalid trusted origin", "origin", origin, "error", err)
+		}
+	}
+	for _, pattern := range publicCrossOriginBypassPaths {
+		cop.AddInsecureBypassPattern(pattern)
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+			if hasHeaderCredentialInternal(req) {
+				return next(c)
+			}
+			if err := cop.Check(req); err != nil {
+				slog.WarnContext(req.Context(), "CSRF: cross-origin request blocked",
+					"path", req.URL.Path,
+					"method", req.Method,
+					"origin", req.Header.Get("Origin"),
+					"sec_fetch_site", req.Header.Get("Sec-Fetch-Site"),
+				)
+				return c.JSON(http.StatusForbidden, models.APIError{
+					Code:    models.APIErrorCodeForbidden,
+					Message: "Cross-origin request blocked",
+				})
+			}
+			return next(c)
+		}
+	}
+}
+
+// hasHeaderCredentialInternal reports whether the request carries a credential in a
+// header that a browser cannot forge on a cross-origin request, meaning it is not
+// susceptible to CSRF and should bypass the cross-origin check.
+func hasHeaderCredentialInternal(req *http.Request) bool {
+	return strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") ||
+		req.Header.Get(pkgutils.HeaderApiKey) != "" ||
+		req.Header.Get(pkgutils.HeaderAgentToken) != ""
+}

--- a/backend/internal/middleware/csrf_middleware_test.go
+++ b/backend/internal/middleware/csrf_middleware_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func newCSRFTestRouterInternal() *echo.Echo {
+	cfg := &config.Config{Environment: "production", AppUrl: "https://arcane.example.com"}
+	router := echo.New()
+	router.Use(NewCSRFMiddleware(cfg).Add())
+	router.POST("/api/test", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	router.POST("/api/webhooks/trigger/:token", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	return router
+}
+
+func TestCSRF_BlocksCrossSiteStateChange(t *testing.T) {
+	router := newCSRFTestRouterInternal()
+	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestCSRF_AllowsSameOrigin(t *testing.T) {
+	router := newCSRFTestRouterInternal()
+	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Non-browser clients (curl, CLI, CI, the report's Python PoC) send no Origin or
+// Sec-Fetch-Site header and must not be blocked.
+func TestCSRF_AllowsNonBrowserClient(t *testing.T) {
+	router := newCSRFTestRouterInternal()
+	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// A header credential cannot be forged cross-origin by a browser, so even a
+// cross-site Origin must not block such a request.
+func TestCSRF_SkipsHeaderCredentialedRequests(t *testing.T) {
+	router := newCSRFTestRouterInternal()
+	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Header.Set("X-Api-Key", "some-key")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Public webhook trigger authenticates via its path token, not the session cookie,
+// and may receive an Origin header from an external caller; it must be bypassed.
+func TestCSRF_AllowsPublicBypassPaths(t *testing.T) {
+	router := newCSRFTestRouterInternal()
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/trigger/abc", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", "https://ci.example.com")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -562,6 +562,8 @@ test.describe('New Compose Project Page', () => {
 	});
 
 	test('should create a new project successfully', async ({ page }) => {
+		test.slow();
+
 		const projectName = `test-project-${Date.now()}`;
 		const containerName = `test-nginx-container-${Date.now()}`;
 		const envFile = TEST_ENV_FILE.replace(/CONTAINER_NAME=.*/m, `CONTAINER_NAME=${containerName}`);
@@ -654,10 +656,24 @@ test.describe('New Compose Project Page', () => {
 			.getByRole('button', { name: 'Up', exact: true })
 			.filter({ hasText: 'Up' })
 			.last();
+		const deployResponsePromise = page.waitForResponse(
+			(response) =>
+				response.request().method() === 'POST' &&
+				/\/api\/environments\/[^/]+\/projects\/[^/]+\/up$/.test(getPathname(response.url()))
+		);
 		await deployButton.click();
 
-		await page.waitForTimeout(5000);
-		await page.waitForLoadState('load');
+		const deployResponse = await deployResponsePromise;
+		expect(deployResponse.ok()).toBe(true);
+		expect(await deployResponse.finished()).toBeNull();
+
+		const projectId = createdProjectId ?? getProjectIdFromPageUrl(page.url());
+		await expect
+			.poll(async () => (await fetchProjectDetail(page, projectId))?.status, {
+				message: 'Expected project to be running after deploy',
+				timeout: 60000
+			})
+			.toBe('running');
 
 		expect(projectPullRequestCount).toBe(0);
 		await expect(page.getByText('Running', { exact: true }).first()).toBeVisible({


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a global CSRF middleware to the Echo router that leverages Go 1.24's `net/http.CrossOriginProtection` to reject cross-origin state-changing requests to the cookie-backed API. The implementation closely mirrors the existing `CORSMiddleware` — sharing origin derivation logic, skipping in EdgeAgent mode, and exempting header-credentialed requests (Bearer / API key / agent token) that browsers cannot forge cross-origin.

- **`csrf_middleware.go`**: New middleware wrapping `http.NewCrossOriginProtection`, with explicit bypass patterns for the public webhook trigger and federated token exchange endpoints, plus a `hasHeaderCredentialInternal` helper for the header-credential exemption.
- **`router_bootstrap.go`**: One-line registration of the new middleware immediately after CORS, ensuring preflight OPTIONS requests are handled by CORS before CSRF runs.
- **`csrf_middleware_test.go`**: Five tests covering cross-site blocking, same-origin pass-through, non-browser client pass-through, header-credential bypass, and public bypass path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only finding is a test helper function name that doesn't follow the project's Internal suffix convention.

The CSRF middleware is well-structured, correctly reuses origin derivation logic shared with CORS, and is appropriately placed in the middleware chain. The only gap is a naming convention violation in the test helper function.

No files require special attention beyond the minor naming fix in csrf_middleware_test.go.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fadd-global-csrf%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fadd-global-csrf%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fmiddleware%2Fcsrf_middleware_test.go%3A13%0AThe%20helper%20function%20%60newCSRFTestRouter%60%20is%20unexported%20but%20lacks%20the%20required%20%60Internal%60%20suffix%20mandated%20by%20the%20team's%20naming%20rule.%20All%20unexported%20functions%20in%20this%20codebase%20should%20follow%20the%20%60*Internal%60%20naming%20convention%2C%20as%20seen%20throughout%20the%20production%20code%20%28e.g.%2C%20%60shouldLogRequestInternal%60%2C%20%60requestLoggerMiddlewareInternal%60%29.%0A%0A%60%60%60suggestion%0Afunc%20newCSRFTestRouterInternal%28%29%20*echo.Echo%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fmiddleware%2Fcsrf_middleware_test.go%3A13%0AThe%20helper%20function%20%60newCSRFTestRouter%60%20is%20unexported%20but%20lacks%20the%20required%20%60Internal%60%20suffix%20mandated%20by%20the%20team's%20naming%20rule.%20All%20unexported%20functions%20in%20this%20codebase%20should%20follow%20the%20%60*Internal%60%20naming%20convention%2C%20as%20seen%20throughout%20the%20production%20code%20%28e.g.%2C%20%60shouldLogRequestInternal%60%2C%20%60requestLoggerMiddlewareInternal%60%29.%0A%0A%60%60%60suggestion%0Afunc%20newCSRFTestRouterInternal%28%29%20*echo.Echo%20%7B%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2780&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/middleware/csrf_middleware_test.go:13
The helper function `newCSRFTestRouter` is unexported but lacks the required `Internal` suffix mandated by the team's naming rule. All unexported functions in this codebase should follow the `*Internal` naming convention, as seen throughout the production code (e.g., `shouldLogRequestInternal`, `requestLoggerMiddlewareInternal`).

```suggestion
func newCSRFTestRouterInternal() *echo.Echo {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add global csrf middleware"](https://github.com/getarcaneapp/arcane/commit/d775e1d70e9de9d9c0e165ceccfdecc149c61460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34819476)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->