### PR TITLE
feat(skills): add arcane-cli agent skill

### DIFF
--- a/skills/arcane-cli/SKILL.md
+++ b/skills/arcane-cli/SKILL.md
@@ -340,9 +340,12 @@ arcane-cli completion bash|zsh|fish|powershell
 
 ```yaml
 server_url: https://your-arcane-server.com/
-api_key: arc_xxxxx
+api_key: arc_xxxxx                  # or use `auth login` for JWT
 default_environment: "0"
 log_level: info
+# jwt_token / refresh_token are written by `arcane-cli auth login`
+# federated_audience: ""            # default audience for `auth federated`
+# cli_update_channel: stable        # stable | next
 pagination:
   default:
     limit: 25
@@ -357,7 +360,7 @@ pagination:
       limit: 40
 ```
 
-Config keys for `arcane-cli config set`: `server-url`, `api-key`, `default-environment`, `log-level`
+Config keys for `arcane-cli config set`: `server-url`, `api-key`, `jwt-token`, `default-environment`, `federated-audience`, `log-level`, `cli-update-channel`, `default-limit`, `resource-limit`
 
 ## Common Patterns
 

--- a/skills/arcane-cli/SKILL.md
+++ b/skills/arcane-cli/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: arcane-cli
+description: |
+  Arcane Docker management platform CLI (arcane-cli).
+  Use for all operations against the Arcane server: containers, projects
+  (Docker Compose), images, volumes, networks, environments, registries,
+  GitOps syncs, background jobs, admin, and system tasks.
+
+  Triggers: arcane, arcane-cli, docker management, project up/down,
+  container start/stop/redeploy, image updates, GitOps sync, environments.
+---
+
+# Arcane CLI Skill
+
+## Critical Facts
+
+- **Binary name**: `arcane-cli`
+- **Config file**: `~/.config/arcanecli.yml`
+- **Local environment ID**: `"0"` — the Arcane manager's own Docker socket. Always pass `--env <id>` explicitly; if `environments list` returns empty, the API key is missing `environments:list` permission.
+- **API key format**: `arc_<hex>` — set via `arcane-cli config set api-key arc_...` or directly in the YAML
+- **Output**: `--output json` (or `--json`) for machine-readable output; default is human text
+- **Host-specific config** (env IDs, server URL): read `~/.agentSecrets/arcane-cli/secrets.md` before running any commands
+
+## JSON Response Shape
+
+Most list/get commands return `{"success": true, "data": [...], "pagination": {...}}` — index into `.data`.
+
+**Flat responses (no wrapper)** — these commands return a plain object directly:
+
+| Command | Shape |
+|---|---|
+| `containers counts` | `{runningContainers, stoppedContainers, totalContainers}` |
+| `images updates summary` | `{totalImages, imagesWithUpdates, digestUpdates, errorsCount}` |
+| `volumes counts` | `{inuse, total, unused}` |
+| `networks counts` | `{inuse, unused, total}` |
+| `jobs get` | flat object with cron schedule strings per job |
+| `updater status` | `{updatingContainers, updatingProjects, containerIds, projectIds}` |
+| `settings list` | returns a JSON array directly |
+| `system upgrade-check` | `{canUpgrade, error, message}` |
+| `system docker-info` | raw Docker daemon info struct |
+
+```bash
+# list/get — index .data
+arcane-cli containers list --env 0 --json | jq '.data[] | {id, name: .names[0]}'
+
+# flat — use directly
+arcane-cli containers counts --env 0 --json | jq '.runningContainers'
+arcane-cli images updates summary --env 0 --json | jq '.imagesWithUpdates'
+```
+
+Container fields: `id`, `names` (array, use `names[0]`), `image`, `state`, `status`, `ports`, `labels`, `mounts`, `composeInfo`
+
+Project fields: `id`, `name`, `dirName`, `status`, `serviceCount`, `runningCount`, `updateInfo`, `runtimeServices`, `createdAt`, `updatedAt`
+
+## Setup / Auth
+
+```bash
+# Show current config
+arcane-cli config show
+
+# Set server and key
+arcane-cli config set server-url https://your-arcane-server.com
+arcane-cli config set api-key arc_xxxxx
+
+# Test connection
+arcane-cli config test
+
+# OIDC login (requires OIDC enabled on server)
+arcane-cli auth login
+
+# Who am I
+arcane-cli auth me
+
+# Switch default environment interactively
+arcane-cli environments switch
+```
+
+## Global Flags (work on every command)
+
+| Flag | Description |
+|---|---|
+| `--env <id>` | Override default environment for this call (`"0"` = local) |
+| `--output text\|json` | Output mode (alias: `--json`) |
+| `--yes` / `-y` | Skip confirmation prompts |
+| `--no-color` | Disable ANSI color |
+| `--request-timeout <dur>` | e.g. `--request-timeout 2m` |
+| `--log-level debug` | Verbose debug output |
+
+## Containers
+
+```bash
+arcane-cli containers list                          # running containers
+arcane-cli containers list --all                    # include stopped
+arcane-cli containers list --limit 50 --start 0    # paginate
+arcane-cli containers list --updates has_update     # filter by update status
+arcane-cli containers get <id|name>
+arcane-cli containers start <id|name>
+arcane-cli containers stop <id|name>
+arcane-cli containers restart <id|name>
+arcane-cli containers redeploy <id|name>           # pull image + recreate
+arcane-cli containers update <id|name>             # update container config
+arcane-cli containers delete <id|name>
+arcane-cli containers counts                        # status counts
+arcane-cli containers updates                       # list containers with available updates
+
+# Create a container
+arcane-cli containers create \
+  --name myapp \
+  --image nginx:latest \
+  --port 8080:80 \
+  --env KEY=VALUE \
+  --volume /host:/container \
+  --network shared-web \
+  --restart unless-stopped
+
+# Create from JSON file
+arcane-cli containers create --file container.json
+```
+
+## Projects (Docker Compose)
+
+```bash
+arcane-cli projects list
+arcane-cli projects list --updates has_update      # filter by update status
+arcane-cli projects get <id|name>
+arcane-cli projects up <id|name>                   # start services
+arcane-cli projects down <id|name>                 # stop services
+arcane-cli projects restart <id|name>
+arcane-cli projects redeploy <id|name>             # pull images + restart
+arcane-cli projects pull <id|name>                 # pull latest images only
+arcane-cli projects destroy <id|name>              # remove all containers
+arcane-cli projects destroy <id|name> --force      # skip confirmation
+arcane-cli projects counts
+
+# Create project from compose file
+arcane-cli projects create \
+  --name myproject \
+  --file docker-compose.yml \
+  --env-file .env
+
+# Update project (only pass flags you want to change)
+arcane-cli projects update <id|name> --file docker-compose.yml
+arcane-cli projects update <id|name> --name new-name
+arcane-cli projects update-includes <id|name> --file override.yml
+```
+
+## Images
+
+```bash
+arcane-cli images list
+arcane-cli images get <id|name>
+arcane-cli images remove <id|name>
+arcane-cli images pull nginx:latest
+arcane-cli images prune                            # remove unused images
+arcane-cli images counts
+arcane-cli images upload image.tar                 # upload from tar archive
+
+# Image update checks
+arcane-cli images updates check                    # check default image for updates
+arcane-cli images updates check-all                # check all images
+arcane-cli images updates check-image <image-id>   # check specific image
+arcane-cli images updates summary
+```
+
+## Volumes
+
+```bash
+arcane-cli volumes list
+arcane-cli volumes get <volume-name>
+arcane-cli volumes delete <volume-name>
+arcane-cli volumes prune                           # remove unused volumes
+arcane-cli volumes counts
+arcane-cli volumes sizes                           # disk usage summary
+arcane-cli volumes usage <volume-name>             # specific volume usage
+arcane-cli volumes create --name myvolume
+```
+
+## Networks
+
+```bash
+arcane-cli networks list
+arcane-cli networks get <id|name>
+arcane-cli networks delete <id|name>
+arcane-cli networks prune
+arcane-cli networks counts
+```
+
+## Environments
+
+Environments are Docker hosts managed by Arcane. ID `"0"` is always the Arcane manager's own local Docker socket. Remote environments have UUID IDs.
+
+**If `environments list` returns empty**, the API key is missing `environments:list` permission — create a new key with full admin permissions. Host-specific env IDs live in `~/.agentSecrets/arcane-cli/secrets.md`.
+
+```bash
+arcane-cli environments list
+arcane-cli environments get <id>
+arcane-cli environments test <id>                  # test connectivity
+arcane-cli environments switch                     # interactive default-env picker
+arcane-cli environments update <id>
+arcane-cli environments version <id>               # get agent version on that env
+arcane-cli environments delete <id>
+```
+
+## Registries
+
+```bash
+arcane-cli registries list
+arcane-cli registries get <id>
+arcane-cli registries test <id>
+arcane-cli registries sync                         # sync registry configs
+arcane-cli registries update <id>
+arcane-cli registries delete <id>
+```
+
+## GitOps
+
+```bash
+arcane-cli gitops list
+arcane-cli gitops create
+arcane-cli gitops get <id|name>
+arcane-cli gitops update <id|name>
+arcane-cli gitops delete <id|name>
+arcane-cli gitops status <id|name>
+arcane-cli gitops sync <id|name>                   # trigger a sync now
+arcane-cli gitops files <id|name>                  # list files in the git repo
+arcane-cli gitops import                           # import sync config
+```
+
+## Git Repositories
+
+```bash
+arcane-cli repos list
+arcane-cli repos create
+arcane-cli repos get <repository>
+arcane-cli repos update <repository>
+arcane-cli repos delete <repository>
+arcane-cli repos test <repository>
+arcane-cli repos branches <repository>
+arcane-cli repos files <repository>
+arcane-cli repos sync                              # sync all repos
+```
+
+## Background Jobs
+
+```bash
+arcane-cli jobs get                                # view job schedules
+arcane-cli jobs update                             # update schedule intervals
+```
+
+## Updater (auto-update workflow)
+
+```bash
+arcane-cli updater status
+arcane-cli updater run                             # trigger update run
+arcane-cli updater history
+```
+
+## Settings
+
+```bash
+arcane-cli settings list                           # list environment settings
+arcane-cli settings update                         # update environment settings
+arcane-cli settings public                         # list public settings
+```
+
+## System
+
+```bash
+arcane-cli system prune                            # prune all unused resources
+arcane-cli system docker-info                      # Docker daemon info
+arcane-cli system containers-start-all            # start all containers
+arcane-cli system containers-stop-all             # stop all containers
+arcane-cli system start-stopped                   # start only stopped containers
+arcane-cli system convert "docker run ..."        # convert docker run → compose YAML
+arcane-cli system upgrade                          # trigger Arcane self-upgrade
+arcane-cli system upgrade-check                   # check if upgrade is available
+```
+
+## Admin
+
+```bash
+# API keys
+arcane-cli admin api-keys list
+arcane-cli admin api-keys create <name>
+arcane-cli admin api-keys get <id>
+arcane-cli admin api-keys update <id>
+arcane-cli admin api-keys delete <id>
+
+# Users
+arcane-cli admin users list
+arcane-cli admin users create
+arcane-cli admin users get <user-id>
+arcane-cli admin users update <user-id>            # update profile (roles managed separately)
+arcane-cli admin users delete <user-id>
+
+# Roles & RBAC
+arcane-cli admin roles list
+arcane-cli admin roles get <role-id>
+arcane-cli admin roles create
+arcane-cli admin roles update <role-id>
+arcane-cli admin roles delete <role-id>
+arcane-cli admin roles permissions                 # full permission manifest
+arcane-cli admin roles assignments <user-id>       # list user's current roles
+arcane-cli admin roles assign <user-id> \
+  --role role_editor:env_prod \
+  --role role_viewer                          # replace user's role assignments
+
+# OIDC group → role mappings
+arcane-cli admin oidc-mappings list
+arcane-cli admin oidc-mappings create --claim docker-admins --role role_admin
+arcane-cli admin oidc-mappings update <id>
+arcane-cli admin oidc-mappings delete <id>
+```
+
+## Templates (Docker Compose templates)
+
+```bash
+arcane-cli templates list                          # list local templates
+arcane-cli templates default                       # get built-in default templates
+arcane-cli templates get <template-id|name>        # get template content
+arcane-cli templates content <template-id>         # get raw template content
+arcane-cli templates variables <template-id>       # list template variables
+arcane-cli templates registries                    # list template registries
+arcane-cli templates delete <template-id>
+arcane-cli templates delete-registry <registry-id>
+```
+
+## Utilities
+
+```bash
+arcane-cli generate                                # generate secrets / tokens
+arcane-cli auth federated                          # exchange CI OIDC token for Arcane token
+arcane-cli doctor                                  # run local CLI diagnostics
+arcane-cli version
+arcane-cli self-update                             # update the CLI binary
+arcane-cli completion bash|zsh|fish|powershell
+```
+
+## Config File Reference (`~/.config/arcanecli.yml`)
+
+```yaml
+server_url: https://your-arcane-server.com/
+api_key: arc_xxxxx
+default_environment: "0"
+log_level: info
+pagination:
+  default:
+    limit: 25
+  resources:
+    containers:
+      limit: 50
+    images:
+      limit: 100
+    volumes:
+      limit: 40
+    networks:
+      limit: 40
+```
+
+Config keys for `arcane-cli config set`: `server-url`, `api-key`, `default-environment`, `log-level`
+
+## Common Patterns
+
+```bash
+# JSON output for scripting
+arcane-cli containers list --json | jq '.[].name'
+
+# Target a specific environment
+arcane-cli containers list --env 2
+
+# Skip confirmation on destructive ops
+arcane-cli projects destroy myproject --yes
+
+# Check what's outdated
+arcane-cli containers updates --json
+arcane-cli projects list --updates has_update
+
+# Redeploy a project (pull + restart)
+arcane-cli projects redeploy myproject
+
+# Full system cleanup
+arcane-cli system prune --yes
+```
+
+## Access Rules
+
+**NEVER SSH into any server without explicit user permission.** Use arcane-cli for all remote container/project operations. SSH to servers is not a substitute for arcane-cli commands.
+
+## Project Env File Rules
+
+Arcane projects use env files (`--env-file`) that hold compose secrets (DB passwords, API keys, tokens). These rules apply whenever you're working with a project's env file — whether reading it locally, passing it to `projects create/update`, or inspecting it on the server.
+
+| Operation | Allowed | How |
+|---|---|---|
+| View keys | ✅ | `grep -o '^[^#=][^=]*' .env` — keys only, no values |
+| Check if a key exists | ✅ | `grep -q '^KEY=' .env && echo set \|\| echo missing` |
+| Count entries | ✅ | `grep -c '=' .env` |
+| Add a variable | ✅ | `echo 'KEY=value' >> .env` |
+| Pass to arcane-cli | ✅ | `arcane-cli projects create --env-file .env` — CLI sends it, Claude never reads it |
+| View values | ❌ | Never — not even partially or redacted |
+| Output file contents | ❌ | Never `cat`, `Read`, or print the file |
+
+```bash
+# ✅ What keys are configured?
+grep -o '^[^#=][^=]*' .env
+
+# ✅ How many entries?
+grep -c '=' .env
+
+# ✅ Is DATABASE_URL set?
+grep -q '^DATABASE_URL=' .env && echo "set" || echo "missing"
+
+# ✅ Deploy with env file — Claude passes the path, never reads the values
+arcane-cli projects create --name myapp --file docker-compose.yml --env-file .env
+
+# ❌ Never
+cat .env
+```
+
+## Pitfalls
+
+- `--env` is the **environment ID** (Docker host), not an env-var flag. On `containers create` specifically, `--env`/`-e` also means environment variable (KEY=VALUE) — context matters.
+- Environment ID `"0"` is always the Arcane manager's local Docker socket. It works fine as long as the API key has sufficient permissions.
+- If `environments list` returns empty or `success: false`, the API key lacks `environments:list` — generate a new full-admin key.
+- `arcane-cli projects destroy` removes all containers — use `arcane-cli projects down` to just stop them.
+- `arcane-cli config set` takes key-value pairs: `arcane-cli config set server-url https://... api-key arc_...` (multiple pairs in one call).
+- IDs and names are interchangeable for most resources (the CLI resolves either).

