### PR TITLE
fix: dont check image updates on locally built images

### DIFF
--- a/backend/internal/models/image_update.go
+++ b/backend/internal/models/image_update.go
@@ -43,6 +43,7 @@ type ImageUpdate struct {
 const (
 	UpdateTypeDigest = "digest"
 	UpdateTypeTag    = "tag"
+	UpdateTypeLocal  = "local"
 )
 
 func (i *ImageUpdateRecord) NeedsUpdate() bool {

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -51,6 +51,7 @@ type localImageSnapshot struct {
 	Tag           string
 	PrimaryDigest string
 	AllDigests    []string
+	IsLocalBuild  bool
 }
 
 func NewImageUpdateService(db *database.DB, settingsService *SettingsService, registryService *ContainerRegistryService, dockerService *DockerClientService, eventService *EventService, notificationService *NotificationService, activityService *ActivityService) *ImageUpdateService {
@@ -231,11 +232,14 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 
 	digestResult.ResponseTimeMs = int(time.Since(startTime).Milliseconds())
 	digestResult.ActivityID = utils.StringPtrFromTrimmed(activityID)
+	if digestResult.UpdateType == models.UpdateTypeLocal {
+		s.appendImageUpdateActivityMessageInternal(ctx, activityID, models.ActivityMessageLevelInfo, imageRef+" — local build, registry check skipped", 100, "Skipping image update check")
+	}
 	metadata := models.JSON{
 		"action":         "check_update",
 		"imageRef":       imageRef,
 		"hasUpdate":      digestResult.HasUpdate,
-		"updateType":     "digest",
+		"updateType":     digestResult.UpdateType,
 		"currentDigest":  digestResult.CurrentDigest,
 		"latestDigest":   digestResult.LatestDigest,
 		"responseTimeMs": digestResult.ResponseTimeMs,
@@ -295,6 +299,11 @@ func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.C
 
 	imageRef := fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag)
 	start := time.Now()
+	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+	if err == nil && snapshot.IsLocalBuild {
+		return localBuildImageUpdateResultInternal(snapshot, int(time.Since(start).Milliseconds())), snapshot, nil
+	}
+
 	registryCtx, registryCancel := s.registryContextInternal(ctx)
 	digestResult, err := s.registryService.inspectImageDigestInternal(registryCtx, imageRef, nil)
 	registryCancel()
@@ -315,9 +324,11 @@ func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.C
 		}, nil, fmt.Errorf("failed to get remote digest: %w", err)
 	}
 
-	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get local digest: %w", err)
+	if snapshot == nil {
+		snapshot, err = s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get local digest: %w", err)
+		}
 	}
 
 	localDigest := snapshot.PrimaryDigest
@@ -339,7 +350,7 @@ func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.C
 
 	return &imageupdate.Response{
 		HasUpdate:      hasUpdate,
-		UpdateType:     "digest",
+		UpdateType:     models.UpdateTypeDigest,
 		CurrentDigest:  localDigest,
 		LatestDigest:   digestResult.Digest,
 		CheckTime:      time.Now(),
@@ -349,6 +360,17 @@ func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.C
 		AuthRegistry:   digestResult.AuthRegistry,
 		UsedCredential: digestResult.UsedCredential,
 	}, snapshot, nil
+}
+
+func localBuildImageUpdateResultInternal(snapshot *localImageSnapshot, responseTimeMs int) *imageupdate.Response {
+	return &imageupdate.Response{
+		HasUpdate:      false,
+		UpdateType:     models.UpdateTypeLocal,
+		CurrentVersion: snapshot.Tag,
+		CurrentDigest:  snapshot.PrimaryDigest,
+		CheckTime:      time.Now(),
+		ResponseTimeMs: responseTimeMs,
+	}
 }
 
 func (s *ImageUpdateService) parseImageReference(imageRef string) *ImageParts {
@@ -558,6 +580,7 @@ func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Conte
 
 	var allDigests []string
 	var primaryDigest string
+	isLocalBuild := false
 
 	// Extract all digests from RepoDigests
 	if len(inspectResponse.RepoDigests) > 0 {
@@ -578,6 +601,7 @@ func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Conte
 
 	// Fallback to image ID if no repo digests available
 	if primaryDigest == "" {
+		isLocalBuild = true
 		primaryDigest = inspectResponse.ID
 		allDigests = []string{primaryDigest}
 	}
@@ -590,6 +614,7 @@ func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Conte
 		Tag:           tag,
 		PrimaryDigest: primaryDigest,
 		AllDigests:    allDigests,
+		IsLocalBuild:  isLocalBuild,
 	}, nil
 }
 
