### PR TITLE
fix: events create rbac role removed cause its pointless

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -285,7 +285,7 @@ func registerHandlersInternal(api huma.API, svc *di.Services, handlerAppCtx hand
 	handlers.RegisterUsers(api, svc.User, svc.Auth)
 	handlers.RegisterProjects(api, svc.Project, svc.Activity, handlerAppCtx)
 	handlers.RegisterVersion(api, svc.Version)
-	handlers.RegisterEvents(api, svc.Event, svc.ApiKey)
+	handlers.RegisterEvents(api, svc.Event)
 	handlers.RegisterActivities(api, svc.Activity, svc.Environment)
 	handlers.RegisterOidc(api, svc.Auth, svc.Oidc, svc.Role, svc.User, cfg)
 	handlers.RegisterEnvironments(api, svc.Environment, svc.Settings, svc.ApiKey, svc.Event, cfg)

--- a/backend/api/api_test.go
+++ b/backend/api/api_test.go
@@ -168,3 +168,15 @@ func TestSetupAPIForSpec_TemplateReadRoutesProtected(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupAPIForSpec_DoesNotRegisterPublicCreateEvent(t *testing.T) {
+	api := SetupAPIForSpec()
+
+	pathItem := api.OpenAPI().Paths["/events"]
+	if pathItem == nil {
+		t.Fatal("expected /events path to be registered for list events")
+	}
+	if pathItem.Post != nil {
+		t.Fatal("expected POST /events to be absent from the public API")
+	}
+}

--- a/backend/api/handlers/environments.go
+++ b/backend/api/handlers/environments.go
@@ -156,7 +156,7 @@ type DeploymentSnippet struct {
 type DeploymentSnippetFile struct {
 	Name          string `json:"name" doc:"Suggested filename"`
 	Content       string `json:"content,omitempty" doc:"PEM file contents. Omitted for sensitive files such as private keys; use downloadUrl instead."`
-	DownloadURL   string `json:"downloadUrl,omitempty" doc:"Admin-only endpoint to download this file when content is withheld"`
+	DownloadURL   string `json:"downloadUrl,omitempty" doc:"Pairing-permission endpoint to download this file when content is withheld"`
 	Sensitive     bool   `json:"sensitive,omitempty" doc:"True when this file is sensitive and must be fetched via downloadUrl"`
 	ContainerPath string `json:"containerPath" doc:"Container mount path expected by the mTLS snippet"`
 	Permissions   string `json:"permissions" doc:"Suggested file mode"`
@@ -358,7 +358,7 @@ func RegisterEnvironments(api huma.API, environmentService *services.Environment
 			{"BearerAuth": {}},
 			{"ApiKeyAuth": {}},
 		},
-		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsRead),
+		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsPair),
 	}, h.GetDeploymentSnippets)
 
 	huma.Register(api, huma.Operation{
@@ -372,7 +372,7 @@ func RegisterEnvironments(api huma.API, environmentService *services.Environment
 			{"BearerAuth": {}},
 			{"ApiKeyAuth": {}},
 		},
-		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsRead),
+		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsPair),
 	}, h.DownloadEnvironmentMTLSBundle)
 
 	huma.Register(api, huma.Operation{
@@ -386,7 +386,7 @@ func RegisterEnvironments(api huma.API, environmentService *services.Environment
 			{"BearerAuth": {}},
 			{"ApiKeyAuth": {}},
 		},
-		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsRead),
+		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsPair),
 	}, h.DownloadEnvironmentMTLSFile)
 
 	huma.Register(api, huma.Operation{
@@ -414,7 +414,7 @@ func RegisterEnvironments(api huma.API, environmentService *services.Environment
 			{"BearerAuth": {}},
 			{"ApiKeyAuth": {}},
 		},
-		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsRead),
+		Middlewares: humamw.RequirePermission(api, authz.PermEnvironmentsPair),
 	}, h.DownloadEdgeMTLSCA)
 }
 

--- a/backend/api/handlers/environments_test.go
+++ b/backend/api/handlers/environments_test.go
@@ -1,16 +1,61 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/getarcaneapp/arcane/backend/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	envtypes "github.com/getarcaneapp/arcane/types/environment"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestEnvironmentSecretDeploymentRoutesRequirePairPermission(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{name: "deployment snippets", path: "/api/environments/env-1/deployment"},
+		{name: "mtls bundle", path: "/api/environments/env-1/deployment/mtls/bundle"},
+		{name: "mtls file", path: "/api/environments/env-1/deployment/mtls/agent.key"},
+		{name: "edge ca", path: "/api/edge-mtls/ca"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name+" read denied", func(t *testing.T) {
+			ps := authz.NewPermissionSet()
+			ps.AddGlobal(authz.PermEnvironmentsRead)
+			router, api := newPermissionGatingRouterInternal(t, ps)
+			RegisterEnvironments(api, nil, nil, nil, nil, nil)
+
+			req := httptest.NewRequest(http.MethodGet, testCase.path, nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusForbidden, rec.Code)
+			require.Contains(t, rec.Body.String(), authz.PermEnvironmentsPair)
+		})
+
+		t.Run(testCase.name+" pair allowed", func(t *testing.T) {
+			ps := authz.NewPermissionSet()
+			ps.AddGlobal(authz.PermEnvironmentsPair)
+			router, api := newPermissionGatingRouterInternal(t, ps)
+			RegisterEnvironments(api, nil, nil, nil, nil, nil)
+
+			req := httptest.NewRequest(http.MethodGet, testCase.path, nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.NotEqual(t, http.StatusForbidden, rec.Code)
+		})
+	}
+}
 
 func TestEnvironmentMTLSAssetDownloadName(t *testing.T) {
 	env := &models.Environment{Name: "Lab Server"}

--- a/backend/api/handlers/events.go
+++ b/backend/api/handlers/events.go
@@ -2,20 +2,26 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	humamw "github.com/getarcaneapp/arcane/backend/api/middleware"
 	"github.com/getarcaneapp/arcane/backend/internal/common"
+	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/services"
 	"github.com/getarcaneapp/arcane/backend/pkg/authz"
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/base"
 	"github.com/getarcaneapp/arcane/types/event"
+	"github.com/labstack/echo/v4"
 )
 
 // EventHandler handles event management endpoints.
 type EventHandler struct {
 	eventService *services.EventService
-	apiKeySvc    *services.ApiKeyService
 }
 
 // ============================================================================
@@ -58,15 +64,6 @@ type GetEventsByEnvironmentOutput struct {
 	Body EventPaginatedResponse
 }
 
-type CreateEventInput struct {
-	XAPIKey string `header:"X-API-Key" doc:"API key for environment-scoped event forwarding"`
-	Body    event.CreateEvent
-}
-
-type CreateEventOutput struct {
-	Body base.ApiResponse[event.Event]
-}
-
 type DeleteEventInput struct {
 	EventID string `path:"eventId" doc:"Event ID"`
 }
