### PR TITLE
fix: fix project update order and authentication

### DIFF
--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -114,6 +114,11 @@ func provideContainerRegistryServiceInternal(db *database.DB, docker *services.D
 	}, kv)
 }
 
+func provideProjectServiceInternal(db *database.DB, settings *services.SettingsService, event *services.EventService, image *services.ImageService, docker *services.DockerClientService, build *services.BuildService, environment *services.EnvironmentService, cfg *config.Config) *services.ProjectService {
+	return services.NewProjectService(db, settings, event, image, docker, build, cfg).
+		WithRegistryCredentialsProvider(environment.GetEnabledRegistryCredentials)
+}
+
 // provideUpdaterServiceInternal passes *SystemUpgradeService for the unexported
 // selfUpgradeService parameter so wire never sees the unexported type.
 func provideUpdaterServiceInternal(db *database.DB, settings *services.SettingsService, docker *services.DockerClientService, project *services.ProjectService, imageUpdate *services.ImageUpdateService, registry *services.ContainerRegistryService, event *services.EventService, image *services.ImageService, notification *services.NotificationService, systemUpgrade *services.SystemUpgradeService, activity *services.ActivityService) *services.UpdaterService {

--- a/backend/internal/di/wire.go
+++ b/backend/internal/di/wire.go
@@ -45,7 +45,7 @@ var ServiceSet = wire.NewSet(
 	services.NewImageService,
 	services.NewBuildService,
 	services.NewBuildWorkspaceService,
-	services.NewProjectService,
+	provideProjectServiceInternal,
 	services.NewContainerService,
 	services.NewDashboardService,
 	services.NewNetworkService,

--- a/backend/internal/di/wire_gen.go
+++ b/backend/internal/di/wire_gen.go
@@ -43,7 +43,7 @@ func InitializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	imageService := services.NewImageService(db, dockerClientService, containerRegistryService, imageUpdateService, vulnerabilityService, eventService)
 	gitRepositoryService := provideGitRepositoryServiceInternal(db, cfg, eventService, settingsService)
 	buildService := services.NewBuildService(db, settingsService, dockerClientService, containerRegistryService, gitRepositoryService, eventService)
-	projectService := services.NewProjectService(db, settingsService, eventService, imageService, dockerClientService, buildService, cfg)
+	projectService := provideProjectServiceInternal(db, settingsService, eventService, imageService, dockerClientService, buildService, environmentService, cfg)
 	jobService := services.NewJobService(db, settingsService, cfg)
 	settingsSearchService := services.NewSettingsSearchService()
 	customizeSearchService := services.NewCustomizeSearchService()
@@ -163,7 +163,7 @@ func InitializeJobs(ctx context.Context, cfg *config.Config, svcs *Services) *Jo
 // no longer maintained by hand. wire.Struct assembles the aggregate Services.
 var ServiceSet = wire.NewSet(
 
-	provideResourcesFSInternal, services.NewEventService, services.NewActivityService, services.NewSettingsService, services.NewKVService, services.NewJobService, services.NewSettingsSearchService, services.NewCustomizeSearchService, services.NewApplicationImagesService, services.NewDockerClientService, services.NewRoleService, services.NewSessionService, services.NewEnvironmentService, services.NewNotificationService, services.NewVulnerabilityService, services.NewImageUpdateService, services.NewImageService, services.NewBuildService, services.NewBuildWorkspaceService, services.NewProjectService, services.NewContainerService, services.NewDashboardService, services.NewNetworkService, services.NewPortService, services.NewSwarmService, services.NewTemplateService, services.NewOidcService, services.NewSystemService, services.NewSystemUpgradeService, services.NewDiagnosticsService, services.NewGitOpsSyncService, services.NewWebhookService, provideVersionServiceInternal,
+	provideResourcesFSInternal, services.NewEventService, services.NewActivityService, services.NewSettingsService, services.NewKVService, services.NewJobService, services.NewSettingsSearchService, services.NewCustomizeSearchService, services.NewApplicationImagesService, services.NewDockerClientService, services.NewRoleService, services.NewSessionService, services.NewEnvironmentService, services.NewNotificationService, services.NewVulnerabilityService, services.NewImageUpdateService, services.NewImageService, services.NewBuildService, services.NewBuildWorkspaceService, provideProjectServiceInternal, services.NewContainerService, services.NewDashboardService, services.NewNetworkService, services.NewPortService, services.NewSwarmService, services.NewTemplateService, services.NewOidcService, services.NewSystemService, services.NewSystemUpgradeService, services.NewDiagnosticsService, services.NewGitOpsSyncService, services.NewWebhookService, provideVersionServiceInternal,
 	provideGitRepositoryServiceInternal,
 	provideVolumeServiceInternal,
 	provideAuthServiceInternal,

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -42,18 +42,21 @@ import (
 )
 
 type ProjectService struct {
-	db              *database.DB
-	settingsService *SettingsService
-	eventService    *EventService
-	imageService    *ImageService
-	dockerService   *DockerClientService
-	buildService    *BuildService
-	config          *config.Config
+	db                          *database.DB
+	settingsService             *SettingsService
+	eventService                *EventService
+	imageService                *ImageService
+	dockerService               *DockerClientService
+	buildService                *BuildService
+	config                      *config.Config
+	registryCredentialsProvider registryCredentialsProviderInternal
 
 	composeNameCacheMu  sync.RWMutex
 	composeNameToProjID map[string]string
 	composeCache        *cache.KeyedCache[string, composeCacheEntry]
 }
+
+type registryCredentialsProviderInternal func(context.Context) ([]containerregistry.Credential, error)
 
 type composeCacheEntry struct {
 	composePath   string
@@ -73,6 +76,27 @@ func NewProjectService(db *database.DB, settingsService *SettingsService, eventS
 		config:          cfg,
 		composeCache:    cache.NewKeyed[string, composeCacheEntry](),
 	}
+}
+
+func (s *ProjectService) WithRegistryCredentialsProvider(provider func(context.Context) ([]containerregistry.Credential, error)) *ProjectService {
+	if s == nil {
+		return nil
+	}
+	s.registryCredentialsProvider = provider
+	return s
+}
+
+func (s *ProjectService) resolveRegistryCredentialsInternal(ctx context.Context) ([]containerregistry.Credential, error) {
+	if s == nil || s.registryCredentialsProvider == nil {
+		return nil, nil
+	}
+
+	credentials, err := s.registryCredentialsProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get enabled registry credentials: %w", err)
+	}
+
+	return credentials, nil
 }
 
 func (s *ProjectService) getPathMapper(ctx context.Context) *projects.PathMapper {
@@ -203,7 +227,6 @@ const (
 )
 
 var (
-	composePullProjectServicesInternal = projects.ComposePull
 	composeStopProjectServicesInternal = projects.ComposeStop
 	composeUpProjectServicesInternal   = projects.ComposeUp
 )
@@ -686,17 +709,29 @@ func (s *ProjectService) reconcilePulledImageRefsInternal(ctx context.Context, i
 	}
 }
 
-func (s *ProjectService) composePullSelectedServicesInternal(ctx context.Context, compProj *composetypes.Project, servicesToUpdate []string) error {
+func (s *ProjectService) composePullSelectedServicesInternal(
+	ctx context.Context,
+	compProj *composetypes.Project,
+	servicesToUpdate []string,
+	user models.User,
+	credentials []containerregistry.Credential,
+) error {
 	if compProj == nil {
 		return nil
 	}
 
-	imageRefsToReconcile := buildSelectedProjectImageRefsInternal(compProj, servicesToUpdate)
-	if err := composePullProjectServicesInternal(ctx, compProj, servicesToUpdate); err != nil {
-		return err
+	imageRefsToPull := buildSelectedProjectImageRefsInternal(compProj, servicesToUpdate)
+	if len(imageRefsToPull) == 0 {
+		return nil
 	}
 
-	s.reconcilePulledImageRefsInternal(ctx, imageRefsToReconcile)
+	progressWriter, _ := ctx.Value(projects.ProgressWriterKey{}).(io.Writer)
+	for _, imageRef := range imageRefsToPull {
+		if err := s.pullAndReconcileImageInternal(ctx, imageRef, progressWriter, user, credentials); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -707,6 +742,10 @@ func (s *ProjectService) pullAndReconcileImageInternal(
 	user models.User,
 	credentials []containerregistry.Credential,
 ) error {
+	if s == nil || s.imageService == nil {
+		return errors.New("image service not available")
+	}
+
 	settings := s.settingsService.GetSettingsConfig()
 
 	pullCtx, pullCancel := timeouts.WithTimeout(ctx, settings.DockerImagePullTimeout.AsInt(), timeouts.DefaultDockerImagePull)
@@ -761,9 +800,17 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 		return err
 	}
 
+	credentials, err := s.resolveRegistryCredentialsInternal(ctx)
+	if err != nil {
+		if statusErr := s.updateProjectStatusInternal(ctx, projectID, previousStatus); statusErr != nil {
+			slog.ErrorContext(ctx, "UpdateProjectServices: failed to restore project status after credential lookup failure", "projectID", projectID, "error", statusErr)
+		}
+		return fmt.Errorf("resolve registry credentials: %w", err)
+	}
+
 	// 3. Pull images for specific services
 	writeProjectProgressInternal(ctx, "Pulling updated service images", 20, "pull")
-	if err := s.composePullSelectedServicesInternal(ctx, compProj, servicesToUpdate); err != nil {
+	if err := s.composePullSelectedServicesInternal(ctx, compProj, servicesToUpdate, user, credentials); err != nil {
 		if statusErr := s.updateProjectStatusInternal(ctx, projectID, previousStatus); statusErr != nil {
 			slog.ErrorContext(ctx, "UpdateProjectServices: failed to restore project status after compose pull failure", "projectID", projectID, "error", statusErr)
 		}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/pkg/projects"
 	buildtypes "github.com/getarcaneapp/arcane/types/builds"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	projecttypes "github.com/getarcaneapp/arcane/types/project"
 	libupdater "github.com/getarcaneapp/updater/pkg/labels"
@@ -73,6 +74,10 @@ func setupProjectTestDB(t *testing.T) *database.DB {
 }
 
 func newProjectImagePullServer(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse) *httptest.Server {
+	return newProjectImagePullServerWithObserverInternal(t, inspectByRef, nil)
+}
+
+func newProjectImagePullServerWithObserverInternal(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse, onPull func(fullRef string, authHeader string)) *httptest.Server {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +91,9 @@ func newProjectImagePullServer(t *testing.T, inspectByRef map[string]dockertypes
 				if lastColon <= lastSlash {
 					fullRef += ":" + tag
 				}
+			}
+			if onPull != nil {
+				onPull(fullRef, strings.TrimSpace(r.Header.Get("X-Registry-Auth")))
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -758,17 +766,31 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 	settingsService, err := NewSettingsService(ctx, db)
 	require.NoError(t, err)
 
-	imageRef := "registry.example.com/team/app:9.9.9"
-	repository := "registry.example.com/team/app"
-	imageID := "sha256:team-app-compose"
-	imageDigest := digest.FromString("team-app-compose-digest").String()
+	privateImageRef := "registry.example.com/team/app:9.9.9"
+	privateRepository := "registry.example.com/team/app"
+	privateImageID := "sha256:team-app-compose"
+	privateImageDigest := digest.FromString("team-app-compose-digest").String()
+	publicImageRef := "docker.io/library/nginx:1.27"
+	publicRepository := "docker.io/library/nginx"
+	publicImageID := "sha256:nginx-compose"
+	publicImageDigest := digest.FromString("nginx-compose-digest").String()
 
-	server := newProjectImagePullServer(t, map[string]dockertypesimage.InspectResponse{
-		imageRef: {
-			ID:          imageID,
-			RepoTags:    []string{imageRef},
-			RepoDigests: []string{repository + "@" + imageDigest},
+	pullsByRef := map[string]int{}
+	authHeadersByRef := map[string]string{}
+	server := newProjectImagePullServerWithObserverInternal(t, map[string]dockertypesimage.InspectResponse{
+		privateImageRef: {
+			ID:          privateImageID,
+			RepoTags:    []string{privateImageRef},
+			RepoDigests: []string{privateRepository + "@" + privateImageDigest},
 		},
+		publicImageRef: {
+			ID:          publicImageID,
+			RepoTags:    []string{publicImageRef},
+			RepoDigests: []string{publicRepository + "@" + publicImageDigest},
+		},
+	}, func(fullRef string, authHeader string) {
+		pullsByRef[fullRef]++
+		authHeadersByRef[fullRef] = authHeader
 	})
 
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
@@ -782,11 +804,15 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 		Services: composetypes.Services{
 			"app": {
 				Name:  "app",
-				Image: imageRef,
+				Image: privateImageRef,
+			},
+			"app-copy": {
+				Name:  "app-copy",
+				Image: privateImageRef,
 			},
 			"sidecar": {
 				Name:  "sidecar",
-				Image: "registry.example.com/team/sidecar:1.0.0",
+				Image: publicImageRef,
 			},
 			"builder": {
 				Name:  "builder",
@@ -798,7 +824,7 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 	now := time.Now().UTC().Add(-time.Hour)
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
 		ID:             "sha256:selected-old",
-		Repository:     repository,
+		Repository:     privateRepository,
 		Tag:            "9.9.9",
 		HasUpdate:      true,
 		UpdateType:     models.UpdateTypeDigest,
@@ -807,23 +833,31 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 	}).Error)
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
 		ID:             "sha256:sidecar-old",
-		Repository:     "registry.example.com/team/sidecar",
-		Tag:            "1.0.0",
+		Repository:     publicRepository,
+		Tag:            "1.27",
 		HasUpdate:      true,
 		UpdateType:     models.UpdateTypeDigest,
-		CurrentVersion: "1.0.0",
+		CurrentVersion: "1.27",
 		CheckTime:      now,
 	}).Error)
 
-	originalComposePull := composePullProjectServicesInternal
-	t.Cleanup(func() { composePullProjectServicesInternal = originalComposePull })
+	credentials := []containerregistry.Credential{{
+		URL:      "https://registry.example.com",
+		Username: "arcane-user",
+		Token:    "arcane-token",
+		Enabled:  true,
+	}}
 
-	composePullProjectServicesInternal = func(_ context.Context, _ *composetypes.Project, services []string) error {
-		assert.Equal(t, []string{"app"}, services)
-		return nil
-	}
+	require.NoError(t, svc.composePullSelectedServicesInternal(ctx, projectDef, []string{"app", "app-copy", "sidecar", "builder"}, systemUser, credentials))
+	assert.Equal(t, 1, pullsByRef[privateImageRef], "duplicate service refs should only be pulled once")
+	assert.Equal(t, 1, pullsByRef[publicImageRef], "selected public image should still be pulled")
+	assert.Len(t, pullsByRef, 2, "build-backed services should not trigger image pulls")
 
-	require.NoError(t, svc.composePullSelectedServicesInternal(ctx, projectDef, []string{"app"}))
+	privateAuth := decodeRegistryAuth(t, authHeadersByRef[privateImageRef])
+	assert.Equal(t, "arcane-user", privateAuth.Username)
+	assert.Equal(t, "arcane-token", privateAuth.Password)
+	assert.Equal(t, "registry.example.com", privateAuth.ServerAddress)
+	assert.Empty(t, authHeadersByRef[publicImageRef], "public image pull should not receive unrelated registry auth")
 
 	// sha256:selected-old may still be used by another container — must not be cleared (fixes #2453).
 	var selectedRecord models.ImageUpdateRecord
@@ -834,10 +868,15 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:sidecar-old").First(&sidecarRecord).Error)
 	assert.True(t, sidecarRecord.HasUpdate)
 
-	var currentRecord models.ImageUpdateRecord
-	require.NoError(t, db.WithContext(ctx).Where("id = ?", imageID).First(&currentRecord).Error)
-	assert.False(t, currentRecord.HasUpdate)
-	assert.Equal(t, imageDigest, stringPtrToString(currentRecord.LatestDigest))
+	var privateCurrentRecord models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(ctx).Where("id = ?", privateImageID).First(&privateCurrentRecord).Error)
+	assert.False(t, privateCurrentRecord.HasUpdate)
+	assert.Equal(t, privateImageDigest, stringPtrToString(privateCurrentRecord.LatestDigest))
+
+	var publicCurrentRecord models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(ctx).Where("id = ?", publicImageID).First(&publicCurrentRecord).Error)
+	assert.False(t, publicCurrentRecord.HasUpdate)
+	assert.Equal(t, publicImageDigest, stringPtrToString(publicCurrentRecord.LatestDigest))
 }
 
 func TestProjectService_ComposePullSelectedServicesInternal_LeavesRecordsWhenPullFails(t *testing.T) {
@@ -850,7 +889,16 @@ func TestProjectService_ComposePullSelectedServicesInternal_LeavesRecordsWhenPul
 	imageRef := "registry.example.com/team/app:9.9.9"
 	repository := "registry.example.com/team/app"
 
-	dockerService := &DockerClientService{}
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/images/create") {
+			http.Error(w, "pull failed", http.StatusUnauthorized)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(failingServer.Close)
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, failingServer)}
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, NewEventService(db, nil, nil))
 	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, config.Load())
@@ -875,16 +923,9 @@ func TestProjectService_ComposePullSelectedServicesInternal_LeavesRecordsWhenPul
 		CheckTime:      time.Now().UTC().Add(-time.Hour),
 	}).Error)
 
