### PR TITLE
feat: add removeOrphans option to project deploy/redeploy

### DIFF
--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -108,6 +108,7 @@ type GetProjectFileOutput struct {
 type RedeployProjectInput struct {
 	EnvironmentID string `path:"id" doc:"Environment ID"`
 	ProjectID     string `path:"projectId" doc:"Project ID"`
+	Body          *project.DeployOptions
 }
 
 type RedeployProjectOutput struct {
@@ -811,7 +812,7 @@ func (h *ProjectHandler) RedeployProject(ctx context.Context, input *RedeployPro
 		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
 	}
 
-	if err := h.projectService.RedeployProject(ctx, input.ProjectID, *user); err != nil {
+	if err := h.projectService.RedeployProject(ctx, input.ProjectID, *user, input.Body); err != nil {
 		var archivedErr *common.ProjectArchivedError
 		if errors.As(err, &archivedErr) {
 			return nil, huma.Error400BadRequest(err.Error())

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -682,7 +682,7 @@ func (s *GitOpsSyncService) redeployIfRunningAfterSync(ctx context.Context, proj
 	}
 
 	slog.InfoContext(ctx, "Redeploying project due to content change from Git sync", "syncMode", syncMode, "projectName", project.Name, "projectId", project.ID)
-	if err := s.projectService.RedeployProject(ctx, project.ID, actor); err != nil {
+	if err := s.projectService.RedeployProject(ctx, project.ID, actor, nil); err != nil {
 		slog.ErrorContext(ctx, "Failed to redeploy project after Git sync", "syncMode", syncMode, "error", err, "projectId", project.ID)
 	}
 }
@@ -994,7 +994,7 @@ func (s *GitOpsSyncService) updateProjectForSyncInternal(ctx context.Context, sy
 		details, err := s.projectService.GetProjectDetails(ctx, project.ID, projecttypes.AllDetails())
 		if err == nil && (details.Status == string(models.ProjectStatusRunning) || details.Status == string(models.ProjectStatusPartiallyRunning)) {
 			slog.InfoContext(ctx, "Redeploying project due to content change from Git sync", "projectName", project.Name, "projectId", project.ID)
-			if err := s.projectService.RedeployProject(ctx, project.ID, actor); err != nil {
+			if err := s.projectService.RedeployProject(ctx, project.ID, actor, nil); err != nil {
 				slog.ErrorContext(ctx, "Failed to redeploy project after Git sync", "error", err, "projectId", project.ID)
 			}
 		}

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1843,6 +1843,13 @@ func (s *ProjectService) UnarchiveProject(ctx context.Context, projectID string,
 	return nil
 }
 
+// resolveRemoveOrphans decides whether compose up should remove orphan containers.
+// GitOps-managed projects always remove orphans so the running stack matches the
+// tracked compose file. Non-GitOps callers may opt in per request via DeployOptions.
+func resolveRemoveOrphans(gitOpsManaged bool, options *project.DeployOptions) bool {
+	return gitOpsManaged || (options != nil && options.RemoveOrphans)
+}
+
 func (s *ProjectService) DeployProject(ctx context.Context, projectID string, user models.User, options *project.DeployOptions) error {
 	projectFromDb, err := s.GetProjectFromDatabaseByID(ctx, projectID)
 	if err != nil {
@@ -1880,7 +1887,8 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		return fmt.Errorf("failed to prepare project images for deploy: %w", perr)
 	}
 
-	removeOrphans := projectFromDb.GitOpsManagedBy != nil && *projectFromDb.GitOpsManagedBy != ""
+	gitOpsManaged := projectFromDb.GitOpsManagedBy != nil && *projectFromDb.GitOpsManagedBy != ""
+	removeOrphans := resolveRemoveOrphans(gitOpsManaged, options)
 
 	slog.Info("starting compose up with health check support", "projectID", projectID, "projectName", project.Name, "services", len(project.Services), "removeOrphans", removeOrphans)
 	// Health/progress streaming (if any) is handled inside projects.ComposeUp via ctx.
@@ -2051,7 +2059,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 	return nil
 }
 
-func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, user models.User) error {
+func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, user models.User, options *project.DeployOptions) error {
 	proj, err := s.GetProjectFromDatabaseByID(ctx, projectID)
 	if err != nil {
 		return err
@@ -2077,7 +2085,7 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 		slog.ErrorContext(ctx, "could not log project redeploy action", "error", logErr)
 	}
 
-	return s.DeployProject(ctx, projectID, user, nil)
+	return s.DeployProject(ctx, projectID, user, options)
 }
 
 func (s *ProjectService) projectRedeployDisabledInternal(ctx context.Context, proj models.Project) (bool, error) {

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1843,10 +1843,10 @@ func (s *ProjectService) UnarchiveProject(ctx context.Context, projectID string,
 	return nil
 }
 
-// resolveRemoveOrphans decides whether compose up should remove orphan containers.
+// resolveRemoveOrphansInternal decides whether compose up should remove orphan containers.
 // GitOps-managed projects always remove orphans so the running stack matches the
 // tracked compose file. Non-GitOps callers may opt in per request via DeployOptions.
-func resolveRemoveOrphans(gitOpsManaged bool, options *project.DeployOptions) bool {
+func resolveRemoveOrphansInternal(gitOpsManaged bool, options *project.DeployOptions) bool {
 	return gitOpsManaged || (options != nil && options.RemoveOrphans)
 }
 
@@ -1888,7 +1888,7 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 	}
 
 	gitOpsManaged := projectFromDb.GitOpsManagedBy != nil && *projectFromDb.GitOpsManagedBy != ""
-	removeOrphans := resolveRemoveOrphans(gitOpsManaged, options)
+	removeOrphans := resolveRemoveOrphansInternal(gitOpsManaged, options)
 
 	slog.Info("starting compose up with health check support", "projectID", projectID, "projectName", project.Name, "services", len(project.Services), "removeOrphans", removeOrphans)
 	// Health/progress streaming (if any) is handled inside projects.ComposeUp via ctx.

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -3823,7 +3823,7 @@ func TestResolveRemoveOrphans(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, resolveRemoveOrphans(tt.gitOpsManaged, tt.options))
+			require.Equal(t, tt.want, resolveRemoveOrphansInternal(tt.gitOpsManaged, tt.options))
 		})
 	}
 }

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -3805,3 +3805,25 @@ func dockerHostFromProjectRuntimeServerURLInternal(t *testing.T, serverURL strin
 func ptr(v string) *string {
 	return new(v)
 }
+
+func TestResolveRemoveOrphans(t *testing.T) {
+	tests := []struct {
+		name          string
+		gitOpsManaged bool
+		options       *projecttypes.DeployOptions
+		want          bool
+	}{
+		{"non-gitops, nil options", false, nil, false},
+		{"non-gitops, flag false", false, &projecttypes.DeployOptions{RemoveOrphans: false}, false},
+		{"non-gitops, flag true opts in", false, &projecttypes.DeployOptions{RemoveOrphans: true}, true},
+		{"gitops, nil options stays true", true, nil, true},
+		{"gitops, flag false stays true", true, &projecttypes.DeployOptions{RemoveOrphans: false}, true},
+		{"gitops, flag true stays true", true, &projecttypes.DeployOptions{RemoveOrphans: true}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveRemoveOrphans(tt.gitOpsManaged, tt.options))
+		})
+	}
+}

--- a/backend/internal/services/webhook_service.go
+++ b/backend/internal/services/webhook_service.go
@@ -576,7 +576,7 @@ func (s *WebhookService) executeProjectWebhookActionInternal(ctx context.Context
 		}
 		return nil, nil
 	case models.WebhookActionTypeRedeploy:
-		if err := s.projectService.RedeployProject(ctx, wh.TargetID, systemUser); err != nil {
+		if err := s.projectService.RedeployProject(ctx, wh.TargetID, systemUser, nil); err != nil {
 			return nil, s.wrapWebhookActionErrorInternal(ctx, wh, "project", actionType, err)
 		}
 		return nil, nil

--- a/backend/pkg/projects/cmds_test.go
+++ b/backend/pkg/projects/cmds_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,4 +107,29 @@ func TestFilterProjectServicesForPullInternalReturnsDeepCopiedProject(t *testing
 
 	require.Contains(t, project.Services["web"].DependsOn, "db")
 	require.Contains(t, project.Networks, "default")
+}
+
+func TestComposeUpOptions_RemoveOrphans(t *testing.T) {
+	proj := &composetypes.Project{Name: "test"}
+
+	t.Run("removeOrphans true propagates to CreateOptions", func(t *testing.T) {
+		upOptions, _ := composeUpOptions(proj, nil, true, false)
+		require.True(t, upOptions.RemoveOrphans)
+	})
+
+	t.Run("removeOrphans false leaves CreateOptions disabled", func(t *testing.T) {
+		upOptions, _ := composeUpOptions(proj, nil, false, false)
+		require.False(t, upOptions.RemoveOrphans)
+	})
+
+	t.Run("removeOrphans is independent of forceRecreate", func(t *testing.T) {
+		// forceRecreate drives the Recreate policy, not RemoveOrphans.
+		upOptions, _ := composeUpOptions(proj, nil, true, true)
+		require.True(t, upOptions.RemoveOrphans)
+		require.Equal(t, api.RecreateForce, upOptions.Recreate)
+
+		upOptions, _ = composeUpOptions(proj, nil, false, true)
+		require.False(t, upOptions.RemoveOrphans)
+		require.Equal(t, api.RecreateForce, upOptions.Recreate)
+	})
 }

--- a/types/project/project.go
+++ b/types/project/project.go
@@ -80,6 +80,11 @@ type DeployOptions struct {
 	//
 	// Required: false
 	ForceRecreate bool `json:"forceRecreate,omitempty"`
+
+	// RemoveOrphans removes containers for services not defined in the compose file.
+	//
+	// Required: false
+	RemoveOrphans bool `json:"removeOrphans,omitempty"`
 }
 
 // UpdateIncludeFile is used to update an include file within a project.


### PR DESCRIPTION
## Summary

Adds an opt-in, per-request `removeOrphans` flag to the project deploy/redeploy API so **non-GitOps projects** can remove orphan containers (services deleted from the compose file) on redeploy.

Today `removeOrphans` is hardcoded `true` only for GitOps-managed projects (`project_service.go`, derived from `GitOpsManagedBy`). Imperative, API-driven redeploys of regular projects therefore leave orphan containers running — there is no way to request their removal. This adds the missing knob, mirroring the existing `forceRecreate` option on `DeployOptions`.

## Changes

- `types/project/project.go` — add `RemoveOrphans bool \`json:"removeOrphans,omitempty"\`` to `DeployOptions` (mirrors `ForceRecreate`).
- `backend/internal/services/project_service.go` — extract `resolveRemoveOrphans(gitOpsManaged, options)`: returns `true` if the project is GitOps-managed **or** the caller opted in. `RedeployProject` now accepts `*project.DeployOptions` and forwards it to `DeployProject` instead of `nil`.
- `backend/api/handlers/projects.go` — `RedeployProjectInput` gains an optional `Body *project.DeployOptions` (same shape as the existing `DeployProjectInput.Body`); passed through to the service.
- `gitops_sync_service.go`, `webhook_service.go` — existing internal callers pass `nil` (behavior unchanged; GitOps projects still remove orphans via the `GitOpsManagedBy` condition).

## Behavior

Purely additive and non-breaking. The flag can only turn `removeOrphans` from `false` → `true`, never the reverse. Empty/absent body ⇒ `nil` options ⇒ current default behavior preserved.

`POST /environments/{id}/projects/{projectId}/redeploy` with `{"removeOrphans": true}` now removes orphans; an empty body behaves exactly as before. `/down` is left as-is (already removes orphans unconditionally).

## Tests

- `TestResolveRemoveOrphans` — table test covering the precedence matrix (gitops × flag).
- `TestComposeUpOptions_RemoveOrphans` — asserts the flag propagates into compose `CreateOptions.RemoveOrphans`.

`go build`, `go vet`, `gofmt`, and the `services` + `pkg/projects` test suites all pass.

## Notes

- Frontend/SDK wiring (a UI checkbox in the deploy-options store) is intentionally **deferred** — this is a backend-only, opt-in API addition. Happy to add it in a follow-up if desired.
- Open to changing the design if maintainers would prefer redeploy to remove orphans unconditionally; chose the opt-in flag to stay non-breaking.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in `removeOrphans` field to `DeployOptions` and threads it through the redeploy API path, allowing non-GitOps projects to request removal of orphan containers on redeploy. The existing behavior for GitOps-managed projects and all other internal callers is fully preserved.

- `resolveRemoveOrphansInternal` centralises the precedence logic (`gitOpsManaged || options.RemoveOrphans`), and the new `TestResolveRemoveOrphans` table test covers all six combinations of the flag matrix.
- `RedeployProjectInput` gains an optional `Body *project.DeployOptions`, following the exact same pattern as the existing `DeployProjectInput`; absent/empty body remains nil and behaviour is unchanged.
- As a side-effect, `forceRecreate` is now also accepted via the redeploy endpoint (since the full `DeployOptions` struct is forwarded), which is not called out in the PR description but is consistent with the deploy endpoint's API surface.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is purely additive: no existing call site is altered in behaviour, and all internal callers (GitOps sync, webhook) continue to pass nil options.

The logic is straightforward and well-tested. The resolveRemoveOrphansInternal helper is trivial and covered by a complete 6-case table test. Nil handling throughout is correct, and the HTTP handler follows an identical pattern already used by the deploy endpoint.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: rename resolveRemoveOrphans to..."](https://github.com/getarcaneapp/arcane/commit/4934c73a5b655e56d103d21663f180fc623514c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35053905)</sub>

<!-- /greptile_comment -->