### PR TITLE
fix: decrypting of notification tokens failing

### DIFF
--- a/backend/api/handlers/notifications.go
+++ b/backend/api/handlers/notifications.go
@@ -188,7 +188,7 @@ func (h *NotificationHandler) GetAllNotificationSettings(ctx context.Context, in
 			ID:       setting.ID,
 			Provider: notification.Provider(setting.Provider),
 			Enabled:  setting.Enabled,
-			Config:   base.JsonObject(setting.Config),
+			Config:   base.JsonObject(services.RedactNotificationConfigCredentials(setting.Provider, setting.Config)),
 		}
 	}
 
@@ -210,7 +210,7 @@ func (h *NotificationHandler) GetNotificationSettings(ctx context.Context, input
 		ID:       settings.ID,
 		Provider: notification.Provider(settings.Provider),
 		Enabled:  settings.Enabled,
-		Config:   base.JsonObject(settings.Config),
+		Config:   base.JsonObject(services.RedactNotificationConfigCredentials(settings.Provider, settings.Config)),
 	}
 
 	return &GetNotificationSettingsOutput{Body: response}, nil
@@ -239,7 +239,7 @@ func (h *NotificationHandler) CreateOrUpdateNotificationSettings(ctx context.Con
 		ID:       settings.ID,
 		Provider: notification.Provider(settings.Provider),
 		Enabled:  settings.Enabled,
-		Config:   base.JsonObject(settings.Config),
+		Config:   base.JsonObject(services.RedactNotificationConfigCredentials(settings.Provider, settings.Config)),
 	}
 
 	return &CreateOrUpdateNotificationSettingsOutput{Body: response}, nil