@@ -695,6 +720,9 @@ func imageCheckResultMessageInternal(imageRef string, res *imageupdate.Response)
 	}
 	if err := strings.TrimSpace(res.Error); err != "" {
 		return models.ActivityMessageLevelError, fmt.Sprintf("%s: %s", imageRef, err)
+	}
+	if res.UpdateType == models.UpdateTypeLocal {
+		return models.ActivityMessageLevelInfo, imageRef + " — local build, registry check skipped"
 	}
 	if res.HasUpdate {
 		return models.ActivityMessageLevelSuccess, imageRef + " — update available"
@@ -1027,6 +1055,11 @@ func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context
 
 	start := time.Now()
 	imageRef := fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag)
+	snapshot, ldErr := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+	if ldErr == nil && snapshot.IsLocalBuild {
+		return localBuildImageUpdateResultInternal(snapshot, int(time.Since(start).Milliseconds())), snapshot
+	}
+
 	registryCtx, registryCancel := s.registryContextInternal(ctx)
 	digestResult, digestErr := s.registryService.inspectImageDigestInternal(registryCtx, imageRef, externalCreds)
 	registryCancel()
@@ -1045,17 +1078,19 @@ func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context
 		return resp, nil
 	}
 
-	snapshot, ldErr := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
 	if ldErr != nil {
-		return &imageupdate.Response{
-			Error:          ldErr.Error(),
-			CheckTime:      time.Now(),
-			ResponseTimeMs: int(time.Since(start).Milliseconds()),
-			AuthMethod:     digestResult.AuthMethod,
-			AuthUsername:   digestResult.AuthUsername,
-			AuthRegistry:   digestResult.AuthRegistry,
-			UsedCredential: digestResult.UsedCredential,
-		}, nil
+		snapshot, ldErr = s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+		if ldErr != nil {
+			return &imageupdate.Response{
+				Error:          ldErr.Error(),
+				CheckTime:      time.Now(),
+				ResponseTimeMs: int(time.Since(start).Milliseconds()),
+				AuthMethod:     digestResult.AuthMethod,
+				AuthUsername:   digestResult.AuthUsername,
+				AuthRegistry:   digestResult.AuthRegistry,
+				UsedCredential: digestResult.UsedCredential,
+			}, nil
+		}
 	}
 
 	localDigest := snapshot.PrimaryDigest
