### PR TITLE
perf: group-aware container pagination and table layout fixes

### DIFF
--- a/backend/internal/services/container_service.go
+++ b/backend/internal/services/container_service.go
@@ -910,7 +910,7 @@ func (s *ContainerService) ListContainersPaginated(
 	imageIDs := collectImageIDs(dockerContainers)
 	updateInfoMap := s.getUpdateInfoMap(ctx, imageIDs)
 	currentContainerID, currentContainerErr := dockerutils.GetCurrentContainerID()
-	items := s.buildContainerSummaries(ctx, dockerContainers, updateInfoMap, currentContainerID, currentContainerErr)
+	items := s.buildContainerSummaries(dockerContainers, updateInfoMap, currentContainerID, currentContainerErr)
 
 	config := s.buildContainerPaginationConfig()
 	counts := s.calculateContainerStatusCounts(items)
@@ -922,6 +922,14 @@ func (s *ContainerService) ListContainersPaginated(
 
 		result := pagination.SearchOrderAndPaginate(items, ungroupedParams, config)
 		groups, paginationResp := paginateContainerProjectGroupsInternal(result, params)
+
+		// Icons must be resolved before flattening: groups hold value copies,
+		// so the flattened items only carry icons applied to the groups first.
+		metadataByProject := map[string]projects.ArcaneComposeMetadata{}
+		for gi := range groups {
+			s.applyContainerSummaryIconsInternal(ctx, groups[gi].Items, metadataByProject)
+		}
+
 		return ContainerListResult{
 			Items:      flattenContainerProjectGroupsInternal(groups),
 			Groups:     groups,
@@ -931,6 +939,7 @@ func (s *ContainerService) ListContainersPaginated(
 	}
 
 	result := pagination.SearchOrderAndPaginate(items, params, config)
+	s.applyContainerSummaryIconsInternal(ctx, result.Items, nil)
 	paginationResp := pagination.BuildResponseFromFilterResult(result, params)
 
 	return ContainerListResult{
@@ -945,8 +954,7 @@ func paginateContainerProjectGroupsInternal(
 	params pagination.QueryParams,
 ) ([]containertypes.SummaryGroup, pagination.Response) {
 	groups := groupContainersByProjectInternal(result.Items)
-	groupedItems := flattenContainerProjectGroupsInternal(groups)
-	totalCount := len(groupedItems)
+	totalCount := len(result.Items)
 
 	if params.Limit <= 0 {
 		return groups, pagination.Response{
@@ -958,30 +966,44 @@ func paginateContainerProjectGroupsInternal(
 		}
 	}
 
-	pages := partitionContainerProjectPagesInternal(groups, params.Limit)
-	requestedPage := 1
-	if params.Limit > 0 {
-		requestedPage = (params.Start / params.Limit) + 1
-	}
-
+	requestedPage := (params.Start / params.Limit) + 1
 	if requestedPage < 1 {
 		requestedPage = 1
 	}
 
-	totalPages := len(pages)
-	if totalPages == 0 {
-		totalPages = 1
+	// Pages are contiguous runs of whole groups: a group is never split, so the
+	// group that crosses the limit finishes its page. One walk over group sizes
+	// finds the requested page's group range without materializing other pages.
+	totalPages := 0
+	pageStart, currentCount := 0, 0
+	selStart, selEnd := 0, 0
+	lastStart, lastEnd := 0, 0
+
+	closePage := func(end int) {
+		totalPages++
+		if totalPages == requestedPage {
+			selStart, selEnd = pageStart, end
+		}
+		lastStart, lastEnd = pageStart, end
+		pageStart, currentCount = end, 0
 	}
+
+	for i := range groups {
+		currentCount += len(groups[i].Items)
+		if currentCount >= params.Limit {
+			closePage(i + 1)
+		}
+	}
+	if pageStart < len(groups) || totalPages == 0 {
+		closePage(len(groups))
+	}
+
 	if requestedPage > totalPages {
 		requestedPage = totalPages
+		selStart, selEnd = lastStart, lastEnd
 	}
 
-	pageGroups := []containertypes.SummaryGroup{}
-	if len(pages) > 0 {
-		pageGroups = pages[requestedPage-1]
-	}
-
-	return pageGroups, pagination.Response{
+	return groups[selStart:selEnd], pagination.Response{
 		TotalPages:      int64(totalPages),
 		TotalItems:      int64(totalCount),
 		CurrentPage:     requestedPage,
@@ -1016,33 +1038,6 @@ func flattenContainerProjectGroupsInternal(groups []containertypes.SummaryGroup)
 	}
 
 	return flattened
-}
-
-func partitionContainerProjectPagesInternal(groups []containertypes.SummaryGroup, limit int) [][]containertypes.SummaryGroup {
-	if len(groups) == 0 {
-		return [][]containertypes.SummaryGroup{{}}
-	}
-
-	pages := make([][]containertypes.SummaryGroup, 0)
-	currentPage := make([]containertypes.SummaryGroup, 0)
-	currentCount := 0
-
-	for _, group := range groups {
-		currentPage = append(currentPage, group)
-		currentCount += len(group.Items)
-
-		if currentCount >= limit {
-			pages = append(pages, currentPage)
-			currentPage = make([]containertypes.SummaryGroup, 0)
-			currentCount = 0
-		}
-	}
-
-	if len(currentPage) > 0 || len(pages) == 0 {
-		pages = append(pages, currentPage)
-	}
-
-	return pages
 }
 
 func getContainerProjectNameInternal(container containertypes.Summary) string {
@@ -1144,19 +1139,29 @@ func (s *ContainerService) getUpdateInfoMap(ctx context.Context, imageIDs []stri
 	return updateInfoMap
 }
 
-func (s *ContainerService) buildContainerSummaries(ctx context.Context, containers []container.Summary, updateInfoMap map[string]*imagetypes.UpdateInfo, currentContainerID string, currentContainerErr error) []containertypes.Summary {
+func (s *ContainerService) buildContainerSummaries(containers []container.Summary, updateInfoMap map[string]*imagetypes.UpdateInfo, currentContainerID string, currentContainerErr error) []containertypes.Summary {
 	items := make([]containertypes.Summary, 0, len(containers))
-	metadataByProject := map[string]projects.ArcaneComposeMetadata{}
 	for _, dc := range containers {
 		summary := containertypes.NewSummary(dc)
 		if info, exists := updateInfoMap[dc.ImageID]; exists {
 			summary.UpdateInfo = info
 		}
 		summary.RedeployDisabled = libupdater.ShouldDisableArcaneServerRedeploy(summary.Labels, summary.ID, currentContainerID, currentContainerErr)
-		s.applyContainerSummaryIconInternal(ctx, &summary, metadataByProject)
 		items = append(items, summary)
 	}
 	return items
+}
+
+// applyContainerSummaryIconsInternal resolves icons for a page of summaries.
+// Icon resolution is deferred until after pagination so the cost is bounded by
+// page size rather than the full container list.
+func (s *ContainerService) applyContainerSummaryIconsInternal(ctx context.Context, summaries []containertypes.Summary, metadataByProject map[string]projects.ArcaneComposeMetadata) {
+	if metadataByProject == nil {
+		metadataByProject = map[string]projects.ArcaneComposeMetadata{}
+	}
+	for i := range summaries {
+		s.applyContainerSummaryIconInternal(ctx, &summaries[i], metadataByProject)
+	}
 }
 
 func (s *ContainerService) applyContainerSummaryIconInternal(ctx context.Context, summary *containertypes.Summary, metadataByProject map[string]projects.ArcaneComposeMetadata) {

--- a/backend/internal/services/container_service_test.go
+++ b/backend/internal/services/container_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	containertypes "github.com/getarcaneapp/arcane/types/v2/container"
 	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/moby/moby/api/types/container"
@@ -57,6 +58,77 @@ func TestPaginateContainerProjectGroupsKeepsProjectWhole(t *testing.T) {
 	require.Equal(t, 4, projectCounts["immich"])
 	require.Equal(t, 1, projectCounts["other-1"])
 	require.Equal(t, 1, projectCounts["other-18"])
+}
+
+func TestPaginateContainerProjectGroupsSelectsRequestedPage(t *testing.T) {
+	// With Limit=4 the groups partition into three pages:
+	// page 1: proj-a (4), page 2: proj-b (3) + solo-1 (1), page 3: proj-c (2) + solo-2 (1).
+	items := []containertypes.Summary{
+		newGroupedContainerSummary("a-1", "proj-a"),
+		newGroupedContainerSummary("a-2", "proj-a"),
+		newGroupedContainerSummary("a-3", "proj-a"),
+		newGroupedContainerSummary("a-4", "proj-a"),
+		newGroupedContainerSummary("b-1", "proj-b"),
+		newGroupedContainerSummary("b-2", "proj-b"),
+		newGroupedContainerSummary("b-3", "proj-b"),
+		newGroupedContainerSummary("solo-1", "solo-1"),
+		newGroupedContainerSummary("c-1", "proj-c"),
+		newGroupedContainerSummary("c-2", "proj-c"),
+		newGroupedContainerSummary("solo-2", "solo-2"),
+	}
+	result := pagination.FilterResult[containertypes.Summary]{Items: items, TotalCount: int64(len(items)), TotalAvailable: int64(len(items))}
+
+	pageGroups, resp := paginateContainerProjectGroupsInternal(result, pagination.QueryParams{Params: pagination.Params{Start: 4, Limit: 4}})
+
+	require.Equal(t, []string{"proj-b", "solo-1"}, groupNamesOf(pageGroups))
+	require.Equal(t, 2, resp.CurrentPage)
+	require.Equal(t, int64(3), resp.TotalPages)
+	require.Equal(t, int64(11), resp.TotalItems)
+
+	pageGroups, resp = paginateContainerProjectGroupsInternal(result, pagination.QueryParams{Params: pagination.Params{Start: 400, Limit: 4}})
+
+	require.Equal(t, []string{"proj-c", "solo-2"}, groupNamesOf(pageGroups))
+	require.Equal(t, 3, resp.CurrentPage)
+	require.Equal(t, int64(3), resp.TotalPages)
+}
+
+func TestContainerSummaryIconsAppliedAfterGrouping(t *testing.T) {
+	service := &ContainerService{}
+	dockerContainers := []container.Summary{
+		{ID: "app", Names: []string{"/app"}, Labels: map[string]string{
+			"com.docker.compose.project": "media",
+			projects.ArcaneIconLabel:     "immich",
+		}},
+		{ID: "db", Names: []string{"/db"}, Labels: map[string]string{
+			"com.docker.compose.project": "media",
+		}},
+	}
+
+	items := service.buildContainerSummaries(dockerContainers, nil, "", nil)
+	for _, item := range items {
+		require.Empty(t, item.IconLightURL, "icons must be deferred until after pagination")
+	}
+
+	groups, _ := paginateContainerProjectGroupsInternal(
+		pagination.FilterResult[containertypes.Summary]{Items: items, TotalCount: int64(len(items)), TotalAvailable: int64(len(items))},
+		pagination.QueryParams{Params: pagination.Params{Start: 0, Limit: 20}},
+	)
+	for gi := range groups {
+		service.applyContainerSummaryIconsInternal(t.Context(), groups[gi].Items, map[string]projects.ArcaneComposeMetadata{})
+	}
+	flattened := flattenContainerProjectGroupsInternal(groups)
+
+	require.Len(t, groups, 1)
+	require.NotEmpty(t, groups[0].Items[0].IconLightURL)
+	require.NotEmpty(t, flattened[0].IconLightURL, "flattened items must carry icons applied to the groups")
+}
+
+func groupNamesOf(groups []containertypes.SummaryGroup) []string {
+	names := make([]string, 0, len(groups))
+	for _, group := range groups {
+		names = append(names, group.GroupName)
+	}
+	return names
 }
 
 func TestGroupContainersByProjectUsesNoProjectBucket(t *testing.T) {

--- a/backend/internal/services/dashboard_service.go
+++ b/backend/internal/services/dashboard_service.go
@@ -80,7 +80,7 @@ func (s *DashboardService) GetSnapshot(ctx context.Context, options DashboardAct
 	containerItems := make([]containertypes.Summary, 0, len(filteredContainers))
 	currentContainerID, currentContainerErr := dockerutils.GetCurrentContainerID()
 	if s.containerService != nil {
-		containerItems = s.containerService.buildContainerSummaries(ctx, filteredContainers, nil, currentContainerID, currentContainerErr)
+		containerItems = s.containerService.buildContainerSummaries(filteredContainers, nil, currentContainerID, currentContainerErr)
 	} else {
 		for _, container := range filteredContainers {
 			summary := containertypes.NewSummary(container)
@@ -109,6 +109,9 @@ func (s *DashboardService) GetSnapshot(ctx context.Context, options DashboardAct
 		return containerItems[i].Created > containerItems[j].Created
 	})
 	containerPage := limitDashboardItemsInternal(containerItems, dashboardSnapshotPreloadLimit)
+	if s.containerService != nil {
+		s.containerService.applyContainerSummaryIconsInternal(ctx, containerPage, nil)
+	}
 
 	var projectIDByName map[string]string
 	if s.imageService != nil {

--- a/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
@@ -85,8 +85,6 @@
 	// Narrow, transparent select cell so the row's hover/selected highlight shows through it
 	// uniformly (it carried an opaque background before, which broke the highlight at the edge).
 	const selectCellClasses = 'w-0 pr-4!';
-	// Row actions live in a zero-width host cell; their content floats over the row (see cellContent).
-	const actionsCellClasses = 'relative w-0 p-0 last:pr-0';
 
 	function handleRowClick(event: MouseEvent, rowId: string) {
 		if (shouldIgnoreTableRowClick(event)) return;
@@ -124,6 +122,13 @@
 	const ROW_ESTIMATE_PX = 52;
 	const flatRows = $derived(table.getRowModel().rows);
 	const shouldVirtualize = $derived(!isGrouped && !hasExpand && !!scrollElement && flatRows.length > VIRTUALIZE_THRESHOLD);
+
+	// Row actions live in a host cell that absorbs the table's leftover width, so data columns
+	// size to their content and the floating actions button (see cellContent) gets free room at
+	// the row's end instead of overlapping the last data column. Under the virtualized layout
+	// the table is table-fixed, where a 100%-width column would squash the auto columns to
+	// nothing — there the cell stays zero-width and the button floats over the row as before.
+	const actionsCellClasses = $derived(shouldVirtualize ? 'relative w-0 p-0 last:pr-0' : 'relative w-full p-0 last:pr-0');
 
 	// Runes can't be created conditionally, so the virtualizer always exists but is `enabled` only
 	// when we actually virtualize; disabled, it stays cheap and reports an empty window.

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -398,9 +398,6 @@
 
 	const columnsDef = $derived(cachedColumnsDef.length > 0 ? cachedColumnsDef : buildColumns(columns, selectionDisabled));
 
-	// Compute effective column count (add 1 for expand chevron column when expandable)
-	const effectiveColumnsCount = $derived(columnsDef.length + (expandedRowContent ? 1 : 0));
-
 	const table = createTable({
 		features: arcaneTableFeatures,
 		// Manual / server-side mode: no client row models are registered, so sorting and
@@ -514,6 +511,11 @@
 		}
 	});
 
+	// Rendered column count (add 1 for the expand chevron column when expandable). Based on
+	// visible leaf columns, not columnsDef — hidden columns (e.g. id) would otherwise inflate
+	// colspans and create phantom columns that misalign grouped/empty/expanded rows.
+	const effectiveColumnsCount = $derived(table.getVisibleLeafColumns().length + (expandedRowContent ? 1 : 0));
+
 	function onToggleMobileField(fieldId: string) {
 		mobileFieldVisibility = {
 			...mobileFieldVisibility,
@@ -585,10 +587,10 @@
 		if (onGroupToggle) {
 			onGroupToggle(groupName);
 		} else {
-			// Default behavior: toggle collapsed state
+			// Default behavior: toggle collapsed state (unrecorded groups render collapsed)
 			groupCollapsedState = {
 				...groupCollapsedState,
-				[groupName]: !groupCollapsedState[groupName]
+				[groupName]: !(groupCollapsedState[groupName] ?? true)
 			};
 		}
 	}

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -224,14 +224,15 @@
 		if (!collapsedGroupsState) return;
 		collapsedGroupsState.current = {
 			...collapsedGroupsState.current,
-			[groupName]: !collapsedGroupsState.current[groupName]
+			// Groups with no recorded state render collapsed, so toggle from that default
+			[groupName]: !(collapsedGroupsState.current[groupName] ?? true)
 		};
 	}
 
 	const columns = $derived([
 		{ accessorKey: 'id', title: m.common_id(), cell: IdCell, hidden: true },
 		{ accessorKey: 'names', id: 'name', title: m.common_name(), sortable: !groupByProject, cell: NameCell },
-		{ accessorKey: 'image', title: m.common_image(), sortable: !groupByProject, cell: ImageCell, width: 'max' },
+		{ accessorKey: 'image', title: m.common_image(), sortable: !groupByProject, cell: ImageCell },
 		{ accessorKey: 'state', title: m.common_state(), sortable: !groupByProject, cell: StateCell },
 		{
 			id: 'updates',

--- a/frontend/src/routes/(app)/customize/templates/template-table.svelte
+++ b/frontend/src/routes/(app)/customize/templates/template-table.svelte
@@ -140,7 +140,8 @@
 		if (!collapsedGroupsState) return;
 		collapsedGroupsState.current = {
 			...collapsedGroupsState.current,
-			[groupName]: !collapsedGroupsState.current[groupName]
+			// Groups with no recorded state render collapsed, so toggle from that default
+			[groupName]: !(collapsedGroupsState.current[groupName] ?? true)
 		};
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three distinct bugs in the grouped container view: icons were being applied to pre-pagination value copies and discarded, the first toggle on a default-collapsed group would re-collapse instead of expand, and hidden columns inflated colspans causing misaligned grouped/expanded rows.

- **Backend**: Icon resolution is deferred until after pagination (both grouped and ungrouped paths); the old `partitionContainerProjectPagesInternal` is replaced by a single-pass group walk that selects the requested page's group range without materializing other pages.
- **Frontend (arcane-table)**: `effectiveColumnsCount` now derives from `table.getVisibleLeafColumns()` (post-`createTable`) to exclude hidden columns; group toggle correctly treats an unrecorded group as collapsed before negating (`?? true`); the actions cell class is promoted to a `$derived` that expands to `w-full` in non-virtualized mode.
- **Frontend (container-table / template-table)**: The same `?? true` toggle fix applied to both tables, plus the `width: 'max'` override removed from the image column.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changes are well-scoped fixes to real rendering and interaction bugs, each backed by a targeted test or a directly reproducible failure scenario.

All three bug fixes are logically sound and the new pagination walk has been verified against the added test cases. No pre-existing interfaces are broken and the icon-deferral path is exercised by the new TestContainerSummaryIconsAppliedAfterGrouping test. The score stays off the top because the pagination and icon-deferral changes are moderately complex and lack integration-level test coverage of the full ListContainersPaginated path.

The refactored paginateContainerProjectGroupsInternal and the icon-application loop in ListContainersPaginated (grouped branch) in container_service.go deserve a careful read-through, as the page-selection algebra and the group-item mutation-before-flatten ordering are easy to misread.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: table layout and group toggle issue..."](https://github.com/getarcaneapp/arcane/commit/7db98284b96f15cf47806b3af206062ca7930dd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36600741)</sub>

<!-- /greptile_comment -->