@@ -79,11 +76,72 @@ type DeleteEventOutput struct {
 // Registration
 // ============================================================================
 
+// RegisterAgentEventIngestion registers the manager ingestion endpoint used by
+// direct agents when no edge tunnel is active. This route is not part of the
+// Huma/OpenAPI surface and authenticates only with the configured agent token.
+func RegisterAgentEventIngestion(g *echo.Group, eventService *services.EventService, cfg *config.Config) {
+	g.POST("/events", func(c echo.Context) error {
+		if eventService == nil {
+			return c.JSON(http.StatusInternalServerError, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: "service not available"},
+			})
+		}
+		if cfg == nil || strings.TrimSpace(cfg.AgentToken) == "" {
+			slog.Warn("agent event ingestion is disabled because agent token is not configured")
+			return c.JSON(http.StatusServiceUnavailable, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: "agent event ingestion is not configured"},
+			})
+		}
+		if !validAgentEventIngestionTokenInternal(c.Request(), cfg) {
+			return c.JSON(http.StatusUnauthorized, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: "invalid agent token"},
+			})
+		}
+
+		var input services.CreateEventRequest
+		decoder := json.NewDecoder(http.MaxBytesReader(c.Response(), c.Request().Body, 1<<20))
+		if err := decoder.Decode(&input); err != nil {
+			return c.JSON(http.StatusBadRequest, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: "invalid event payload"},
+			})
+		}
+		if strings.TrimSpace(string(input.Type)) == "" || strings.TrimSpace(input.Title) == "" {
+			return c.JSON(http.StatusBadRequest, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: "event type and title are required"},
+			})
+		}
+
+		if _, err := eventService.CreateEvent(c.Request().Context(), input); err != nil {
+			return c.JSON(http.StatusInternalServerError, base.ApiResponse[base.MessageResponse]{
+				Success: false,
+				Data:    base.MessageResponse{Message: (&common.EventCreationError{Err: err}).Error()},
+			})
+		}
+
+		return c.JSON(http.StatusAccepted, base.ApiResponse[base.MessageResponse]{
+			Success: true,
+			Data:    base.MessageResponse{Message: "event ingested"},
+		})
+	})
+}
+
+func validAgentEventIngestionTokenInternal(r *http.Request, cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	token := r.Header.Get(pkgutils.HeaderAgentToken)
+	return token != "" && token == cfg.AgentToken
+}
+
 // RegisterEvents registers all event management endpoints.
-func RegisterEvents(api huma.API, eventService *services.EventService, apiKeySvc *services.ApiKeyService) {
+func RegisterEvents(api huma.API, eventService *services.EventService) {
 	h := &EventHandler{
 		eventService: eventService,
-		apiKeySvc:    apiKeySvc,
 	}
 
 	huma.Register(api, huma.Operation{
@@ -101,23 +159,6 @@ func RegisterEvents(api huma.API, eventService *services.EventService, apiKeySvc
 	}, h.ListEvents)
 
 	huma.Register(api, huma.Operation{
-		OperationID: "createEvent",
-		Method:      "POST",
-		Path:        "/events",
-		Summary:     "Create an event",
-		Description: "Create a new system event",
-		Tags:        []string{"Events"},
-		Security: []map[string][]string{
-			{"BearerAuth": {}},
-			{"ApiKeyAuth": {}},
-		},
-		// TODO: introduce a dedicated PermEventsCreate (and PermEventsDelete)
-		// permission. Today the events taxonomy only exposes PermEventsRead,
-		// so admin-level write actions reuse the read permission.
-		Middlewares: humamw.RequirePermission(api, authz.PermEventsRead),
-	}, h.CreateEvent)
-
-	huma.Register(api, huma.Operation{
 		OperationID: "deleteEvent",
 		Method:      "DELETE",
 		Path:        "/events/{eventId}",
@@ -128,10 +169,7 @@ func RegisterEvents(api huma.API, eventService *services.EventService, apiKeySvc
 			{"BearerAuth": {}},
 			{"ApiKeyAuth": {}},
 		},
-		// TODO: introduce a dedicated PermEventsDelete permission. Today the
-		// events taxonomy only exposes PermEventsRead, so admin-level write
-		// actions reuse the read permission.
-		Middlewares: humamw.RequirePermission(api, authz.PermEventsRead),
+		Middlewares: humamw.RequirePermission(api, authz.PermEventsDelete),
 	}, h.DeleteEvent)
 
 	huma.Register(api, huma.Operation{
@@ -223,35 +261,6 @@ func (h *EventHandler) GetEventsByEnvironment(ctx context.Context, input *GetEve
 				ItemsPerPage:    paginationResp.ItemsPerPage,
 				GrandTotalItems: paginationResp.GrandTotalItems,
 			},
-		},
-	}, nil
-}
-
-// CreateEvent creates a new event.
-func (h *EventHandler) CreateEvent(ctx context.Context, input *CreateEventInput) (*CreateEventOutput, error) {
-	if h.eventService == nil {
-		return nil, huma.Error500InternalServerError("service not available")
-	}
-
-	if h.apiKeySvc != nil && input.XAPIKey != "" {
-		resolvedEnvironmentID, err := h.apiKeySvc.GetEnvironmentByApiKey(ctx, input.XAPIKey)
-		if err != nil {
-			return nil, huma.Error401Unauthorized("invalid environment API key")
-		}
-		if resolvedEnvironmentID != nil && *resolvedEnvironmentID != "" {
-			input.Body.EnvironmentID = new(*resolvedEnvironmentID)
-		}
-	}
-
-	evt, err := h.eventService.CreateEventFromDto(ctx, input.Body)
-	if err != nil {
-		return nil, huma.Error500InternalServerError((&common.EventCreationError{Err: err}).Error())
-	}
-
-	return &CreateEventOutput{
-		Body: base.ApiResponse[event.Event]{
-			Success: true,
-			Data:    *evt,
 		},
 	}, nil
 }

--- a/backend/api/handlers/events_test.go
+++ b/backend/api/handlers/events_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/internal/config"
+	"github.com/getarcaneapp/arcane/backend/internal/database"
+	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/getarcaneapp/arcane/backend/pkg/authz"
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
+	glsqlite "github.com/glebarez/sqlite"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestEventDeleteRequiresEventsDeletePermission(t *testing.T) {
+	testCases := []struct {
+		name       string
+		permission string
+		wantStatus int
+	}{
+		{
+			name:       "events read cannot delete",
+			permission: authz.PermEventsRead,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "events delete reaches handler",
+			permission: authz.PermEventsDelete,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ps := authz.NewPermissionSet()
+			ps.AddGlobal(testCase.permission)
+			router, api := newPermissionGatingRouterInternal(t, ps)
+			RegisterEvents(api, nil)
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/events/event-1", nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, testCase.wantStatus, rec.Code)
+			if testCase.wantStatus == http.StatusForbidden {
+				require.Contains(t, rec.Body.String(), authz.PermEventsDelete)
+			}
+		})
+	}
+}
+
+func TestAgentEventIngestionRequiresAgentTokenAndPersists(t *testing.T) {
+	ctx := context.Background()
+	db := setupEventIngestionTestDBInternal(t)
+	eventSvc := services.NewEventService(db, &config.Config{}, nil)
+	router := echo.New()
+	RegisterAgentEventIngestion(router.Group("/api"), eventSvc, &config.Config{AgentToken: "agent-token"})
+
+	payload := services.CreateEventRequest{
+		Type:          models.EventTypeContainerStart,
+		Severity:      models.EventSeverityInfo,
+		Title:         "Container started: web",
+		Description:   "Container 'web' has been started",
+		EnvironmentID: ptrStringInternal("0"),
+		Metadata:      models.JSON{"source": "agent"},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	t.Run("unconfigured manager token is service unavailable", func(t *testing.T) {
+		unconfiguredRouter := echo.New()
+		RegisterAgentEventIngestion(unconfiguredRouter.Group("/api"), eventSvc, &config.Config{})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(pkgutils.HeaderAgentToken, "agent-token")
+		rec := httptest.NewRecorder()
+		unconfiguredRouter.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		require.Contains(t, rec.Body.String(), "agent event ingestion is not configured")
+		require.Equal(t, int64(0), countPersistedEventsInternal(t, ctx, db))
+	})
+
+	t.Run("missing token rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		require.Equal(t, int64(0), countPersistedEventsInternal(t, ctx, db))
+	})
+
+	t.Run("api key header is not accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(pkgutils.HeaderApiKey, "agent-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		require.Equal(t, int64(0), countPersistedEventsInternal(t, ctx, db))
+	})
+
+	t.Run("agent token persists event", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(pkgutils.HeaderAgentToken, "agent-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusAccepted, rec.Code)
+
+		var saved models.Event
+		require.NoError(t, db.WithContext(ctx).First(&saved).Error)
+		require.Equal(t, models.EventTypeContainerStart, saved.Type)
+		require.Equal(t, "Container started: web", saved.Title)
+		require.NotNil(t, saved.EnvironmentID)
+		require.Equal(t, "0", *saved.EnvironmentID)
+		require.Equal(t, "agent", saved.Metadata["source"])
+	})
+}
+
+func setupEventIngestionTestDBInternal(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := gorm.Open(glsqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Event{}))
+	return &database.DB{DB: db}
+}
+
+func countPersistedEventsInternal(t *testing.T, ctx context.Context, db *database.DB) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, db.WithContext(ctx).Model(&models.Event{}).Count(&count).Error)
+	return count
+}
+
+func ptrStringInternal(value string) *string {
+	return &value
+}