@@ -1070,7 +1105,7 @@ func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context
 
 	return &imageupdate.Response{
 		HasUpdate:      hasDigestUpdate,
-		UpdateType:     "digest",
+		UpdateType:     models.UpdateTypeDigest,
 		CurrentDigest:  localDigest,
 		LatestDigest:   digestResult.Digest,
 		CheckTime:      time.Now(),

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2163,6 +2163,8 @@
 	"image_update_recheck_button": "Re-check Updates",
 	"image_update_checking_title": "Checking Updates",
 	"image_update_querying_registry": "Querying registry for latest version…",
+	"image_update_local_title": "Local build",
+	"image_update_local_desc": "This image was built locally and has no registry to check against.",
 	"image_update_status_unknown": "Status Unknown",
 	"image_update_click_to_check": "Click to check for updates from registry.",
 	"image_update_unable_check_tags": "Unable to check updates for images without proper tags.",

--- a/frontend/src/lib/components/image-update-item.svelte
+++ b/frontend/src/lib/components/image-update-item.svelte
@@ -19,6 +19,7 @@
 		imageId: string;
 		repo?: string;
 		tag?: string;
+		isLocal?: boolean;
 		onUpdated?: (data: ImageUpdateData) => void;
 		/** Callback when user clicks "Update Container" button */
 		onUpdateContainer?: () => void;
@@ -32,6 +33,7 @@
 		imageId,
 		repo,
 		tag,
+		isLocal = false,
 		onUpdated,
 		onUpdateContainer,
 		debugHasUpdate
@@ -87,7 +89,8 @@
 	const isChecking = $derived(imageUpdateQuery.isFetching);
 	let isOpen = $state(false);
 
-	const canCheckUpdate = $derived(!!(repo && tag && repo !== '<none>' && tag !== '<none>'));
+	const isLocalImage = $derived(!!isLocal || effectiveUpdateInfo?.updateType === 'local');
+	const canCheckUpdate = $derived(!!(repo && tag && repo !== '<none>' && tag !== '<none>') && !isLocalImage);
 	const hasError = $derived(!!effectiveUpdateInfo?.error && effectiveUpdateInfo.error.trim() !== '');
 
 	type AuthBadge = { label: string; classes: string };
@@ -197,6 +200,8 @@
 		if (!effectiveUpdateInfo) return null;
 		if (effectiveUpdateInfo.error)
 			return { level: 'Error', color: 'text-red-500', description: m.image_update_could_not_query_registry() };
+		if (effectiveUpdateInfo.updateType === 'local')
+			return { level: m.image_update_local_title(), color: 'text-slate-500', description: m.image_update_local_desc() };
 		if (!effectiveUpdateInfo.hasUpdate)
 			return { level: 'None', color: 'text-green-500', description: m.image_update_up_to_date_desc() };
 		if (effectiveUpdateInfo.updateType === 'digest')
@@ -408,6 +413,18 @@
 	{@render recheckButton()}
 {/snippet}
 
+{#snippet localState()}
+	<div class="bg-linear-to-br from-slate-50 to-slate-100/40 p-4 dark:from-slate-950/20 dark:to-slate-900/20">
+		<div class="flex items-start gap-3">
+			{@render iconCircle(BoxIcon, 'from-slate-500', 'to-gray-500', 'shadow-slate-500/25')}
+			<div class="flex-1">
+				<div class="text-sm font-semibold text-slate-950 dark:text-slate-100">{m.image_update_local_title()}</div>
+				<div class="text-xs text-slate-900/80 dark:text-slate-300/80">{m.image_update_local_desc()}</div>
+			</div>
+		</div>
+	</div>
+{/snippet}
+
 {#snippet loadingState()}
 	<div class="bg-linear-to-br from-blue-50 to-cyan-50/30 p-4 dark:from-blue-950/20 dark:to-cyan-950/10">
 		<div class="flex items-center gap-3">
@@ -438,7 +455,21 @@
 	</div>
 {/snippet}
 
-{#if effectiveUpdateInfo}
+{#if isLocalImage}
+	<UpdateStatusPopover bind:open={isOpen} contentClass="max-w-[280px] p-0">
+		{#snippet trigger()}
+			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle" data-testid="image-update-trigger">
+				<BoxIcon class="size-4 text-slate-500" />
+			</span>
+		{/snippet}
+
+		{#snippet content()}
+			<div class="overflow-hidden rounded-xl">
+				{@render localState()}
+			</div>
+		{/snippet}
+	</UpdateStatusPopover>
+{:else if effectiveUpdateInfo}
 	<UpdateStatusPopover bind:open={isOpen} contentClass="max-w-[280px] p-0">
 		{#snippet trigger()}
 			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle" data-testid="image-update-trigger">

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -341,7 +341,9 @@
 		{
 			id: 'updates',
 			accessorFn: (row) => {
+				if (!row.repoDigests || row.repoDigests.length === 0) return 'local';
 				if (row.updateInfo?.hasUpdate) return 'has_update';
+				if (row.updateInfo?.updateType === 'local') return 'local';
 				if (row.updateInfo?.error) return 'error';
 				if (row.updateInfo) return 'up_to_date';
 				return 'unknown';
@@ -564,6 +566,7 @@
 			imageId={item.id}
 			repo={item.repo}
 			tag={item.tag}
+			isLocal={!item.repoDigests || item.repoDigests.length === 0}
 			onUpdated={(newInfo) => handleUpdateInfoChanged(item.id, newInfo)}
 		/>
 	</div>
@@ -607,7 +610,11 @@
 					: null,
 			(item: ImageSummaryDto) => {
 				if (!(mobileFieldVisibility['updates'] ?? false)) return null;
+				if (!item.repoDigests || item.repoDigests.length === 0) {
+					return { variant: 'gray' as const, text: m.image_update_local_title() };
+				}
 				if (item.updateInfo?.hasUpdate) return { variant: 'blue' as const, text: m.images_has_updates() };
+				if (item.updateInfo?.updateType === 'local') return { variant: 'gray' as const, text: m.image_update_local_title() };
 				if (item.updateInfo?.error) return { variant: 'red' as const, text: m.common_error() };
 				if (item.updateInfo) return { variant: 'green' as const, text: m.images_no_updates() };
 				return { variant: 'gray' as const, text: m.common_unknown() };


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents image update checks from hitting the registry for locally built images — those with no `RepoDigests` — by detecting them early via the `IsLocalBuild` flag and returning a dedicated `"local"` update type instead.

- **Backend**: Both the single-image (`checkDigestUpdateWithSnapshotInternal`) and batch (`checkSingleImageInBatchInternal`) paths now call `inspectLocalImageSnapshotInternal` first; if the image is local, they short-circuit and skip all registry I/O. A new `UpdateTypeLocal` constant and `localBuildImageUpdateResultInternal` helper are added.
- **Frontend**: The `image-table.svelte` passes `isLocal` to `ImageUpdateItem` (derived from `repoDigests`), which renders a dedicated "Local build" popover state and disables the re-check button for local images.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped and does not alter behavior for registry-backed images.

Both code paths (single-image and batch) correctly detect the local-build case before touching the registry, the snapshot variable reuse after the early-exit check is sound, and the frontend dual-source detection (prop + updateType fallback) handles stale state gracefully. No regressions introduced on the normal registry-check path.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: dont check image updates on locally..."](https://github.com/getarcaneapp/arcane/commit/61b151ddd40c393b4d6577510a497cc8b836ce8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37116375)</sub>

<!-- /greptile_comment -->