### PR TITLE
fix: skip checking for updates on pinned digests

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getarcaneapp/arcane/cli v1.19.5
 	github.com/getarcaneapp/arcane/types v1.19.5
-	github.com/getarcaneapp/updater v0.3.4
+	github.com/getarcaneapp/updater v0.3.5
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/goccy/go-yaml v1.19.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -171,8 +171,7 @@ github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQ
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getarcaneapp/updater v0.3.4 h1:xLkME2B6PAElLVY7+NnLqv3bITrs9IK3fkkHCOcdAYU=
-github.com/getarcaneapp/updater v0.3.4/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
+github.com/getarcaneapp/updater v0.3.5 h1:QMQgHF9vELSqoKKTKFAZuDgGkp4aU4GvlOP5bQ25l+8=
 github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ=
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -164,6 +164,33 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 	startTime := time.Now()
 	activityID := s.startImageUpdateActivityInternal(ctx, imageRef, 1)
 	ctx = s.activityService.Track(ctx, activityID)
+
+	if result, ok := digestPinnedImageUpdateResultInternal(imageRef); ok {
+		result.ResponseTimeMs = int(time.Since(startTime).Milliseconds())
+		result.ActivityID = utils.StringPtrFromTrimmed(activityID)
+		s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, imageRef+" — digest pinned, skipped", 100, "Skipping image update check")
+		if saveErr := s.saveUpdateResultWithSnapshotInternal(ctx, imageRef, result, nil); saveErr != nil {
+			slog.WarnContext(ctx, "Failed to save digest-pinned update result", "imageRef", imageRef, "error", saveErr.Error())
+		}
+		if s.eventService != nil {
+			metadata := models.JSON{
+				"action":         "check_update",
+				"imageRef":       imageRef,
+				"hasUpdate":      false,
+				"updateType":     models.UpdateTypeDigest,
+				"currentDigest":  result.CurrentDigest,
+				"latestDigest":   result.LatestDigest,
+				"responseTimeMs": result.ResponseTimeMs,
+				"skippedReason":  "digest_pinned",
+			}
+			if logErr := s.eventService.LogImageEvent(ctx, models.EventTypeImageScan, "", imageRef, systemUser.ID, systemUser.Username, "0", metadata); logErr != nil {
+				slog.WarnContext(ctx, "Failed to log digest-pinned image update check event", "imageRef", imageRef, "error", logErr.Error())
+			}
+		}
+		s.completeImageUpdateActivityInternal(ctx, activityID, true, "Image update check skipped")
+		return result, nil
+	}
+
 	s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, "Checking "+imageRef, 20, "Checking remote digest")
 
 	parts := s.parseImageReference(imageRef)
@@ -233,6 +260,32 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 	}
 	s.completeImageUpdateActivityInternal(ctx, activityID, true, finalMessage)
 	return digestResult, nil
