### PR TITLE
feat: customizable font size per user

### DIFF
--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -68,6 +68,7 @@ type UpdateMyProfileInput struct {
 		DisplayName *string `json:"displayName,omitempty"`
 		Email       *string `json:"email,omitempty"`
 		Locale      *string `json:"locale,omitempty"`
+		FontSize    *int    `json:"fontSize,omitempty" minimum:"12" maximum:"20"`
 	}
 }
 
@@ -410,6 +411,9 @@ func (h *AuthHandler) UpdateMyProfile(ctx context.Context, input *UpdateMyProfil
 	}
 	if input.Body.Locale != nil {
 		userModel.Locale = input.Body.Locale
+	}
+	if input.Body.FontSize != nil {
+		userModel.FontSize = input.Body.FontSize
 	}
 
 	updated, err := h.userService.UpdateUser(ctx, userModel)

--- a/backend/cli/upgrade/upgrade.go
+++ b/backend/cli/upgrade/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -180,11 +181,26 @@ func isLegacyServerLabel(labels map[string]string) bool {
 		return false
 	}
 	for k, v := range labels {
-		if strings.EqualFold(k, "com.getarcaneapp.arcane.server") {
+		if strings.EqualFold(k, updaterlabels.LabelArcaneLegacyServer) {
 			return strings.EqualFold(strings.TrimSpace(v), "true")
 		}
 	}
 	return false
+}
+
+func normalizeRecreatedArcaneLabelsInternal(labels map[string]string) map[string]string {
+	normalized := maps.Clone(labels)
+	if normalized == nil {
+		return nil
+	}
+	if updaterlabels.IsArcaneContainer(labels) || isLegacyServerLabel(labels) {
+		normalized[updaterlabels.LabelArcane] = "true"
+	}
+	if updaterlabels.IsArcaneAgentContainer(labels) {
+		normalized[updaterlabels.LabelArcaneAgent] = "true"
+		normalized[updaterlabels.LabelArcane] = "true"
+	}
+	return normalized
 }
 
 func isAgentContainer(inspect container.InspectResponse) bool {
@@ -341,6 +357,7 @@ func upgradeContainer(ctx context.Context, dockerClient *client.Client, oldConta
 	// Create new container config
 	config := *oldContainer.Config
 	config.Image = newImage
+	config.Labels = normalizeRecreatedArcaneLabelsInternal(config.Labels)
 
 	hostConfig, sanitizedMemorySwappiness, engineInfo, err := libarcane.PrepareRecreateHostConfigForEngine(ctx, dockerClient, oldContainer.HostConfig)
 	if err != nil {

--- a/backend/cli/upgrade/upgrade_test.go
+++ b/backend/cli/upgrade/upgrade_test.go
@@ -1,0 +1,71 @@
+package upgrade
+
+import (
+	"testing"
+
+	updaterlabels "github.com/getarcaneapp/updater/pkg/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRecreatedArcaneLabelsInternal(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     map[string]string
+		want       map[string]string
+		wantSource map[string]string
+	}{
+		{
+			name: "legacy server gains current Arcane label",
+			labels: map[string]string{
+				updaterlabels.LabelArcaneLegacyServer: "true",
+				updaterlabels.LabelUpdater:            "false",
+				"com.example.unrelated":               "keep",
+			},
+			want: map[string]string{
+				updaterlabels.LabelArcaneLegacyServer: "true",
+				updaterlabels.LabelArcane:             "true",
+				updaterlabels.LabelUpdater:            "false",
+				"com.example.unrelated":               "keep",
+			},
+			wantSource: map[string]string{
+				updaterlabels.LabelArcaneLegacyServer: "true",
+				updaterlabels.LabelUpdater:            "false",
+				"com.example.unrelated":               "keep",
+			},
+		},
+		{
+			name: "agent gains current Arcane label",
+			labels: map[string]string{
+				updaterlabels.LabelArcaneAgent: "true",
+			},
+			want: map[string]string{
+				updaterlabels.LabelArcane:      "true",
+				updaterlabels.LabelArcaneAgent: "true",
+			},
+			wantSource: map[string]string{
+				updaterlabels.LabelArcaneAgent: "true",
+			},
+		},
+		{
+			name: "unrelated labels are preserved without Arcane label",
+			labels: map[string]string{
+				"com.example.unrelated": "keep",
+			},
+			want: map[string]string{
+				"com.example.unrelated": "keep",
+			},
+			wantSource: map[string]string{
+				"com.example.unrelated": "keep",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeRecreatedArcaneLabelsInternal(tt.labels)
+
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantSource, tt.labels)
+		})
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getarcaneapp/arcane/cli v1.19.5
 	github.com/getarcaneapp/arcane/types v1.19.5
-	github.com/getarcaneapp/updater v0.3.5
+	github.com/getarcaneapp/updater v0.3.6
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/goccy/go-yaml v1.19.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -171,7 +171,7 @@ github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQ
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getarcaneapp/updater v0.3.5 h1:QMQgHF9vELSqoKKTKFAZuDgGkp4aU4GvlOP5bQ25l+8=
+github.com/getarcaneapp/updater v0.3.6 h1:OKoXANvlGZ/s6mQuqVeVHXJXn9Pc3cUwUSG8A3ToOQ4=
 github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ=
 github.com/glebarez/go-sqlite v1.22.0/go.mod h1:PlBIdHe0+aUEFn+r2/uthrWq4FxbzugL0L8Li6yQJbc=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	OidcSubjectId          *string    `json:"oidcSubjectId,omitempty" gorm:"column:oidc_subject_id"`
 	LastLogin              *time.Time `json:"lastLogin,omitempty" gorm:"column:last_login" sortable:"true"`
 	Locale                 *string    `json:"locale,omitempty" gorm:"column:locale"`
+	FontSize               *int       `json:"fontSize,omitempty" gorm:"column:font_size"`
 	RequiresPasswordChange bool       `json:"requiresPasswordChange" gorm:"column:requires_password_change"`
 	IsServiceAccount       bool       `json:"isServiceAccount" gorm:"column:is_service_account;not null;default:false"`
 

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -2889,6 +2889,18 @@ func TestProjectService_MapProjectToDto_SetsRedeployDisabledFromRuntimeServices(
 			wantService: true,
 		},
 		{
+			name:               "current legacy Arcane server container disables project redeploy",
+			containerID:        "arcane1234567890",
+			currentContainerID: "arcane1234567890",
+			labels: map[string]string{
+				"com.docker.compose.project":       "arcane",
+				"com.docker.compose.service":       "server",
+				libupdater.LabelArcaneLegacyServer: "true",
+			},
+			wantProject: true,
+			wantService: true,
+		},
+		{
 			name:        "Arcane server container fails closed when current container is unavailable",
 			containerID: "arcane1234567890",
 			currentErr:  errors.New("not running in docker"),

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -677,6 +677,98 @@ func TestUpdaterService_ApplyPending_ProjectFailureDoesNotBlockOtherProjectsInte
 	assert.Contains(t, recordedStatuses, moduletypes.StatusUpdated)
 }
 
+func TestUpdaterService_ApplyPending_RoutesLegacyArcaneServerThroughSelfUpgradeInternal(t *testing.T) {
+	ctx := context.Background()
+
+	oldRef := "ghcr.io/getarcaneapp/arcane:1.0.0"
+	newRef := "ghcr.io/getarcaneapp/arcane:1.0.1"
+	oldImageID := "sha256:old-arcane"
+	newImageID := "sha256:new-arcane"
+	arcaneLabels := map[string]string{
+		"com.docker.compose.project":          "arcane",
+		"com.docker.compose.service":          "server",
+		updaterlabels.LabelArcaneLegacyServer: "true",
+	}
+
+	containers := []container.Summary{
+		{
+			ID:      "arcane-container",
+			Names:   []string{"/arcane"},
+			Image:   oldRef,
+			ImageID: oldImageID,
+			Labels:  arcaneLabels,
+			State:   "running",
+		},
+	}
+	verificationByService := map[string][]container.Summary{
+		"arcane/server": {
+			{
+				ID:      "arcane-container-new",
+				Names:   []string{"/arcane"},
+				Image:   newRef,
+				ImageID: newImageID,
+				Labels:  arcaneLabels,
+				State:   "running",
+			},
+		},
+	}
+	inspectByID := map[string]container.InspectResponse{
+		"arcane-container": {
+			ID:    "arcane-container",
+			Name:  "/arcane",
+			Image: oldImageID,
+			Config: &container.Config{
+				Image:  oldRef,
+				Labels: arcaneLabels,
+			},
+		},
+	}
+	imageInspectByRef := map[string]dockertypesimage.InspectResponse{
+		newRef: {
+			ID:       newImageID,
+			RepoTags: []string{newRef},
+		},
+	}
+
+	server := newUpdaterApplyPendingDockerServerInternal(t, containers, verificationByService, inspectByID, imageInspectByRef)
+	dockerProvider := fakeDockerClientProviderInternal{client: newTestDockerClient(t, server)}
+	puller := &fakeImagePullerInternal{}
+	projectUpdater := &fakeProjectUpdaterInternal{
+		projects: map[string]moduletypes.ComposeProject{
+			"arcane": {ID: "project-arcane", Name: "arcane"},
+		},
+	}
+	mockUpgrade := &mockSystemUpgradeServiceInternal{}
+
+	svc := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+	svc.engine = moduleapi.NewService(moduleapi.Config{
+		DockerClientProvider: dockerProvider,
+		ImagePuller:          puller,
+		PendingStore: moduleapi.NewMemoryPendingStore(moduletypes.ImageUpdateRecord{
+			ID:             oldImageID,
+			Repository:     "ghcr.io/getarcaneapp/arcane",
+			Tag:            "1.0.0",
+			HasUpdate:      true,
+			UpdateType:     moduletypes.UpdateTypeTag,
+			CurrentVersion: "1.0.0",
+			LatestVersion:  ptr("1.0.1"),
+		}),
+		Settings:       fakeSettingsProviderInternal{},
+		ProjectUpdater: projectUpdater,
+		SelfUpdater:    svc,
+		UsedImageCollector: fakeUsedImageCollectorInternal{images: map[string]struct{}{
+			oldRef: {},
+		}},
+		LabelPolicy: updaterlabels.DefaultLabelPolicy(),
+	})
+
+	result, err := svc.ApplyPending(ctx, arcaneupdater.Options{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, mockUpgrade.triggerCalled, "scheduled auto-update should use CLI self-upgrade for legacy Arcane server labels")
+	assert.Empty(t, projectUpdater.calls, "legacy Arcane server should not be updated through project services")
+}
+
 func TestResolvePullableImageRefInternal(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -442,6 +442,7 @@ func (s *UserService) toUserResponseDtoInternal(ctx context.Context, u models.Us
 		CanDelete:              true,
 		OidcSubjectId:          u.OidcSubjectId,
 		Locale:                 u.Locale,
+		FontSize:               u.FontSize,
 		RequiresPasswordChange: u.RequiresPasswordChange,
 		CreatedAt:              u.CreatedAt.Format("2006-01-02T15:04:05.999999Z"),
 		UpdatedAt:              u.UpdatedAt.Format("2006-01-02T15:04:05.999999Z"),

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -134,3 +134,26 @@ func TestDeleteUserRejectsDeletingOnlyCustomAllPermissionsAdmin(t *testing.T) {
 	require.False(t, users[0].CanDelete)
 	require.True(t, users[0].IsGlobalAdmin)
 }
+
+func TestUpdateUserPersistsFontSizeAndMapsToDto(t *testing.T) {
+	userSvc, _ := setupUserAndRoleServices(t)
+	ctx := context.Background()
+
+	u := createTestUser(t, userSvc, "user-1", "fontuser")
+	require.Nil(t, u.FontSize, "new users default to no explicit font size")
+
+	size := 16
+	u.FontSize = &size
+	_, err := userSvc.UpdateUser(ctx, u)
+	require.NoError(t, err)
+
+	reloaded, err := userSvc.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.FontSize)
+	require.Equal(t, 16, *reloaded.FontSize)
+
+	dto, err := userSvc.ToUserResponseDto(ctx, *reloaded)
+	require.NoError(t, err)
+	require.NotNil(t, dto.FontSize)
+	require.Equal(t, 16, *dto.FontSize)
+}

--- a/backend/resources/migrations/postgres/057_add_user_font_size.sql
+++ b/backend/resources/migrations/postgres/057_add_user_font_size.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN IF NOT EXISTS font_size INTEGER;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS font_size;

--- a/backend/resources/migrations/sqlite/057_add_user_font_size.sql
+++ b/backend/resources/migrations/sqlite/057_add_user_font_size.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN font_size INTEGER;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN font_size;

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4,6 +4,8 @@
 	"layout_title": "Arcane",
 	"accent_color": "Accent Color",
 	"accent_color_description": "Select an accent color to customize the appearance of Arcane",
+	"font_size": "Font size",
+	"font_size_description": "Adjust the size of text and the UI",
 	"application_theme": "Application Theme",
 	"application_theme_description": "Choose the overall visual theme for Arcane. This setting is stored globally and previews immediately.",
 	"application_theme_default": "Default",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -5,6 +5,12 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Orientation/state variants used by shadcn components (e.g. the slider),
+   which key off bits-ui's data-orientation / data-disabled attributes. */
+@custom-variant data-horizontal (&[data-orientation='horizontal']);
+@custom-variant data-vertical (&[data-orientation='vertical']);
+@custom-variant data-disabled (&[data-disabled]);
+
 /* BASE THEMES */
 :root {
 	--radius: 0.6rem;

--- a/frontend/src/lib/components/font-size-picker.svelte
+++ b/frontend/src/lib/components/font-size-picker.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import * as Slider from '$lib/components/ui/slider/index.js';
+	import userStore from '$lib/stores/user-store';
+	import { userService } from '$lib/services/user-service';
+	import { applyFontSize, FONT_SIZE_MIN, FONT_SIZE_MAX, FONT_SIZE_DEFAULT } from '$lib/utils/theme';
+	import { debounced } from '$lib/utils/ws';
+	import { queryKeys } from '$lib/query/query-keys';
+	import { useQueryClient } from '@tanstack/svelte-query';
+	import { get } from 'svelte/store';
+	import { m } from '$lib/paraglide/messages';
+
+	let { id = 'fontSizePicker', class: className = '' }: { id?: string; class?: string } = $props();
+
+	const queryClient = useQueryClient();
+
+	const initialSize = get(userStore)?.fontSize ?? FONT_SIZE_DEFAULT;
+	let currentSize = $state(initialSize);
+	let lastPersisted = initialSize;
+
+	const persist = debounced(async (px: number) => {
+		const previous = lastPersisted;
+		try {
+			await userService.updateMyProfile({ fontSize: px });
+			lastPersisted = px;
+			await queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
+		} catch (err) {
+			console.error('Failed to update font size', err);
+			currentSize = previous;
+			applyFontSize(previous);
+		}
+	}, 400);
+
+	function handleChange(px: number) {
+		applyFontSize(px);
+		persist(px);
+	}
+</script>
+
+<div class={`font-size-picker flex items-center gap-3 ${className}`}>
+	<Slider.Root
+		type="single"
+		bind:value={currentSize}
+		min={FONT_SIZE_MIN}
+		max={FONT_SIZE_MAX}
+		step={1}
+		showTicks
+		onValueChange={handleChange}
+		{id}
+		aria-label={m.font_size()}
+		class="w-40 sm:w-44"
+	/>
+	<span class="text-muted-foreground w-10 text-right text-sm tabular-nums">{currentSize}px</span>
+</div>

--- a/frontend/src/lib/components/ui/slider/index.ts
+++ b/frontend/src/lib/components/ui/slider/index.ts
@@ -1,0 +1,7 @@
+import Root from './slider.svelte';
+
+export {
+	Root,
+	//
+	Root as Slider
+};

--- a/frontend/src/lib/components/ui/slider/slider.svelte
+++ b/frontend/src/lib/components/ui/slider/slider.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { Slider as SliderPrimitive } from 'bits-ui';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		orientation = 'horizontal',
+		showTicks = false,
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> & { showTicks?: boolean } = $props();
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<SliderPrimitive.Root
+	bind:ref
+	bind:value={value as never}
+	data-slot="slider"
+	{orientation}
+	class={cn(
+		'data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col',
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ thumbItems, ticks })}
+		<span
+			data-slot="slider-track"
+			data-orientation={orientation}
+			class={cn(
+				'bg-muted relative grow overflow-hidden rounded-full data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1'
+			)}
+		>
+			<SliderPrimitive.Range
+				data-slot="slider-range"
+				class={cn('bg-primary absolute select-none data-horizontal:h-full data-vertical:w-full')}
+			/>
+		</span>
+		{#if showTicks && orientation === 'horizontal' && ticks.length > 1}
+			<span
+				aria-hidden="true"
+				data-slot="slider-ticks"
+				class="pointer-events-none absolute inset-x-0 top-1/2 -mt-0.5 h-1"
+				style="background-image: repeating-linear-gradient(to right, var(--muted-foreground) 0, var(--muted-foreground) 1px, transparent 1px, transparent calc((100% - 1px) / {ticks.length -
+					1}));"
+			></span>
+		{/if}
+		{#each thumbItems as thumb (thumb.index)}
+			<SliderPrimitive.Thumb
+				data-slot="slider-thumb"
+				index={thumb.index}
+				class="border-ring ring-ring/50 relative block size-3 shrink-0 rounded-full border bg-white transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
+			/>
+		{/each}
+	{/snippet}
+</SliderPrimitive.Root>

--- a/frontend/src/lib/services/user-service.ts
+++ b/frontend/src/lib/services/user-service.ts
@@ -38,7 +38,7 @@ class UserAPIService extends BaseAPIService {
 		return this.handleResponse(this.api.post('/auth/sessions/logout-all')) as Promise<void>;
 	}
 
-	async updateMyProfile(data: { displayName?: string; email?: string; locale?: string }): Promise<User> {
+	async updateMyProfile(data: { displayName?: string; email?: string; locale?: string; fontSize?: number }): Promise<User> {
 		return this.handleResponse(this.api.put('/auth/me/profile', data)) as Promise<User>;
 	}
 }

--- a/frontend/src/lib/stores/user-store.ts
+++ b/frontend/src/lib/stores/user-store.ts
@@ -2,6 +2,7 @@ import type { User } from '$lib/types/auth';
 import { GLOBAL_SCOPE, SUDO_PERMISSION } from '$lib/types/auth';
 import { writable, get } from 'svelte/store';
 import { setLocale } from '$lib/utils/formatting';
+import { applyFontSize, FONT_SIZE_DEFAULT } from '$lib/utils/theme';
 
 const userStore = writable<User | null>(null);
 
@@ -9,10 +10,12 @@ const setUser = async (user: User) => {
 	if (user.locale) {
 		await setLocale(user.locale, false);
 	}
+	applyFontSize(user.fontSize ?? FONT_SIZE_DEFAULT);
 	userStore.set(user);
 };
 
 const clearUser = () => {
+	applyFontSize(FONT_SIZE_DEFAULT);
 	userStore.set(null);
 };
 

--- a/frontend/src/lib/types/auth.ts
+++ b/frontend/src/lib/types/auth.ts
@@ -143,6 +143,7 @@ export type User = {
 	updatedAt?: string;
 	oidcSubjectId?: string;
 	locale?: Locale;
+	fontSize?: number;
 	requiresPasswordChange?: boolean;
 };
 

--- a/frontend/src/lib/utils/theme.ts
+++ b/frontend/src/lib/utils/theme.ts
@@ -364,3 +364,28 @@ export function applyOledMode(enabled: boolean): void {
 
 	syncBrowserThemeColor();
 }
+
+export const FONT_SIZE_MIN = 12;
+export const FONT_SIZE_MAX = 20;
+export const FONT_SIZE_DEFAULT = 14; // matches `html { font-size: 14px }` in app.css
+
+/**
+ * Apply the user's preferred root font size. The UI is sized in `rem` off the
+ * root element, so this scales text and spacing together (a whole-UI zoom). At
+ * the default size we remove the inline override so the CSS rule wins.
+ */
+export function applyFontSize(px?: number | null): void {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	const root = document.documentElement;
+
+	if (px == null || px === FONT_SIZE_DEFAULT) {
+		root.style.removeProperty('font-size');
+		return;
+	}
+
+	const clamped = Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, Math.round(px)));
+	root.style.fontSize = `${clamped}px`;
+}

--- a/frontend/src/routes/(app)/account/+page.svelte
+++ b/frontend/src/routes/(app)/account/+page.svelte
@@ -13,6 +13,8 @@
 	import * as Avatar from '$lib/components/ui/avatar';
 	import { ArcaneButton } from '$lib/components/arcane-button/index.js';
 	import LocalePicker from '$lib/components/locale-picker.svelte';
+	import FontSizePicker from '$lib/components/font-size-picker.svelte';
+	import { m } from '$lib/paraglide/messages';
 	import { userService } from '$lib/services/user-service';
 	import { apiKeyService } from '$lib/services/api-key-service';
 	import { roleService } from '$lib/services/role-service';
@@ -383,6 +385,13 @@
 								<div class="text-muted-foreground text-xs">UI language for this account</div>
 							</div>
 							<LocalePicker inline />
+						</div>
+						<div class="flex items-center justify-between gap-4 p-3">
+							<div class="min-w-0">
+								<div class="text-sm font-medium">{m.font_size()}</div>
+								<div class="text-muted-foreground text-xs">{m.font_size_description()}</div>
+							</div>
+							<FontSizePicker />
 						</div>
 					</div>
 				</Card>

--- a/go.work.sum
+++ b/go.work.sum
@@ -477,8 +477,9 @@ github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getarcaneapp/arcane/types v0.0.0-20251219045603-8a9960a2bf04/go.mod h1:7Wj+0JnpYq4RQS+otyM6e4zkyJKDC01wxkWPyFCHwZA=
-github.com/getarcaneapp/updater v0.3.5 h1:QMQgHF9vELSqoKKTKFAZuDgGkp4aU4GvlOP5bQ25l+8=
 github.com/getarcaneapp/updater v0.3.5/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
+github.com/getarcaneapp/updater v0.3.6 h1:OKoXANvlGZ/s6mQuqVeVHXJXn9Pc3cUwUSG8A3ToOQ4=
+github.com/getarcaneapp/updater v0.3.6/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gin-contrib/cors v1.7.7/go.mod h1:K5tW0RkzJtWSiOdikXloy8VEZlgdVNpHNw8FpjUPNrE=

--- a/types/user/user.go
+++ b/types/user/user.go
@@ -41,6 +41,7 @@ type User struct {
 	CanDelete              bool                    `json:"canDelete" doc:"Whether the user can currently be deleted"`
 	OidcSubjectId          *string                 `json:"oidcSubjectId,omitempty" doc:"OIDC subject identifier for SSO users"`
 	Locale                 *string                 `json:"locale,omitempty" doc:"Locale preference of the user" example:"en-US"`
+	FontSize               *int                    `json:"fontSize,omitempty" minimum:"12" maximum:"20" doc:"Preferred root UI font size in px" example:"14"`
 	CreatedAt              string                  `json:"createdAt,omitempty" doc:"Date and time when the user was created"`
 	UpdatedAt              string                  `json:"updatedAt,omitempty" doc:"Date and time when the user was last updated"`
 	RequiresPasswordChange bool                    `json:"requiresPasswordChange" doc:"Whether the user must change their password"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds per-user font-size preference: a new `font_size` INTEGER column on the `users` table (with Postgres and SQLite migrations), a Huma-validated `fontSize` field on the profile-update endpoint, an `applyFontSize` helper that scales the UI via `rem`, and a slider component on the account page that debounces persistence and rolls back visually on failure. It also bumps `getarcaneapp/updater` from v0.3.5 to v0.3.6 and adds `normalizeRecreatedArcaneLabelsInternal` to ensure containers carrying only the legacy Arcane label get the current `LabelArcane` label applied during upgrades.

- **Font-size feature**: server-side range validation via Huma struct tags (`minimum:"12" maximum:"20"`), client-side clamping in `applyFontSize`, and UI rollback on API error are all present and correct.
- **Updater change**: the new label-normalization logic is exercised by a new table-driven test that also verifies the source map is not mutated (via `maps.Clone`).
- **Migrations**: both Postgres and SQLite up migrations are correct; SQLite down follows the existing comment-only convention used for `locale` (migration 012).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only finding is a style inconsistency in the font-size picker.

The feature is well-rounded: server-side range enforcement, client-side clamping, visual rollback on error, and good test coverage across Go and frontend. The one issue is the Promise chain in font-size-picker.svelte where async/await is the project standard.

frontend/src/lib/components/font-size-picker.svelte — the persist callback style.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat%2Fcustomizable-font-size%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcustomizable-font-size%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Ffont-size-picker.svelte%3A20-33%0AThe%20%60persist%60%20callback%20uses%20a%20Promise%20chain%20%28%60.then%28%29.catch%28%29%60%29%20rather%20than%20%60async%2Fawait%60%2C%20which%20violates%20the%20project's%20JS%2FTS%20style%20rule.%20The%20debounce%20wrapper%20discards%20the%20return%20value%20anyway%2C%20so%20an%20%60async%60%20callback%20works%20correctly%20here%20%E2%80%94%20errors%20are%20caught%20inside%20the%20function%20before%20they%20can%20bubble.%0A%0A%60%60%60suggestion%0A%09const%20persist%20%3D%20debounced%28async%20%28px%3A%20number%29%20%3D%3E%20%7B%0A%09%09const%20previous%20%3D%20lastPersisted%3B%0A%09%09try%20%7B%0A%09%09%09await%20userService.updateMyProfile%28%7B%20fontSize%3A%20px%20%7D%29%3B%0A%09%09%09lastPersisted%20%3D%20px%3B%0A%09%09%09await%20queryClient.invalidateQueries%28%7B%20queryKey%3A%20queryKeys.users.all%20%7D%29%3B%0A%09%09%7D%20catch%20%28err%29%20%7B%0A%09%09%09console.error%28'Failed%20to%20update%20font%20size'%2C%20err%29%3B%0A%09%09%09currentSize%20%3D%20previous%3B%0A%09%09%09applyFontSize%28previous%29%3B%0A%09%09%7D%0A%09%7D%2C%20400%29%3B%0A%60%60%60%0A%0AUse%20const%2Fle...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=2848&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Ffont-size-picker.svelte%3A20-33%0AThe%20%60persist%60%20callback%20uses%20a%20Promise%20chain%20%28%60.then%28%29.catch%28%29%60%29%20rather%20than%20%60async%2Fawait%60%2C%20which%20violates%20the%20project's%20JS%2FTS%20style%20rule.%20The%20debounce%20wrapper%20discards%20the%20return%20value%20anyway%2C%20so%20an%20%60async%60%20callback%20works%20correctly%20here%20%E2%80%94%20errors%20are%20caught%20inside%20the%20function%20before%20they%20can%20bubble.%0A%0A%60%60%60suggestion%0A%09const%20persist%20%3D%20debounced%28async%20%28px%3A%20number%29%20%3D%3E%20%7B%0A%09%09const%20previous%20%3D%20lastPersisted%3B%0A%09%09try%20%7B%0A%09%09%09await%20userService.updateMyProfile%28%7B%20fontSize%3A%20px%20%7D%29%3B%0A%09%09%09lastPersisted%20%3D%20px%3B%0A%09%09%09await%20queryClient.invalidateQueries%28%7B%20queryKey%3A%20queryKeys.users.all%20%7D%29%3B%0A%09%09%7D%20catch%20%28err%29%20%7B%0A%09%09%09console.error%28'Failed%20to%20update%20font%20size'%2C%20err%29%3B%0A%09%09%09currentSize%20%3D%20previous%3B%0A%09%09%09applyFontSize%28previous%29%3B%0A%09%09%7D%0A%09%7D%2C%20400%29%3B%0A%60%60%60%0A%0AUse%20const%2Fle...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D68c6ab5b-40de-4e3c-a803-95d60efb41a6%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=2848&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/lib/components/font-size-picker.svelte:20-33
The `persist` callback uses a Promise chain (`.then().catch()`) rather than `async/await`, which violates the project's JS/TS style rule. The debounce wrapper discards the return value anyway, so an `async` callback works correctly here — errors are caught inside the function before they can bubble.

```suggestion
	const persist = debounced(async (px: number) => {
		const previous = lastPersisted;
		try {
			await userService.updateMyProfile({ fontSize: px });
			lastPersisted = px;
			await queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
		} catch (err) {
			console.error('Failed to update font size', err);
			currentSize = previous;
			applyFontSize(previous);
		}
	}, 400);
```

Use const/le... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: customizable font size per user"](https://github.com/getarcaneapp/arcane/commit/f3f3dcb02351ed2c32cc7f2efdd1a45937a3ae9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36085999)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - JavaScript/TypeScript Best Practices

Use const/le... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=68c6ab5b-40de-4e3c-a803-95d60efb41a6))

<!-- /greptile_comment -->