-	originalComposePull := composePullProjectServicesInternal
-	t.Cleanup(func() { composePullProjectServicesInternal = originalComposePull })
-
-	composePullProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
-		return errors.New("compose pull failed")
-	}
-
-	err = svc.composePullSelectedServicesInternal(ctx, projectDef, []string{"app"})
+	err = svc.composePullSelectedServicesInternal(ctx, projectDef, []string{"app"}, systemUser, nil)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "compose pull failed")
+	assert.ErrorContains(t, err, "failed to pull image")
 
 	var selectedRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:selected-old").First(&selectedRecord).Error)
@@ -905,8 +946,22 @@ func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *t
 	require.NoError(t, err)
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
+	imageRef := "registry.example.com/team/app:9.9.9"
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/images/create") {
+			http.Error(w, "compose pull failed", http.StatusUnauthorized)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(failingServer.Close)
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, failingServer)}
+	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
+	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, NewEventService(db, nil, nil))
+
 	projectPath := createComposeProjectDir(t, projectsDir, "compose-update-pull-fail")
-	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: registry.example.com/team/app:9.9.9\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: "+imageRef+"\n"), 0o644))
 
 	projectRecord := &models.Project{
 		BaseModel: models.BaseModel{ID: "project-update-pull-fail"},
@@ -926,23 +981,17 @@ func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *t
 		CheckTime:      time.Now().UTC().Add(-time.Hour),
 	}).Error)
 