--- a/skills/arcane-cli/SKILL.md
+++ b/skills/arcane-cli/SKILL.md
@@ -363,7 +363,7 @@ Config keys for `arcane-cli config set`: `server-url`, `api-key`, `default-envir
 
 ```bash
 # JSON output for scripting
-arcane-cli containers list --json | jq '.[].name'
+arcane-cli containers list --json | jq '.data[].names[0]'
 
 # Target a specific environment
 arcane-cli containers list --env 2


### PR DESCRIPTION
## Summary

- Adds `skills/arcane-cli/SKILL.md` — an AI agent skill for the arcane-cli, compatible with Claude Code and the [skills.sh](https://skills.sh) ecosystem
- Once merged, users can install it with: `npx skills add getarcaneapp/arcane@arcane-cli -g`

## What's in the skill

- Full command reference for all CLI subcommands (containers, projects, images, volumes, networks, environments, registries, gitops, repos, jobs, admin, system, templates)
- JSON response shapes — documents which commands return `{success, data}` wrappers vs flat objects (`counts`, `jobs get`, `updater status`, etc.)
- Environment discovery — explains the `environments list` 403 pattern when API key lacks permissions and how to resolve it
- Project env file security rules — keys-only access, never expose values
- Global flags, common patterns, and pitfalls

## Test plan

- [ ] `npx skills add getarcaneapp/arcane@arcane-cli -g` installs cleanly after merge
- [ ] Skill triggers correctly when asking Claude to manage containers/projects via arcane-cli

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `skills/arcane-cli/SKILL.md`, an AI agent skill that documents the full `arcane-cli` command surface for Claude Code and the skills.sh ecosystem.

- The skill covers all major subcommands, JSON response shapes, auth setup, global flags, env file security rules, and common pitfalls — good coverage overall.
- One concrete logic error exists in the Common Patterns section: the `containers list` JSON scripting snippet uses `.[].name`, contradicting the JSON Response Shape section (which documents a `{success, data, pagination}` wrapper) and the Container fields note (which specifies `names` as an array accessed via `names[0]`).
- The Config File Reference is a simplified subset of the real config format; `default_limit`, `jwt_token`, `refresh_token`, and `resource_limits` are absent, and `default-limit` is missing from the `config set` key list.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the jq scripting example corrected; the broken pattern would cause agents to emit non-functional shell commands for container scripting.

The jq pattern in Common Patterns directly contradicts the JSON shape documented two sections earlier — an agent trusting both sections will produce a broken pipeline. The config reference is a less critical simplification. Everything else in the skill reads as accurate and consistent with the website docs.

skills/arcane-cli/SKILL.md — specifically the Common Patterns jq example and the Config File Reference section.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat%2Farcane-cli-skill%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Farcane-cli-skill%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Askills%2Farcane-cli%2FSKILL.md%3A365-366%0AThe%20%60containers%20list%60%20JSON%20scripting%20example%20in%20Common%20Patterns%20uses%20%60.%5B%5D.name%60%2C%20but%20the%20JSON%20Response%20Shape%20section%20explicitly%20documents%20that%20list%20commands%20return%20a%20%60%7B%22success%22%3A%20true%2C%20%22data%22%3A%20%5B...%5D%2C%20%22pagination%22%3A%20%7B...%7D%7D%60%20wrapper%20%E2%80%94%20meaning%20%60.data%5B%5D%60%20must%20be%20used.%20Additionally%2C%20the%20Container%20fields%20section%20states%20the%20field%20is%20%60names%60%20%28an%20array%29%2C%20so%20the%20correct%20accessor%20is%20%60.names%5B0%5D%60%2C%20not%20%60.name%60.%20An%20AI%20agent%20following%20this%20skill%20will%20generate%20broken%20jq%20pipelines%20for%20container%20scripting.%0A%0A%60%60%60suggestion%0A%23%20JSON%20output%20for%20scripting%0Aarcane-cli%20containers%20list%20--json%20%7C%20jq%20'.data%5B%5D.names%5B0%5D'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Askills%2Farcane-cli%2FSKILL.md%3A339-360%0AThe%20config%20file%20example%20omits%20several%20real%20keys%20present%20in%20the%20actual%20config%20format%20%28confirmed%20against%20the%20%5Bwebsite%20CLI%20config%20docs%5D%28https%3A%2F%2Fgithub.com%2Fgetarcaneapp%2Fwebsite%2Fblob%2FHEAD%2Fcontent%2Fcli%2Fconfig.md%29%29%3A%20%60default_limit%60%2C%20%60jwt_token%60%2C%20%60refresh_token%60%2C%20and%20the%20%60resource_limits%60%20block.%20An%20agent%20constructing%20or%20patching%20a%20config%20file%20by%20hand%20will%20produce%20an%20incomplete%20YAML.%20The%20%60default-limit%60%20key%20is%20also%20missing%20from%20the%20%22Config%20keys%20for%20%60arcane-cli%20config%20set%60%22%20note%20at%20the%20bottom.%0A%0A%60%60%60suggestion%0A%23%23%20Config%20File%20Reference%20%28%60~%2F.config%2Farcanecli.yml%60%29%0A%0A%60%60%60yaml%0Aserver_url%3A%20https%3A%2F%2Fyour-arcane-server.com%2F%0Aapi_key%3A%20arc_xxxxx%0Adefault_environment%3A%20%220%22%0Adefault_limit%3A%2020%0Alog_level%3A%20info%0Ajwt_token%3A%20''%0Arefresh_token%3A%20''%0Apagination%3A%0A%20%20default%3A%0A%20%20%20%20limit%3A%2025%0A%20%20resources%3A%0A%20%20%20%20containers%3A%0A%20%20%20%20%20%20limit%3A%2050%0A%20%20%20%20images%3A%0A%20%20%20%20%20%20limit%3A%20100%0A%20%20%20%20volumes%3A%0A%20%20%20%20%20%20limit%3A%2040%0A%20%20%20%20networks%3A%0A%20%20%20%20%20%20limit%3A%2040%0Aresource_limits%3A%0A%20%20containers%3A%2050%0A%20%20images%3A%20100%0A%20%20volumes%3A%2040%0A%20%20networks%3A%2040%0A%60%60%60%0A%0AConfig%20keys%20for%20%60arcane-cli%20config%20set%60%3A%20%60server-url%60%2C%20%60api-key%60%2C%20%60default-environment%60%2C%20%60default-limit%60%2C%20%60log-level%60%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2873&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Askills%2Farcane-cli%2FSKILL.md%3A365-366%0AThe%20%60containers%20list%60%20JSON%20scripting%20example%20in%20Common%20Patterns%20uses%20%60.%5B%5D.name%60%2C%20but%20the%20JSON%20Response%20Shape%20section%20explicitly%20documents%20that%20list%20commands%20return%20a%20%60%7B%22success%22%3A%20true%2C%20%22data%22%3A%20%5B...%5D%2C%20%22pagination%22%3A%20%7B...%7D%7D%60%20wrapper%20%E2%80%94%20meaning%20%60.data%5B%5D%60%20must%20be%20used.%20Additionally%2C%20the%20Container%20fields%20section%20states%20the%20field%20is%20%60names%60%20%28an%20array%29%2C%20so%20the%20correct%20accessor%20is%20%60.names%5B0%5D%60%2C%20not%20%60.name%60.%20An%20AI%20agent%20following%20this%20skill%20will%20generate%20broken%20jq%20pipelines%20for%20container%20scripting.%0A%0A%60%60%60suggestion%0A%23%20JSON%20output%20for%20scripting%0Aarcane-cli%20containers%20list%20--json%20%7C%20jq%20'.data%5B%5D.names%5B0%5D'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Askills%2Farcane-cli%2FSKILL.md%3A339-360%0AThe%20config%20file%20example%20omits%20several%20real%20keys%20present%20in%20the%20actual%20config%20format%20%28confirmed%20against%20the%20%5Bwebsite%20CLI%20config%20docs%5D%28https%3A%2F%2Fgithub.com%2Fgetarcaneapp%2Fwebsite%2Fblob%2FHEAD%2Fcontent%2Fcli%2Fconfig.md%29%29%3A%20%60default_limit%60%2C%20%60jwt_token%60%2C%20%60refresh_token%60%2C%20and%20the%20%60resource_limits%60%20block.%20An%20agent%20constructing%20or%20patching%20a%20config%20file%20by%20hand%20will%20produce%20an%20incomplete%20YAML.%20The%20%60default-limit%60%20key%20is%20also%20missing%20from%20the%20%22Config%20keys%20for%20%60arcane-cli%20config%20set%60%22%20note%20at%20the%20bottom.%0A%0A%60%60%60suggestion%0A%23%23%20Config%20File%20Reference%20%28%60~%2F.config%2Farcanecli.yml%60%29%0A%0A%60%60%60yaml%0Aserver_url%3A%20https%3A%2F%2Fyour-arcane-server.com%2F%0Aapi_key%3A%20arc_xxxxx%0Adefault_environment%3A%20%220%22%0Adefault_limit%3A%2020%0Alog_level%3A%20info%0Ajwt_token%3A%20''%0Arefresh_token%3A%20''%0Apagination%3A%0A%20%20default%3A%0A%20%20%20%20limit%3A%2025%0A%20%20resources%3A%0A%20%20%20%20containers%3A%0A%20%20%20%20%20%20limit%3A%2050%0A%20%20%20%20images%3A%0A%20%20%20%20%20%20limit%3A%20100%0A%20%20%20%20volumes%3A%0A%20%20%20%20%20%20limit%3A%2040%0A%20%20%20%20networks%3A%0A%20%20%20%20%20%20limit%3A%2040%0Aresource_limits%3A%0A%20%20containers%3A%2050%0A%20%20images%3A%20100%0A%20%20volumes%3A%2040%0A%20%20networks%3A%2040%0A%60%60%60%0A%0AConfig%20keys%20for%20%60arcane-cli%20config%20set%60%3A%20%60server-url%60%2C%20%60api-key%60%2C%20%60default-environment%60%2C%20%60default-limit%60%2C%20%60log-level%60%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2873&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
skills/arcane-cli/SKILL.md:365-366
The `containers list` JSON scripting example in Common Patterns uses `.[].name`, but the JSON Response Shape section explicitly documents that list commands return a `{"success": true, "data": [...], "pagination": {...}}` wrapper — meaning `.data[]` must be used. Additionally, the Container fields section states the field is `names` (an array), so the correct accessor is `.names[0]`, not `.name`. An AI agent following this skill will generate broken jq pipelines for container scripting.

```suggestion
# JSON output for scripting
arcane-cli containers list --json | jq '.data[].names[0]'
```

### Issue 2 of 2
skills/arcane-cli/SKILL.md:339-360
The config file example omits several real keys present in the actual config format (confirmed against the [website CLI config docs](https://github.com/getarcaneapp/website/blob/HEAD/content/cli/config.md)): `default_limit`, `jwt_token`, `refresh_token`, and the `resource_limits` block. An agent constructing or patching a config file by hand will produce an incomplete YAML. The `default-limit` key is also missing from the "Config keys for `arcane-cli config set`" note at the bottom.

```suggestion
## Config File Reference (`~/.config/arcanecli.yml`)

```yaml
server_url: https://your-arcane-server.com/
api_key: arc_xxxxx
default_environment: "0"
default_limit: 20
log_level: info
jwt_token: ''
refresh_token: ''
pagination:
  default:
    limit: 25
  resources:
    containers:
      limit: 50
    images:
      limit: 100
    volumes:
      limit: 40
    networks:
      limit: 40
resource_limits:
  containers: 50
  images: 100
  volumes: 40
  networks: 40
```

Config keys for `arcane-cli config set`: `server-url`, `api-key`, `default-environment`, `default-limit`, `log-level`
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(skills): add arcane-cli agent skill"](https://github.com/getarcaneapp/arcane/commit/1f22aab3235063fee035962bb913df7391601df5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36153679)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->