### PR TITLE
fix: slog-go nil pointer dereference

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -76,6 +76,9 @@ func requestLoggerMiddlewareInternal() echo.MiddlewareFunc {
 			if edge.IsInternalTunnelRequest(c.Request().Context()) {
 				return next(c)
 			}
+			if c.Request().Body == nil {
+				c.Request().Body = http.NoBody
+			}
 			return loggerMiddleware(next)(c)
 		}
 	}


### PR DESCRIPTION
Here's the filled-out template based on everything from this conversation:

---

## Checklist
- [X] This PR is **not** opened from my fork's `main` branch

## What This PR Implements

Fixes a panic in `requestLoggerMiddlewareInternal` caused by a nil pointer dereference in `slog-echo v1.23.0` when `req.Body` is nil.

Fixes: 

## Changes Made

- Added a nil-guard for `req.Body` in `requestLoggerMiddlewareInternal` before passing the request to the slog-echo middleware
- If `req.Body` is nil, it is replaced with `http.NoBody` (a valid no-op `io.ReadCloser`) prior to logging

## Testing Done

- [x] Development environment started: `./scripts/development/dev.sh start`
- [x] Frontend verified at http://localhost:3000
- [x] Backend verified at http://localhost:3552
- [X] Manual testing completed: Reproduced by deploying two new `arcane_gitops_sync` resources via OpenTofu simultaneously; both previously returned HTTP 500 due to the panic. After the fix both resources are created successfully.
- [x] No linting errors (e.g., `just lint all`)
- [x] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

AI Tool: Claude (Anthropic)  
Assistance Level: Significant  
What AI helped with: Root cause analysis of the panic stack trace, tracing the nil `ReadCloser` through `slog-echo`'s `dump.go` and huma's `readBody`, and writing the one-line fix with inline comment  
I reviewed and edited all AI-generated output:  
I ran all required tests and manually verified changes:  

## Additional Context

`slog-echo v1.23.0` unconditionally calls `newBodyReader(req.Body, ...)` and embeds the result as an `io.ReadCloser` — even when `WithRequestBody` is `false`. If `req.Body` is nil at that point (possible when Echo recycles request context objects between concurrent requests), the embedded `ReadCloser` is nil. huma's `readBody` then calls `defer closer.Close()` on the wrapper, which delegates to the nil `ReadCloser` and panics. The recover middleware catches it and returns a 500, even though the actual handler already completed successfully.

This is also a bug in `slog-echo` itself (`newBodyReader` should guard for nil) and is worth reporting upstream at `samber/slog-echo`.

---

You'll want to fill in the issue number for **Fixes:** and check off the testing boxes you actually ran.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a nil-guard for `req.Body` in `requestLoggerMiddlewareInternal` before invoking the `slog-echo` logger middleware, replacing a nil body with `http.NoBody` to prevent a nil pointer dereference inside the library.

- The panic was triggered by `slog-echo` v1.23.0 unconditionally calling `newBodyReader(req.Body, ...)` — when `req.Body` is nil (possible when Echo recycles request contexts under concurrency), the resulting wrapper's `Close` call panics, which the recover middleware catches and converts to a 500.
- `http.NoBody` is the idiomatic Go sentinel for an empty body; it satisfies `io.ReadCloser`, returns `(0, io.EOF)` on `Read`, and is a no-op on `Close`, so downstream handlers see semantically equivalent behaviour to a nil body.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line guard with no functional side effects on well-formed requests.

The change is minimal: one nil check plus an assignment to `http.NoBody`, a stdlib constant with well-defined read/close semantics. It is placed before the logger call, so both the logger and the downstream handler see a non-nil body, which matches expected Go HTTP conventions. The manual reproduction confirms the fix resolves the panic without breaking concurrent resource creation.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: slog-go nil pointer dereference"](https://github.com/getarcaneapp/arcane/commit/df07e38304b8918a4f86ca0944d99f550864817c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34823543)</sub>

<!-- /greptile_comment -->