-	originalComposePull := composePullProjectServicesInternal
 	originalComposeUp := composeUpProjectServicesInternal
 	t.Cleanup(func() {
-		composePullProjectServicesInternal = originalComposePull
 		composeUpProjectServicesInternal = originalComposeUp
 	})
-
-	composePullProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
-		return errors.New("compose pull failed")
-	}
 	upCalled := false
 	composeUpProjectServicesInternal = func(context.Context, *composetypes.Project, []string, bool, bool) error {
 		upCalled = true
 		return errors.New("compose up should not run")
 	}
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, config.Load())
 	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "pull updated service images")
@@ -967,8 +1016,25 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
+	imageRef := "registry.example.com/team/app:9.9.9"
+	repository := "registry.example.com/team/app"
+	imageID := "sha256:project-update-force"
+	imageDigest := digest.FromString("project-update-force-digest").String()
+
+	server := newProjectImagePullServer(t, map[string]dockertypesimage.InspectResponse{
+		imageRef: {
+			ID:          imageID,
+			RepoTags:    []string{imageRef},
+			RepoDigests: []string{repository + "@" + imageDigest},
+		},
+	})
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
+	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, NewEventService(db, nil, nil))
+
 	projectPath := createComposeProjectDir(t, projectsDir, "compose-update-force")
