### PR TITLE
fix: bind mounts fail to update after git syncs

### DIFF
--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -1738,47 +1738,67 @@ func (s *GitOpsSyncService) createDirectorySyncProjectInternal(ctx context.Conte
 	return project, nil
 }
 
-// updateDirectorySyncProjectInternal swaps a validated staged tree into the existing
-// project path with a temporary backup so failed promotion can roll back.
+// updateDirectorySyncProjectInternal mirrors a validated staged tree into the
+// existing project path in place so running containers keep their bind-mount
+// inodes; a temporary backup copy allows rollback if promotion fails.
 func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Context, sync *models.GitOpsSync, stage *stagedDirectorySync) (*models.Project, error) {
 	project := stage.project
 	projectPath := filepath.Clean(project.Path)
 	backupPath := ""
+	existed := true
 
 	if info, err := os.Stat(projectPath); err == nil {
 		if !info.IsDir() {
 			return nil, fmt.Errorf("project path is not a directory: %s", projectPath)
 		}
-		backupPath = fmt.Sprintf("%s.gitops-backup-%d", projectPath, time.Now().UnixNano())
-		if err := os.Rename(projectPath, backupPath); err != nil {
-			return nil, fmt.Errorf("failed to move current project directory out of the way: %w", err)
+	} else if errors.Is(err, os.ErrNotExist) {
+		existed = false
+		if err := os.MkdirAll(projectPath, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to recreate project directory: %w", err)
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else {
 		return nil, fmt.Errorf("failed to inspect current project directory: %w", err)
 	}
 
-	if err := os.Rename(stage.stagePath, projectPath); err != nil {
-		if backupPath != "" {
-			_ = os.Rename(backupPath, projectPath)
+	if existed {
+		projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get projects directory: %w", err)
 		}
+		backupPath, err = os.MkdirTemp(projectsDir, ".gitops-backup-*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create backup directory: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(backupPath) }()
+		if err := projects.CopyDirectoryContents(projectPath, backupPath); err != nil {
+			return nil, fmt.Errorf("failed to back up current project directory: %w", err)
+		}
+	}
+
+	restore := func() {
+		var restoreErr error
+		if existed {
+			restoreErr = projects.MirrorDirectoryContents(backupPath, projectPath)
+		} else {
+			restoreErr = os.RemoveAll(projectPath)
+		}
+		if restoreErr != nil {
+			slog.ErrorContext(ctx, "Failed to restore project directory after sync promotion failure; directory may be in a mixed state", "projectPath", projectPath, "backupPath", backupPath, "error", restoreErr)
+		}
+	}
+
+	if err := projects.MirrorDirectoryContents(stage.stagePath, projectPath); err != nil {
+		restore()
 		return nil, fmt.Errorf("failed to promote staged project directory: %w", err)
 	}
-	stage.stagePath = ""
 
 	if err := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", project.ID).Updates(map[string]any{
 		"service_count":     stage.serviceCount,
 		"gitops_managed_by": sync.ID,
 		"updated_at":        time.Now(),
 	}).Error; err != nil {
-		if backupPath != "" {
-			_ = os.RemoveAll(projectPath)
-			_ = os.Rename(backupPath, projectPath)
-		}
+		restore()
 		return nil, fmt.Errorf("failed to update project metadata after directory sync: %w", err)
-	}
-
-	if backupPath != "" {
-		_ = os.RemoveAll(backupPath)
 	}
 
 	return project, nil

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -452,6 +452,61 @@ func CopyDirectoryContents(srcDir, destDir string) error {
 	})
 }
 
+// MirrorDirectoryContents makes destDir match srcDir while updating files and
+// directories in place, so existing inodes (and therefore container bind
+// mounts into destDir) stay valid. Entries missing from srcDir or whose type
+// differs are removed, then srcDir is copied over the result.
+func MirrorDirectoryContents(srcDir, destDir string) error {
+	if err := pruneDirectoryContentsInternal(srcDir, destDir); err != nil {
+		return err
+	}
+	return CopyDirectoryContents(srcDir, destDir)
+}
+
+func pruneDirectoryContentsInternal(srcDir, destDir string) error {
+	srcRoot, err := os.OpenRoot(srcDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcRoot.Close() }()
+
+	destRoot, err := os.OpenRoot(destDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destRoot.Close() }()
+
+	return filepath.WalkDir(destDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == destDir {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(destDir, path)
+		if err != nil {
+			return err
+		}
+
+		srcInfo, err := srcRoot.Lstat(relPath)
+		if err == nil && srcInfo.Mode()&os.ModeType == d.Type() {
+			return nil
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		if err := destRoot.RemoveAll(relPath); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+}
+
 // CreateUniqueDir creates a unique directory within the allowed projectsRoot.
 // It validates that the created directory is always within projectsRoot.
 func CreateUniqueDir(projectsRoot, basePath, name string, perm os.FileMode) (path, folderName string, err error) {

--- a/backend/pkg/projects/fs_util_unix_test.go
+++ b/backend/pkg/projects/fs_util_unix_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package projects
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func inodeOfInternal(t *testing.T, path string) uint64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	return stat.Ino
+}
+
+func TestMirrorDirectoryContents_PreservesInodesAndPrunes(t *testing.T) {
+	dst := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dst, "site"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "site", "index.html"), []byte("old"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "removed.txt"), []byte("stale"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, ".env"), []byte("KEY=1"), 0o644))
+
+	src := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "site"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "site", "index.html"), []byte("new"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".env"), []byte("KEY=1"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "added.txt"), []byte("fresh"), 0o644))
+
+	rootIno := inodeOfInternal(t, dst)
+	siteIno := inodeOfInternal(t, filepath.Join(dst, "site"))
+	indexIno := inodeOfInternal(t, filepath.Join(dst, "site", "index.html"))
+
+	require.NoError(t, MirrorDirectoryContents(src, dst))
+
+	assert.Equal(t, rootIno, inodeOfInternal(t, dst))
+	assert.Equal(t, siteIno, inodeOfInternal(t, filepath.Join(dst, "site")))
+	assert.Equal(t, indexIno, inodeOfInternal(t, filepath.Join(dst, "site", "index.html")))
+
+	content, err := os.ReadFile(filepath.Join(dst, "site", "index.html"))
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(content))
+
+	assert.NoFileExists(t, filepath.Join(dst, "removed.txt"))
+	assert.FileExists(t, filepath.Join(dst, "added.txt"))
+
+	envContent, err := os.ReadFile(filepath.Join(dst, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, "KEY=1", string(envContent))
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2885

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes bind-mount breakage after git syncs by switching the project directory update strategy from a rename-and-replace to an in-place mirror. Previously, `os.Rename` replaced the project directory with a staged copy, changing its inode and invalidating any container bind mounts targeting that path. The new approach keeps the directory inode stable by pruning stale entries and overwriting files in place via `MirrorDirectoryContents`.

- **`fs_util.go`**: Adds `MirrorDirectoryContents` (prune-then-copy) and its unexported helper `pruneDirectoryContentsInternal`, which walks the destination, removes entries absent from or type-mismatched against the source, and then delegates to the existing `CopyDirectoryContents` to update file content in place.
- **`gitops_sync_service.go`**: Replaces the rename-based swap with `MirrorDirectoryContents`; backup is now a directory copy (preserving the original inode tree), and the `restore()` closure correctly mirrors the backup back if promotion or the DB update fails, with restore errors surfaced via `slog.ErrorContext`.
- **`fs_util_unix_test.go`**: New unix-only test verifying inode stability on the root dir, a subdirectory, and an existing file, along with prune and add assertions including explicit `.env` content preservation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; the in-place mirror logic is correct and the backup/restore path now logs failures explicitly.

The inode-preserving mirror approach correctly solves the bind-mount problem. pruneDirectoryContentsInternal handles directory deletion with SkipDir safely, type-mismatch detection is correct, and CopyDirectoryContents overwrites file content while retaining the inode. The backup/restore flow in updateDirectorySyncProjectInternal is sequentially correct — defer runs after restore() completes — and restore failures are now observable via structured logging. All previously flagged concerns (naming convention, .env assertion, silent restore errors) have been addressed.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bind mounts fail to update after gi..."](https://github.com/getarcaneapp/arcane/commit/936a1b60c6f2dfb15da2962b7d3a7acf1af95a18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36604021)</sub>

<!-- /greptile_comment -->