### PR TITLE
fix: normalize git repo url, and allow changing of repo url

### DIFF
--- a/backend/pkg/gitutil/git.go
+++ b/backend/pkg/gitutil/git.go
@@ -10,6 +10,7 @@ import (
 	nethttp "net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/gofrs/flock"
@@ -27,9 +29,48 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+// go-git's file transport execs the git binary, which doesn't exist in the
+// distroless image. Unregister it so a repository URL can never reach it.
+func init() {
+	client.InstallProtocol("file", nil)
+}
+
 // Client handles git operations
 type Client struct {
 	workDir string
+}
+
+var scpLikeURLPattern = regexp.MustCompile(`^[^@/]+@[^:/]+:`)
+
+const errUnsupportedURL = "repository URL must use http(s)://, ssh://, git://, or git@host:path"
+
+// normalizeURL coerces a repository URL into a form go-git resolves to a
+// network transport, never the file transport (which execs the git binary).
+// Schemeless host-style URLs (e.g. github.com/org/repo.git) get https://.
+func normalizeURL(raw string) (string, error) {
+	url := strings.TrimSpace(raw)
+	if url == "" {
+		return "", errors.New("repository URL is empty")
+	}
+
+	if scheme, _, found := strings.Cut(url, "://"); found {
+		switch strings.ToLower(scheme) {
+		case "http", "https", "ssh", "git":
+			return url, nil
+		default:
+			return "", errors.New(errUnsupportedURL)
+		}
+	}
+
+	if scpLikeURLPattern.MatchString(url) {
+		return url, nil
+	}
+
+	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, ".") || strings.HasPrefix(url, "~") {
+		return "", errors.New(errUnsupportedURL)
+	}
+
+	return "https://" + url, nil
 }
 
 // NewClient creates a new git client
@@ -254,6 +295,12 @@ func (c *Client) Clone(ctx context.Context, url, branch string, auth AuthConfig)
 		return "", err
 	}
 
+	url, err = normalizeURL(url)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return "", err
+	}
+
 	cloneOptions := &git.CloneOptions{
 		URL:      url,
 		Progress: nil,
@@ -372,6 +419,11 @@ func (c *Client) ProbeRemote(ctx context.Context, url string, auth AuthConfig) e
 
 func (c *Client) listRemoteReferences(ctx context.Context, url string, auth AuthConfig) ([]*plumbing.Reference, error) {
 	authMethod, err := c.getAuth(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err = normalizeURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -631,3 +631,42 @@ func generateTestPublicKeyVariant(t *testing.T) gossh.PublicKey {
 	}
 	return key
 }
+
+func TestNormalizeURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "schemeless gets https prefix", in: "github.com/org/repo.git", want: "https://github.com/org/repo.git"},
+		{name: "https kept as-is", in: "https://github.com/org/repo.git", want: "https://github.com/org/repo.git"},
+		{name: "ssh kept as-is", in: "ssh://git@github.com/org/repo.git", want: "ssh://git@github.com/org/repo.git"},
+		{name: "git kept as-is", in: "git://github.com/org/repo.git", want: "git://github.com/org/repo.git"},
+		{name: "scp-like kept as-is", in: "git@github.com:org/repo.git", want: "git@github.com:org/repo.git"},
+		{name: "file scheme rejected", in: "file:///tmp/repo", wantErr: true},
+		{name: "unsupported scheme rejected", in: "ftp://github.com/org/repo.git", wantErr: true},
+		{name: "local path rejected", in: "/tmp/repo", wantErr: true},
+		{name: "relative path rejected", in: "./repo", wantErr: true},
+		{name: "home-relative path rejected", in: "~/repo", wantErr: true},
+		{name: "empty rejected", in: "", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeURL(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/frontend/src/lib/components/dialogs/gitops-sync-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/gitops-sync-dialog.svelte
@@ -131,7 +131,7 @@
 	});
 
 	$effect(() => {
-		if (!open || !syncToEdit || repositories.length === 0) return;
+		if (!open || !syncToEdit || repositories.length === 0 || selectedRepository) return;
 		const repo = repositories.find((r) => r.id === syncToEdit.repositoryId);
 		if (repo) {
 			selectedRepository = { value: repo.id, label: repo.name };


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2845

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds URL normalization for git repository URLs to block local file transport access (`file://`, absolute paths, and relative paths), and fixes a UI regression in the GitOps sync dialog where a user's repository selection change was being reverted whenever the repositories query refetched.

- `normalizeURL` validates and coerces repository URLs to a network transport scheme, while an `init()` call also unregisters go-git's built-in `file://` transport as an additional defence layer for the distroless image environment.
- The Svelte dialog adds a `|| selectedRepository` guard to the initialization effect so that an already-populated selection is not overwritten by subsequent reactive re-runs after the user changes it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The normalization logic, transport unregistration, and Svelte effect ordering are all correct and the test suite covers the key input classes.

Both the Go normalization function and the Svelte dialog fix are straightforward and well-scoped. The normalization is applied at every entry point that accepts a user-supplied URL (`Clone` and `listRemoteReferences`, which covers `ListBranches` and `ProbeRemote`). Effect ordering in the Svelte component is correct: the reset effect (line 122) always runs before the populate effect (line 133), so the `|| selectedRepository` guard does not risk showing stale state on initial open. No data paths are left unguarded.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: normalize git repo url, and allow c..."](https://github.com/getarcaneapp/arcane/commit/a0c1b5492a2282d03adfbfe529484263fefef087) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36608449)</sub>

<!-- /greptile_comment -->