### PR TITLE
fix: add missing swarm-identity endpoint in edge tunnel

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -211,7 +212,11 @@ func setupRouter(ctx context.Context, cfg *config.Config, appServices *di.Servic
 	}
 
 	if err := frontend.RegisterFrontend(e); err != nil {
-		slog.Error("Failed to register frontend", "error", err)
+		if errors.Is(err, frontend.ErrFrontendNotIncluded) {
+			slog.Debug("Frontend not included in this build; skipping frontend registration")
+		} else {
+			slog.Error("Failed to register frontend", "error", err)
+		}
 	}
 
 	return e, tunnelServer

--- a/backend/pkg/libarcane/edge/commands.go
+++ b/backend/pkg/libarcane/edge/commands.go
@@ -17,6 +17,7 @@ var commandRoutes = []commandRoute{
 	{Method: http.MethodGet, PathPattern: "/api/health", CommandName: "system.health"},
 	{Method: http.MethodHead, PathPattern: "/api/health", CommandName: "system.health"},
 	{Method: http.MethodGet, PathPattern: "/api/app-version", CommandName: "system.version"},
+	{Method: http.MethodGet, PathPattern: "/api/swarm/node-identity", CommandName: "swarm.node_identity"},
 	{Method: http.MethodPost, PathPattern: "/api/container-registries/sync", CommandName: "container_registry.sync"},
 	{Method: http.MethodPost, PathPattern: "/api/git-repositories/sync", CommandName: "git_repository.sync"},
 

--- a/backend/pkg/libarcane/edge/commands_test.go
+++ b/backend/pkg/libarcane/edge/commands_test.go
@@ -31,6 +31,7 @@ func TestResolveEdgeCommandName(t *testing.T) {
 		{name: "activity history clear", method: "DELETE", path: "/api/environments/0/activities/history", command: "activity.history.clear", shouldHit: true},
 		{name: "activity stream remains manager local", method: "GET", path: "/api/environments/0/activities/stream?limit=50", shouldHit: false},
 		{name: "health", method: "HEAD", path: "/api/environments/0/system/health", command: "system.health", shouldHit: true},
+		{name: "swarm node identity", method: "GET", path: "/api/swarm/node-identity", command: "swarm.node_identity", shouldHit: true},
 		{name: "unknown", method: "PATCH", path: "/api/environments/0/containers", shouldHit: false},
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2734

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the missing `GET /api/swarm/node-identity` route to the edge tunnel command registry so the manager can proxy swarm identity requests through to agents. It also demotes the `ErrFrontendNotIncluded` log from error to debug for builds that intentionally omit the frontend.

- **`commands.go`**: Registers `swarm.node_identity` in `commandRoutes`, exposing it through the edge tunnel alongside the existing global routes (`/api/health`, `/api/app-version`).
- **`commands_test.go`**: Adds a matching test case verifying the new route resolves and validates correctly.
- **`router_bootstrap.go`**: Wraps `frontend.RegisterFrontend` error handling with an `errors.Is` check to log a debug message (not an error) when the frontend simply isn't compiled in.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is minimal, well-tested, and consistent with existing tunnel routing patterns.

The new tunnel route follows the exact same structure as every other global route in the file, a dedicated test case was added alongside the change, and the router_bootstrap.go fix is a clear log-noise reduction with no behavioral change on the happy path.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add missing swarm-identity endpoint..."](https://github.com/getarcaneapp/arcane/commit/f6c20fbc931acbf772fe43d9dfda26d9d0386530) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36517996)</sub>

<!-- /greptile_comment -->