-	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: registry.example.com/team/app:9.9.9\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: "+imageRef+"\n"), 0o644))
 
 	projectRecord := &models.Project{
 		BaseModel: models.BaseModel{ID: "project-update-force"},
@@ -979,18 +1045,12 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
-	originalComposePull := composePullProjectServicesInternal
 	originalComposeStop := composeStopProjectServicesInternal
 	originalComposeUp := composeUpProjectServicesInternal
 	t.Cleanup(func() {
-		composePullProjectServicesInternal = originalComposePull
 		composeStopProjectServicesInternal = originalComposeStop
 		composeUpProjectServicesInternal = originalComposeUp
 	})
-
-	composePullProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
-		return nil
-	}
 	composeStopProjectServicesInternal = func(context.Context, *composetypes.Project, []string) error {
 		return nil
 	}
@@ -1004,7 +1064,7 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 		return errors.New("compose up failed after assertion")
 	}
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, config.Load())
 	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
 	require.Error(t, err)
 	assert.True(t, upCalled)

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -3,7 +3,13 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,9 +17,158 @@ import (
 	moduleapi "github.com/getarcaneapp/updater/api"
 	updaterlabels "github.com/getarcaneapp/updater/pkg/labels"
 	moduletypes "github.com/getarcaneapp/updater/types"
+	"github.com/moby/moby/api/types/container"
+	dockertypesimage "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeDockerClientProviderInternal struct {
+	client any
+}
+
+func (f fakeDockerClientProviderInternal) DockerClient(context.Context) (*client.Client, error) {
+	cli, _ := f.client.(*client.Client)
+	if cli == nil {
+		return nil, errors.New("docker client unavailable")
+	}
+	return cli, nil
+}
+
+type fakeImagePullerInternal struct {
+	pulled []string
+	fail   map[string]error
+}
+
+func (f *fakeImagePullerInternal) PullImage(_ context.Context, imageRef string, _ io.Writer) error {
+	f.pulled = append(f.pulled, imageRef)
+	if f.fail == nil {
+		return nil
+	}
+	return f.fail[imageRef]
+}
+
+type fakeRunRecorderInternal struct {
+	results []moduletypes.ResourceResult
+}
+
+func (f *fakeRunRecorderInternal) RecordUpdateRun(_ context.Context, result moduletypes.ResourceResult) error {
+	f.results = append(f.results, result)
+	return nil
+}
+
+type fakeSettingsProviderInternal struct{}
+
+func (fakeSettingsProviderInternal) ExcludedContainers(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+type fakeUsedImageCollectorInternal struct {
+	images map[string]struct{}
+}
+
+func (f fakeUsedImageCollectorInternal) UsedImages(context.Context) (map[string]struct{}, error) {
+	return f.images, nil
+}
+
+type fakeProjectUpdaterInternal struct {
+	projects   map[string]moduletypes.ComposeProject
+	updateErrs map[string]error
+	calls      []string
+}
+
+func (f *fakeProjectUpdaterInternal) ProjectByComposeName(_ context.Context, composeName string) (moduletypes.ComposeProject, error) {
+	if project, ok := f.projects[composeName]; ok {
+		return project, nil
+	}
+	return moduletypes.ComposeProject{}, errors.New("project not found")
+}
+
+func (f *fakeProjectUpdaterInternal) UpdateServices(_ context.Context, projectID string, services []string) error {
+	f.calls = append(f.calls, projectID+":"+strings.Join(services, ","))
+	if f.updateErrs == nil {
+		return nil
+	}
+	return f.updateErrs[projectID]
+}
+
+func newUpdaterApplyPendingDockerServerInternal(
+	t *testing.T,
+	containers []container.Summary,
+	verificationByService map[string][]container.Summary,
+	inspectByID map[string]container.InspectResponse,
+	imageInspectByRef map[string]dockertypesimage.InspectResponse,
+) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/_ping"):
+			_, _ = io.WriteString(w, "OK")
+		case strings.HasSuffix(r.URL.Path, "/version"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"ApiVersion":    "1.41",
+				"MinAPIVersion": "1.24",
+				"Version":       "24.0.0",
+			})
+		case strings.HasSuffix(r.URL.Path, "/images/json"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]dockertypesimage.Summary{})
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			encodedRef := strings.TrimSuffix(r.URL.Path[strings.LastIndex(r.URL.Path, "/images/")+len("/images/"):], "/json")
+			imageRef, err := url.PathUnescape(encodedRef)
+			require.NoError(t, err)
+			inspect, ok := imageInspectByRef[imageRef]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(inspect)
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			response := containers
+			if filters := strings.TrimSpace(r.URL.Query().Get("filters")); filters != "" {
+				var raw map[string]map[string]bool
+				require.NoError(t, json.Unmarshal([]byte(filters), &raw))
+				projectName := ""
+				serviceName := ""
+				for value := range raw["label"] {
+					switch {
+					case strings.HasPrefix(value, "com.docker.compose.project="):
+						projectName = strings.TrimPrefix(value, "com.docker.compose.project=")
+					case strings.HasPrefix(value, "com.docker.compose.service="):
+						serviceName = strings.TrimPrefix(value, "com.docker.compose.service=")
+					}
+				}
+				if projectName != "" && serviceName != "" {
+					if matched, ok := verificationByService[projectName+"/"+serviceName]; ok {
+						response = matched
+					} else {
+						response = nil
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		case strings.Contains(r.URL.Path, "/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			containerID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path[strings.LastIndex(r.URL.Path, "/containers/"):], "/containers/"), "/json")
+			inspect, ok := inspectByID[containerID]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(inspect)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	t.Cleanup(server.Close)
+	return server
+}
 
 type mockSystemUpgradeServiceInternal struct {
 	triggerCalled bool
@@ -285,6 +440,165 @@ func TestUpdaterService_RecordUpdateRunAdapterInternal(t *testing.T) {
 	assert.Equal(t, "nginx:1.2.3", record.OldImageVersions["main"])
 	assert.Equal(t, "nginx:1.2.4", record.NewImageVersions["main"])
 	assert.Equal(t, "test", record.Details["source"])
+}
+
+func TestUpdaterService_ApplyPending_ProjectFailureDoesNotBlockOtherProjectsInternal(t *testing.T) {
+	ctx := context.Background()
+
+	oldRefFailed := "registry.example.com/team/fail:1.0.0"
+	newRefFailed := "registry.example.com/team/fail:1.0.1"
+	oldRefUpdated := "registry.example.com/team/success:2.0.0"
+	newRefUpdated := "registry.example.com/team/success:2.0.1"
+	oldImageIDFailed := "sha256:old-fail"
+	newImageIDFailed := "sha256:new-fail"
+	oldImageIDUpdated := "sha256:old-success"
+	newImageIDUpdated := "sha256:new-success"
+
+	failedLabels := map[string]string{
+		"com.docker.compose.project": "proj-fail",
+		"com.docker.compose.service": "app",
+	}
+	updatedLabels := map[string]string{
+		"com.docker.compose.project": "proj-success",
+		"com.docker.compose.service": "app",
+	}
+
+	containers := []container.Summary{
+		{
+			ID:      "container-fail",
+			Names:   []string{"/proj-fail-app-1"},
+			Image:   oldRefFailed,
+			ImageID: oldImageIDFailed,
+			Labels:  failedLabels,
+			State:   "running",
+		},
+		{
+			ID:      "container-success",
+			Names:   []string{"/proj-success-app-1"},
+			Image:   oldRefUpdated,
+			ImageID: oldImageIDUpdated,
+			Labels:  updatedLabels,
+			State:   "running",
+		},
+	}
+
+	verificationByService := map[string][]container.Summary{
+		"proj-success/app": {
+			{
+				ID:      "container-success-new",
+				Names:   []string{"/proj-success-app-1"},
+				Image:   newRefUpdated,
+				ImageID: newImageIDUpdated,
+				Labels:  updatedLabels,
+				State:   "running",
+			},
+		},
+	}
+
+	inspectByID := map[string]container.InspectResponse{
+		"container-fail": {
+			ID:    "container-fail",
+			Image: oldImageIDFailed,
+			Config: &container.Config{
+				Image:  oldRefFailed,
+				Labels: failedLabels,
+			},
+		},
+		"container-success": {
+			ID:    "container-success",
+			Image: oldImageIDUpdated,
+			Config: &container.Config{
+				Image:  oldRefUpdated,
+				Labels: updatedLabels,
+			},
+		},
+	}
+
+	imageInspectByRef := map[string]dockertypesimage.InspectResponse{
+		newRefFailed: {
+			ID:       newImageIDFailed,
+			RepoTags: []string{newRefFailed},
+		},
+		newRefUpdated: {
+			ID:       newImageIDUpdated,
+			RepoTags: []string{newRefUpdated},
+		},
+	}
+
+	server := newUpdaterApplyPendingDockerServerInternal(t, containers, verificationByService, inspectByID, imageInspectByRef)
+	dockerProvider := fakeDockerClientProviderInternal{client: newTestDockerClient(t, server)}
+	puller := &fakeImagePullerInternal{}
+	recorder := &fakeRunRecorderInternal{}
+	projectUpdater := &fakeProjectUpdaterInternal{
+		projects: map[string]moduletypes.ComposeProject{
+			"proj-fail":    {ID: "project-fail", Name: "proj-fail"},
+			"proj-success": {ID: "project-success", Name: "proj-success"},
+		},
+		updateErrs: map[string]error{
+			"project-fail": errors.New("pull updated service images: unauthorized"),
+		},
+	}
+
+	svc := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc.engine = moduleapi.NewService(moduleapi.Config{
+		DockerClientProvider: dockerProvider,
+		ImagePuller:          puller,
+		PendingStore: moduleapi.NewMemoryPendingStore(
+			moduletypes.ImageUpdateRecord{
+				ID:             oldImageIDFailed,
+				Repository:     "registry.example.com/team/fail",
+				Tag:            "1.0.0",
+				HasUpdate:      true,
+				UpdateType:     moduletypes.UpdateTypeTag,
+				CurrentVersion: "1.0.0",
+				LatestVersion:  ptr("1.0.1"),
+			},
+			moduletypes.ImageUpdateRecord{
+				ID:             oldImageIDUpdated,
+				Repository:     "registry.example.com/team/success",
+				Tag:            "2.0.0",
+				HasUpdate:      true,
+				UpdateType:     moduletypes.UpdateTypeTag,
+				CurrentVersion: "2.0.0",
+				LatestVersion:  ptr("2.0.1"),
+			},
+		),
+		RunRecorder:    recorder,
+		Settings:       fakeSettingsProviderInternal{},
+		ProjectUpdater: projectUpdater,
+		UsedImageCollector: fakeUsedImageCollectorInternal{images: map[string]struct{}{
+			oldRefFailed:  {},
+			oldRefUpdated: {},
+		}},
+		LabelPolicy: updaterlabels.DefaultLabelPolicy(),
+	})
+
+	result, err := svc.ApplyPending(ctx, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 3, result.Updated, "updated count should include both image pulls and the successfully updated container")
+	assert.Equal(t, 1, result.Failed, "the failed project should be recorded as failed")
+	assert.GreaterOrEqual(t, len(result.Items), 4)
+	assert.ElementsMatch(t, []string{newRefFailed, newRefUpdated}, puller.pulled)
+	assert.ElementsMatch(t, []string{"project-fail:app", "project-success:app"}, projectUpdater.calls)
+
+	statusByResource := map[string]string{}
+	errorByResource := map[string]string{}
+	for _, item := range result.Items {
+		statusByResource[item.ResourceID] = item.Status
+		errorByResource[item.ResourceID] = item.Error
+	}
+
+	assert.Equal(t, moduletypes.StatusFailed, statusByResource["container-fail"])
+	assert.Contains(t, errorByResource["container-fail"], "project-level update failed")
+	assert.Equal(t, moduletypes.StatusUpdated, statusByResource["container-success"])
+
+	var recordedStatuses []string
+	for _, recorded := range recorder.results {
+		recordedStatuses = append(recordedStatuses, recorded.Status)
+	}
+	assert.Contains(t, recordedStatuses, moduletypes.StatusFailed)
+	assert.Contains(t, recordedStatuses, moduletypes.StatusUpdated)
 }
 
 func TestResolvePullableImageRefInternal(t *testing.T) {

--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -70,33 +70,6 @@ func ComposeRestart(ctx context.Context, proj *types.Project, services []string)
 	})
 }
 
-func ComposePull(ctx context.Context, proj *types.Project, services []string) error {
-	// Detach from the HTTP request context so that proxy timeouts do not cancel
-	// long image pulls. See #1209.
-	pullCtx, cancel := detachFromHTTPContextInternal(ctx)
-	defer cancel()
-
-	c, err := NewClient(pullCtx)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = c.Close() }()
-
-	filteredProject, err := filterProjectServicesForPullInternal(proj, services)
-	if err != nil {
-		return err
-	}
-	return c.svc.Pull(pullCtx, filteredProject, api.PullOptions{})
-}
-
-func filterProjectServicesForPullInternal(proj *types.Project, services []string) (*types.Project, error) {
-	if proj == nil || len(services) == 0 {
-		return proj, nil
-	}
-
-	return proj.WithSelectedServices(services, types.IgnoreDependencies)
-}
-
 func ComposeStop(ctx context.Context, proj *types.Project, services []string) error {
 	if len(services) == 0 {
 		return nil

--- a/backend/pkg/projects/cmds_test.go
+++ b/backend/pkg/projects/cmds_test.go
@@ -83,43 +83,6 @@ func TestComposeStopSkipsWhenNoServicesSpecified(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFilterProjectServicesForPullInternalReturnsDeepCopiedProject(t *testing.T) {
-	project := &composetypes.Project{
-		Name: "demo",
-		Services: composetypes.Services{
-			"web": {
-				Name: "web",
-				DependsOn: composetypes.DependsOnConfig{
-					"db": {Condition: "service_started"},
-				},
-			},
-			"db": {
-				Name: "db",
-			},
-		},
-		Networks: composetypes.Networks{
-			"default": composetypes.NetworkConfig{
-				Name: "demo_default",
-			},
-		},
-	}
-
-	filtered, err := filterProjectServicesForPullInternal(project, []string{"web"})
-	require.NoError(t, err)
-	require.NotNil(t, filtered)
-
-	require.Contains(t, filtered.Services, "web")
-	require.NotContains(t, filtered.Services, "db")
-
-	web := filtered.Services["web"]
-	delete(web.DependsOn, "db")
-	filtered.Services["web"] = web
-	delete(filtered.Networks, "default")
-
-	require.Contains(t, project.Services["web"].DependsOn, "db")
-	require.Contains(t, project.Networks, "default")
-}
-
 func TestComposeUpOptions_RemoveOrphans(t *testing.T) {
 	proj := &composetypes.Project{Name: "test"}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the project update flow by threading proper registry credentials (sourced from `EnvironmentService.GetEnabledRegistryCredentials`) through the DI layer into image pulls, so private registry auth headers are only sent to the matching registry. It also replaces the single `docker compose pull` call with per-image `pullAndReconcileImageInternal` calls, giving the application full control over which credentials each image pull receives.

- A new `provideProjectServiceInternal` DI provider wires `EnvironmentService` into `ProjectService` via the new `WithRegistryCredentialsProvider` builder method, and `resolveRegistryCredentialsInternal` fetches credentials once before the pull step in `UpdateProjectServices`.
- `composePullSelectedServicesInternal` now iterates deduplicated image refs and calls `pullAndReconcileImageInternal` per image instead of delegating to `projects.ComposePull`, and the dead `composePullProjectServicesInternal` package-level var is removed.
- Tests are upgraded from global-variable swapping to real HTTP test-server mocks and now verify that the correct `X-Registry-Auth` header is sent for private images while public images receive no auth.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the credential-threading fix is correct and well-tested, and the one noted edge case is a rare partial-failure scenario that is not a blocking regression.

The authentication fix is sound end-to-end: credentials are resolved once in `UpdateProjectServices`, deduplicated image refs are pulled with per-registry auth headers, and the new HTTP-server-based tests verify the right `X-Registry-Auth` header is sent for private images and absent for public ones. The only concern is the shift from all-or-nothing reconciliation to per-image reconciliation, which can leave a service's update record cleared while its container still runs the old image if a later pull in the same call fails.

backend/internal/services/project_service.go — specifically the reconciliation ordering inside `composePullSelectedServicesInternal` when a multi-image project partially fails during pull.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/project_service.go`, line 229-233 ([link](https://github.com/getarcaneapp/arcane/blob/530e401b2a81424043ee584a2ef243d181e04b34/backend/internal/services/project_service.go#L229-L233)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> After the refactoring, `composePullProjectServicesInternal` is no longer called anywhere in the codebase — the new `composePullSelectedServicesInternal` calls `pullAndReconcileImageInternal` directly. The variable still exists as a package-level declaration, making it dead code. While Go won't reject it at compile time, `golangci-lint` (with the `unused` linter) will flag it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 229-233

   Comment:
   After the refactoring, `composePullProjectServicesInternal` is no longer called anywhere in the codebase — the new `composePullSelectedServicesInternal` calls `pullAndReconcileImageInternal` directly. The variable still exists as a package-level declaration, making it dead code. While Go won't reject it at compile time, `golangci-lint` (with the `unused` linter) will flag it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-order%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-order%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20229-233%0A%0AComment%3A%0AAfter%20the%20refactoring%2C%20%60composePullProjectServicesInternal%60%20is%20no%20longer%20called%20anywhere%20in%20the%20codebase%20%E2%80%94%20the%20new%20%60composePullSelectedServicesInternal%60%20calls%20%60pullAndReconcileImageInternal%60%20directly.%20The%20variable%20still%20exists%20as%20a%20package-level%20declaration%2C%20making%20it%20dead%20code.%20While%20Go%20won't%20reject%20it%20at%20compile%20time%2C%20%60golangci-lint%60%20%28with%20the%20%60unused%60%20linter%29%20will%20flag%20it.%0A%0A%60%60%60suggestion%0Avar%20%28%0A%09composeStopProjectServicesInternal%20%3D%20projects.ComposeStop%0A%09composeUpProjectServicesInternal%20%20%20%3D%20projects.ComposeUp%0A%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20229-233%0A%0AComment%3A%0AAfter%20the%20refactoring%2C%20%60composePullProjectServicesInternal%60%20is%20no%20longer%20called%20anywhere%20in%20the%20codebase%20%E2%80%94%20the%20new%20%60composePullSelectedServicesInternal%60%20calls%20%60pullAndReconcileImageInternal%60%20directly.%20The%20variable%20still%20exists%20as%20a%20package-level%20declaration%2C%20making%20it%20dead%20code.%20While%20Go%20won't%20reject%20it%20at%20compile%20time%2C%20%60golangci-lint%60%20%28with%20the%20%60unused%60%20linter%29%20will%20flag%20it.%0A%0A%60%60%60suggestion%0Avar%20%28%0A%09composeStopProjectServicesInternal%20%3D%20projects.ComposeStop%0A%09composeUpProjectServicesInternal%20%20%20%3D%20projects.ComposeUp%0A%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2794&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-order%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-order%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A729-733%0A**Partial%20reconciliation%20on%20multi-image%20pull%20failure**%0A%0ABefore%20this%20PR%2C%20%60reconcilePulledImageRefsInternal%60%20was%20called%20only%20after%20all%20images%20succeeded%20%28via%20the%20single%20%60composePullProjectServicesInternal%60%20call%29%2C%20giving%20all-or-nothing%20semantics.%20Now%20each%20image%20is%20reconciled%20immediately%20after%20its%20individual%20pull%2C%20so%20if%20image%20A%20is%20pulled%20and%20reconciled%20but%20image%20B%20subsequently%20fails%2C%20A's%20%60HasUpdate%60%20record%20is%20cleared%20%28%60false%60%29%20even%20though%20%60composeUp%60%20never%20ran%20and%20A's%20container%20still%20runs%20the%20old%20image.%0A%0AOn%20the%20next%20auto-updater%20run%2C%20A's%20image%20record%20%28%60HasUpdate%20%3D%20false%60%29%20is%20excluded%20from%20%60PendingImageUpdates%60%2C%20so%20the%20updater's%20%60buildComposeGroupsInternal%60%20never%20adds%20A's%20container%20to%20the%20restart%20candidates.%20%60UpdateProjectServices%60%20is%20then%20called%20with%20only%20%60%5B%22B%22%5D%60%2C%20compose-up%20only%20restarts%20B%2C%20and%20A's%20container%20is%20permanently%20stuck%20on%20the%20old%20image%20until%20the%20user%20forces%20a%20manual%20update.%0A%0AThis%20is%20an%20edge%20case%20%28requires%20a%20successful%20pull%20for%20A%20then%20a%20network%2Fauth%20failure%20for%20B%20in%20the%20same%20%60composePullSelectedServicesInternal%60%20call%29%2C%20but%20it%20is%20a%20regression%20in%20correctness%20compared%20to%20the%20old%20atomic%20behaviour.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fproject_service.go%3A729-733%0A**Partial%20reconciliation%20on%20multi-image%20pull%20failure**%0A%0ABefore%20this%20PR%2C%20%60reconcilePulledImageRefsInternal%60%20was%20called%20only%20after%20all%20images%20succeeded%20%28via%20the%20single%20%60composePullProjectServicesInternal%60%20call%29%2C%20giving%20all-or-nothing%20semantics.%20Now%20each%20image%20is%20reconciled%20immediately%20after%20its%20individual%20pull%2C%20so%20if%20image%20A%20is%20pulled%20and%20reconciled%20but%20image%20B%20subsequently%20fails%2C%20A's%20%60HasUpdate%60%20record%20is%20cleared%20%28%60false%60%29%20even%20though%20%60composeUp%60%20never%20ran%20and%20A's%20container%20still%20runs%20the%20old%20image.%0A%0AOn%20the%20next%20auto-updater%20run%2C%20A's%20image%20record%20%28%60HasUpdate%20%3D%20false%60%29%20is%20excluded%20from%20%60PendingImageUpdates%60%2C%20so%20the%20updater's%20%60buildComposeGroupsInternal%60%20never%20adds%20A's%20container%20to%20the%20restart%20candidates.%20%60UpdateProjectServices%60%20is%20then%20called%20with%20only%20%60%5B%22B%22%5D%60%2C%20compose-up%20only%20restarts%20B%2C%20and%20A's%20container%20is%20permanently%20stuck%20on%20the%20old%20image%20until%20the%20user%20forces%20a%20manual%20update.%0A%0AThis%20is%20an%20edge%20case%20%28requires%20a%20successful%20pull%20for%20A%20then%20a%20network%2Fauth%20failure%20for%20B%20in%20the%20same%20%60composePullSelectedServicesInternal%60%20call%29%2C%20but%20it%20is%20a%20regression%20in%20correctness%20compared%20to%20the%20old%20atomic%20behaviour.%0A%0A&repo=getarcaneapp%2Farcane&pr=2794&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/project_service.go:729-733
**Partial reconciliation on multi-image pull failure**

Before this PR, `reconcilePulledImageRefsInternal` was called only after all images succeeded (via the single `composePullProjectServicesInternal` call), giving all-or-nothing semantics. Now each image is reconciled immediately after its individual pull, so if image A is pulled and reconciled but image B subsequently fails, A's `HasUpdate` record is cleared (`false`) even though `composeUp` never ran and A's container still runs the old image.

On the next auto-updater run, A's image record (`HasUpdate = false`) is excluded from `PendingImageUpdates`, so the updater's `buildComposeGroupsInternal` never adds A's container to the restart candidates. `UpdateProjectServices` is then called with only `["B"]`, compose-up only restarts B, and A's container is permanently stuck on the old image until the user forces a manual update.

This is an edge case (requires a successful pull for A then a network/auth failure for B in the same `composePullSelectedServicesInternal` call), but it is a regression in correctness compared to the old atomic behaviour.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: fix project update order and authen..."](https://github.com/getarcaneapp/arcane/commit/51c4f60c2109e356515a45423569015606a9321c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35473815)</sub>

<!-- /greptile_comment -->