### PR TITLE
fix: x-arcane.icon-light/icon-dark overwriting service-level icons

### DIFF
--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -1154,7 +1154,7 @@ func (s *ContainerService) applyContainerDetailsIconInternal(ctx context.Context
 
 func (s *ContainerService) resolveContainerIconInternal(ctx context.Context, labels map[string]string, metadataByProject map[string]projects.ArcaneComposeMetadata) iconcatalog.ResolvedIconSet {
 	explicitIcon := projects.FindArcaneIconSet(labels)
-	if iconSetHasBothVariantsInternal(explicitIcon) {
+	if !explicitIcon.IsEmpty() {
 		return s.resolveIconSetInternal(ctx, explicitIcon)
 	}
 
@@ -1171,10 +1171,6 @@ func (s *ContainerService) resolveContainerIconInternal(ctx context.Context, lab
 		meta.ServiceIconSets[serviceName],
 		meta.ProjectIcon,
 	))
-}
-
-func iconSetHasBothVariantsInternal(iconSet iconcatalog.IconSet) bool {
-	return strings.TrimSpace(iconSet.Light) != "" && strings.TrimSpace(iconSet.Dark) != ""
 }
 
 func (s *ContainerService) getCachedProjectIconMetadataInternal(ctx context.Context, projectName string, metadataByProject map[string]projects.ArcaneComposeMetadata) projects.ArcaneComposeMetadata {

--- a/backend/pkg/projects/custom_labels_test.go
+++ b/backend/pkg/projects/custom_labels_test.go
@@ -36,6 +36,30 @@ x-arcane:
 	require.Equal(t, []string{"https://www.example.com"}, meta.ProjectURLS)
 }
 
+func TestParseArcaneComposeMetadata_ServiceLabelIconsOutrankProjectIcon(t *testing.T) {
+	tempDir := t.TempDir()
+
+	composeContent := `x-arcane:
+  icon-light: umami
+  icon-dark: umami
+services:
+  umami:
+    image: ghcr.io/umami-software/umami:latest
+  db:
+    image: postgres:16
+    labels:
+      com.getarcaneapp.arcane.icon-light: postgres
+      com.getarcaneapp.arcane.icon-dark: postgres
+`
+	composePath := filepath.Join(tempDir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte(composeContent), 0o600))
+
+	meta, err := ParseArcaneComposeMetadata(context.Background(), composePath, tempDir, false)
+	require.NoError(t, err)
+	require.Equal(t, IconSet{Light: "postgres", Dark: "postgres"}, meta.ServiceIconSets["db"])
+	require.NotContains(t, meta.ServiceIconSets, "umami")
+}
+
 func TestParseArcaneComposeMetadata_IncludeSupport(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/backend/pkg/utils/iconcatalog/iconcatalog.go
+++ b/backend/pkg/utils/iconcatalog/iconcatalog.go
@@ -30,39 +30,14 @@ func (s IconSet) IsEmpty() bool {
 		strings.TrimSpace(s.Dark) == ""
 }
 
-func (s IconSet) HasVariant() bool {
-	return strings.TrimSpace(s.Light) != "" || strings.TrimSpace(s.Dark) != ""
-}
-
+// FirstNonEmpty returns the first set that defines any icon value. Levels are
+// isolated: a set that defines one variant never inherits the others from
+// lower-precedence sets.
 func FirstNonEmpty(sets ...IconSet) IconSet {
-	merged := IconSet{}
-	fallback := ""
-
 	for _, set := range sets {
-		if fallback == "" {
-			fallback = strings.TrimSpace(set.Icon)
+		if !set.IsEmpty() {
+			return set
 		}
-		if merged.Light == "" {
-			merged.Light = strings.TrimSpace(set.Light)
-		}
-		if merged.Dark == "" {
-			merged.Dark = strings.TrimSpace(set.Dark)
-		}
-	}
-
-	if strings.TrimSpace(merged.Light) != "" || strings.TrimSpace(merged.Dark) != "" {
-		if fallback != "" {
-			if merged.Light == "" {
-				merged.Light = fallback
-			}
-			if merged.Dark == "" {
-				merged.Dark = fallback
-			}
-		}
-		return merged
-	}
-	if fallback != "" {
-		return IconSet{Icon: fallback}
 	}
 	return IconSet{}
 }
@@ -77,19 +52,22 @@ func Resolve(catalog string, set IconSet) ResolvedIconSet {
 		}
 	}
 
-	light := strings.TrimSpace(set.Light)
-	if light == "" {
-		light = strings.TrimSpace(set.Icon)
-	}
-	dark := strings.TrimSpace(set.Dark)
-	if dark == "" {
-		dark = strings.TrimSpace(set.Icon)
-	}
+	light := firstNonEmptyValueInternal(set.Light, set.Icon, set.Dark)
+	dark := firstNonEmptyValueInternal(set.Dark, set.Icon, set.Light)
 
 	return ResolvedIconSet{
 		IconLightURL: resolveValueInternal(selectedCatalog, light, "light"),
 		IconDarkURL:  resolveValueInternal(selectedCatalog, dark, "dark"),
 	}
+}
+
+func firstNonEmptyValueInternal(values ...string) string {
+	for _, v := range values {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func normalizeCatalogInternal(catalog string) string {

--- a/backend/pkg/utils/iconcatalog/iconcatalog_test.go
+++ b/backend/pkg/utils/iconcatalog/iconcatalog_test.go
@@ -1,0 +1,21 @@
+package iconcatalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirstNonEmpty_LevelIsolation(t *testing.T) {
+	containerSet := IconSet{Light: "postgres"}
+	projectSet := IconSet{Light: "umami", Dark: "umami"}
+
+	require.Equal(t, containerSet, FirstNonEmpty(containerSet, IconSet{}, projectSet))
+	require.Equal(t, projectSet, FirstNonEmpty(IconSet{}, IconSet{}, projectSet))
+}
+
+func TestResolve_SingleVariantFallsBackWithinLevel(t *testing.T) {
+	resolved := Resolve(CatalogSelfhst, IconSet{Light: "postgres"})
+	require.Equal(t, "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/postgres-light.svg", resolved.IconLightURL)
+	require.Equal(t, "https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/postgres-dark.svg", resolved.IconDarkURL)
+}

--- a/backend/pkg/utils/strings.go
+++ b/backend/pkg/utils/strings.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -70,6 +71,15 @@ func AsStringMap(value any) (map[string]any, bool) {
 			}
 		}
 		return res, len(res) > 0
+	}
+	// Named map types (e.g. compose-go's types.Labels) don't match the cases above.
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Map && rv.Type().Key().Kind() == reflect.String {
+		res := make(map[string]any, rv.Len())
+		for iter := rv.MapRange(); iter.Next(); {
+			res[iter.Key().String()] = iter.Value().Interface()
+		}
+		return res, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2879

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where a container-level `x-arcane.icon-light`/`icon-dark` label (with only one variant set) was not taking precedence over the project-level icon, because the previous guard required **both** `Light` and `Dark` to be non-empty before returning early. The fix uses `IsEmpty()` (any non-empty field) instead, and refactors `FirstNonEmpty` to be level-isolated (no cross-set variant merging) and `Resolve` to fall back within a single `IconSet` (light→icon→dark, dark→icon→light).

- **`resolveContainerIconInternal`**: guard changed from requiring both variants to requiring any non-empty value; removes `iconSetHasBothVariantsInternal` helper.
- **`FirstNonEmpty` (iconcatalog)**: now returns the first non-empty `IconSet` atomically instead of merging fields across sets; `HasVariant()` method removed (no other callers).
- **`Resolve`**: single-variant fallback now cross-falls within the same set using `firstNonEmptyValueInternal`, so `IconSet{Light: "postgres"}` produces valid URLs for both themes.
- **`AsStringMap`**: adds a reflect-based fallback for named map types (e.g. compose-go's `types.Labels`) that don't match the existing type-switch cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrow, well-tested, and makes the icon-resolution logic more permissive and consistent with user intent.

The guard change from 'both variants required' to 'any non-empty field' directly matches the reported bug scenario. `FirstNonEmpty` and `Resolve` are refactored in a complementary way: level isolation prevents the old cross-set bleed, and within-set fallback ensures a single-variant label still produces usable URLs for both light and dark themes. New unit and integration tests cover the key cases. The `AsStringMap` reflect addition is limited in scope and the callers handle an empty-map result correctly.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: x-arcane.icon-light/icon-dark overw..."](https://github.com/getarcaneapp/arcane/commit/a14d511520da7ef4cab005b609f6d826eb79818f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36583859)</sub>

<!-- /greptile_comment -->