### PR TITLE
refactor: reduce handler duplication and cleanup

### DIFF
--- a/backend/api/handlers/activities.go
+++ b/backend/api/handlers/activities.go
@@ -189,15 +189,9 @@ func (h *ActivityHandler) ListActivities(ctx context.Context, input *ListActivit
 
 	return &ListActivitiesOutput{
 		Body: base.Paginated[activity.Activity]{
-			Success: true,
-			Data:    activities,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       activities,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/apikeys.go
+++ b/backend/api/handlers/apikeys.go
@@ -10,7 +10,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/apikey"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 )
@@ -202,19 +201,7 @@ func (h *ApiKeyHandler) ListApiKeys(ctx context.Context, input *ListApiKeysInput
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: input.Search,
-		},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-	}
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 
 	apiKeys, paginationResp, err := h.apiKeyService.ListApiKeys(ctx, params)
 	if err != nil {
@@ -223,15 +210,9 @@ func (h *ApiKeyHandler) ListApiKeys(ctx context.Context, input *ListApiKeysInput
 
 	return &ListApiKeysOutput{
 		Body: ApiKeyPaginatedResponse{
-			Success: true,
-			Data:    apiKeys,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       apiKeys,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -266,9 +247,9 @@ func (h *ApiKeyHandler) UpdateApiKey(ctx context.Context, input *UpdateApiKeyInp
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	apiKey, err := h.apiKeyService.UpdateApiKey(ctx, user.ID, input.ID, input.Body)
@@ -325,9 +306,9 @@ func (h *ApiKeyHandler) ListMyApiKeys(ctx context.Context, input *struct{}) (*Li
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	keys, err := h.apiKeyService.ListApiKeysByUser(ctx, user.ID)
@@ -353,9 +334,9 @@ func (h *ApiKeyHandler) createCurrentUserApiKeyInternal(ctx context.Context, inp
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	apiKey, err := h.apiKeyService.CreateApiKey(ctx, user.ID, input.Body)
@@ -382,9 +363,9 @@ func (h *ApiKeyHandler) DeleteMyApiKey(ctx context.Context, input *DeleteApiKeyI
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	existing, err := h.apiKeyService.GetApiKey(ctx, input.ID)

--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -319,9 +319,9 @@ func (h *AuthHandler) ChangePassword(ctx context.Context, input *ChangePasswordI
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	userModel, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	userModel, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if input.Body.CurrentPassword == "" {
@@ -329,7 +329,7 @@ func (h *AuthHandler) ChangePassword(ctx context.Context, input *ChangePasswordI
 	}
 
 	currentSessionID, _ := humamw.GetCurrentSessionIDFromContext(ctx)
-	err := h.authService.ChangePassword(ctx, userModel.ID, input.Body.CurrentPassword, input.Body.NewPassword, currentSessionID)
+	err = h.authService.ChangePassword(ctx, userModel.ID, input.Body.CurrentPassword, input.Body.NewPassword, currentSessionID)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrInvalidCredentials):
@@ -356,9 +356,9 @@ func (h *AuthHandler) LogoutAllOtherSessions(ctx context.Context, input *struct{
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	userModel, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	userModel, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	currentSessionID, _ := humamw.GetCurrentSessionIDFromContext(ctx)
@@ -383,9 +383,9 @@ func (h *AuthHandler) UpdateMyProfile(ctx context.Context, input *UpdateMyProfil
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	currentUser, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	currentUser, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	isOidcUser := currentUser.OidcSubjectId != nil && *currentUser.OidcSubjectId != ""

--- a/backend/api/handlers/container_registries.go
+++ b/backend/api/handlers/container_registries.go
@@ -242,15 +242,9 @@ func (h *ContainerRegistryHandler) ListRegistries(ctx context.Context, input *Li
 
 	return &ListContainerRegistriesOutput{
 		Body: ContainerRegistryPaginatedResponse{
-			Success: true,
-			Data:    registries,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       registries,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/containers.go
+++ b/backend/api/handlers/containers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2/base"
@@ -261,25 +260,12 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	filters := make(map[string]string)
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.Updates != "" {
-		filters["updates"] = input.Updates
+		params.Filters["updates"] = input.Updates
 	}
 	if input.Standalone != "" {
-		filters["standalone"] = input.Standalone
-	}
-
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{Search: input.Search},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: filters,
+		params.Filters["standalone"] = input.Standalone
 	}
 
 	result, err := h.containerService.ListContainersPaginated(ctx, params, true, input.IncludeInternal, input.GroupBy)
@@ -289,17 +275,11 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 
 	return &ListContainersOutput{
 		Body: ContainerPaginatedResponse{
-			Success: true,
-			Data:    result.Items,
-			Groups:  result.Groups,
-			Counts:  result.Counts,
-			Pagination: base.PaginationResponse{
-				TotalPages:      result.Pagination.TotalPages,
-				TotalItems:      result.Pagination.TotalItems,
-				CurrentPage:     result.Pagination.CurrentPage,
-				ItemsPerPage:    result.Pagination.ItemsPerPage,
-				GrandTotalItems: result.Pagination.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       result.Items,
+			Groups:     result.Groups,
+			Counts:     result.Counts,
+			Pagination: toPaginationResponseInternal(result.Pagination),
 		},
 	}, nil
 }
@@ -553,9 +533,9 @@ func (h *ContainerHandler) CreateContainer(ctx context.Context, input *CreateCon
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	config := buildContainerConfig(input.Body)
@@ -677,9 +657,9 @@ func (h *ContainerHandler) runContainerActionInternal(ctx context.Context, input
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -703,9 +683,9 @@ func (h *ContainerHandler) RedeployContainer(ctx context.Context, input *Contain
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -752,9 +732,9 @@ func (h *ContainerHandler) DeleteContainer(ctx context.Context, input *DeleteCon
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)

--- a/backend/api/handlers/environments.go
+++ b/backend/api/handlers/environments.go
@@ -22,7 +22,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	httputils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
@@ -428,20 +427,7 @@ func (h *EnvironmentHandler) ListEnvironments(ctx context.Context, input *ListEn
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: input.Search,
-		},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: map[string]string{},
-	}
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.Type != "" {
 		params.Filters["type"] = input.Type
 	}
@@ -456,15 +442,9 @@ func (h *EnvironmentHandler) ListEnvironments(ctx context.Context, input *ListEn
 
 	return &ListEnvironmentsOutput{
 		Body: EnvironmentPaginatedResponse{
-			Success: true,
-			Data:    envs,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       envs,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -475,9 +455,9 @@ func (h *EnvironmentHandler) CreateEnvironment(ctx context.Context, input *Creat
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	env := &models.Environment{
@@ -645,9 +625,9 @@ func (h *EnvironmentHandler) UpdateEnvironment(ctx context.Context, input *Updat
 	// If regenerating API key, return the new key
 	var newApiKey *string
 	if input.Body.RegenerateApiKey != nil && *input.Body.RegenerateApiKey {
-		user, exists := humamw.GetCurrentUserFromContext(ctx)
-		if !exists {
-			return nil, huma.Error401Unauthorized("Unauthorized")
+		user, err := requireUserInternal(ctx)
+		if err != nil {
+			return nil, err
 		}
 
 		// Delete existing API key if any

--- a/backend/api/handlers/events.go
+++ b/backend/api/handlers/events.go
@@ -213,15 +213,9 @@ func (h *EventHandler) ListEvents(ctx context.Context, input *ListEventsInput) (
 
 	return &ListEventsOutput{
 		Body: EventPaginatedResponse{
-			Success: true,
-			Data:    events,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       events,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -252,15 +246,9 @@ func (h *EventHandler) GetEventsByEnvironment(ctx context.Context, input *GetEve
 
 	return &GetEventsByEnvironmentOutput{
 		Body: EventPaginatedResponse{
-			Success: true,
-			Data:    events,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       events,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/federated.go
+++ b/backend/api/handlers/federated.go
@@ -9,7 +9,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	federatedtypes "github.com/getarcaneapp/arcane/types/v2/federated"
 	"github.com/labstack/echo/v4"
@@ -187,32 +186,16 @@ func (h *FederatedCredentialHandler) ListFederatedCredentials(ctx context.Contex
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	credentials, paginationResp, err := h.federatedCredentialService.List(ctx, pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{Search: input.Search},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-	})
+	credentials, paginationResp, err := h.federatedCredentialService.List(ctx, buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search))
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to list federated credentials")
 	}
 
 	return &ListFederatedCredentialsOutput{
 		Body: base.Paginated[federatedtypes.FederatedCredential]{
-			Success: true,
-			Data:    credentials,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       credentials,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -221,9 +204,9 @@ func (h *FederatedCredentialHandler) CreateFederatedCredential(ctx context.Conte
 	if h.federatedCredentialService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	credential, err := h.federatedCredentialService.Create(ctx, user.ID, input.Body)
@@ -260,9 +243,9 @@ func (h *FederatedCredentialHandler) UpdateFederatedCredential(ctx context.Conte
 	if h.federatedCredentialService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	credential, err := h.federatedCredentialService.Update(ctx, user.ID, input.ID, input.Body)

--- a/backend/api/handlers/git_repositories.go
+++ b/backend/api/handlers/git_repositories.go
@@ -146,15 +146,9 @@ func (h *GitRepositoryHandler) ListRepositories(ctx context.Context, input *List
 
 	return &ListGitRepositoriesOutput{
 		Body: GitRepositoryPaginatedResponse{
-			Success: true,
-			Data:    repositories,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       repositories,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/gitops_syncs.go
+++ b/backend/api/handlers/gitops_syncs.go
@@ -154,16 +154,10 @@ func (h *GitOpsSyncHandler) ListSyncs(ctx context.Context, input *ListGitOpsSync
 
 	return &ListGitOpsSyncsOutput{
 		Body: GitOpsSyncPaginatedResponse{
-			Success: true,
-			Data:    syncs,
-			Counts:  counts,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       syncs,
+			Counts:     counts,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/helpers.go
+++ b/backend/api/handlers/helpers.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	humamw "github.com/getarcaneapp/arcane/backend/v2/api/middleware"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
@@ -37,17 +39,17 @@ func (c ActivityAppContext) contextInternal() context.Context {
 // buildPaginationParamsInternal converts query parameters to pagination.QueryParams.
 // A limit of -1 means "show all items" (no pagination).
 func buildPaginationParamsInternal(start, limit int, sortCol, sortDir, search string) pagination.QueryParams {
-	// limit = -1 means "show all", preserve it; zero or other negative values default to 20
+	// limit = -1 means "show all" and 0 means "no pagination"; only invalid values default to 20
 	if limit < -1 {
 		limit = 20
 	}
 
 	return pagination.QueryParams{
 		SearchQuery: pagination.SearchQuery{
-			Search: search,
+			Search: strings.TrimSpace(search),
 		},
 		SortParams: pagination.SortParams{
-			Sort:  sortCol,
+			Sort:  strings.TrimSpace(sortCol),
 			Order: pagination.SortOrder(sortDir),
 		},
 		Params: pagination.Params{
@@ -56,6 +58,26 @@ func buildPaginationParamsInternal(start, limit int, sortCol, sortDir, search st
 		},
 		Filters: make(map[string]string),
 	}
+}
+
+// toPaginationResponseInternal converts the pagination package's response into the API response shape.
+func toPaginationResponseInternal(p pagination.Response) base.PaginationResponse {
+	return base.PaginationResponse{
+		TotalPages:      p.TotalPages,
+		TotalItems:      p.TotalItems,
+		CurrentPage:     p.CurrentPage,
+		ItemsPerPage:    p.ItemsPerPage,
+		GrandTotalItems: p.GrandTotalItems,
+	}
+}
+
+// requireUserInternal returns the authenticated user from the request context or a 401 error.
+func requireUserInternal(ctx context.Context) (*models.User, error) {
+	user, exists := humamw.GetCurrentUserFromContext(ctx)
+	if !exists || user == nil {
+		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	}
+	return user, nil
 }
 
 func registerSecuredInternal[I, O any](

--- a/backend/api/handlers/images.go
+++ b/backend/api/handlers/images.go
@@ -15,7 +15,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/types/v2/base"
@@ -331,27 +330,12 @@ func (h *ImageHandler) ListImages(ctx context.Context, input *ListImagesInput) (
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	filters := make(map[string]string)
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.InUse != "" {
-		filters["inUse"] = input.InUse
+		params.Filters["inUse"] = input.InUse
 	}
 	if input.Updates != "" {
-		filters["updates"] = input.Updates
-	}
-
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: input.Search,
-		},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: filters,
+		params.Filters["updates"] = input.Updates
 	}
 
 	if params.Limit == 0 {
@@ -369,15 +353,9 @@ func (h *ImageHandler) ListImages(ctx context.Context, input *ListImagesInput) (
 
 	return &ListImagesOutput{
 		Body: ImagePaginatedResponse{
-			Success: true,
-			Data:    images,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       images,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -407,9 +385,9 @@ func (h *ImageHandler) RemoveImage(ctx context.Context, input *RemoveImageInput)
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := h.imageService.RemoveImage(ctx, input.ImageID, input.Force, *user); err != nil {
@@ -436,9 +414,9 @@ func (h *ImageHandler) PullImage(ctx context.Context, input *PullImageInput) (*h
 		return nil, huma.Error400BadRequest("image name is required")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get full image name with tag and credentials
@@ -492,9 +470,9 @@ func (h *ImageHandler) BuildImage(ctx context.Context, input *BuildImageInput) (
 		return nil, huma.Error400BadRequest("contextDir is required")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	return &huma.StreamResponse{
@@ -567,15 +545,9 @@ func (h *ImageHandler) ListImageBuilds(ctx context.Context, input *ListImageBuil
 
 	return &ListImageBuildsOutput{
 		Body: ImageBuildPaginatedResponse{
-			Success: true,
-			Data:    builds,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       builds,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -738,9 +710,9 @@ func (h *ImageHandler) UploadImage(ctx context.Context, input *UploadImageInput)
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get file from multipart form

--- a/backend/api/handlers/networks.go
+++ b/backend/api/handlers/networks.go
@@ -15,7 +15,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/v2/base"
@@ -218,24 +217,9 @@ func RegisterNetworks(api huma.API, networkSvc *services.NetworkService, dockerS
 }
 
 func (h *NetworkHandler) ListNetworks(ctx context.Context, input *ListNetworksInput) (*ListNetworksOutput, error) {
-	filters := make(map[string]string)
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.InUse != "" {
-		filters["inUse"] = input.InUse
-	}
-
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: strings.TrimSpace(input.Search),
-		},
-		SortParams: pagination.SortParams{
-			Sort:  strings.TrimSpace(input.Sort),
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: filters,
+		params.Filters["inUse"] = input.InUse
 	}
 
 	networks, paginationResp, counts, err := h.networkService.ListNetworksPaginated(ctx, params)
@@ -245,16 +229,10 @@ func (h *NetworkHandler) ListNetworks(ctx context.Context, input *ListNetworksIn
 
 	return &ListNetworksOutput{
 		Body: NetworkPaginatedResponse{
-			Success: true,
-			Data:    networks,
-			Counts:  counts,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       networks,
+			Counts:     counts,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -278,9 +256,9 @@ func (h *NetworkHandler) GetNetworkCounts(ctx context.Context, input *GetNetwork
 }
 
 func (h *NetworkHandler) CreateNetwork(ctx context.Context, input *CreateNetworkInput) (*CreateNetworkOutput, error) {
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Convert to Docker SDK options
@@ -428,9 +406,9 @@ func (h *NetworkHandler) GetNetworkTopology(ctx context.Context, input *GetNetwo
 }
 
 func (h *NetworkHandler) DeleteNetwork(ctx context.Context, input *DeleteNetworkInput) (*DeleteNetworkOutput, error) {
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized("not authenticated")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)

--- a/backend/api/handlers/ports.go
+++ b/backend/api/handlers/ports.go
@@ -3,13 +3,11 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	humamw "github.com/getarcaneapp/arcane/backend/v2/api/middleware"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	porttypes "github.com/getarcaneapp/arcane/types/v2/port"
 )
@@ -56,19 +54,7 @@ func (h *PortHandler) ListPorts(ctx context.Context, input *ListPortsInput) (*Li
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: strings.TrimSpace(input.Search),
-		},
-		SortParams: pagination.SortParams{
-			Sort:  strings.TrimSpace(input.Sort),
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-	}
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 
 	items, paginationResp, err := h.portService.ListPortsPaginated(ctx, params)
 	if err != nil {
@@ -77,15 +63,9 @@ func (h *PortHandler) ListPorts(ctx context.Context, input *ListPortsInput) (*Li
 
 	return &ListPortsOutput{
 		Body: PortPaginatedResponse{
-			Success: true,
-			Data:    items,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       items,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -16,7 +16,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
@@ -505,30 +504,15 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, input *ListProjectsIn
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	filters := map[string]string{}
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.Status != "" {
-		filters["status"] = input.Status
+		params.Filters["status"] = input.Status
 	}
 	if input.Updates != "" {
-		filters["updates"] = input.Updates
+		params.Filters["updates"] = input.Updates
 	}
 	if input.Archived != "" {
-		filters["archived"] = input.Archived
-	}
-
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: input.Search,
-		},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: filters,
+		params.Filters["archived"] = input.Archived
 	}
 
 	projects, paginationResp, err := h.projectService.ListProjects(ctx, params)
@@ -545,15 +529,9 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, input *ListProjectsIn
 
 	return &ListProjectsOutput{
 		Body: ProjectPaginatedResponse{
-			Success: true,
-			Data:    projects,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       projects,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -592,9 +570,9 @@ func (h *ProjectHandler) DeployProject(ctx context.Context, input *DeployProject
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	return &huma.StreamResponse{
@@ -653,9 +631,9 @@ func (h *ProjectHandler) DownProject(ctx context.Context, input *DownProjectInpu
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -690,9 +668,9 @@ func (h *ProjectHandler) CreateProject(ctx context.Context, input *CreateProject
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var proj *models.Project
@@ -867,9 +845,9 @@ func (h *ProjectHandler) DestroyProject(ctx context.Context, input *DestroyProje
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	removeFiles := false
@@ -919,9 +897,9 @@ func (h *ProjectHandler) UpdateProject(ctx context.Context, input *UpdateProject
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -968,9 +946,9 @@ func (h *ProjectHandler) UpdateProjectInclude(ctx context.Context, input *Update
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -1105,9 +1083,9 @@ func (h *ProjectHandler) runProjectActivityActionInternal(ctx context.Context, e
 		return base.MessageResponse{}, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return base.MessageResponse{}, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return base.MessageResponse{}, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -1137,9 +1115,9 @@ func (h *ProjectHandler) ArchiveProject(ctx context.Context, input *ArchiveProje
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := h.projectService.ArchiveProject(ctx, input.ProjectID, *user); err != nil {
@@ -1166,9 +1144,9 @@ func (h *ProjectHandler) UnarchiveProject(ctx context.Context, input *UnarchiveP
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := h.projectService.UnarchiveProject(ctx, input.ProjectID, *user); err != nil {
@@ -1193,9 +1171,9 @@ func (h *ProjectHandler) PullProjectImages(ctx context.Context, input *PullProje
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	return &huma.StreamResponse{
@@ -1254,9 +1232,9 @@ func (h *ProjectHandler) BuildProjectImages(ctx context.Context, input *BuildPro
 		return nil, huma.Error400BadRequest((&common.ProjectIDRequiredError{}).Error())
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	options := services.ProjectBuildOptions{}

--- a/backend/api/handlers/roles.go
+++ b/backend/api/handlers/roles.go
@@ -201,15 +201,9 @@ func (h *RoleHandler) ListRoles(ctx context.Context, input *ListRolesInput) (*Li
 	}
 	return &ListRolesOutput{
 		Body: RolePaginatedResponse{
-			Success: true,
-			Data:    dtos,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       dtos,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/swarm.go
+++ b/backend/api/handlers/swarm.go
@@ -867,9 +867,9 @@ func (h *SwarmHandler) GetNodeAgentDeployment(ctx context.Context, input *GetSwa
 		return nil, mapSwarmServiceError(err, (&common.SwarmNodeNotFoundError{Err: err}).Error())
 	}
 
-	user, ok := humamw.GetCurrentUserFromContext(ctx)
-	if !ok || user == nil {
-		return nil, huma.Error401Unauthorized("Unauthorized")
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	env, apiKey, err := h.environmentService.EnsureSwarmNodeAgentEnvironment(
@@ -1834,15 +1834,9 @@ func (h *SwarmHandler) DeleteSecret(ctx context.Context, input *DeleteSwarmSecre
 // Returns a SwarmPaginatedResponse with `Success` set to true.
 func toSwarmPaginatedResponse[T any](items []T, p pagination.Response) SwarmPaginatedResponse[T] {
 	return SwarmPaginatedResponse[T]{
-		Success: true,
-		Data:    items,
-		Pagination: base.PaginationResponse{
-			TotalPages:      p.TotalPages,
-			TotalItems:      p.TotalItems,
-			CurrentPage:     p.CurrentPage,
-			ItemsPerPage:    p.ItemsPerPage,
-			GrandTotalItems: p.GrandTotalItems,
-		},
+		Success:    true,
+		Data:       items,
+		Pagination: toPaginationResponseInternal(p),
 	}
 }
 

--- a/backend/api/handlers/system.go
+++ b/backend/api/handlers/system.go
@@ -511,14 +511,14 @@ func (h *SystemHandler) TriggerUpgrade(ctx context.Context, input *TriggerUpgrad
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	slog.Info("System upgrade triggered", "user", user.Username, "userId", user.ID)
 
-	err := h.upgradeService.TriggerUpgradeViaCLI(ctx, *user)
+	err = h.upgradeService.TriggerUpgradeViaCLI(ctx, *user)
 	if err != nil {
 		slog.Error("System upgrade failed", "error", err, "user", user.Username)
 

--- a/backend/api/handlers/templates.go
+++ b/backend/api/handlers/templates.go
@@ -431,15 +431,9 @@ func (h *TemplateHandler) ListTemplates(ctx context.Context, input *ListTemplate
 
 	return &ListTemplatesOutput{
 		Body: TemplatePaginatedResponse{
-			Success: true,
-			Data:    templates,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       templates,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/users.go
+++ b/backend/api/handlers/users.go
@@ -177,15 +177,9 @@ func (h *UserHandler) ListUsers(ctx context.Context, input *ListUsersInput) (*Li
 
 	return &ListUsersOutput{
 		Body: UserPaginatedResponse{
-			Success: true,
-			Data:    users,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       users,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/handlers/volumes.go
+++ b/backend/api/handlers/volumes.go
@@ -662,24 +662,9 @@ func (h *VolumeHandler) ListVolumes(ctx context.Context, input *ListVolumesInput
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	filters := make(map[string]string)
+	params := buildPaginationParamsInternal(input.Start, input.Limit, input.Sort, input.Order, input.Search)
 	if input.InUse != "" {
-		filters["inUse"] = input.InUse
-	}
-
-	params := pagination.QueryParams{
-		SearchQuery: pagination.SearchQuery{
-			Search: input.Search,
-		},
-		SortParams: pagination.SortParams{
-			Sort:  input.Sort,
-			Order: pagination.SortOrder(input.Order),
-		},
-		Params: pagination.Params{
-			Start: input.Start,
-			Limit: input.Limit,
-		},
-		Filters: filters,
+		params.Filters["inUse"] = input.InUse
 	}
 
 	if params.Limit == 0 {
@@ -704,13 +689,7 @@ func (h *VolumeHandler) ListVolumes(ctx context.Context, input *ListVolumesInput
 				Unused: counts.Unused,
 				Total:  counts.Total,
 			},
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -740,9 +719,9 @@ func (h *VolumeHandler) CreateVolume(ctx context.Context, input *CreateVolumeInp
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	options := client.VolumeCreateOptions{
@@ -792,9 +771,9 @@ func (h *VolumeHandler) RemoveVolume(ctx context.Context, input *RemoveVolumeInp
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -1144,15 +1123,9 @@ func (h *VolumeHandler) ListBackups(ctx context.Context, input *ListBackupsInput
 
 	return &ListBackupsOutput{
 		Body: VolumeBackupPaginatedResponse{
-			Success: true,
-			Data:    backups,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       backups,
+			Pagination: toPaginationResponseInternal(paginationResp),
 			Warnings: func() []string {
 				if warning == "" {
 					return nil
@@ -1167,9 +1140,9 @@ func (h *VolumeHandler) CreateBackup(ctx context.Context, input *CreateBackupInp
 	if h.volumeService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var backup *models.VolumeBackup
@@ -1206,9 +1179,9 @@ func (h *VolumeHandler) RestoreBackup(ctx context.Context, input *RestoreBackupI
 	if h.volumeService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -1245,9 +1218,9 @@ func (h *VolumeHandler) RestoreBackupFiles(ctx context.Context, input *RestoreBa
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(input.Body.Paths) == 0 {
@@ -1387,9 +1360,9 @@ func (h *VolumeHandler) UploadAndRestore(ctx context.Context, input *UploadAndRe
 	if h.volumeService == nil {
 		return nil, huma.Error500InternalServerError("service not available")
 	}
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	files := input.RawBody.File["file"]

--- a/backend/api/handlers/vulnerabilities.go
+++ b/backend/api/handlers/vulnerabilities.go
@@ -305,9 +305,9 @@ func (h *VulnerabilityHandler) ScanImage(ctx context.Context, input *ScanImageIn
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
@@ -428,15 +428,9 @@ func (h *VulnerabilityHandler) ListImageVulnerabilities(ctx context.Context, inp
 
 	return &ListImageVulnerabilitiesOutput{
 		Body: base.Paginated[vulnerability.Vulnerability]{
-			Success: true,
-			Data:    items,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       items,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -492,15 +486,9 @@ func (h *VulnerabilityHandler) ListAllVulnerabilities(ctx context.Context, input
 
 	return &ListAllVulnerabilitiesOutput{
 		Body: base.Paginated[vulnerability.VulnerabilityWithImage]{
-			Success: true,
-			Data:    items,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       items,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }
@@ -563,9 +551,9 @@ func (h *VulnerabilityHandler) IgnoreVulnerability(ctx context.Context, input *I
 		return nil, huma.Error500InternalServerError("service not available")
 	}
 
-	user, exists := humamw.GetCurrentUserFromContext(ctx)
-	if !exists {
-		return nil, huma.Error401Unauthorized((&common.NotAuthenticatedError{}).Error())
+	user, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	payload := &input.Body
@@ -661,15 +649,9 @@ func (h *VulnerabilityHandler) ListIgnoredVulnerabilities(ctx context.Context, i
 
 	return &ListIgnoredVulnerabilitiesOutput{
 		Body: base.Paginated[vulnerability.IgnoredVulnerability]{
-			Success: true,
-			Data:    items,
-			Pagination: base.PaginationResponse{
-				TotalPages:      paginationResp.TotalPages,
-				TotalItems:      paginationResp.TotalItems,
-				CurrentPage:     paginationResp.CurrentPage,
-				ItemsPerPage:    paginationResp.ItemsPerPage,
-				GrandTotalItems: paginationResp.GrandTotalItems,
-			},
+			Success:    true,
+			Data:       items,
+			Pagination: toPaginationResponseInternal(paginationResp),
 		},
 	}, nil
 }

--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -943,8 +943,34 @@ func (h *WebSocketHandler) ContainerExec(c echo.Context) error {
 	ctx, cancel := context.WithCancel(c.Request().Context())
 	defer cancel()
 
+	const execPongWait = 60 * time.Second
+	_ = conn.SetReadDeadline(time.Now().Add(execPongWait))
+	conn.SetPongHandler(func(string) error {
+		_ = conn.SetReadDeadline(time.Now().Add(execPongWait))
+		return nil
+	})
+	go h.pingExecConnInternal(ctx, conn, execPongWait*9/10)
+
 	h.runContainerExecInternal(ctx, cancel, conn, containerID, shell)
 	return nil
+}
+
+// pingExecConnInternal keeps the exec websocket alive; pongs refresh the read
+// deadline so a silently-dead client fails the next read instead of blocking
+// forever. WriteControl is safe concurrently with the exec output writer.
+func (h *WebSocketHandler) pingExecConnInternal(ctx context.Context, conn *websocket.Conn, period time.Duration) {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second)); err != nil {
+				return
+			}
+		}
+	}
 }
 
 func (h *WebSocketHandler) runContainerExecInternal(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn, containerID, shell string) {

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -137,20 +138,19 @@ func (m *AuthMiddleware) agentAuth(ctx context.Context, c echo.Context, next ech
 
 	req := c.Request()
 	if strings.HasPrefix(req.URL.Path, pkgutils.AgentPairingPrefix) &&
-		m.cfg.AgentToken != "" &&
-		req.Header.Get(pkgutils.HeaderAgentBootstrap) == m.cfg.AgentToken {
+		agentTokenMatchesInternal(req.Header.Get(pkgutils.HeaderAgentBootstrap), m.cfg.AgentToken) {
 		slog.InfoContext(ctx, "Agent auth: bootstrap pairing accepted", "path", req.URL.Path, "method", req.Method)
 		agentSudoInternal(c)
 		return next(c)
 	}
 
-	if tok := req.Header.Get(pkgutils.HeaderAgentToken); tok != "" && m.cfg.AgentToken != "" && tok == m.cfg.AgentToken {
+	if agentTokenMatchesInternal(req.Header.Get(pkgutils.HeaderAgentToken), m.cfg.AgentToken) {
 		agentSudoInternal(c)
 		return next(c)
 	}
 
 	// Check for API key as agent token
-	if tok := req.Header.Get(pkgutils.HeaderApiKey); tok != "" && m.cfg.AgentToken != "" && tok == m.cfg.AgentToken {
+	if agentTokenMatchesInternal(req.Header.Get(pkgutils.HeaderApiKey), m.cfg.AgentToken) {
 		agentSudoInternal(c)
 		return next(c)
 	}
@@ -165,6 +165,15 @@ func (m *AuthMiddleware) agentAuth(ctx context.Context, c echo.Context, next ech
 		Code:    "FORBIDDEN",
 		Message: "Invalid or missing agent token",
 	})
+}
+
+// agentTokenMatchesInternal compares a presented token against the configured
+// agent token in constant time to avoid timing side channels.
+func agentTokenMatchesInternal(presented, configured string) bool {
+	if presented == "" || configured == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(configured)) == 1
 }
 
 func (m *AuthMiddleware) managerAuth(ctx context.Context, c echo.Context, next echo.HandlerFunc) error {

--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	libupdater "go.getarcane.app/updater/pkg/labels"
+	"golang.org/x/sync/singleflight"
 )
 
 type ContainerService struct {
@@ -42,6 +44,7 @@ type ContainerService struct {
 	projectService  *ProjectService
 	statsHistory    containerstats.Store
 	updateInfoCache *cache.KeyedCache[string, *imagetypes.UpdateInfo]
+	updateInfoSF    singleflight.Group
 	iconMetaCache   *cache.TTL[projects.ArcaneComposeMetadata]
 }
 
@@ -1100,20 +1103,42 @@ func (s *ContainerService) getUpdateInfoMap(ctx context.Context, imageIDs []stri
 	}
 
 	updateInfoMap := make(map[string]*imagetypes.UpdateInfo, len(imageIDs))
+	var uncachedIDs []string
 	for _, imageID := range imageIDs {
-		info, err := s.updateInfoCache.GetOrFetch(ctx, imageID, nil, func(fetchCtx context.Context) (*imagetypes.UpdateInfo, error) {
-			infos, fetchErr := s.imageService.GetUpdateInfoByImageIDs(fetchCtx, []string{imageID})
-			if fetchErr != nil {
-				return nil, fetchErr
-			}
-			return infos[imageID], nil
-		})
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to fetch image update info for container image", "imageID", imageID, "error", err)
+		info, ok := s.updateInfoCache.Get(imageID)
+		if !ok {
+			uncachedIDs = append(uncachedIDs, imageID)
 			continue
 		}
 		if info != nil {
 			updateInfoMap[imageID] = info
+		}
+	}
+
+	if len(uncachedIDs) > 0 {
+		// Singleflight keyed by the uncached set so concurrent list requests
+		// that miss on the same images share one batch query.
+		slices.Sort(uncachedIDs)
+		res, err, _ := s.updateInfoSF.Do(strings.Join(uncachedIDs, ","), func() (any, error) {
+			infos, fetchErr := s.imageService.GetUpdateInfoByImageIDs(ctx, uncachedIDs)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			for _, imageID := range uncachedIDs {
+				// Cache nil results too so absent rows don't refetch until invalidation.
+				s.updateInfoCache.Set(imageID, infos[imageID])
+			}
+			return infos, nil
+		})
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to fetch image update info for container images", "imageIDs", len(uncachedIDs), "error", err)
+			return updateInfoMap
+		}
+		infos, _ := res.(map[string]*imagetypes.UpdateInfo)
+		for _, imageID := range uncachedIDs {
+			if info := infos[imageID]; info != nil {
+				updateInfoMap[imageID] = info
+			}
 		}
 	}
 	return updateInfoMap

--- a/backend/internal/services/customize_search_service.go
+++ b/backend/internal/services/customize_search_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -68,7 +69,7 @@ func (s *CustomizeSearchService) buildCategoriesFromModel() []category.Category 
 		}
 
 		// Track category order from first appearance
-		if len(categories[categoryID]) == 0 && !utils.Contains(categoryOrder, categoryID) {
+		if len(categories[categoryID]) == 0 && !slices.Contains(categoryOrder, categoryID) {
 			categoryOrder = append(categoryOrder, categoryID)
 		}
 

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -492,17 +492,7 @@ func (s *NotificationService) sendImageUpdateNotificationForTargetInternal(ctx c
 
 // isEventEnabled checks if a specific event type is enabled in the config
 func (s *NotificationService) isEventEnabled(config models.JSON, eventType models.NotificationEventType) bool {
-	configBytes, err := json.Marshal(config)
-	if err != nil {
-		return true // Default to enabled if we can't parse
-	}
-
-	var configMap map[string]any
-	if err := json.Unmarshal(configBytes, &configMap); err != nil {
-		return true // Default to enabled if we can't parse
-	}
-
-	events, ok := configMap["events"].(map[string]any)
+	events, ok := config["events"].(map[string]any)
 	if !ok {
 		return true // If no events config, default to enabled
 	}

--- a/backend/internal/services/settings_search_service.go
+++ b/backend/internal/services/settings_search_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -77,7 +78,7 @@ func (s *SettingsSearchService) buildCategoriesFromModel() []category.Category {
 		}
 
 		// Track category order from first appearance
-		if len(categories[categoryID]) == 0 && !utils.Contains(categoryOrder, categoryID) {
+		if len(categories[categoryID]) == 0 && !slices.Contains(categoryOrder, categoryID) {
 			categoryOrder = append(categoryOrder, categoryID)
 		}
 

--- a/backend/internal/services/system_service.go
+++ b/backend/internal/services/system_service.go
@@ -599,13 +599,15 @@ func (s *SystemService) pruneNetworksInternal(ctx context.Context, options syste
 	return nil
 }
 
+var dockerRunPrefixPattern = regexp.MustCompile(`^docker\s+run\s+`)
+
 func (s *SystemService) ParseDockerRunCommand(command string) (*system.DockerRunCommand, error) {
 	if command == "" {
 		return nil, errors.New("docker run command must be a non-empty string")
 	}
 
 	cmd := strings.TrimSpace(command)
-	cmd = regexp.MustCompile(`^docker\s+run\s+`).ReplaceAllString(cmd, "")
+	cmd = dockerRunPrefixPattern.ReplaceAllString(cmd, "")
 
 	if cmd == "" {
 		return nil, errors.New("no arguments found after 'docker run'")

--- a/backend/pkg/pagination/search.go
+++ b/backend/pkg/pagination/search.go
@@ -15,7 +15,7 @@ type SearchQuery struct {
 }
 
 func searchFn[T any](items []T, params SearchQuery, accessors []SearchAccessor[T]) []T {
-	search := strings.TrimSpace(params.Search)
+	search := strings.ToLower(strings.TrimSpace(params.Search))
 
 	if search == "" {
 		return items
@@ -26,7 +26,7 @@ func searchFn[T any](items []T, params SearchQuery, accessors []SearchAccessor[T
 	for iIdx := range items {
 		for aIdx := range accessors {
 			value, err := accessors[aIdx](items[iIdx])
-			if err == nil && strings.Contains(strings.ToLower(value), strings.ToLower(search)) {
+			if err == nil && strings.Contains(strings.ToLower(value), search) {
 				results = append(results, items[iIdx])
 				break
 			}

--- a/backend/pkg/projects/fs_templates.go
+++ b/backend/pkg/projects/fs_templates.go
@@ -40,15 +40,19 @@ func ReadFolderComposeTemplate(baseDir, folder string) (string, *string, string,
 	return string(b), envPtr, desc, true, nil
 }
 
+var (
+	slugInvalidCharsPattern = regexp.MustCompile(`[^a-z0-9\-_]+`)
+	slugDashRunPattern      = regexp.MustCompile(`-+`)
+)
+
 func Slugify(in string) string {
 	in = strings.TrimSpace(strings.ToLower(in))
 	if in == "" {
 		return ""
 	}
 	in = strings.ReplaceAll(in, " ", "-")
-	re := regexp.MustCompile(`[^a-z0-9\-_]+`)
-	in = re.ReplaceAllString(in, "-")
-	in = regexp.MustCompile(`-+`).ReplaceAllString(in, "-")
+	in = slugInvalidCharsPattern.ReplaceAllString(in, "-")
+	in = slugDashRunPattern.ReplaceAllString(in, "-")
 	return strings.Trim(in, "-")
 }
 

--- a/backend/pkg/utils/cache/cache_util.go
+++ b/backend/pkg/utils/cache/cache_util.go
@@ -43,6 +43,21 @@ func NewKeyed[K comparable, T any]() *KeyedCache[K, T] {
 	}
 }
 
+// Get returns the cached value for key, if present.
+func (c *KeyedCache[K, T]) Get(key K) (T, bool) {
+	c.mu.RLock()
+	cached, ok := c.entries[key]
+	c.mu.RUnlock()
+	return cached, ok
+}
+
+// Set stores value for key, replacing any existing entry.
+func (c *KeyedCache[K, T]) Set(key K, value T) {
+	c.mu.Lock()
+	c.entries[key] = value
+	c.mu.Unlock()
+}
+
 func (c *KeyedCache[K, T]) GetOrFetch(
 	ctx context.Context,
 	key K,

--- a/backend/pkg/utils/cache/cache_util_test.go
+++ b/backend/pkg/utils/cache/cache_util_test.go
@@ -1,0 +1,30 @@
+package cache
+
+import "testing"
+
+func TestKeyedCacheGetSet(t *testing.T) {
+	c := NewKeyed[string, *int]()
+
+	if _, ok := c.Get("missing"); ok {
+		t.Fatal("expected miss for unset key")
+	}
+
+	v := 42
+	c.Set("hit", &v)
+	got, ok := c.Get("hit")
+	if !ok || got == nil || *got != 42 {
+		t.Fatalf("expected cached value 42, got %v (ok=%v)", got, ok)
+	}
+
+	// Nil values are valid entries and must report as hits.
+	c.Set("nil-entry", nil)
+	got, ok = c.Get("nil-entry")
+	if !ok || got != nil {
+		t.Fatalf("expected nil hit, got %v (ok=%v)", got, ok)
+	}
+
+	c.Invalidate("hit")
+	if _, ok := c.Get("hit"); ok {
+		t.Fatal("expected miss after invalidate")
+	}
+}

--- a/backend/pkg/utils/reflection.go
+++ b/backend/pkg/utils/reflection.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -63,9 +62,4 @@ func ExtractCategoryMetadata(model any, categoryIDsInOrder []string) map[string]
 	}
 
 	return result
-}
-
-// Contains checks if a string slice contains an item
-func Contains(slice []string, item string) bool {
-	return slices.Contains(slice, item)
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces handler boilerplate across ~20 files by extracting three shared helpers (`buildPaginationParamsInternal`, `toPaginationResponseInternal`, `requireUserInternal`) and backfills several consistency improvements including constant-time agent token comparison, batch+singleflight update-info fetching, a WebSocket exec keepalive loop, and package-level regex compilation.

- **Handler de-duplication**: Every `List*` handler now calls `toPaginationResponseInternal` and `buildPaginationParamsInternal`; every mutation handler uses `requireUserInternal`, which also adds a `nil` user guard that several call sites were missing.
- **Security**: `agentTokenMatchesInternal` in `auth_middleware.go` uses `crypto/subtle.ConstantTimeCompare` to eliminate timing-oracle potential in agent token checks.
- **Batch cache with singleflight**: `getUpdateInfoMap` fetches all uncached image IDs in one call; concurrent requests sharing the same uncached set are deduplicated via `singleflight.Group`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the one behavioural nuance is in the singleflight context propagation for container update-info, which causes a one-cycle miss on update badges rather than any data loss.

All handler changes are mechanical substitutions of the new helpers with identical semantics plus small correctness improvements (nil user guard, whitespace trim). The constant-time token comparison and keepalive goroutine are straightforward improvements. The only non-trivial change is `getUpdateInfoMap`: the singleflight's first-caller context could propagate cancellations to deduped waiters, leaving them without freshly fetched update info for one cycle — a cosmetic miss, not a correctness failure.

backend/internal/services/container_service.go deserves a second look for the singleflight context ownership; backend/internal/middleware/auth_middleware.go for the token-comparison rewrite.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor%2Fhandler-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fhandler-clean%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fcontainer_service.go%3A1122-1136%0A**Singleflight%20closes%20over%20first%20caller's%20context**%0A%0AThe%20%60singleflight.Do%60%20closure%20captures%20the%20outer%20%60ctx%60%2C%20so%20whichever%20goroutine%20wins%20the%20flight%20owns%20the%20HTTP%20call.%20If%20that%20caller's%20context%20is%20cancelled%20%28e.g.%2C%20user%20closes%20a%20tab%20mid-request%29%2C%20the%20in-flight%20query%20is%20cancelled%20and%20**all%20deduped%20waiters%20receive%20the%20cancellation%20error**%20even%20though%20their%20own%20contexts%20are%20still%20valid.%20They%20fall%20back%20to%20returning%20only%20the%20already-cached%20entries%2C%20potentially%20displaying%20stale%20or%20missing%20update%20info%20until%20the%20next%20successful%20request.%20The%20impact%20is%20a%20one-cycle%20miss%20per%20cancelled%20leader%3B%20subsequent%20calls%20start%20a%20fresh%20flight.%20Consider%20detaching%20the%20context%20or%20using%20a%20longer-lived%20service%20context%20for%20the%20actual%20fetch%20while%20still%20honoring%20per-caller%20deadlines%20at%20a%20higher%20level.%0A%0A&repo=getarcaneapp%2Farcane&pr=2889&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fcontainer_service.go%3A1122-1136%0A**Singleflight%20closes%20over%20first%20caller's%20context**%0A%0AThe%20%60singleflight.Do%60%20closure%20captures%20the%20outer%20%60ctx%60%2C%20so%20whichever%20goroutine%20wins%20the%20flight%20owns%20the%20HTTP%20call.%20If%20that%20caller's%20context%20is%20cancelled%20%28e.g.%2C%20user%20closes%20a%20tab%20mid-request%29%2C%20the%20in-flight%20query%20is%20cancelled%20and%20**all%20deduped%20waiters%20receive%20the%20cancellation%20error**%20even%20though%20their%20own%20contexts%20are%20still%20valid.%20They%20fall%20back%20to%20returning%20only%20the%20already-cached%20entries%2C%20potentially%20displaying%20stale%20or%20missing%20update%20info%20until%20the%20next%20successful%20request.%20The%20impact%20is%20a%20one-cycle%20miss%20per%20cancelled%20leader%3B%20subsequent%20calls%20start%20a%20fresh%20flight.%20Consider%20detaching%20the%20context%20or%20using%20a%20longer-lived%20service%20context%20for%20the%20actual%20fetch%20while%20still%20honoring%20per-caller%20deadlines%20at%20a%20higher%20level.%0A%0A&repo=getarcaneapp%2Farcane&pr=2889&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/container_service.go:1122-1136
**Singleflight closes over first caller's context**

The `singleflight.Do` closure captures the outer `ctx`, so whichever goroutine wins the flight owns the HTTP call. If that caller's context is cancelled (e.g., user closes a tab mid-request), the in-flight query is cancelled and **all deduped waiters receive the cancellation error** even though their own contexts are still valid. They fall back to returning only the already-cached entries, potentially displaying stale or missing update info until the next successful request. The impact is a one-cycle miss per cancelled leader; subsequent calls start a fresh flight. Consider detaching the context or using a longer-lived service context for the actual fetch while still honoring per-caller deadlines at a higher level.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: reduce handler duplication and..."](https://github.com/getarcaneapp/arcane/commit/07b3de3bba6ef8038f6b650506aaeae95784fa9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36590317)</sub>

<!-- /greptile_comment -->