### PR TITLE
refactor: enhance updater functionality with restart status and options handling

### DIFF
--- a/backend/api/handlers/updater.go
+++ b/backend/api/handlers/updater.go
@@ -128,13 +128,13 @@ func (h *UpdaterHandler) RunUpdater(ctx context.Context, input *RunUpdaterInput)
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	dryRun := false
+	options := updater.Options{}
 	if input.Body != nil {
-		dryRun = input.Body.DryRun
+		options = *input.Body
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
-	out, err := h.updaterService.ApplyPending(runtimeCtx, dryRun)
+	out, err := h.updaterService.ApplyPending(runtimeCtx, options)
 	if err != nil {
 		return nil, huma.Error500InternalServerError((&common.UpdaterRunError{Err: err}).Error())
 	}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,8 @@ replace (
 	github.com/getarcaneapp/arcane/types => ../types
 )
 
+tool github.com/google/wire/cmd/wire
+
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.17
@@ -24,7 +26,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getarcaneapp/arcane/cli v1.19.5
 	github.com/getarcaneapp/arcane/types v1.19.5
-	github.com/getarcaneapp/updater v0.3.2
+	github.com/getarcaneapp/updater v0.3.4
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/goccy/go-yaml v1.19.2
@@ -235,5 +237,3 @@ require (
 	modernc.org/sqlite v1.50.1 // indirect
 	tags.cncf.io/container-device-interface v1.1.0 // indirect
 )
-
-tool github.com/google/wire/cmd/wire

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -173,8 +173,8 @@ github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQ
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getarcaneapp/updater v0.3.2 h1:mSyMlb7q+EyLjGKrcMg64b+D+wVwMBkq8ZduC8PQawE=
-github.com/getarcaneapp/updater v0.3.2/go.mod h1:0o8qpysU0YdEuEyCq6FtQPyuTTPDEV5Epwx7ctROAKM=
+github.com/getarcaneapp/updater v0.3.4 h1:xLkME2B6PAElLVY7+NnLqv3bITrs9IK3fkkHCOcdAYU=
+github.com/getarcaneapp/updater v0.3.4/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
 github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ=
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=

--- a/backend/internal/models/auto_update.go
+++ b/backend/internal/models/auto_update.go
@@ -13,6 +13,7 @@ const (
 	AutoUpdateStatusCompleted AutoUpdateStatus = "completed"
 	AutoUpdateStatusFailed    AutoUpdateStatus = "failed"
 	AutoUpdateStatusSkipped   AutoUpdateStatus = "skipped"
+	AutoUpdateStatusRestarted AutoUpdateStatus = "restarted"
 )
 
 type AutoUpdateRecord struct {

--- a/backend/internal/services/image_service_test.go
+++ b/backend/internal/services/image_service_test.go
@@ -3,6 +3,10 @@ package services
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +18,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/internal/database"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
 	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
+	"github.com/getarcaneapp/arcane/types/containerregistry"
 	imagetypes "github.com/getarcaneapp/arcane/types/image"
 	"github.com/getarcaneapp/arcane/types/vulnerability"
 	dockerauthconfig "github.com/moby/moby/api/pkg/authconfig"
@@ -176,6 +181,51 @@ func TestGetPullOptionsWithAuth_DBRegistryUsesValidCredentials(t *testing.T) {
 	assert.Equal(t, "docker-user", authCfg.Username)
 	assert.Equal(t, "docker-token", authCfg.Password)
 	assert.Equal(t, "https://index.docker.io/v1/", authCfg.ServerAddress)
+}
+
+func TestGetPullOptionsWithAuth_ExternalCredentialsOverrideDBRegistryInternal(t *testing.T) {
+	svc, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://registry.example.com", "db-user", "db-token")
+
+	pullOptions, err := svc.getPullOptionsWithAuth(context.Background(), "registry.example.com/team/app:latest", []containerregistry.Credential{
+		{URL: "https://registry.example.com", Username: "external-user", Token: "external-token", Enabled: true},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, pullOptions.RegistryAuth)
+
+	authCfg := decodeRegistryAuth(t, pullOptions.RegistryAuth)
+	assert.Equal(t, "external-user", authCfg.Username)
+	assert.Equal(t, "external-token", authCfg.Password)
+	assert.Equal(t, "registry.example.com", authCfg.ServerAddress)
+}
+
+func TestImageServicePullImageRetriesAnonymouslyAfterAuthRejectedInternal(t *testing.T) {
+	db := setupProjectTestDB(t)
+	authHeaders := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/images/create") {
+			http.NotFound(w, r)
+			return
+		}
+		authHeaders = append(authHeaders, r.Header.Get(dockerregistry.AuthHeader))
+		if len(authHeaders) == 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"Pulled anonymously"}` + "\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	imageSvc := NewImageService(db, dockerService, nil, nil, nil, NewEventService(db, nil, nil))
+
+	err := imageSvc.PullImage(context.Background(), "registry.example.com/team/app:latest", io.Discard, systemUser, []containerregistry.Credential{
+		{URL: "https://registry.example.com", Username: "external-user", Token: "external-token", Enabled: true},
+	})
+	require.NoError(t, err)
+	require.Len(t, authHeaders, 2)
+	assert.NotEmpty(t, authHeaders[0])
+	assert.Empty(t, authHeaders[1])
 }
 
 func TestShouldRetryAnonymousPullInternal_UnauthorizedWithAuth(t *testing.T) {

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -137,9 +137,9 @@ func (s *UpdaterService) registryDigestResolverInternal() updaterdigest.RemoteRe
 }
 
 // ApplyPending executes pending image updates.
-func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *updater.Result, err error) {
+func (s *UpdaterService) ApplyPending(ctx context.Context, options updater.Options) (out *updater.Result, err error) {
 	start := time.Now()
-	activityID := s.startAutoUpdateActivityInternal(ctx, dryRun)
+	activityID := s.startAutoUpdateActivityInternal(ctx, options.DryRun)
 	out = &updater.Result{Items: []updater.ResourceResult{}, ActivityID: utils.StringPtrFromTrimmed(activityID)}
 	ctx = s.trackActivityInternal(ctx, activityID)
 	ctx = contextWithActivityIDInternal(ctx, activityID)
@@ -156,13 +156,14 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *up
 	}()
 
 	s.recordAutoUpdateEventInternal(ctx, models.EventSeverityInfo, models.JSON{
-		"phase":  "start",
-		"dryRun": dryRun,
-		"time":   time.Now().UTC().Format(time.RFC3339),
+		"phase":       "start",
+		"dryRun":      options.DryRun,
+		"forceUpdate": options.ForceUpdate,
+		"time":        time.Now().UTC().Format(time.RFC3339),
 	})
 	s.appendAutoUpdateActivityMessageInternal(ctx, activityID, "Planning pending updates", "Planning updates", 5)
 
-	moduleResult, engineErr := s.engineInternal().ApplyPending(ctx, moduletypes.Options{DryRun: dryRun})
+	moduleResult, engineErr := s.engineInternal().ApplyPending(ctx, moduleOptionsFromUpdaterOptionsInternal(options))
 	if moduleResult != nil {
 		out = resultFromModuleInternal(moduleResult)
 		out.ActivityID = utils.StringPtrFromTrimmed(activityID)
@@ -173,7 +174,7 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *up
 		return out, err
 	}
 
-	if !dryRun && s.deps.ImageUpdates != nil {
+	if !options.DryRun && s.deps.ImageUpdates != nil {
 		s.appendAutoUpdateActivityMessageInternal(ctx, activityID, "Cleaning up update records", "Cleaning up", 95)
 		if cleanupErr := s.deps.ImageUpdates.CleanupOrphanedRecords(ctx); cleanupErr != nil {
 			s.loggerInternal().WarnContext(ctx, "cleanup orphaned update records failed", "error", cleanupErr)
@@ -181,13 +182,14 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, dryRun bool) (out *up
 	}
 
 	s.recordAutoUpdateEventInternal(ctx, models.EventSeverityInfo, models.JSON{
-		"phase":    "complete",
-		"checked":  out.Checked,
-		"updated":  out.Updated,
-		"skipped":  out.Skipped,
-		"failed":   out.Failed,
-		"duration": out.Duration,
-		"time":     time.Now().UTC().Format(time.RFC3339),
+		"phase":     "complete",
+		"checked":   out.Checked,
+		"updated":   out.Updated,
+		"restarted": out.Restarted,
+		"skipped":   out.Skipped,
+		"failed":    out.Failed,
+		"duration":  out.Duration,
+		"time":      time.Now().UTC().Format(time.RFC3339),
 	})
 	return out, nil
 }
@@ -362,9 +364,17 @@ func (s *UpdaterService) PullImage(ctx context.Context, imageRef string, progres
 	}
 	activityID := activityIDFromContextInternal(ctx)
 	writer := activitylib.NewWriter(ctx, s.deps.Activity, activityID, progress, "Pulling updated images")
-	err := s.deps.ImagePuller.PullImage(ctx, imageRef, writer, s.deps.SystemUser, nil)
-	activitylib.FlushWriter(writer)
-	return err
+	defer activitylib.FlushWriter(writer)
+
+	if s.deps.Projects != nil {
+		resolved, err := s.deps.Projects.resolveRegistryCredentialsInternal(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve registry credentials: %w", err)
+		}
+		return s.deps.ImagePuller.PullImage(ctx, imageRef, writer, s.deps.SystemUser, resolved)
+	}
+
+	return s.deps.ImagePuller.PullImage(ctx, imageRef, writer, s.deps.SystemUser, nil)
 }
 
 // PendingImageUpdates returns pending image update records from Arcane's database.
@@ -659,6 +669,15 @@ func imageUpdateRecordToModuleInternal(record models.ImageUpdateRecord) modulety
 	}
 }
 
+func moduleOptionsFromUpdaterOptionsInternal(options updater.Options) moduletypes.Options {
+	return moduletypes.Options{
+		Type:        options.Type,
+		ResourceIDs: slices.Clone(options.ResourceIds),
+		Force:       options.ForceUpdate,
+		DryRun:      options.DryRun,
+	}
+}
+
 func resultFromModuleInternal(result *moduletypes.Result) *updater.Result {
 	if result == nil {
 		return &updater.Result{Items: []updater.ResourceResult{}}
@@ -667,6 +686,7 @@ func resultFromModuleInternal(result *moduletypes.Result) *updater.Result {
 		Success:    result.Success,
 		Checked:    result.Checked,
 		Updated:    result.Updated,
+		Restarted:  result.Restarted,
 		Skipped:    result.Skipped,
 		Failed:     result.Failed,
 		StartTime:  result.StartTime,

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -13,7 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getarcaneapp/arcane/backend/internal/config"
 	"github.com/getarcaneapp/arcane/backend/internal/models"
+	"github.com/getarcaneapp/arcane/backend/pkg/libarcane/crypto"
+	arcaneupdater "github.com/getarcaneapp/arcane/types/updater"
 	moduleapi "github.com/getarcaneapp/updater/api"
 	updaterlabels "github.com/getarcaneapp/updater/pkg/labels"
 	moduletypes "github.com/getarcaneapp/updater/types"
@@ -187,7 +190,7 @@ func TestUpdaterService_ApplyPendingNoRecordsInternal(t *testing.T) {
 	db := setupProjectTestDB(t)
 	svc := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	result, err := svc.ApplyPending(ctx, true)
+	result, err := svc.ApplyPending(ctx, arcaneupdater.Options{DryRun: true})
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -220,6 +223,44 @@ func TestUpdaterService_ConfigUsesComposeStandaloneFallbackSettingInternal(t *te
 
 		assert.True(t, cfg.AllowComposeStandaloneFallback)
 	})
+}
+
+func TestUpdaterService_ModuleOptionsFromUpdaterOptionsInternal(t *testing.T) {
+	got := moduleOptionsFromUpdaterOptionsInternal(arcaneupdater.Options{
+		Type:        moduletypes.ResourceTypeImage,
+		ResourceIds: []string{"image-1", "image-2"},
+		ForceUpdate: true,
+		DryRun:      true,
+	})
+
+	assert.Equal(t, moduletypes.ResourceTypeImage, got.Type)
+	assert.Equal(t, []string{"image-1", "image-2"}, got.ResourceIDs)
+	assert.True(t, got.Force)
+	assert.True(t, got.DryRun)
+}
+
+func TestUpdaterService_ResultFromModulePreservesRestartedInternal(t *testing.T) {
+	got := resultFromModuleInternal(&moduletypes.Result{
+		Success:   true,
+		Checked:   2,
+		Updated:   1,
+		Restarted: 1,
+		Items: []moduletypes.ResourceResult{
+			{
+				ResourceID:    "web-id",
+				ResourceName:  "web",
+				ResourceType:  moduletypes.ResourceTypeContainer,
+				Status:        moduletypes.StatusRestarted,
+				UpdateApplied: true,
+			},
+		},
+	})
+
+	require.NotNil(t, got)
+	assert.Equal(t, 1, got.Restarted)
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, arcaneupdater.StatusRestarted, got.Items[0].Status)
+	assert.True(t, got.Items[0].UpdateApplied)
 }
 
 func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
@@ -360,6 +401,41 @@ func TestUpdaterService_PullImageAdapterInternal(t *testing.T) {
 		err := svc.PullImage(ctx, "nginx:latest", &progress)
 
 		require.NoError(t, err)
+		assert.Contains(t, progress.String(), "Pulled")
+	})
+
+	t.Run("passes database registry credentials to Arcane image puller", func(t *testing.T) {
+		db := setupProjectTestDB(t)
+		require.NoError(t, db.AutoMigrate(&models.ContainerRegistry{}, &models.KVEntry{}))
+		crypto.InitEncryption(&crypto.Config{
+			Environment:   string(config.AppEnvironmentTest),
+			EncryptionKey: "test-encryption-key-for-testing-32bytes-min",
+		})
+		createTestPullRegistry(t, db, "https://registry.example.com", "db-user", "db-token")
+
+		imageRef := "registry.example.com/team/app:latest"
+		var gotAuth string
+		server := newProjectImagePullServerWithObserverInternal(t, nil, func(fullRef string, authHeader string) {
+			if fullRef == imageRef {
+				gotAuth = authHeader
+			}
+		})
+		dockerSvc := &DockerClientService{client: newTestDockerClient(t, server)}
+		registrySvc := NewContainerRegistryService(db, nil, NewKVService(db))
+		imageSvc := NewImageService(db, dockerSvc, registrySvc, nil, nil, NewEventService(db, nil, nil))
+		envSvc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
+		projectSvc := NewProjectService(db, nil, nil, nil, nil, nil, nil).
+			WithRegistryCredentialsProvider(envSvc.GetEnabledRegistryCredentials)
+		svc := NewUpdaterService(db, nil, dockerSvc, projectSvc, nil, nil, nil, imageSvc, nil, nil, nil)
+		var progress bytes.Buffer
+
+		err := svc.PullImage(ctx, imageRef, &progress)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, gotAuth)
+		authConfig := decodeRegistryAuth(t, gotAuth)
+		assert.Equal(t, "db-user", authConfig.Username)
+		assert.Equal(t, "db-token", authConfig.Password)
 		assert.Contains(t, progress.String(), "Pulled")
 	})
 }
@@ -573,7 +649,7 @@ func TestUpdaterService_ApplyPending_ProjectFailureDoesNotBlockOtherProjectsInte
 		LabelPolicy: updaterlabels.DefaultLabelPolicy(),
 	})
 
-	result, err := svc.ApplyPending(ctx, false)
+	result, err := svc.ApplyPending(ctx, arcaneupdater.Options{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 3, result.Updated, "updated count should include both image pulls and the successfully updated container")

--- a/backend/internal/services/webhook_service.go
+++ b/backend/internal/services/webhook_service.go
@@ -590,7 +590,7 @@ func (s *WebhookService) executeUpdaterWebhookActionInternal(ctx context.Context
 		return nil, ErrWebhookInvalidAction
 	}
 
-	result, err := s.updaterService.ApplyPending(ctx, false)
+	result, err := s.updaterService.ApplyPending(ctx, updater.Options{})
 	if err != nil {
 		return nil, s.wrapWebhookActionErrorInternal(ctx, wh, "updater", actionType, err)
 	}

--- a/backend/pkg/scheduler/auto_update_job.go
+++ b/backend/pkg/scheduler/auto_update_job.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/getarcaneapp/arcane/backend/internal/services"
+	"github.com/getarcaneapp/arcane/types/updater"
 )
 
 type AutoUpdateJob struct {
@@ -48,7 +49,7 @@ func (j *AutoUpdateJob) Run(ctx context.Context) {
 
 	slog.InfoContext(ctx, "auto-update run started")
 
-	result, err := j.updaterService.ApplyPending(ctx, false)
+	result, err := j.updaterService.ApplyPending(ctx, updater.Options{})
 	if err != nil {
 		slog.ErrorContext(ctx, "auto-update run failed", "err", err)
 		return
@@ -57,6 +58,7 @@ func (j *AutoUpdateJob) Run(ctx context.Context) {
 	slog.InfoContext(ctx, "auto-update run completed",
 		"checked", result.Checked,
 		"updated", result.Updated,
+		"restarted", result.Restarted,
 		"skipped", result.Skipped,
 		"failed", result.Failed,
 	)

--- a/frontend/src/lib/types/automation.ts
+++ b/frontend/src/lib/types/automation.ts
@@ -13,6 +13,7 @@ export interface AutoUpdateCheck {
 export interface AutoUpdateResult {
 	checked: number;
 	updated: number;
+	restarted?: number;
 	skipped: number;
 	failed: number;
 	items: AutoUpdateResourceResult[];
@@ -24,7 +25,7 @@ export interface AutoUpdateResourceResult {
 	resourceId: string;
 	resourceName: string;
 	resourceType: AutoUpdateResourceType;
-	status: 'checked' | 'up_to_date' | 'update_available' | 'updated' | 'failed' | 'skipped';
+	status: 'checked' | 'up_to_date' | 'update_available' | 'updated' | 'restarted' | 'failed' | 'skipped';
 	updateAvailable: boolean;
 	updateApplied: boolean;
 	oldImages?: Record<string, string>;

--- a/go.work.sum
+++ b/go.work.sum
@@ -463,8 +463,8 @@ github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getarcaneapp/arcane/types v0.0.0-20251219045603-8a9960a2bf04/go.mod h1:7Wj+0JnpYq4RQS+otyM6e4zkyJKDC01wxkWPyFCHwZA=
-github.com/getarcaneapp/updater v0.3.2 h1:mSyMlb7q+EyLjGKrcMg64b+D+wVwMBkq8ZduC8PQawE=
-github.com/getarcaneapp/updater v0.3.2/go.mod h1:0o8qpysU0YdEuEyCq6FtQPyuTTPDEV5Epwx7ctROAKM=
+github.com/getarcaneapp/updater v0.3.4 h1:xLkME2B6PAElLVY7+NnLqv3bITrs9IK3fkkHCOcdAYU=
+github.com/getarcaneapp/updater v0.3.4/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gin-contrib/cors v1.7.7/go.mod h1:K5tW0RkzJtWSiOdikXloy8VEZlgdVNpHNw8FpjUPNrE=

--- a/types/updater/updater.go
+++ b/types/updater/updater.go
@@ -1,5 +1,22 @@
 package updater
 
+const (
+	// StatusChecked indicates a resource was checked.
+	StatusChecked = "checked"
+	// StatusUpdated indicates a resource was updated.
+	StatusUpdated = "updated"
+	// StatusRestarted indicates a resource was restarted because a dependency changed.
+	StatusRestarted = "restarted"
+	// StatusSkipped indicates a resource was skipped.
+	StatusSkipped = "skipped"
+	// StatusFailed indicates a resource failed to update.
+	StatusFailed = "failed"
+	// StatusUpToDate indicates a resource is already up to date.
+	StatusUpToDate = "up_to_date"
+	// StatusUpdateAvailable indicates an update is available.
+	StatusUpdateAvailable = "update_available"
+)
+
 type Options struct {
 	// Type filters updates by resource type ("image" | "container" | "project")
 	Type string `json:"type,omitempty"`
@@ -31,7 +48,7 @@ type ResourceResult struct {
 	// Required: true
 	ResourceType string `json:"resourceType"`
 
-	// Status is the current status ("checked" | "updated" | "skipped" | "failed" | "up_to_date" | "update_available").
+	// Status is the current status ("checked" | "updated" | "restarted" | "skipped" | "failed" | "up_to_date" | "update_available").
 	//
 	// Required: true
 	Status string `json:"status"`
@@ -83,6 +100,11 @@ type Result struct {
 	//
 	// Required: true
 	Updated int `json:"updated"`
+
+	// Restarted is the number of resources restarted because a dependency changed.
+	//
+	// Required: false
+	Restarted int `json:"restarted,omitempty"`
 
 	// Skipped is the number of resources skipped.
 	//


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades `getarcaneapp/updater` from v0.3.2 to v0.3.4 and wires in the new capabilities: a `restarted` status/count, a richer `Options` struct replacing the bare `dryRun bool` parameter, and registry-credential resolution in `PullImage`.

- `ApplyPending` now accepts `updater.Options` (carrying `Type`, `ResourceIds`, `ForceUpdate`, and `DryRun`) instead of a bare `bool`, with a thin `moduleOptionsFromUpdaterOptionsInternal` adapter mapping to the upstream module types.
- `Restarted` is propagated through `resultFromModuleInternal`, the log event, the auto-update job logger, and the frontend `AutoUpdateResult` type; `AutoUpdateStatusRestarted` is added to the model constants.
- `PullImage` gains a `defer activitylib.FlushWriter(writer)` cleanup and conditionally resolves per-project registry credentials when `s.deps.Projects` is set, backed by new tests in both `updater_service_test.go` and `image_service_test.go`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all call sites that previously passed a bare `false` now pass `updater.Options{}` which is semantically equivalent, the new credential-resolution path falls back gracefully when `Projects` is nil, and the new `Restarted` field uses `omitempty` so existing clients are unaffected.

The signature change is mechanical and covered at every call site. The `PullImage` credential path is guarded by a nil check and has integration-test coverage. The new `Restarted` field is additive and omitted when zero, keeping the wire format backward-compatible. No logic that could cause incorrect behavior or data loss was introduced.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: enhance updater functionality ..."](https://github.com/getarcaneapp/arcane/commit/2286863babc8615efa21c3505afc2251b2c8b332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35751391)</sub>

<!-- /greptile_comment -->