+}
+
+func digestPinnedImageUpdateResultInternal(imageRef string) (*imageupdate.Response, bool) {
+	imageRef = strings.TrimSpace(imageRef)
+	pinnedDigest, ok := updaterdigest.FromReferenceSuffix(imageRef)
+	if !ok {
+		return nil, false
+	}
+
+	tag := "latest"
+	if named, err := ref.ParseNormalizedNamed(imageRef); err == nil {
+		if tagged, ok := named.(ref.NamedTagged); ok {
+			tag = tagged.Tag()
+		}
+	}
+
+	return &imageupdate.Response{
+		HasUpdate:      false,
+		UpdateType:     models.UpdateTypeDigest,
+		CurrentVersion: tag,
+		LatestVersion:  tag,
+		CurrentDigest:  pinnedDigest,
+		LatestDigest:   pinnedDigest,
+		CheckTime:      time.Now(),
+		ResponseTimeMs: 0,
+	}, true
 }
 
 func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.Context, parts *ImageParts) (*imageupdate.Response, *localImageSnapshot, error) {
@@ -929,6 +982,11 @@ func (s *ImageUpdateService) parseAndGroupImagesInternal(imageRefs []string) (ma
 	indexByNormalizedRef := make(map[string]int)
 
 	for _, ref := range imageRefs {
+		if result, ok := digestPinnedImageUpdateResultInternal(ref); ok {
+			results[ref] = result
+			continue
+		}
+
 		parts := s.parseImageReference(ref)
 		if parts == nil {
 			results[ref] = &imageupdate.Response{
@@ -1133,9 +1191,21 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	regRepos, initialResults, images := s.parseAndGroupImagesInternal(imageRefs)
 	maps.Copy(results, initialResults)
-	for _, result := range initialResults {
-		if result != nil {
-			result.ActivityID = utils.StringPtrFromTrimmed(activityID)
+	for imageRef, result := range initialResults {
+		if result == nil {
+			continue
+		}
+		result.ActivityID = utils.StringPtrFromTrimmed(activityID)
+		if strings.TrimSpace(result.Error) != "" {
+			continue
+		}
+		if _, ok := updaterdigest.FromReferenceSuffix(imageRef); !ok {
+			continue
+		}
+
+		s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, imageRef+" — digest pinned, skipped", 5, "Skipping image update check")
+		if err := s.saveUpdateResultWithSnapshotInternal(ctx, imageRef, result, nil); err != nil {
+			slog.WarnContext(ctx, "Failed to save digest-pinned update result", "imageRef", imageRef, "error", err.Error())
 		}
 	}
 

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -500,6 +500,79 @@ func TestImageUpdateService_GetImageRefByIDInternal_UsesContainerFallback(t *tes
 	}
 }
 
+func TestImageUpdateService_CheckImageUpdate_SkipsDigestPinnedReferenceInternal(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+	pinnedDigest := digest.FromString("pinned-newt").String()
+	imageRef := "ghcr.io/fosrl/newt@" + pinnedDigest
+	eventService := NewEventService(db, nil, nil)
+	svc := NewImageUpdateService(db, nil, nil, nil, eventService, nil, nil)
+
+	result, err := svc.CheckImageUpdate(context.Background(), imageRef)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.HasUpdate)
+	assert.Equal(t, "digest", result.UpdateType)
+	assert.Equal(t, pinnedDigest, result.CurrentDigest)
+	assert.Equal(t, pinnedDigest, result.LatestDigest)
+	assert.Empty(t, result.Error)
+}
+
+func TestImageUpdateService_CheckMultipleImages_SkipsDigestPinnedReferenceInternal(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+	pinnedDigest := digest.FromString("batch-pinned-newt").String()
+	imageRef := "ghcr.io/fosrl/newt@" + pinnedDigest
+	svc := NewImageUpdateService(db, nil, nil, nil, nil, nil, nil)
+
+	regRepos, initialResults, grouped := svc.parseAndGroupImagesInternal([]string{imageRef})
+	require.Empty(t, regRepos)
+	require.Empty(t, grouped)
+	require.Contains(t, initialResults, imageRef)
+	require.NotNil(t, initialResults[imageRef])
+	assert.Empty(t, initialResults[imageRef].Error)
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{imageRef}, nil)
+	require.NoError(t, err)
+	require.Contains(t, results, imageRef)
+	require.NotNil(t, results[imageRef])
+	assert.False(t, results[imageRef].HasUpdate)
+	assert.Equal(t, "digest", results[imageRef].UpdateType)
+	assert.Equal(t, pinnedDigest, results[imageRef].CurrentDigest)
+	assert.Equal(t, pinnedDigest, results[imageRef].LatestDigest)
+	assert.Empty(t, results[imageRef].Error)
+}
+
+func TestImageUpdateService_CheckMultipleImages_SkippedDigestPinnedReferenceClearsStaleErrorInternal(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+	pinnedDigest := digest.FromString("stale-pinned-newt").String()
+	imageRef := "ghcr.io/fosrl/newt@" + pinnedDigest
+	repository := "ghcr.io/fosrl/newt"
+	staleError := "failed to get remote digest"
+	recordID := buildSyntheticImageUpdateRecordIDInternal(repository, "latest")
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:             recordID,
+		Repository:     repository,
+		Tag:            "latest",
+		HasUpdate:      false,
+		UpdateType:     "digest",
+		CurrentVersion: "latest",
+		LastError:      &staleError,
+		CheckTime:      time.Now().Add(-time.Hour),
+	}).Error)
+	svc := NewImageUpdateService(db, nil, nil, nil, nil, nil, nil)
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{imageRef}, nil)
+	require.NoError(t, err)
+	require.Contains(t, results, imageRef)
+	assert.Empty(t, results[imageRef].Error)
+
+	var saved models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", recordID).First(&saved).Error)
+	assert.False(t, saved.HasUpdate)
+	assert.Nil(t, saved.LastError)
+	assert.Equal(t, pinnedDigest, stringPtrToString(saved.CurrentDigest))
+	assert.Equal(t, pinnedDigest, stringPtrToString(saved.LatestDigest))
+}
+
 func TestImageUpdateService_CheckImageUpdate_UsesRegistryFallback(t *testing.T) {
 	db := setupImageUpdateTestDB(t)
 	localDigest := digest.FromString("localdigest").String()

--- a/go.work.sum
+++ b/go.work.sum
@@ -477,6 +477,8 @@ github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getarcaneapp/arcane/types v0.0.0-20251219045603-8a9960a2bf04/go.mod h1:7Wj+0JnpYq4RQS+otyM6e4zkyJKDC01wxkWPyFCHwZA=
+github.com/getarcaneapp/updater v0.3.5 h1:QMQgHF9vELSqoKKTKFAZuDgGkp4aU4GvlOP5bQ25l+8=
+github.com/getarcaneapp/updater v0.3.5/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gin-contrib/cors v1.7.7/go.mod h1:K5tW0RkzJtWSiOdikXloy8VEZlgdVNpHNw8FpjUPNrE=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

<!-- List specific changes with brief explanations -->

-
-
-

## Testing Done

<!-- Check all that apply and describe what you tested -->

- [ ] Development environment started: `./scripts/development/dev.sh start`
- [ ] Frontend verified at http://localhost:3000
- [ ] Backend verified at http://localhost:3552
- [ ] Manual testing completed (describe):
- [ ] No linting errors (e.g., `just lint all`)
- [ ] Backend tests pass: `just test backend`

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

AI Tool:
Assistance Level: <!-- Significant | Moderate | Minor | N/A -->
What AI helped with:
I reviewed and edited all AI-generated output:
I ran all required tests and manually verified changes:

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR skips remote registry checks for images referenced by pinned digest (e.g. `image@sha256:abc…`) and immediately returns a synthetic "no update" result, since a pinned-digest reference is immutable by definition. The `updater` dependency is bumped from v0.3.4 to v0.3.5 to expose `digest.FromReferenceSuffix`, which the new helper uses.

- Adds `digestPinnedImageUpdateResultInternal` to detect and short-circuit pinned-digest refs; wired into both the single-image (`CheckImageUpdate`) and batch (`CheckMultipleImages`) code paths.
- Refactors the `initialResults` loop in `CheckMultipleImages` to persist results and emit an activity message for pinned images, reporting progress at `5` (fixing the earlier `100` regression concern).
- Adds three table-driven tests covering the single-image skip, the batch skip, and stale-error clearing on a persisted record.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, both code paths are covered by new tests, and the fix avoids unnecessary network calls without altering any existing behavior for non-pinned images.

The logic is straightforward: pinned-digest images are detected via `FromReferenceSuffix` and short-circuited before any network call. The three new tests verify the single-image path, the batch path, and stale-error clearing on persisted records. No data-loss or regression risk was identified.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip checking for updates on pinned..."](https://github.com/getarcaneapp/arcane/commit/1bb76c2c436ef961812a0b6f9ca345f64e0f93ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36017770)</sub>

<!-- /greptile_comment -->