--- a/backend/api/handlers/notifications_test.go
+++ b/backend/api/handlers/notifications_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/crypto"
 	notificationdto "github.com/getarcaneapp/arcane/types/v2/notification"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,41 @@ func TestNormalizeNotificationTestType(t *testing.T) {
 	assert.Equal(t, "simple", normalizeNotificationTestType("  "))
 	assert.Equal(t, "auto-heal", normalizeNotificationTestType("auto-heal"))
 	assert.Equal(t, "auto-heal", normalizeNotificationTestType("  auto-heal  "))
+}
+
+func TestNotificationHandlerGetAllNotificationSettingsRedactsCredentialsInternal(t *testing.T) {
+	ctx := context.Background()
+	crypto.InitEncryption(&crypto.Config{
+		EncryptionKey: "test-encryption-key-for-testing-32bytes-min",
+		Environment:   "test",
+	})
+
+	db, svc := setupNotificationHandlerTestService(t)
+	h := &NotificationHandler{
+		notificationService: svc,
+		config:              &config.Config{},
+	}
+
+	_, err := svc.CreateOrUpdateSettings(ctx, models.NotificationProviderDiscord, true, models.JSON{
+		"webhookId": "123456789",
+		"token":     "discord-secret-token",
+		"username":  "Arcane",
+	})
+	require.NoError(t, err)
+
+	output, err := h.GetAllNotificationSettings(ctx, &GetAllNotificationSettingsInput{EnvironmentID: "0"})
+	require.NoError(t, err)
+	require.Len(t, output.Body, 1)
+	require.Equal(t, "123456789", output.Body[0].Config["webhookId"])
+	require.Equal(t, "Arcane", output.Body[0].Config["username"])
+	require.Empty(t, output.Body[0].Config["token"])
+
+	var stored models.NotificationSettings
+	require.NoError(t, db.WithContext(ctx).Where("provider = ?", models.NotificationProviderDiscord).First(&stored).Error)
+	require.NotEqual(t, "discord-secret-token", stored.Config["token"])
+	decrypted, err := crypto.Decrypt(stored.Config["token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, "discord-secret-token", decrypted)
 }
 
 func TestDispatchNotification_RejectsAgentModeInternal(t *testing.T) {

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -3,11 +3,13 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/mail"
 	"strings"
@@ -43,6 +45,18 @@ var supportedNotificationTestTypes = map[string]struct{}{
 	notificationTestTypeVulnerability:    {},
 	notificationTestTypePruneReport:      {},
 	notificationTestTypeAutoHeal:         {},
+}
+
+var notificationCredentialFieldsByProviderInternal = map[models.NotificationProvider][]string{
+	models.NotificationProviderDiscord:  {"token"},
+	models.NotificationProviderEmail:    {"smtpPassword"},
+	models.NotificationProviderTelegram: {"botToken"},
+	models.NotificationProviderSignal:   {"password", "token"},
+	models.NotificationProviderSlack:    {"token"},
+	models.NotificationProviderNtfy:     {"password"},
+	models.NotificationProviderPushover: {"token"},
+	models.NotificationProviderGotify:   {"token"},
+	models.NotificationProviderMatrix:   {"password"},
 }
 
 var ErrUnauthorizedNotificationDispatch = errors.New("unauthorized notification dispatch")
@@ -264,12 +278,23 @@ func (s *NotificationService) GetSettingsByProvider(ctx context.Context, provide
 func (s *NotificationService) CreateOrUpdateSettings(ctx context.Context, provider models.NotificationProvider, enabled bool, config models.JSON) (*models.NotificationSettings, error) {
 	var setting models.NotificationSettings
 
+	err := s.db.WithContext(ctx).Where("provider = ?", provider).First(&setting).Error
+	existingConfig := models.JSON(nil)
+	if err == nil {
+		existingConfig = setting.Config
+	}
+
 	// Clear config if provider is disabled
 	if !enabled {
 		config = models.JSON{}
 	}
 
-	err := s.db.WithContext(ctx).Where("provider = ?", provider).First(&setting).Error
+	encryptedConfig, encryptErr := encryptNotificationConfigCredentialsInternal(provider, config, existingConfig)
+	if encryptErr != nil {
+		return nil, encryptErr
+	}
+	config = encryptedConfig
+
 	if err != nil {
 		setting = models.NotificationSettings{
 			Provider: provider,
@@ -288,6 +313,82 @@ func (s *NotificationService) CreateOrUpdateSettings(ctx context.Context, provid
 	}
 
 	return &setting, nil
+}
+
+// RedactNotificationConfigCredentials returns a copy of config with provider credential fields blanked for API responses.
+func RedactNotificationConfigCredentials(provider models.NotificationProvider, config models.JSON) models.JSON {
+	redacted := cloneNotificationConfigInternal(config)
+	for _, field := range notificationCredentialFieldsByProviderInternal[provider] {
+		value, ok := redacted[field]
+		if !ok {
+			continue
+		}
+		if value == "" {
+			delete(redacted, field)
+			continue
+		}
+		redacted[field] = ""
+	}
+	return redacted
+}
+
+func encryptNotificationConfigCredentialsInternal(provider models.NotificationProvider, config models.JSON, existingConfig models.JSON) (models.JSON, error) {
+	encryptedConfig := cloneNotificationConfigInternal(config)
+	preserveConfig := existingConfig
+	if provider == models.NotificationProviderSignal {
+		preserveConfig = signalCredentialPreservationConfigInternal(config, existingConfig)
+	}
+	for _, field := range notificationCredentialFieldsByProviderInternal[provider] {
+		value, _ := encryptedConfig[field].(string)
+		if value == "" {
+			if existingValue, ok := preserveConfig[field].(string); ok && existingValue != "" {
+				encryptedConfig[field] = existingValue
+			}
+			continue
+		}
+
+		encrypted, err := encryptNotificationCredentialInternal(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt notification credential %q: %w", field, err)
+		}
+		encryptedConfig[field] = encrypted
+	}
+	return encryptedConfig, nil
+}
+
+func signalCredentialPreservationConfigInternal(config models.JSON, existingConfig models.JSON) models.JSON {
+	preserveConfig := cloneNotificationConfigInternal(existingConfig)
+	user, _ := config["user"].(string)
+	password, _ := config["password"].(string)
+	token, _ := config["token"].(string)
+
+	if strings.TrimSpace(token) != "" {
+		delete(preserveConfig, "password")
+	}
+	if strings.TrimSpace(user) != "" || strings.TrimSpace(password) != "" {
+		delete(preserveConfig, "token")
+	}
+
+	return preserveConfig
+}
+
+func encryptNotificationCredentialInternal(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if _, err := crypto.Decrypt(value); err == nil {
+		return value, nil
+	}
+	return crypto.Encrypt(value)
+}
+
+func cloneNotificationConfigInternal(config models.JSON) models.JSON {
+	if config == nil {
+		return models.JSON{}
+	}
+	cloned := make(models.JSON, len(config))
+	maps.Copy(cloned, config)
+	return cloned
 }
 
 func (s *NotificationService) DeleteSettings(ctx context.Context, provider models.NotificationProvider) error {
@@ -589,13 +690,8 @@ func (s *NotificationService) sendDiscordNotification(ctx context.Context, envir
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	// Decrypt token if encrypted
-	if discordConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(discordConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		discordConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildImageUpdateNotificationMessage(
@@ -629,13 +725,8 @@ func (s *NotificationService) sendTelegramNotification(ctx context.Context, envi
 		return errors.New("no telegram chat IDs configured")
 	}
 
-	// Decrypt bot token if encrypted
-	if telegramConfig.BotToken != "" {
-		decrypted, err := crypto.Decrypt(telegramConfig.BotToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		telegramConfig.BotToken = decrypted
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+		return err
 	}
 
 	message := notifications.BuildImageUpdateNotificationMessage(
@@ -683,12 +774,8 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, environ
 		}
 	}
 
-	if emailConfig.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(emailConfig.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		emailConfig.SMTPPassword = decrypted
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+		return err
 	}
 
 	htmlBody, _, err := s.renderEmailTemplate(environmentName, imageRef, updateInfo)
@@ -766,13 +853,8 @@ func (s *NotificationService) sendDiscordContainerUpdateNotification(ctx context
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	// Decrypt token if encrypted
-	if discordConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(discordConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		discordConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildContainerUpdateNotificationMessage(
@@ -808,13 +890,8 @@ func (s *NotificationService) sendTelegramContainerUpdateNotification(ctx contex
 		return errors.New("no telegram chat IDs configured")
 	}
 
-	// Decrypt bot token if encrypted
-	if telegramConfig.BotToken != "" {
-		decrypted, err := crypto.Decrypt(telegramConfig.BotToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		telegramConfig.BotToken = decrypted
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+		return err
 	}
 
 	message := notifications.BuildContainerUpdateNotificationMessage(
@@ -864,12 +941,8 @@ func (s *NotificationService) sendEmailContainerUpdateNotification(ctx context.C
 		}
 	}
 
-	if emailConfig.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(emailConfig.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		emailConfig.SMTPPassword = decrypted
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+		return err
 	}
 
 	htmlBody, _, err := s.renderContainerUpdateEmailTemplate(environmentName, containerName, imageRef, oldDigest, newDigest)
@@ -1224,12 +1297,8 @@ func (s *NotificationService) sendTestEmail(ctx context.Context, environmentName
 		}
 	}
 
-	if emailConfig.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(emailConfig.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		emailConfig.SMTPPassword = decrypted
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+		return err
 	}
 
 	htmlBody, _, err := s.renderTestEmailTemplate(environmentName)
@@ -1416,13 +1485,8 @@ func (s *NotificationService) sendBatchTelegramNotification(ctx context.Context,
 		return fmt.Errorf("failed to unmarshal telegram config: %w", err)
 	}
 
-	// Decrypt bot token
-	if telegramConfig.BotToken != "" {
-		decrypted, err := crypto.Decrypt(telegramConfig.BotToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		telegramConfig.BotToken = decrypted
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+		return err
 	}
 
 	message := notifications.BuildBatchImageUpdateNotificationMessage(
@@ -1469,12 +1533,8 @@ func (s *NotificationService) sendBatchEmailNotification(ctx context.Context, en
 		}
 	}
 
-	if emailConfig.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(emailConfig.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		emailConfig.SMTPPassword = decrypted
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+		return err
 	}
 
 	htmlBody, _, err := s.renderBatchEmailTemplate(environmentName, updates)
@@ -1580,20 +1640,11 @@ func (s *NotificationService) sendSignalNotification(ctx context.Context, enviro
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	// Decrypt sensitive fields if encrypted
-	if signalConfig.Password != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Password)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Password = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+		return err
 	}
-	if signalConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildImageUpdateNotificationMessage(
@@ -1643,20 +1694,11 @@ func (s *NotificationService) sendSignalContainerUpdateNotification(ctx context.
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	// Decrypt sensitive fields if encrypted
-	if signalConfig.Password != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Password)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Password = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+		return err
 	}
-	if signalConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildContainerUpdateNotificationMessage(
@@ -1695,20 +1737,11 @@ func (s *NotificationService) sendBatchSignalNotification(ctx context.Context, e
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	// Decrypt sensitive fields if encrypted
-	if signalConfig.Password != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Password)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Password = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+		return err
 	}
-	if signalConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildBatchImageUpdateNotificationMessage(
@@ -2046,12 +2079,8 @@ func (s *NotificationService) sendEmailVulnerabilityNotification(ctx context.Con
 			return fmt.Errorf("invalid to address %s: %w", addr, err)
 		}
 	}
-	if emailConfig.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(emailConfig.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		emailConfig.SMTPPassword = decrypted
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+		return err
 	}
 	htmlBody, _, err := s.renderVulnerabilitySummaryEmailTemplate(environmentName, payload)
 	if err != nil {
@@ -2076,12 +2105,8 @@ func (s *NotificationService) sendDiscordVulnerabilityNotification(ctx context.C
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
 		return errors.New("discord webhook ID or token not configured")
 	}
-	if discordConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(discordConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		discordConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+		return err
 	}
 	message := notifications.BuildVulnerabilitySummaryNotificationMessage(
 		notifications.MessageFormatMarkdown,
@@ -2113,12 +2138,8 @@ func (s *NotificationService) sendTelegramVulnerabilityNotification(ctx context.
 	if len(telegramConfig.ChatIDs) == 0 {
 		return errors.New("no telegram chat IDs configured")
 	}
-	if telegramConfig.BotToken != "" {
-		decrypted, err := crypto.Decrypt(telegramConfig.BotToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		telegramConfig.BotToken = decrypted
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+		return err
 	}
 	if telegramConfig.ParseMode == "" {
 		telegramConfig.ParseMode = "HTML"
@@ -2150,19 +2171,11 @@ func (s *NotificationService) sendSignalVulnerabilityNotification(ctx context.Co
 	if signalConfig.Host == "" || signalConfig.Port == 0 || signalConfig.Source == "" || len(signalConfig.Recipients) == 0 {
 		return errors.New("signal not fully configured")
 	}
-	if signalConfig.Password != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Password)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Password = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+		return err
 	}
-	if signalConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(signalConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		signalConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+		return err
 	}
 	message := notifications.BuildVulnerabilitySummaryNotificationMessage(
 		notifications.MessageFormatPlain,
@@ -2519,7 +2532,7 @@ func (s *NotificationService) sendDiscordPruneNotification(ctx context.Context, 
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	if err := s.decryptDiscordTokenInternal(&discordConfig); err != nil {
+	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
 		return err
 	}
 
@@ -2542,7 +2555,7 @@ func (s *NotificationService) sendTelegramPruneNotification(ctx context.Context,
 		return errors.New("telegram bot token or chat IDs not configured")
 	}
 
-	if err := s.decryptTelegramTokenInternal(&telegramConfig); err != nil {
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 
@@ -2569,7 +2582,7 @@ func (s *NotificationService) sendEmailPruneNotification(ctx context.Context, en
 		return err
 	}
 
-	if err := s.decryptEmailPasswordInternal(&emailConfig); err != nil {
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -2657,12 +2670,8 @@ func (s *NotificationService) sendGotifyPruneNotification(ctx context.Context, e
 	if err := s.unmarshalConfigInternal(config, &gotifyConfig); err != nil {
 		return err
 	}
-	if gotifyConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(gotifyConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		gotifyConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&gotifyConfig.Token); err != nil {
+		return err
 	}
 
 	message := notifications.BuildPruneReportNotificationMessage(notifications.MessageFormatPlain, environmentName, result)
@@ -2761,7 +2770,7 @@ func (s *NotificationService) sendDiscordAutoHealNotification(ctx context.Contex
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
 		return errors.New("discord webhook ID or token not configured")
 	}
-	if err := s.decryptDiscordTokenInternal(&discordConfig); err != nil {
+	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
 		return err
 	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatMarkdown, environmentName, containerName)
@@ -2776,7 +2785,7 @@ func (s *NotificationService) sendEmailAutoHealNotification(ctx context.Context,
 	if err := s.validateEmailConfigInternal(&emailConfig); err != nil {
 		return err
 	}
-	if err := s.decryptEmailPasswordInternal(&emailConfig); err != nil {
+	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 	subject := notifications.BuildEmailSubject(environmentName, fmt.Sprintf("Auto Heal: Container '%s' Restarted", containerName))
@@ -2796,7 +2805,7 @@ func (s *NotificationService) sendTelegramAutoHealNotification(ctx context.Conte
 	if telegramConfig.BotToken == "" || len(telegramConfig.ChatIDs) == 0 {
 		return errors.New("telegram bot token or chat IDs not configured")
 	}
-	if err := s.decryptTelegramTokenInternal(&telegramConfig); err != nil {
+	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 	if telegramConfig.ParseMode == "" {
@@ -2850,12 +2859,8 @@ func (s *NotificationService) sendGotifyAutoHealNotification(ctx context.Context
 	if err := s.unmarshalConfigInternal(config, &gotifyConfig); err != nil {
 		return err
 	}
-	if gotifyConfig.Token != "" {
-		decrypted, err := crypto.Decrypt(gotifyConfig.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		gotifyConfig.Token = decrypted
+	if err := decryptStringCredentialInternal(&gotifyConfig.Token); err != nil {
+		return err
 	}
 	if gotifyConfig.Title == "" {
 		gotifyConfig.Title = notifications.BuildEmailSubject(environmentName, "Auto Heal")
@@ -2924,10 +2929,23 @@ func decryptStringCredentialInternal(value *string) error {
 
 	decrypted, err := crypto.Decrypt(*value)
 	if err != nil {
-		return fmt.Errorf("failed to decrypt notification credential: %w", err)
+		if isPlausibleEncryptedCredentialInternal(*value) {
+			return fmt.Errorf("failed to decrypt notification credential: %w", err)
+		}
+		slog.Warn("Failed to decrypt notification credential, using raw legacy value", "error", err)
+		return nil
 	}
 	*value = decrypted
 	return nil
+}
+
+func isPlausibleEncryptedCredentialInternal(value string) bool {
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	const minAESGCMCiphertextSize = 12 + 16
+	return len(data) >= minAESGCMCiphertextSize
 }
 
 func prepareSlackConfigInternal(config models.JSON, providerName string, requireToken bool) (models.SlackConfig, error) {
@@ -3001,39 +3019,6 @@ func buildVulnerabilitySummaryMessageInternal(format notifications.MessageFormat
 		payload.Severity,
 		payload.PkgName,
 	)
-}
-
-func (s *NotificationService) decryptDiscordTokenInternal(config *models.DiscordConfig) error {
-	if config.Token != "" {
-		decrypted, err := crypto.Decrypt(config.Token)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		config.Token = decrypted
-	}
-	return nil
-}
-
-func (s *NotificationService) decryptTelegramTokenInternal(config *models.TelegramConfig) error {
-	if config.BotToken != "" {
-		decrypted, err := crypto.Decrypt(config.BotToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		config.BotToken = decrypted
-	}
-	return nil
-}
-
-func (s *NotificationService) decryptEmailPasswordInternal(config *models.EmailConfig) error {
-	if config.SMTPPassword != "" {
-		decrypted, err := crypto.Decrypt(config.SMTPPassword)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		config.SMTPPassword = decrypted
-	}
-	return nil
 }
 
 func (s *NotificationService) renderTemplatesInternal(name string, data any) (string, string, error) {

--- a/backend/internal/services/notification_service_test.go
+++ b/backend/internal/services/notification_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -434,6 +435,130 @@ func TestBuildAutoHealNotificationMessageInternal_IncludesEnvironment(t *testing
 
 	require.Contains(t, message, "**Environment:** Cluster One")
 	require.Equal(t, 1, strings.Count(message, "Environment"))
+}
+
+func TestNotificationCredentialInternal_KeepsPlaintextLegacyValues(t *testing.T) {
+	setupNotificationTestDB(t)
+
+	value := "discord-webhook-token/plaintext"
+
+	require.NoError(t, decryptStringCredentialInternal(&value))
+	require.Equal(t, "discord-webhook-token/plaintext", value)
+}
+
+func TestNotificationCredentialInternal_DecryptsEncryptedValues(t *testing.T) {
+	setupNotificationTestDB(t)
+
+	encrypted, err := crypto.Encrypt("gotify-application-token")
+	require.NoError(t, err)
+
+	require.NoError(t, decryptStringCredentialInternal(&encrypted))
+	require.Equal(t, "gotify-application-token", encrypted)
+}
+
+func TestNotificationCredentialInternal_ReturnsErrorForCorruptedCiphertext(t *testing.T) {
+	setupNotificationTestDB(t)
+
+	encrypted, err := crypto.Encrypt("gotify-application-token")
+	require.NoError(t, err)
+
+	ciphertext, err := base64.StdEncoding.DecodeString(encrypted)
+	require.NoError(t, err)
+	ciphertext[len(ciphertext)-1] ^= 0xff
+	corrupted := base64.StdEncoding.EncodeToString(ciphertext)
+
+	require.Error(t, decryptStringCredentialInternal(&corrupted))
+}
+
+func TestNotificationCredentialInternal_LeavesEmptyValuesEmpty(t *testing.T) {
+	setupNotificationTestDB(t)
+
+	value := ""
+
+	require.NoError(t, decryptStringCredentialInternal(&value))
+	require.Empty(t, value)
+}
+
+func TestNotificationService_CreateOrUpdateSettingsEncryptsCredentialFieldsInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupNotificationTestDB(t)
+	svc := NewNotificationService(db, &config.Config{}, nil)
+
+	_, err := svc.CreateOrUpdateSettings(ctx, models.NotificationProviderDiscord, true, models.JSON{
+		"webhookId": "123456789",
+		"token":     "discord-secret-token",
+		"username":  "Arcane",
+	})
+	require.NoError(t, err)
+
+	var stored models.NotificationSettings
+	require.NoError(t, db.WithContext(ctx).Where("provider = ?", models.NotificationProviderDiscord).First(&stored).Error)
+	require.Equal(t, "123456789", stored.Config["webhookId"])
+	require.Equal(t, "Arcane", stored.Config["username"])
+	require.NotEqual(t, "discord-secret-token", stored.Config["token"])
+
+	decrypted, err := crypto.Decrypt(stored.Config["token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, "discord-secret-token", decrypted)
+}
+
+func TestNotificationService_CreateOrUpdateSettingsPreservesStoredCredentialWhenEmptyInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupNotificationTestDB(t)
+	svc := NewNotificationService(db, &config.Config{}, nil)
+
+	_, err := svc.CreateOrUpdateSettings(ctx, models.NotificationProviderGotify, true, models.JSON{
+		"host":  "gotify.example",
+		"token": "initial-gotify-token",
+		"title": "Initial",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.CreateOrUpdateSettings(ctx, models.NotificationProviderGotify, true, models.JSON{
+		"host":  "gotify.example",
+		"token": "",
+		"title": "Updated",
+	})
+	require.NoError(t, err)
+
+	var stored models.NotificationSettings
+	require.NoError(t, db.WithContext(ctx).Where("provider = ?", models.NotificationProviderGotify).First(&stored).Error)
+	require.Equal(t, "Updated", stored.Config["title"])
+
+	decrypted, err := crypto.Decrypt(stored.Config["token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, "initial-gotify-token", decrypted)
+}
+
+func TestNotificationService_CreateOrUpdateSettingsPreservesCredentialAcrossDisableInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupNotificationTestDB(t)
+	svc := NewNotificationService(db, &config.Config{}, nil)
+
+	_, err := svc.CreateOrUpdateSettings(ctx, models.NotificationProviderGotify, true, models.JSON{
+		"host":  "gotify.example",
+		"token": "initial-gotify-token",
+		"title": "Initial",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.CreateOrUpdateSettings(ctx, models.NotificationProviderGotify, false, models.JSON{})
+	require.NoError(t, err)
+
+	_, err = svc.CreateOrUpdateSettings(ctx, models.NotificationProviderGotify, true, models.JSON{
+		"host":  "gotify.example",
+		"token": "",
+		"title": "Re-enabled",
+	})
+	require.NoError(t, err)
+
+	var stored models.NotificationSettings
+	require.NoError(t, db.WithContext(ctx).Where("provider = ?", models.NotificationProviderGotify).First(&stored).Error)
+	require.Equal(t, "Re-enabled", stored.Config["title"])
+
+	decrypted, err := crypto.Decrypt(stored.Config["token"].(string))
+	require.NoError(t, err)
+	require.Equal(t, "initial-gotify-token", decrypted)
 }
 
 func TestSupportedNotificationTestTypes_IncludesAutoHeal(t *testing.T) {

--- a/backend/internal/services/version_service.go
+++ b/backend/internal/services/version_service.go
@@ -129,6 +129,10 @@ func (s *VersionService) normalizeVersion(ver string) string {
 	if ver == "" {
 		return "v0.0.0"
 	}
+	trimmed := strings.TrimPrefix(ver, "v")
+	if trimmed == "" || trimmed[0] < '0' || trimmed[0] > '9' {
+		return ver
+	}
 	if !strings.HasPrefix(ver, "v") {
 		ver = "v" + ver
 	}

--- a/backend/internal/services/version_service_test.go
+++ b/backend/internal/services/version_service_test.go
@@ -106,3 +106,14 @@ func TestVersionService_GetAppVersionInfoDoesNotUseStoredDigestUpdateForSemverBu
 	assert.Equal(t, latestDigest, info.NewestDigest)
 	assert.Equal(t, currentDigest, info.CurrentDigest)
 }
+
+func TestVersionService_GetAppVersionInfoPreservesDevVersionInternal(t *testing.T) {
+	svc := NewVersionService(nil, true, "dev", "unknown", nil, nil, nil)
+
+	info := svc.GetAppVersionInfo(context.Background())
+
+	require.NotNil(t, info)
+	assert.Equal(t, "dev", info.CurrentVersion)
+	assert.Equal(t, "dev", info.DisplayVersion)
+	assert.False(t, info.IsSemverVersion)
+}

--- a/frontend/src/routes/(app)/settings/notifications/+page.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/+page.svelte
@@ -139,6 +139,10 @@
 			genericHasChanges
 	);
 
+	function hasSavedCredential(settings: NotificationSettings | null, field: string) {
+		return settings?.config ? Object.prototype.hasOwnProperty.call(settings.config, field) : false;
+	}
+
 	// Sync with settings form context
 	$effect(() => {
 		if (formState) {
@@ -268,8 +272,7 @@
 			if (signalHasChanges) {
 				try {
 					const settings = signalFormValuesToSettings(signalValues);
-					await notificationService.updateSettings('signal', settings);
-					savedSettings.signal = settings;
+					savedSettings.signal = await notificationService.updateSettings('signal', settings);
 					signalBaseline = { ...signalValues };
 				} catch (error: any) {
 					const errorMsg = error?.response?.data?.error || error.message || 'Unknown error';
@@ -438,6 +441,7 @@
 						bind:values={emailValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.email !== null}
 						onTest={(testType) => testNotification('email', testType)}
 					/>
 				</Tabs.Content>
@@ -449,6 +453,7 @@
 						bind:values={discordValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.discord !== null}
 						onTest={(testType) => testNotification('discord', testType)}
 					/>
 				</Tabs.Content>
@@ -460,6 +465,7 @@
 						bind:values={telegramValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.telegram !== null}
 						onTest={(testType) => testNotification('telegram', testType)}
 					/>
 				</Tabs.Content>
@@ -471,6 +477,9 @@
 						bind:values={signalValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.signal !== null}
+						hasExistingPassword={hasSavedCredential(savedSettings.signal, 'password')}
+						hasExistingToken={hasSavedCredential(savedSettings.signal, 'token')}
 						onTest={(testType) => testNotification('signal', testType)}
 					/>
 				</Tabs.Content>
@@ -482,6 +491,7 @@
 						bind:values={slackValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.slack !== null}
 						onTest={(testType) => testNotification('slack', testType)}
 					/>
 				</Tabs.Content>
@@ -493,6 +503,7 @@
 						bind:values={ntfyValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.ntfy !== null}
 						onTest={(testType) => testNotification('ntfy', testType)}
 					/>
 				</Tabs.Content>
@@ -504,6 +515,7 @@
 						bind:values={pushoverValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.pushover !== null}
 						onTest={(testType) => testNotification('pushover', testType)}
 					/>
 				</Tabs.Content>
@@ -515,6 +527,7 @@
 						bind:values={gotifyValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.gotify !== null}
 						onTest={(testType) => testNotification('gotify', testType)}
 					/>
 				</Tabs.Content>
@@ -526,6 +539,7 @@
 						bind:values={matrixValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.matrix !== null}
 						onTest={(testType) => testNotification('matrix', testType)}
 					/>
 				</Tabs.Content>
@@ -537,6 +551,7 @@
 						bind:values={genericValues}
 						disabled={isReadOnly}
 						{isTesting}
+						hasExistingCredentials={savedSettings.generic !== null}
 						onTest={(testType) => testNotification('generic', testType)}
 					/>
 				</Tabs.Content>

--- a/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
@@ -16,10 +16,22 @@
 		values: AnyBuiltInValues;
 		disabled?: boolean;
 		isTesting?: boolean;
+		hasExistingCredentials?: boolean;
+		hasExistingPassword?: boolean;
+		hasExistingToken?: boolean;
 		onTest?: (testType?: string) => void;
 	}
 
-	let { provider, values = $bindable(), disabled = false, isTesting = false, onTest }: Props = $props();
+	let {
+		provider,
+		values = $bindable(),
+		disabled = false,
+		isTesting = false,
+		hasExistingCredentials = false,
+		hasExistingPassword = false,
+		hasExistingToken = false,
+		onTest
+	}: Props = $props();
 
 	const providerMeta: Record<NotificationProviderKey, { title: string; description: string }> = {
 		discord: {
@@ -82,6 +94,12 @@
 		}
 	}
 
+	function addRequiredCredentialIssue(ctx: z.RefinementCtx, value: string, path: string, message: string) {
+		if (!value.trim() && !hasExistingCredentials) {
+			addCustomFieldIssue(ctx, path, message);
+		}
+	}
+
 	const providerSchemas: Record<NotificationProviderKey, z.ZodTypeAny> = {
 		discord: z
 			.object({
@@ -95,7 +113,7 @@
 			.superRefine((d, ctx) => {
 				if (!d.enabled) return;
 				addRequiredTrimmedFieldIssue(ctx, d.webhookId, 'webhookId', 'Webhook ID is required when Discord is enabled');
-				addRequiredTrimmedFieldIssue(ctx, d.token, 'token', 'Webhook Token is required when Discord is enabled');
+				addRequiredCredentialIssue(ctx, d.token, 'token', 'Webhook Token is required when Discord is enabled');
 			}),
 		email: z
 			.object({
@@ -160,7 +178,7 @@
 			})
 			.superRefine((d, ctx) => {
 				if (!d.enabled) return;
-				addRequiredTrimmedFieldIssue(ctx, d.botToken, 'botToken', 'Bot Token is required when Telegram is enabled');
+				addRequiredCredentialIssue(ctx, d.botToken, 'botToken', 'Bot Token is required when Telegram is enabled');
 				if (!d.chatIds.trim()) {
 					ctx.addIssue({
 						code: 'custom',
@@ -203,8 +221,16 @@
 					ctx.addIssue({ code: 'custom', message: m.notifications_signal_recipients_required(), path: ['recipients'] });
 				}
 
-				const hasBasicAuth = d.user.trim() && d.password.trim();
-				const hasTokenAuth = d.token.trim();
+				const wantsBasicAuth = Boolean(d.user.trim() || d.password.trim());
+				const hasBasicAuth = Boolean(d.user.trim() && (d.password.trim() || hasExistingPassword));
+				const hasTokenAuth = Boolean(d.token.trim() || (!wantsBasicAuth && hasExistingToken));
+				if (d.user.trim() && !d.password.trim() && !hasExistingPassword) {
+					ctx.addIssue({
+						code: 'custom',
+						message: m.notifications_signal_auth_required(),
+						path: ['password']
+					});
+				}
 				if (!hasBasicAuth && !hasTokenAuth) {
 					ctx.addIssue({
 						code: 'custom',
@@ -234,7 +260,7 @@
 			})
 			.superRefine((d, ctx) => {
 				if (!d.enabled) return;
-				addRequiredTrimmedFieldIssue(ctx, d.token, 'token', m.notifications_slack_token_required());
+				addRequiredCredentialIssue(ctx, d.token, 'token', m.notifications_slack_token_required());
 			}),
 		ntfy: z
 			.object({
@@ -272,7 +298,7 @@
 			})
 			.superRefine((d, ctx) => {
 				if (!d.enabled) return;
-				addRequiredTrimmedFieldIssue(ctx, d.token, 'token', m.common_required());
+				addRequiredCredentialIssue(ctx, d.token, 'token', m.common_required());
 				addRequiredTrimmedFieldIssue(ctx, d.user, 'user', m.common_required());
 			}),
 		gotify: z
@@ -290,7 +316,7 @@
 			.superRefine((d, ctx) => {
 				if (!d.enabled) return;
 				addRequiredTrimmedFieldIssue(ctx, d.host, 'host', m.common_required());
-				addRequiredTrimmedFieldIssue(ctx, d.token, 'token', m.common_required());
+				addRequiredCredentialIssue(ctx, d.token, 'token', m.common_required());
 			}),
 		matrix: z
 			.object({


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes notification token decryption failures by introducing a full credential lifecycle: credentials are now encrypted on write (`encryptNotificationConfigCredentialsInternal`), redacted in API responses (`RedactNotificationConfigCredentials`), and preserved across updates when the user leaves a credential field blank. A `normalizeVersion` fix prevents non-numeric version strings like `"dev"` from receiving a spurious `v` prefix.

- **Credential encryption on save**: `CreateOrUpdateSettings` now encrypts all credential fields and preserves existing encrypted values when the incoming field is empty, including across provider disable/re-enable cycles — validated by a dedicated test.
- **API redaction**: All three `GetAllNotificationSettings`, `GetNotificationSettings`, and `CreateOrUpdateNotificationSettings` handlers now pass the stored config through `RedactNotificationConfigCredentials` before returning it, sending an empty string for each set credential field so the frontend can signal "credential on file" without exposing the secret.
- **Frontend validation**: `addRequiredCredentialIssue` replaces `addRequiredTrimmedFieldIssue` for credential fields, skipping the "required" error when `hasExistingCredentials` is true; Signal gets per-field `hasExistingPassword`/`hasExistingToken` flags for its two mutually-exclusive auth modes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the encryption/preservation/redaction pipeline is well-structured and each logical branch is covered by a targeted test.

The credential preservation path (disable → re-enable without re-entering a token) is explicitly tested and the code trace confirms it works: the disable step copies the existing encrypted value into the disabled record, so the re-enable step finds it and restores it. No handler that already had per-field decryption was overlooked in the refactor. The isPlausibleEncryptedCredentialInternal heuristic was already noted in earlier review threads and is a known trade-off. The version_service.go guard is straightforward and covered by a test.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/services/notification_service.go`, line 280-296 ([link](https://github.com/getarcaneapp/arcane/blob/825e0f2549be0df1a2b955689178f03a361d5c7e/backend/internal/services/notification_service.go#L280-L296)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Credential loss when re-enabling a provider**

   When a provider is disabled, the existing code clears its config entirely to `models.JSON{}` (line 281-283). After this PR, the frontend sees a non-null `savedSettings.xxx` for a disabled provider (the DB row still exists) and sets `hasExistingCredentials=true`, suppressing the "credential required" validation. If the user then re-enables the provider without re-entering credentials, the backend reaches `encryptNotificationConfigCredentialsInternal` with both the incoming and existing credential fields empty, so no value is preserved. The provider is saved as enabled with empty credentials and notifications silently fail.

   The encryption/preservation block should run regardless of the `enabled` flag so that re-enabling an existing row restores preserved credentials even when the incoming config has blanked credential fields.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/notification_service.go
   Line: 280-296

   Comment:
   **Credential loss when re-enabling a provider**

   When a provider is disabled, the existing code clears its config entirely to `models.JSON{}` (line 281-283). After this PR, the frontend sees a non-null `savedSettings.xxx` for a disabled provider (the DB row still exists) and sets `hasExistingCredentials=true`, suppressing the "credential required" validation. If the user then re-enables the provider without re-entering credentials, the backend reaches `encryptNotificationConfigCredentialsInternal` with both the incoming and existing credential fields empty, so no value is preserved. The provider is saved as enabled with empty credentials and notifications silently fail.

   The encryption/preservation block should run regardless of the `enabled` flag so that re-enabling an existing row restores preserved credentials even when the incoming config has blanked credential fields.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fnotification-tokens%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnotification-tokens%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fnotification_service.go%0ALine%3A%20280-296%0A%0AComment%3A%0A**Credential%20loss%20when%20re-enabling%20a%20provider**%0A%0AWhen%20a%20provider%20is%20disabled%2C%20the%20existing%20code%20clears%20its%20config%20entirely%20to%20%60models.JSON%7B%7D%60%20%28line%20281-283%29.%20After%20this%20PR%2C%20the%20frontend%20sees%20a%20non-null%20%60savedSettings.xxx%60%20for%20a%20disabled%20provider%20%28the%20DB%20row%20still%20exists%29%20and%20sets%20%60hasExistingCredentials%3Dtrue%60%2C%20suppressing%20the%20%22credential%20required%22%20validation.%20If%20the%20user%20then%20re-enables%20the%20provider%20without%20re-entering%20credentials%2C%20the%20backend%20reaches%20%60encryptNotificationConfigCredentialsInternal%60%20with%20both%20the%20incoming%20and%20existing%20credential%20fields%20empty%2C%20so%20no%20value%20is%20preserved.%20The%20provider%20is%20saved%20as%20enabled%20with%20empty%20credentials%20and%20notifications%20silently%20fail.%0A%0AThe%20encryption%2Fpreservation%20block%20should%20run%20regardless%20of%20the%20%60enabled%60%20flag%20so%20that%20re-enabling%20an%20existing%20row%20restores%20preserved%20credentials%20even%20when%20the%20incoming%20config%20has%20blanked%20credential%20fields.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2850&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fnotification_service.go%0ALine%3A%20280-296%0A%0AComment%3A%0A**Credential%20loss%20when%20re-enabling%20a%20provider**%0A%0AWhen%20a%20provider%20is%20disabled%2C%20the%20existing%20code%20clears%20its%20config%20entirely%20to%20%60models.JSON%7B%7D%60%20%28line%20281-283%29.%20After%20this%20PR%2C%20the%20frontend%20sees%20a%20non-null%20%60savedSettings.xxx%60%20for%20a%20disabled%20provider%20%28the%20DB%20row%20still%20exists%29%20and%20sets%20%60hasExistingCredentials%3Dtrue%60%2C%20suppressing%20the%20%22credential%20required%22%20validation.%20If%20the%20user%20then%20re-enables%20the%20provider%20without%20re-entering%20credentials%2C%20the%20backend%20reaches%20%60encryptNotificationConfigCredentialsInternal%60%20with%20both%20the%20incoming%20and%20existing%20credential%20fields%20empty%2C%20so%20no%20value%20is%20preserved.%20The%20provider%20is%20saved%20as%20enabled%20with%20empty%20credentials%20and%20notifications%20silently%20fail.%0A%0AThe%20encryption%2Fpreservation%20block%20should%20run%20regardless%20of%20the%20%60enabled%60%20flag%20so%20that%20re-enabling%20an%20existing%20row%20restores%20preserved%20credentials%20even%20when%20the%20incoming%20config%20has%20blanked%20credential%20fields.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2850&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `backend/internal/services/notification_service.go`, line 2899-2911 ([link](https://github.com/getarcaneapp/arcane/blob/825e0f2549be0df1a2b955689178f03a361d5c7e/backend/internal/services/notification_service.go#L2899-L2911)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent fallback on decryption error hides key-mismatch and data-corruption failures**

   When `crypto.Decrypt` returns an error for a non-empty value, the function now logs a warning and continues with the raw value instead of returning an error. For a genuine legacy plaintext token this is fine, but the same path is taken if the encryption key rotates, the ciphertext is truncated, or the DB column is silently corrupted. In those cases the raw (mangled or ciphertext) string is forwarded to the notification provider, causing confusing authentication failures at the call site with no clear signal that decryption failed. Consider checking whether the value already looks like a ciphertext envelope (e.g. matching the expected prefix/format the `crypto` package uses) before falling back silently.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/notification_service.go
   Line: 2899-2911

   Comment:
   **Silent fallback on decryption error hides key-mismatch and data-corruption failures**

   When `crypto.Decrypt` returns an error for a non-empty value, the function now logs a warning and continues with the raw value instead of returning an error. For a genuine legacy plaintext token this is fine, but the same path is taken if the encryption key rotates, the ciphertext is truncated, or the DB column is silently corrupted. In those cases the raw (mangled or ciphertext) string is forwarded to the notification provider, causing confusing authentication failures at the call site with no clear signal that decryption failed. Consider checking whether the value already looks like a ciphertext envelope (e.g. matching the expected prefix/format the `crypto` package uses) before falling back silently.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fnotification-tokens%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnotification-tokens%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fnotification_service.go%0ALine%3A%202899-2911%0A%0AComment%3A%0A**Silent%20fallback%20on%20decryption%20error%20hides%20key-mismatch%20and%20data-corruption%20failures**%0A%0AWhen%20%60crypto.Decrypt%60%20returns%20an%20error%20for%20a%20non-empty%20value%2C%20the%20function%20now%20logs%20a%20warning%20and%20continues%20with%20the%20raw%20value%20instead%20of%20returning%20an%20error.%20For%20a%20genuine%20legacy%20plaintext%20token%20this%20is%20fine%2C%20but%20the%20same%20path%20is%20taken%20if%20the%20encryption%20key%20rotates%2C%20the%20ciphertext%20is%20truncated%2C%20or%20the%20DB%20column%20is%20silently%20corrupted.%20In%20those%20cases%20the%20raw%20%28mangled%20or%20ciphertext%29%20string%20is%20forwarded%20to%20the%20notification%20provider%2C%20causing%20confusing%20authentication%20failures%20at%20the%20call%20site%20with%20no%20clear%20signal%20that%20decryption%20failed.%20Consider%20checking%20whether%20the%20value%20already%20looks%20like%20a%20ciphertext%20envelope%20%28e.g.%20matching%20the%20expected%20prefix%2Fformat%20the%20%60crypto%60%20package%20uses%29%20before%20falling%20back%20silently.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2850&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fnotification_service.go%0ALine%3A%202899-2911%0A%0AComment%3A%0A**Silent%20fallback%20on%20decryption%20error%20hides%20key-mismatch%20and%20data-corruption%20failures**%0A%0AWhen%20%60crypto.Decrypt%60%20returns%20an%20error%20for%20a%20non-empty%20value%2C%20the%20function%20now%20logs%20a%20warning%20and%20continues%20with%20the%20raw%20value%20instead%20of%20returning%20an%20error.%20For%20a%20genuine%20legacy%20plaintext%20token%20this%20is%20fine%2C%20but%20the%20same%20path%20is%20taken%20if%20the%20encryption%20key%20rotates%2C%20the%20ciphertext%20is%20truncated%2C%20or%20the%20DB%20column%20is%20silently%20corrupted.%20In%20those%20cases%20the%20raw%20%28mangled%20or%20ciphertext%29%20string%20is%20forwarded%20to%20the%20notification%20provider%2C%20causing%20confusing%20authentication%20failures%20at%20the%20call%20site%20with%20no%20clear%20signal%20that%20decryption%20failed.%20Consider%20checking%20whether%20the%20value%20already%20looks%20like%20a%20ciphertext%20envelope%20%28e.g.%20matching%20the%20expected%20prefix%2Fformat%20the%20%60crypto%60%20package%20uses%29%20before%20falling%20back%20silently.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2850&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: decrypting of notification tokens f..."](https://github.com/getarcaneapp/arcane/commit/5d3c95eb2faf30a53ca3d64a57942da2a7eb6c97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36101070)</sub>

<!-- /greptile_comment -->