### PR TITLE
fix: image update checks timeout for no reason

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -1342,7 +1342,18 @@ func isDistributionFallbackEligibleInternal(err error) bool {
 		return false
 	}
 
-	return updaterregistry.IsFallbackEligibleDaemonError(err)
+	if updaterregistry.IsFallbackEligibleDaemonError(err) {
+		return true
+	}
+
+	if isUnauthorizedRegistryErrorInternal(err) {
+		return false
+	}
+
+	errLower := strings.ToLower(err.Error())
+	return strings.Contains(errLower, "context deadline exceeded") ||
+		strings.Contains(errLower, "client.timeout exceeded") ||
+		strings.Contains(errLower, "i/o timeout")
 }
 
 func (s *ContainerRegistryService) fetchDigestFromRegistryInternal(ctx context.Context, registryHost, repository, tag string, credential *resolvedRegistryCredential) (string, error) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `isDistributionFallbackEligibleInternal` to return `true` for network timeout errors, enabling the direct HTTP registry fallback path instead of immediately surfacing a permanent error when the Docker daemon's distribution inspect call times out.

- The old code delegated entirely to `updaterregistry.IsFallbackEligibleDaemonError`, which only returns `true` for a specific set of positive indicators (404, 403, proxy errors, etc.) and returns `false` for everything else — including timeouts — causing daemon timeout errors to be treated as permanent failures with no fallback attempt.
- The new code first checks `IsFallbackEligibleDaemonError`, then guards against unauthorized typed errors via `isUnauthorizedRegistryErrorInternal`, and finally returns `true` when the error string indicates a network timeout (`context deadline exceeded`, `client.timeout exceeded`, `i/o timeout`), allowing the fallback to the distribution HTTP client to proceed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; it widens the fallback path only for clear network timeout errors while keeping unauthorized and TLS errors blocked.

The logic is sound: timeout errors were previously passed to backoff.Permanent with no fallback attempt; now they route to the direct HTTP registry client, which uses an independent connection path and is unaffected by the daemon's internal timeout. The isUnauthorizedRegistryErrorInternal guard correctly prevents typed auth errors from slipping through to the timeout branch. The fallback itself already wraps its failure in backoff.Permanent, so there is no retry-loop risk.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: image update checks timeout for no ..."](https://github.com/getarcaneapp/arcane/commit/c4054f7ac78d5f11a72e434967fb9937f445553d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35282421)</sub>

<!-- /greptile_comment -->