--- a/backend/api/handlers/permission_gating_test.go
+++ b/backend/api/handlers/permission_gating_test.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humaecho"
+	humamw "github.com/getarcaneapp/arcane/backend/api/middleware"
+	"github.com/getarcaneapp/arcane/backend/pkg/authz"
+	"github.com/labstack/echo/v4"
+)
+
+func newPermissionGatingRouterInternal(t *testing.T, ps *authz.PermissionSet) (*echo.Echo, huma.API) {
+	t.Helper()
+	if ps == nil {
+		ps = authz.NewPermissionSet()
+	}
+
+	router := echo.New()
+	api := humaecho.NewWithGroup(router, router.Group("/api"), huma.DefaultConfig("test", "1.0.0"))
+	api.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		next(huma.WithContext(ctx, context.WithValue(ctx.Context(), humamw.ContextKeyUserPermissions, ps)))
+	})
+	return router, api
+}

--- a/backend/api/handlers/roles_access_policy_test.go
+++ b/backend/api/handlers/roles_access_policy_test.go
@@ -32,3 +32,21 @@ func TestBuildPermissionsManifestIncludesAccessSurfaces(t *testing.T) {
 	registrySurfaces := authz.AccessSurfaces()
 	require.Len(t, manifest.AccessSurfaces, len(registrySurfaces))
 }
+
+func TestBuildPermissionsManifestIncludesEventsDelete(t *testing.T) {
+	manifest := buildPermissionsManifestInternal()
+
+	for _, resource := range manifest.Resources {
+		if resource.Key != "events" {
+			continue
+		}
+		for _, action := range resource.Actions {
+			if action.Permission == authz.PermEventsDelete {
+				return
+			}
+		}
+		t.Fatalf("events resource did not include %s", authz.PermEventsDelete)
+	}
+
+	t.Fatal("events resource not found")
+}

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -177,6 +177,7 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *di.Servic
 	// Register public webhook trigger endpoint before auth middleware (token in URL is the sole auth)
 	api.RegisterWebhookTrigger(apiGroup, appServices.Webhook, handlerAppCtx) //nolint:contextcheck // app lifecycle context is intentionally wrapped for detached activity work.
 	handlers.RegisterFederatedTokenExchange(apiGroup, appServices.Federated) //nolint:contextcheck // public RFC 8693 form endpoint uses request context.
+	handlers.RegisterAgentEventIngestion(apiGroup, appServices.Event, cfg)   //nolint:contextcheck // internal agent-token route; intentionally outside user/RBAC auth.
 
 	//nolint:contextcheck // Echo middleware reads context from echo.Context.Request().Context(), not a parameter.
 	envProxyMiddleware := middleware.NewEnvProxyMiddlewareWithParam(

--- a/backend/internal/services/event_service.go
+++ b/backend/internal/services/event_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/edge"
 	"github.com/getarcaneapp/arcane/backend/pkg/pagination"
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/event"
 	"golang.org/x/text/cases"
@@ -176,9 +177,9 @@ func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel
 		return fmt.Errorf("manager API URL is invalid for manager event sync: %w", err)
 	}
 
