### PR TITLE
fix: newly synced git content does not show without a refresh

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -13,7 +13,6 @@
 	import { getStatusVariant, getThemedIconUrl } from '$lib/utils/docker';
 	import { capitalizeFirstLetter } from '$lib/utils/formatting';
 	import { page } from '$app/state';
-	import { invalidateAll } from '$app/navigation';
 	import { mode } from 'mode-watcher';
 	import { toast } from 'svelte-sonner';
 	import { tryCatch } from '$lib/utils/api';
@@ -253,6 +252,15 @@
 		selectedFile?: 'compose' | 'env' | string;
 	};
 
+	type RebaseEditorDraftOptions = {
+		preserveEditableDrafts?: boolean;
+		clearLoadedFileCache?: boolean;
+	};
+
+	type RefreshProjectDetailsOptions = RebaseEditorDraftOptions & {
+		forceRebaseDraft?: boolean;
+	};
+
 	const defaultComposeUIPrefs: ComposeUIPrefs = {
 		tab: 'compose',
 		composeOpen: true,
@@ -308,18 +316,51 @@
 		return [...refs];
 	}
 
-	function rebaseEditorDraft(details: Project) {
+	function getProjectIncludeFileContents(details: Project | null | undefined): Record<string, string> {
+		return Object.fromEntries(
+			(details?.includeFiles ?? []).flatMap((file) =>
+				file.content === undefined ? [] : [[file.relativePath, file.content] as const]
+			)
+		);
+	}
+
+	function getDirtyIncludeDrafts(): Record<string, string> {
+		return Object.fromEntries(
+			Object.entries(includeFilesState).filter(([relativePath, content]) => content !== serverIncludeFiles[relativePath])
+		);
+	}
+
+	function clearLoadedProjectFileCache() {
+		loadedIncludeFileContents = {};
+		loadedDirectoryFileContents = {};
+		projectFilePromises = {};
+	}
+
+	function rebaseEditorDraft(details: Project, options: RebaseEditorDraftOptions = {}) {
+		const envDraft = $inputs.envContent.value;
+		const shouldPreserveEnvDraft = options.preserveEditableDrafts === true && envDraft !== serverEnvContent;
+		const dirtyIncludeDrafts = options.preserveEditableDrafts === true ? getDirtyIncludeDrafts() : {};
+
+		if (options.clearLoadedFileCache === true) {
+			clearLoadedProjectFileCache();
+		}
+
 		const normalizedProject = withLoadedProjectFileContent(details);
 		if (!normalizedProject) return;
 
 		$inputs.name.value = normalizedProject.name || '';
 		$inputs.composeContent.value = normalizedProject.composeContent || '';
-		$inputs.envContent.value = normalizedProject.envContent || '';
-		includeFilesState = Object.fromEntries(
-			(normalizedProject.includeFiles ?? []).flatMap((file) =>
-				file.content === undefined ? [] : [[file.relativePath, file.content] as const]
+		$inputs.envContent.value = shouldPreserveEnvDraft ? envDraft : normalizedProject.envContent || '';
+
+		const freshIncludeFiles = getProjectIncludeFileContents(normalizedProject);
+		includeFilesState = {
+			...freshIncludeFiles,
+			...Object.fromEntries(
+				Object.entries(dirtyIncludeDrafts).filter(([relativePath]) =>
+					(normalizedProject.includeFiles ?? []).some((file) => file.relativePath === relativePath)
+				)
 			)
-		);
+		};
 	}
 
 	async function syncProjectQueries(updatedProject: Project) {
@@ -606,14 +647,14 @@
 		globalVariables: globalVariableMap
 	});
 
-	async function refreshProjectDetails() {
+	async function refreshProjectDetails(options: RefreshProjectDetailsOptions = {}) {
 		if (!projectId) return;
-		handleApiResultWithCallbacks({
+		await handleApiResultWithCallbacks({
 			result: await tryCatch(projectService.getProject(projectId)),
 			message: m.common_refresh_failed({ resource: m.project() }),
 			onSuccess: async (updatedProject) => {
-				if (!hasChanges) {
-					rebaseEditorDraft(updatedProject);
+				if (options.forceRebaseDraft || !hasChanges) {
+					rebaseEditorDraft(updatedProject, options);
 				}
 				await syncProjectQueries(updatedProject);
 			}
@@ -623,13 +664,18 @@
 	async function handleSyncFromGit() {
 		if (!envId || !project?.gitOpsManagedBy) return;
 		isLoading.syncing = true;
-		handleApiResultWithCallbacks({
+		await handleApiResultWithCallbacks({
 			result: await tryCatch(gitOpsSyncService.performSync(envId, project.gitOpsManagedBy)),
 			message: m.git_sync_failed(),
 			setLoadingState: (value) => (isLoading.syncing = value),
 			onSuccess: async () => {
+				await refreshProjectDetails({
+					forceRebaseDraft: true,
+					preserveEditableDrafts: true,
+					clearLoadedFileCache: true
+				});
+				await queryClient.invalidateQueries({ queryKey: queryKeys.gitOpsSyncs.all });
 				toast.success(m.git_sync_success());
-				await invalidateAll();
 			}
 		});
 	}
@@ -816,15 +862,17 @@
 					bind:restartLoading={isLoading.restarting}
 					bind:removeLoading={isLoading.removing}
 					bind:redeployLoading={isLoading.redeploying}
-					onActionComplete={refreshProjectDetails}
-					onRefresh={refreshProjectDetails}
+					onActionComplete={() => {
+						void refreshProjectDetails();
+					}}
+					onRefresh={() => refreshProjectDetails()}
 				/>
 			</div>
 		{/snippet}
 
 		{#snippet tabContent()}
 			<Tabs.Content value="services" class="h-full">
-				<ProjectContainersTable services={project.runtimeServices} {projectId} onRefresh={refreshProjectDetails} />
+				<ProjectContainersTable services={project.runtimeServices} {projectId} onRefresh={() => refreshProjectDetails()} />
 			</Tabs.Content>
 
 			<Tabs.Content value="compose" class="h-full min-h-0">


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2829

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where git-synced content didn't appear in the editor without a manual page refresh. The root cause was that `handleApiResultWithCallbacks` was not being `await`-ed in both `refreshProjectDetails` and `handleSyncFromGit`, so the refresh completed asynchronously and the calling code returned before state was updated.

- `handleSyncFromGit` now replaces the broad `invalidateAll()` call with a targeted sequence: `await refreshProjectDetails(...)` (with `forceRebaseDraft`, `preserveEditableDrafts`, and `clearLoadedFileCache` flags), followed by an explicit `invalidateQueries` for gitops-syncs.
- Three new helpers (`getProjectIncludeFileContents`, `getDirtyIncludeDrafts`, `clearLoadedProjectFileCache`) support the new rebase options, which preserve locally-dirty env and include-file drafts while clearing the lazy-file cache so git-synced content is re-fetched.
- `onActionComplete` and `onRefresh` callback wrappers are slightly inconsistent in how they handle the returned promise (`void` on one, implicit return on the other).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are well-scoped to the git-sync flow and use existing patterns correctly.

The fix correctly adds `await` to the previously-unawaited `handleApiResultWithCallbacks` calls, and the new rebase-draft logic is carefully ordered (dirty drafts are captured before the file cache is cleared). A minor style inconsistency exists between the two callback wrappers on `ActionButtons`, but it has no behavioral impact.

No files require special attention.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fgit-sync-reload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgit-sync-reload%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A865-869%0A**Inconsistent%20promise%20handling%20in%20callbacks**%20%E2%80%94%20%60onActionComplete%60%20uses%20%60void%60%20to%20explicitly%20discard%20the%20returned%20promise%2C%20while%20%60onRefresh%60%20on%20the%20same%20component%20returns%20it.%20Both%20wrappers%20should%20use%20the%20same%20pattern%3B%20consider%20adding%20%60void%60%20to%20%60onRefresh%60%20as%20well%20so%20the%20intent%20is%20unambiguous%20to%20future%20readers.%0A%0A&repo=getarcaneapp%2Farcane&pr=2870&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A865-869%0A**Inconsistent%20promise%20handling%20in%20callbacks**%20%E2%80%94%20%60onActionComplete%60%20uses%20%60void%60%20to%20explicitly%20discard%20the%20returned%20promise%2C%20while%20%60onRefresh%60%20on%20the%20same%20component%20returns%20it.%20Both%20wrappers%20should%20use%20the%20same%20pattern%3B%20consider%20adding%20%60void%60%20to%20%60onRefresh%60%20as%20well%20so%20the%20intent%20is%20unambiguous%20to%20future%20readers.%0A%0A&repo=getarcaneapp%2Farcane&pr=2870&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/routes/(app)/projects/[projectId]/+page.svelte:865-869
**Inconsistent promise handling in callbacks** — `onActionComplete` uses `void` to explicitly discard the returned promise, while `onRefresh` on the same component returns it. Both wrappers should use the same pattern; consider adding `void` to `onRefresh` as well so the intent is unambiguous to future readers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: newly synced git content does not s..."](https://github.com/getarcaneapp/arcane/commit/d028858fea274f346e5cf04222cf55279b1d404d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36111579)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->