-	payload := event.CreateEvent{
-		Type:          string(eventModel.Type),
-		Severity:      string(eventModel.Severity),
+	payload := CreateEventRequest{
+		Type:          eventModel.Type,
+		Severity:      eventModel.Severity,
 		Title:         eventModel.Title,
 		Description:   eventModel.Description,
 		ResourceType:  eventModel.ResourceType,
@@ -190,7 +191,7 @@ func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel
 	}
 
 	if len(eventModel.Metadata) > 0 {
-		payload.Metadata = map[string]any(eventModel.Metadata)
+		payload.Metadata = eventModel.Metadata
 	}
 
 	body, err := json.Marshal(payload)
@@ -203,7 +204,7 @@ func (s *EventService) forwardEventToManagerHTTP(ctx context.Context, eventModel
 		return fmt.Errorf("failed to create manager event request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-Key", s.cfg.AgentToken)
+	req.Header.Set(pkgutils.HeaderAgentToken, s.cfg.AgentToken)
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
@@ -279,39 +280,6 @@ func copyOptionalStringPtr(value *string) *string {
 		return nil
 	}
 	return new(*value)
-}
-
-func (s *EventService) CreateEventFromDto(ctx context.Context, req event.CreateEvent) (*event.Event, error) {
-	severity := models.EventSeverity(req.Severity)
-	if severity == "" {
-		severity = models.EventSeverityInfo
-	}
-
-	metadata := models.JSON{}
-	if req.Metadata != nil {
-		metadata = models.JSON(req.Metadata)
-	}
-
-	createReq := CreateEventRequest{
-		Type:          models.EventType(req.Type),
-		Severity:      severity,
-		Title:         req.Title,
-		Description:   req.Description,
-		ResourceType:  req.ResourceType,
-		ResourceID:    req.ResourceID,
-		ResourceName:  req.ResourceName,
-		UserID:        req.UserID,
-		Username:      req.Username,
-		EnvironmentID: req.EnvironmentID,
-		Metadata:      metadata,
-	}
-
-	event, err := s.CreateEvent(ctx, createReq)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.toEventDto(event), nil
 }
 
 func (s *EventService) ListEventsPaginated(ctx context.Context, params pagination.QueryParams) ([]event.Event, pagination.Response, error) {
@@ -639,31 +607,6 @@ var eventDefinitions = map[models.EventType]struct {
 	models.EventTypeUserLogin:         {"User logged in: %s", "User '%s' has logged in", models.EventSeverityInfo},
 	models.EventTypeUserLogout:        {"User logged out: %s", "User '%s' has logged out", models.EventSeverityInfo},
 	models.EventTypeFederatedExchange: {"Federated credential exchange: %s", "Federated credential exchange for '%s'", models.EventSeverityInfo},
-}
-
-func (s *EventService) toEventDto(e *models.Event) *event.Event {
-	var metadata map[string]any
-	if e.Metadata != nil {
-		metadata = map[string]any(e.Metadata)
-	}
-
-	return &event.Event{
-		ID:            e.ID,
-		Type:          string(e.Type),
-		Severity:      string(e.Severity),
-		Title:         e.Title,
-		Description:   e.Description,
-		ResourceType:  e.ResourceType,
-		ResourceID:    e.ResourceID,
-		ResourceName:  e.ResourceName,
-		UserID:        e.UserID,
-		Username:      e.Username,
-		EnvironmentID: e.EnvironmentID,
-		Metadata:      metadata,
-		Timestamp:     e.Timestamp,
-		CreatedAt:     e.CreatedAt,
-		UpdatedAt:     e.UpdatedAt,
-	}
 }
 
 func (s *EventService) generateEventTitle(eventType models.EventType, resourceName string) string {

--- a/backend/internal/services/event_service_test.go
+++ b/backend/internal/services/event_service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
-	"github.com/getarcaneapp/arcane/types/event"
+	pkgutils "github.com/getarcaneapp/arcane/backend/pkg/utils"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -182,14 +182,14 @@ func TestEventService_CreateEvent_ForwardsToManagerAPIInAgentMode(t *testing.T) 
 	ctx := context.Background()
 	db := setupEventServiceTestDB(t)
 
-	requests := make(chan event.CreateEvent, 1)
+	requests := make(chan CreateEventRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/api/events", r.URL.Path)
-		require.Equal(t, "test-agent-token", r.Header.Get("X-API-Key"))
+		require.Equal(t, "test-agent-token", r.Header.Get(pkgutils.HeaderAgentToken))
 
 		defer func() { _ = r.Body.Close() }()
-		var payload event.CreateEvent
+		var payload CreateEventRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
 
 		select {
@@ -220,8 +220,8 @@ func TestEventService_CreateEvent_ForwardsToManagerAPIInAgentMode(t *testing.T) 
 
 	select {
 	case payload := <-requests:
-		require.Equal(t, string(models.EventTypeContainerStart), payload.Type)
-		require.Equal(t, string(models.EventSeverityInfo), payload.Severity)
+		require.Equal(t, models.EventTypeContainerStart, payload.Type)
+		require.Equal(t, models.EventSeverityInfo, payload.Severity)
 		require.Equal(t, "Container started: web", payload.Title)
 		require.NotNil(t, payload.EnvironmentID)
 		require.Equal(t, "0", *payload.EnvironmentID)

--- a/backend/internal/services/role_service.go
+++ b/backend/internal/services/role_service.go
@@ -152,10 +152,10 @@ func legacyRolesContainsAdminInternal(raw string) bool {
 }
 
 // AssertGlobalAdminExists returns a *common.NoGlobalAdminRemainsError if zero
-// users hold a globally-scoped Admin role assignment. Called at boot after the
-// backfill migration; also called from inside mutation paths.
+// non-service users resolve to global administrator permissions. Called at boot
+// after the backfill migration; also called from inside mutation paths.
 func (s *RoleService) AssertGlobalAdminExists(ctx context.Context) error {
-	count, err := s.countGlobalAdminsInternal(ctx, s.db.WithContext(ctx))
+	count, err := s.countEffectiveGlobalAdminsInternal(ctx, s.db.WithContext(ctx), "")
 	if err != nil {
 		return err
 	}
@@ -458,7 +458,7 @@ func (s *RoleService) SetUserAssignments(ctx context.Context, userID string, des
 				return fmt.Errorf("failed to insert assignments: %w", err)
 			}
 		}
-		count, err := s.countGlobalAdminsInternal(ctx, tx)
+		count, err := s.countEffectiveGlobalAdminsInternal(ctx, tx, "")
 		if err != nil {
 			return err
 		}
@@ -547,7 +547,7 @@ func (s *RoleService) ReplaceOidcAssignments(ctx context.Context, userID string,
 				return fmt.Errorf("failed to insert oidc assignments: %w", err)
 			}
 		}
-		count, err := s.countGlobalAdminsInternal(ctx, tx)
+		count, err := s.countEffectiveGlobalAdminsInternal(ctx, tx, "")
 		if err != nil {
 			return err
 		}
@@ -563,33 +563,55 @@ func (s *RoleService) ReplaceOidcAssignments(ctx context.Context, userID string,
 	return nil
 }
 
-// CountGlobalAdminsExcludingUser returns the number of distinct users (other
-// than excludedUserID) that hold a global Admin assignment. Used as the
-// authoritative check for "removing this user / demoting this assignment
-// would leave the system with no admin."
+// CountGlobalAdminsExcludingUser returns the number of non-service users (other
+// than excludedUserID) whose resolved global permissions satisfy IsGlobalAdmin.
+// Used as the authoritative check for "removing this user / demoting this
+// assignment would leave the system with no admin."
 func (s *RoleService) CountGlobalAdminsExcludingUser(ctx context.Context, excludedUserID string) (int, error) {
-	var count int64
-	if err := s.db.WithContext(ctx).
-		Table("user_role_assignments AS ura").
-		Joins("JOIN users ON users.id = ura.user_id").
-		Distinct("ura.user_id").
-		Where("ura.role_id = ? AND ura.environment_id IS NULL AND ura.user_id <> ? AND users.is_service_account = ?", authz.BuiltInRoleAdmin, excludedUserID, false).
-		Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("failed to count global admins: %w", err)
-	}
-	return int(count), nil
+	return s.countEffectiveGlobalAdminsInternal(ctx, s.db.WithContext(ctx), excludedUserID)
 }
 
-func (s *RoleService) countGlobalAdminsInternal(_ context.Context, tx *gorm.DB) (int, error) {
-	var count int64
-	if err := tx.Table("user_role_assignments AS ura").
-		Joins("JOIN users ON users.id = ura.user_id").
-		Distinct("ura.user_id").
-		Where("ura.role_id = ? AND ura.environment_id IS NULL AND users.is_service_account = ?", authz.BuiltInRoleAdmin, false).
-		Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("failed to count global admins: %w", err)
+func (s *RoleService) countEffectiveGlobalAdminsInternal(ctx context.Context, tx *gorm.DB, excludedUserID string) (int, error) {
+	type globalPermissionRow struct {
+		UserID      string `gorm:"column:user_id"`
+		Permissions string `gorm:"column:permissions"`
 	}
-	return int(count), nil
+
+	var rows []globalPermissionRow
+	query := tx.WithContext(ctx).
+		Table("users AS u").
+		Select("u.id AS user_id, r.permissions AS permissions").
+		Joins("INNER JOIN user_role_assignments ura ON ura.user_id = u.id AND ura.environment_id IS NULL").
+		Joins("INNER JOIN roles r ON r.id = ura.role_id").
+		Where("u.is_service_account = ?", false)
+	if strings.TrimSpace(excludedUserID) != "" {
+		query = query.Where("u.id <> ?", excludedUserID)
+	}
+	if err := query.Scan(&rows).Error; err != nil {
+		return 0, fmt.Errorf("failed to list global role permissions for admin count: %w", err)
+	}
+
+	permissionsByUser := make(map[string]*authz.PermissionSet, len(rows))
+	for _, r := range rows {
+		ps := permissionsByUser[r.UserID]
+		if ps == nil {
+			ps = authz.NewPermissionSet()
+			permissionsByUser[r.UserID] = ps
+		}
+		perms, err := decodePermissionsJSONInternal(r.Permissions)
+		if err != nil {
+			return 0, fmt.Errorf("failed to decode role permissions: %w", err)
+		}
+		ps.AddGlobal(perms...)
+	}
+
+	count := 0
+	for _, ps := range permissionsByUser {
+		if ps.IsGlobalAdmin() {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // ---------- Permission resolution ----------

--- a/backend/internal/services/role_service_test.go
+++ b/backend/internal/services/role_service_test.go
@@ -102,3 +102,56 @@ func TestSetUserAssignmentsRejectsUnknownRole(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, common.IsInvalidRoleAssignmentError(err))
 }
+
+func TestEffectiveGlobalAdminCountIncludesCustomAllPermissionsRole(t *testing.T) {
+	ctx := context.Background()
+	userSvc, roleSvc := setupUserAndRoleServices(t)
+	user := createTestUser(t, userSvc, "custom-admin", "custom-admin")
+	customRole, err := roleSvc.CreateRole(ctx, "Custom Admin", nil, authz.AllPermissions())
+	require.NoError(t, err)
+
+	require.NoError(t, roleSvc.SetUserAssignments(ctx, user.ID, []models.UserRoleAssignment{
+		{RoleID: customRole.ID, EnvironmentID: nil},
+	}))
+
+	count, err := roleSvc.CountGlobalAdminsExcludingUser(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.NoError(t, roleSvc.AssertGlobalAdminExists(ctx))
+
+	err = roleSvc.SetUserAssignments(ctx, user.ID, nil)
+	require.Error(t, err)
+	require.True(t, common.IsNoGlobalAdminRemainsError(err))
+}
+
+func TestEffectiveGlobalAdminCountIgnoresEnvScopedAndServiceAccounts(t *testing.T) {
+	ctx := context.Background()
+	userSvc, roleSvc := setupUserAndRoleServices(t)
+	customRole, err := roleSvc.CreateRole(ctx, "Custom Admin", nil, authz.AllPermissions())
+	require.NoError(t, err)
+	envID := "env-1"
+	createTestEnvironment(t, roleSvc.db, envID, "http://localhost:3552", nil)
+
+	globalAdmin := createTestUser(t, userSvc, "global-admin", "global-admin")
+	envScopedAdmin := createTestUser(t, userSvc, "env-scoped-admin", "env-scoped-admin")
+	serviceAdmin := &models.User{
+		BaseModel:        models.BaseModel{ID: "service-admin"},
+		Username:         "service-admin",
+		IsServiceAccount: true,
+	}
+	require.NoError(t, roleSvc.db.WithContext(ctx).Create(serviceAdmin).Error)
+
+	require.NoError(t, roleSvc.SetUserAssignments(ctx, globalAdmin.ID, []models.UserRoleAssignment{
+		{RoleID: customRole.ID, EnvironmentID: nil},
+	}))
+	require.NoError(t, roleSvc.SetUserAssignments(ctx, envScopedAdmin.ID, []models.UserRoleAssignment{
+		{RoleID: customRole.ID, EnvironmentID: &envID},
+	}))
+	require.NoError(t, roleSvc.SetUserAssignments(ctx, serviceAdmin.ID, []models.UserRoleAssignment{
+		{RoleID: customRole.ID, EnvironmentID: nil},
+	}))
+
+	count, err := roleSvc.CountGlobalAdminsExcludingUser(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -334,22 +334,15 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 }
 
 func (s *UserService) DeleteUser(ctx context.Context, id string) error {
-	// Last-admin guard: if this user holds the only global Admin assignment,
-	// refuse the delete. Checked OUTSIDE the transaction because RoleService
-	// uses its own session — and the guard is informational only (the unique
-	// index in user_role_assignments wouldn't catch this cross-row condition).
+	// Last-admin guard: if this user's effective permissions make them the only
+	// global admin, refuse the delete. Checked outside the transaction because
+	// RoleService uses its own session and the guard spans rows.
 	if s.roleService != nil {
-		var holdsGlobalAdmin bool
-		assignments, err := s.roleService.ListUserAssignments(ctx, id)
-		if err == nil {
-			for _, a := range assignments {
-				if a.RoleID == authz.BuiltInRoleAdmin && a.EnvironmentID == nil {
-					holdsGlobalAdmin = true
-					break
-				}
-			}
+		ps, err := s.roleService.ResolvePermissions(ctx, &models.User{BaseModel: models.BaseModel{ID: id}})
+		if err != nil {
+			return err
 		}
-		if holdsGlobalAdmin {
+		if ps != nil && ps.IsGlobalAdmin() {
 			remaining, err := s.roleService.CountGlobalAdminsExcludingUser(ctx, id)
 			if err != nil {
 				return err
@@ -439,8 +432,7 @@ func (s *UserService) toUserResponseDtosInternal(ctx context.Context, users []mo
 
 // toUserResponseDtoInternal builds the public User DTO. RoleAssignments and
 // PermissionsByEnv come from the RBAC service. CanDelete is false when this
-// user holds the only global Admin assignment (i.e. removing them would orphan
-// the instance).
+// user is the only effective global admin.
 func (s *UserService) toUserResponseDtoInternal(ctx context.Context, u models.User) user.User {
 	dto := user.User{
 		ID:                     u.ID,
@@ -467,18 +459,16 @@ func (s *UserService) toUserResponseDtoInternal(ctx context.Context, u models.Us
 				EnvironmentID: r.EnvironmentID,
 				Source:        r.Source,
 			}
-			// Last-admin guard: this user is non-deletable if they hold the
-			// only global Admin assignment.
-			if r.RoleID == authz.BuiltInRoleAdmin && r.EnvironmentID == nil {
-				if remaining, cerr := s.roleService.CountGlobalAdminsExcludingUser(ctx, u.ID); cerr == nil && remaining == 0 {
-					dto.CanDelete = false
-				}
-			}
 		}
 	}
 	if ps, err := s.roleService.ResolvePermissions(ctx, &u); err == nil && ps != nil {
 		dto.IsGlobalAdmin = ps.IsGlobalAdmin()
 		dto.PermissionsByEnv = permissionSetToMap(ps)
+		if dto.IsGlobalAdmin {
+			if remaining, cerr := s.roleService.CountGlobalAdminsExcludingUser(ctx, u.ID); cerr == nil && remaining == 0 {
+				dto.CanDelete = false
+			}
+		}
 	}
 	return dto
 }

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -109,3 +109,28 @@ func TestListUsersPaginatedSetsCanDeleteFromGlobalAdminCount(t *testing.T) {
 	require.False(t, canDeleteByID[lastAdmin.ID])
 	require.True(t, canDeleteByID[nonAdmin.ID])
 }
+
+func TestDeleteUserRejectsDeletingOnlyCustomAllPermissionsAdmin(t *testing.T) {
+	userSvc, roleSvc := setupUserAndRoleServices(t)
+	ctx := context.Background()
+
+	customAdmin := createTestUser(t, userSvc, "custom-admin", "custom-admin")
+	customRole, err := roleSvc.CreateRole(ctx, "Custom Admin", nil, authz.AllPermissions())
+	require.NoError(t, err)
+	require.NoError(t, roleSvc.SetUserAssignments(ctx, customAdmin.ID, []models.UserRoleAssignment{
+		{RoleID: customRole.ID, EnvironmentID: nil},
+	}))
+
+	err = userSvc.DeleteUser(ctx, customAdmin.ID)
+	require.ErrorIs(t, err, ErrCannotRemoveLastAdmin)
+
+	users, _, err := userSvc.ListUsersPaginated(ctx, pagination.QueryParams{
+		Params:     pagination.Params{Start: 0, Limit: 20},
+		SortParams: pagination.SortParams{Sort: "Username", Order: pagination.SortOrder("asc")},
+		Filters:    map[string]string{},
+	})
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	require.False(t, users[0].CanDelete)
+	require.True(t, users[0].IsGlobalAdmin)
+}

--- a/backend/pkg/authz/catalog.go
+++ b/backend/pkg/authz/catalog.go
@@ -88,6 +88,7 @@ var permissionCatalog = []PermissionCatalogResource{
 	}},
 	{"events", "Events", PermissionScopeGlobal, []PermissionCatalogAction{
 		{"read", PermEventsRead, "Read", ""},
+		{"delete", PermEventsDelete, "Delete", ""},
 	}},
 	{"customize", "Customize", PermissionScopeGlobal, []PermissionCatalogAction{
 		{"manage", PermCustomizeManage, "Manage", ""},

--- a/backend/pkg/authz/permissions.go
+++ b/backend/pkg/authz/permissions.go
@@ -78,6 +78,7 @@ const (
 	PermGitReposSync   = "git-repositories:sync"
 
 	PermEventsRead      = "events:read"
+	PermEventsDelete    = "events:delete"
 	PermCustomizeManage = "customize:manage"
 
 	// PermDiagnosticsRead gates the admin-only runtime diagnostics surface

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2955,6 +2955,17 @@
 	"roles_subtitle": "Define what users and API keys can do",
 	"roles_create_title": "Create role",
 	"roles_edit_title": "Edit role",
+	"roles_delete_title": "Delete role \"{name}\"?",
+	"roles_delete_selected_title": [
+		{
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["countPlural"],
+			"match": {
+				"countPlural=one": "Delete {count} role?",
+				"countPlural=other": "Delete {count} roles?"
+			}
+		}
+	],
 	"roles_delete_message": "Delete role \"{name}\"? This removes every assignment of it.",
 	"roles_save_changes": "Save changes",
 	"roles_clone_button": "Clone as custom role",
@@ -2974,7 +2985,16 @@
 	"roles_col_type": "Type",
 	"roles_col_assigned_users": "Assigned users",
 	"roles_col_permissions": "Permissions",
-	"roles_assigned_users_count": "{count} users",
+	"roles_assigned_users_count": [
+		{
+			"declarations": ["input count", "local countPlural = count: plural"],
+			"selectors": ["countPlural"],
+			"match": {
+				"countPlural=one": "{count} user",
+				"countPlural=other": "{count} users"
+			}
+		}
+	],
 	"_comment_permissions": "=== PERMISSION PICKER ===",
 	"permissions_group_label": "{resource} ({selected}/{total})",
 	"permissions_select_all": "Select all",
@@ -2987,8 +3007,12 @@
 	"oidc_mappings_subtitle": "Map OIDC group claims to roles assigned on login",
 	"oidc_mappings_create_title": "Add OIDC mapping",
 	"oidc_mappings_edit_title": "Edit OIDC mapping",
+	"oidc_mappings_delete_title": "Delete OIDC mapping?",
 	"oidc_mappings_delete_message": "Delete mapping for claim \"{claim}\"? Users logged in through this claim will lose their assigned role on next login.",
+	"oidc_mappings_delete_failed": "Failed to delete mapping",
+	"oidc_mappings_delete_success": "Mapping deleted",
 	"oidc_mappings_col_claim": "Claim value",
+	"oidc_mappings_col_role": "Role",
 	"oidc_mappings_col_scope": "Environment",
 	"oidc_mappings_claim_label": "Claim value",
 	"oidc_mappings_claim_placeholder": "e.g. docker-admins",

--- a/frontend/src/routes/(app)/environments/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/+page.svelte
@@ -18,6 +18,7 @@
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import type { AppVersionInformation } from '$lib/types/settings';
 	import type { Environment, EnvironmentStatus } from '$lib/types/environment';
+	import { hasPermission } from '$lib/utils/auth';
 	import { isEnvironmentOnline, resolveEnvironmentStatus } from '$lib/utils/docker';
 	import MobileFloatingFormActions from '$lib/components/form/mobile-floating-form-actions.svelte';
 	import { createSettingsForm } from '$lib/utils/settings';
@@ -71,8 +72,10 @@
 	let isCurrentlyStandby = $derived(currentStatus === 'standby');
 	let showSettingsTabs = $derived(runtimeEnvironment.enabled && isCurrentlyOnline && settings !== null);
 	let hasMTLSAssets = $derived(Boolean(runtimeEnvironment.edgeMTLSCertificate));
+	let canPairEnvironments = $derived(hasPermission('environments:pair'));
 	let showMTLSDownloads = $derived(
-		runtimeEnvironment.id !== '0' &&
+		canPairEnvironments &&
+			runtimeEnvironment.id !== '0' &&
 			runtimeEnvironment.isEdge &&
 			(runtimeEnvironment.edgeSecurityMode === 'mtls' || hasMTLSAssets)
 	);

--- a/frontend/src/routes/(app)/events/+page.svelte
+++ b/frontend/src/routes/(app)/events/+page.svelte
@@ -86,7 +86,7 @@
 		});
 	}
 
-	const canManageEvents = $derived(hasPermission('events:read'));
+	const canManageEvents = $derived(hasPermission('events:delete'));
 
 	const actionButtons: ActionButton[] = $derived([
 		...(selectedIds.length > 0 && canManageEvents

--- a/frontend/src/routes/(app)/events/event-table.svelte
+++ b/frontend/src/routes/(app)/events/event-table.svelte
@@ -269,7 +269,7 @@
 					{m.common_view_details()}
 				</DropdownMenu.Item>
 
-				<IfPermitted perm="events:read">
+				<IfPermitted perm="events:delete">
 					<DropdownMenu.Separator />
 
 					<DropdownMenu.Item

--- a/frontend/src/routes/(app)/settings/authentication/oidc-mapping-table.svelte
+++ b/frontend/src/routes/(app)/settings/authentication/oidc-mapping-table.svelte
@@ -102,8 +102,7 @@
 	async function handleDeleteMapping(mapping: OidcRoleMapping) {
 		const safeClaim = mapping.claimValue?.trim() || m.common_unknown();
 		openConfirmDialog({
-			// TODO: i18n — add oidc_mappings_delete_title key
-			title: 'Delete OIDC mapping?',
+			title: m.oidc_mappings_delete_title(),
 			message: m.oidc_mappings_delete_message({ claim: safeClaim }),
 			confirm: {
 				label: m.common_delete(),
@@ -112,12 +111,10 @@
 					isLoading.removing = true;
 					handleApiResultWithCallbacks({
 						result: await tryCatch(oidcMappingService.delete(mapping.id)),
-						// TODO: i18n — add oidc_mappings_delete_failed key
-						message: 'Failed to delete mapping',
+						message: m.oidc_mappings_delete_failed(),
 						setLoadingState: (value) => (isLoading.removing = value),
 						onSuccess: async () => {
-							// TODO: i18n — add oidc_mappings_delete_success key
-							toast.success('Mapping deleted');
+							toast.success(m.oidc_mappings_delete_success());
 							await onRefresh();
 						}
 					});
@@ -131,7 +128,7 @@
 		{
 			id: 'roleId',
 			accessorKey: 'roleId',
-			title: 'Role' /* TODO: i18n — add oidc_mappings_col_role key */,
+			title: m.oidc_mappings_col_role(),
 			sortable: true,
 			cell: RoleCell
 		},
@@ -145,7 +142,7 @@
 	] satisfies ColumnSpec<OidcRoleMapping>[];
 
 	const mobileFields = [
-		{ id: 'roleId', label: 'Role' /* TODO: i18n — add oidc_mappings_col_role key */, defaultVisible: true },
+		{ id: 'roleId', label: m.oidc_mappings_col_role(), defaultVisible: true },
 		{ id: 'environmentId', label: m.oidc_mappings_col_scope(), defaultVisible: true }
 	];
 

--- a/frontend/src/routes/(app)/settings/roles/roles-table.svelte
+++ b/frontend/src/routes/(app)/settings/roles/roles-table.svelte
@@ -73,8 +73,7 @@
 		if (deletableSelectedIds.length === 0) return;
 
 		openConfirmDialog({
-			// TODO: i18n — add roles_delete_selected_title key
-			title: `Delete ${deletableSelectedIds.length} role${deletableSelectedIds.length === 1 ? '' : 's'}?`,
+			title: m.roles_delete_selected_title({ count: deletableSelectedIds.length }),
 			message: m.roles_delete_message({ name: m.common_unknown() }),
 			confirm: {
 				label: m.common_delete(),
@@ -122,8 +121,7 @@
 
 		const safeName = role.name?.trim() || m.common_unknown();
 		openConfirmDialog({
-			// TODO: i18n — add roles_delete_title key
-			title: `Delete role "${safeName}"?`,
+			title: m.roles_delete_title({ name: safeName }),
 			message: m.roles_delete_message({ name: safeName }),
 			confirm: {
 				label: m.common_delete(),
@@ -145,9 +143,8 @@
 	}
 
 	const columns = [
-		// TODO: i18n — add roles_name_label and roles_description_label keys
-		{ accessorKey: 'name', title: 'Name', sortable: true, cell: NameCell },
-		{ accessorKey: 'description', title: 'Description', sortable: false, cell: DescriptionCell },
+		{ accessorKey: 'name', title: m.roles_name_label(), sortable: true, cell: NameCell },
+		{ accessorKey: 'description', title: m.roles_description_label(), sortable: false, cell: DescriptionCell },
 		{ id: 'type', accessorKey: 'builtIn', title: m.roles_col_type(), sortable: false, cell: TypeCell },
 		{
 			id: 'assignedUsers',
@@ -166,8 +163,7 @@
 	] satisfies ColumnSpec<Role>[];
 
 	const mobileFields = [
-		// TODO: i18n — add roles_description_label key
-		{ id: 'description', label: 'Description', defaultVisible: true },
+		{ id: 'description', label: m.roles_description_label(), defaultVisible: true },
 		{ id: 'permissions', label: m.roles_col_permissions(), defaultVisible: true },
 		{ id: 'assignedUsers', label: m.roles_col_assigned_users(), defaultVisible: true }
 	];
@@ -206,7 +202,7 @@
 {/snippet}
 
 {#snippet AssignedUsersCell({ item }: { item: Role })}
-	<span class="tabular-nums">{item.assignedUserCount === 1 ? '1 user' : `${item.assignedUserCount} users`}</span>
+	<span class="tabular-nums">{m.roles_assigned_users_count({ count: item.assignedUserCount })}</span>
 {/snippet}
 
 {#snippet PermissionsCell({ item }: { item: Role })}
@@ -242,8 +238,7 @@
 			},
 			{
 				label: m.roles_col_assigned_users(),
-				// TODO: i18n — roles_assigned_users_count has a malformed ICU plural in en.json
-				getValue: (item: Role) => (item.assignedUserCount === 1 ? '1 user' : `${item.assignedUserCount} users`),
+				getValue: (item: Role) => m.roles_assigned_users_count({ count: item.assignedUserCount }),
 				icon: ShieldAlertIcon,
 				iconVariant: 'gray' as const,
 				show: mobileFieldVisibility['assignedUsers'] ?? true

--- a/types/event/event.go
+++ b/types/event/event.go
@@ -80,63 +80,6 @@ type Event struct {
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
-type CreateEvent struct {
-	// Type of the event.
-	//
-	// Required: true
-	Type string `json:"type" binding:"required"`
-
-	// Severity level of the event.
-	//
-	// Required: false
-	Severity string `json:"severity,omitempty"`
-
-	// Title of the event.
-	//
-	// Required: true
-	Title string `json:"title" binding:"required"`
-
-	// Description of the event.
-	//
-	// Required: false
-	Description string `json:"description,omitempty"`
-
-	// ResourceType is the type of the resource associated with the event.
-	//
-	// Required: false
-	ResourceType *string `json:"resourceType,omitempty"`
-
-	// ResourceID is the ID of the resource associated with the event.
-	//
-	// Required: false
-	ResourceID *string `json:"resourceId,omitempty"`
-
-	// ResourceName is the name of the resource associated with the event.
-	//
-	// Required: false
-	ResourceName *string `json:"resourceName,omitempty"`
-
-	// UserID is the ID of the user who triggered the event.
-	//
-	// Required: false
-	UserID *string `json:"userId,omitempty"`
-
-	// Username is the username of the user who triggered the event.
-	//
-	// Required: false
-	Username *string `json:"username,omitempty"`
-
-	// EnvironmentID is the ID of the environment associated with the event.
-	//
-	// Required: false
-	EnvironmentID *string `json:"environmentId,omitempty"`
-
-	// Metadata contains additional key-value data associated with the event.
-	//
-	// Required: false
-	Metadata map[string]any `json:"metadata,omitempty"`
-}
-
 type ListReponse struct {
 	// Events is a list of events.
 	//


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors event ingestion and RBAC by removing the RBAC-gated `POST /events` endpoint from the Huma/OpenAPI surface and replacing it with a dedicated Echo route (`RegisterAgentEventIngestion`) authenticated solely by an agent token. It also adds a proper `events:delete` permission, tightens four mTLS/deployment-snippet routes from `environments:read` to `environments:pair`, and generalises the last-admin guard to work with any custom all-permissions role rather than only the built-in Admin role.

- Event creation is now exclusively via a raw Echo route gated by `X-Arcane-Agent-Token`; the Huma `createEvent` operation (and the `types/event.CreateEvent` DTO) are removed entirely, and `services.CreateEventRequest` is used end-to-end.
- `events:delete` is introduced as a first-class permission; the delete handler now requires it instead of re-using `events:read`, and the frontend permission checks are updated to match.
- The last-admin guard (`countEffectiveGlobalAdminsInternal`) is rewritten to resolve every non-service-account user's effective global permissions through the role system, so custom all-permissions roles protect the guard just like the built-in Admin role.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The changes are intentional RBAC hardening with comprehensive test coverage, and all core logic paths (event ingestion, last-admin guard, permission resolution) have been verified.

The event ingestion refactor, permission additions, and last-admin guard rewrite all look correct. CreateEvent handles empty Severity with a default, ResolvePermissions queries by user ID from the database (not from the partial struct), and countEffectiveGlobalAdminsInternal uses a single JOIN query with in-memory IsGlobalAdmin evaluation. The mTLS route permission change and the events:delete introduction are well-tested and intentional.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/api/handlers/events.go`, line 248-254 ([link](https://github.com/getarcaneapp/arcane/blob/9d73feddcc8a2aa591bb3c4bec17a44f7e28acc0/backend/api/handlers/events.go#L248-L254)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Empty `AgentToken` silently disables event ingestion instead of returning a useful error**

   When `cfg.AgentToken` is blank, `validAgentEventIngestionTokenInternal` returns `false`, so every request hits the 401 branch with the generic `"invalid agent token"` message. A manager deployed without a configured agent token will silently drop all inbound agent events with no observable error on the server side (the agent just sees 401). Consider logging a warning (or returning a distinct 503/500) when `AgentToken` is unconfigured, so operators know to set it rather than chasing a token-mismatch.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/handlers/events.go
   Line: 248-254

   Comment:
   **Empty `AgentToken` silently disables event ingestion instead of returning a useful error**

   When `cfg.AgentToken` is blank, `validAgentEventIngestionTokenInternal` returns `false`, so every request hits the 401 branch with the generic `"invalid agent token"` message. A manager deployed without a configured agent token will silently drop all inbound agent events with no observable error on the server side (the agent just sees 401). Consider logging a warning (or returning a distinct 503/500) when `AgentToken` is unconfigured, so operators know to set it rather than chasing a token-mismatch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fevents-rbac%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fevents-rbac%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fevents.go%0ALine%3A%20248-254%0A%0AComment%3A%0A**Empty%20%60AgentToken%60%20silently%20disables%20event%20ingestion%20instead%20of%20returning%20a%20useful%20error**%0A%0AWhen%20%60cfg.AgentToken%60%20is%20blank%2C%20%60validAgentEventIngestionTokenInternal%60%20returns%20%60false%60%2C%20so%20every%20request%20hits%20the%20401%20branch%20with%20the%20generic%20%60%22invalid%20agent%20token%22%60%20message.%20A%20manager%20deployed%20without%20a%20configured%20agent%20token%20will%20silently%20drop%20all%20inbound%20agent%20events%20with%20no%20observable%20error%20on%20the%20server%20side%20%28the%20agent%20just%20sees%20401%29.%20Consider%20logging%20a%20warning%20%28or%20returning%20a%20distinct%20503%2F500%29%20when%20%60AgentToken%60%20is%20unconfigured%2C%20so%20operators%20know%20to%20set%20it%20rather%20than%20chasing%20a%20token-mismatch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fevents.go%0ALine%3A%20248-254%0A%0AComment%3A%0A**Empty%20%60AgentToken%60%20silently%20disables%20event%20ingestion%20instead%20of%20returning%20a%20useful%20error**%0A%0AWhen%20%60cfg.AgentToken%60%20is%20blank%2C%20%60validAgentEventIngestionTokenInternal%60%20returns%20%60false%60%2C%20so%20every%20request%20hits%20the%20401%20branch%20with%20the%20generic%20%60%22invalid%20agent%20token%22%60%20message.%20A%20manager%20deployed%20without%20a%20configured%20agent%20token%20will%20silently%20drop%20all%20inbound%20agent%20events%20with%20no%20observable%20error%20on%20the%20server%20side%20%28the%20agent%20just%20sees%20401%29.%20Consider%20logging%20a%20warning%20%28or%20returning%20a%20distinct%20503%2F500%29%20when%20%60AgentToken%60%20is%20unconfigured%2C%20so%20operators%20know%20to%20set%20it%20rather%20than%20chasing%20a%20token-mismatch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2795&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: events create rbac role removed cau..."](https://github.com/getarcaneapp/arcane/commit/92ee3373b221f6abc035a77170ecda1dba243436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35504304)</sub>

<!-- /greptile_comment -->