### PR TITLE
fix: fix tables rows not flex redering to use the full table width

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1718,7 +1718,7 @@
 	"templates_edit_template": "Edit Template",
 	"templates_delete_template": "Delete Template",
 	"templates_template_name_label": "Template Name",
-	"templates_template_name_placeholder": "e.g. My Nginx Stack",
+	"templates_template_name_placeholder": "e.g. My Nginx Project",
 	"templates_template_name_required": "Template name is required",
 	"templates_template_description_label": "Description",
 	"templates_template_description_placeholder": "Briefly describe this template",

--- a/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte
@@ -128,12 +128,16 @@
 	const flatRows = $derived(table.getRowModel().rows);
 	const shouldVirtualize = $derived(!isGrouped && !hasExpand && !!scrollElement && flatRows.length > VIRTUALIZE_THRESHOLD);
 
-	// Row actions live in a host cell that absorbs the table's leftover width, so data columns
-	// size to their content and the floating actions button (see cellContent) gets free room at
-	// the row's end instead of overlapping the last data column. Under the virtualized layout
-	// the table is table-fixed, where a 100%-width column would squash the auto columns to
-	// nothing — there the cell stays zero-width and the button floats over the row as before.
-	const actionsCellClasses = $derived(shouldVirtualize ? 'relative w-0 p-0 last:pr-0' : 'relative w-full p-0 last:pr-0');
+	// Row actions are a real pinned column: sticky to the row's right edge with its own reserved
+	// width, so the floating button never overlaps data columns and survives horizontal scroll.
+	// bg-inherit picks up the row's background (including hover/selected tints) to mask content
+	// scrolling beneath the sticky cell. Under the virtualized table-fixed layout an auto-sized
+	// (w-0 + nowrap) column would collapse, so it gets an explicit width there instead.
+	const actionsCellClasses = $derived(
+		shouldVirtualize
+			? 'sticky right-0 z-10 w-24 bg-inherit p-0 whitespace-nowrap'
+			: 'sticky right-0 z-10 w-0 bg-inherit p-0 whitespace-nowrap'
+	);
 
 	// Runes can't be created conditionally, so the virtualizer always exists but is `enabled` only
 	// when we actually virtualize; disabled, it stays cheap and reports an empty window.
@@ -149,13 +153,11 @@
 
 {#snippet cellContent(cell: ArcaneCell<TData>)}
 	{#if cell.column.id === 'actions'}
-		<!-- Row actions float over the row's right edge, revealed on hover/focus (or while the menu is
-		     open). pointer-events are off until revealed so the hidden control can't swallow row clicks. -->
-		<div
-			class="pointer-events-none absolute top-1/2 right-2 z-10 -translate-y-1/2 opacity-0 transition-opacity group-hover/row:pointer-events-auto group-hover/row:opacity-100 group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100"
-			data-row-select-ignore
-		>
-			<FlexRender {cell} />
+		<!-- Pinned row actions: a floating chip at the row's end, always present in its own gutter. -->
+		<div class="flex items-center justify-end py-1 pr-3 pl-2" data-row-select-ignore>
+			<div class="bg-card/90 border-border/50 flex items-center gap-0.5 rounded-full border p-0.5 shadow-sm backdrop-blur-sm">
+				<FlexRender {cell} />
+			</div>
 		</div>
 	{:else}
 		<FlexRender {cell} />
@@ -235,7 +237,10 @@
 					{#each headerGroup.headers as header (header.id)}
 						<Table.Head
 							colspan={header.colSpan}
-							class={cn(header.column.id === 'select' && selectCellClasses, header.column.id === 'actions' && actionsCellClasses)}
+							class={cn(
+								header.column.id === 'select' && selectCellClasses,
+								header.column.id === 'actions' && cn(actionsCellClasses, 'bg-background z-30')
+							)}
 						>
 							{#if !header.isPlaceholder}
 								<FlexRender {header} />

--- a/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table-toolbar.svelte
@@ -87,7 +87,7 @@
 	const activeFilterCount = $derived(table.state.columnFilters.length);
 </script>
 
-<div class={cn('flex flex-wrap items-center gap-2 px-3 py-2.5', className)}>
+<div class={cn('flex flex-wrap items-center gap-2 px-4 py-3', className)}>
 	<div class="order-1 flex min-w-0 flex-1 items-center gap-2 md:flex-none">
 		<div class="relative min-w-0 flex-1 md:w-64 md:flex-none">
 			<SearchIcon class="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -686,7 +686,10 @@
 			</div>
 		{/if}
 
-		<div bind:this={desktopScrollEl} class="[isolation:isolate] hidden h-full min-h-0 flex-1 overflow-auto md:block">
+		<div
+			bind:this={desktopScrollEl}
+			class="bg-background/80 [isolation:isolate] hidden h-full min-h-0 flex-1 overflow-auto md:block"
+		>
 			<ArcaneTableDesktopView
 				{table}
 				{selectedIds}
@@ -708,7 +711,7 @@
 			/>
 		</div>
 
-		<div class="[isolation:isolate] block flex-1 overflow-auto md:hidden">
+		<div class="bg-background/80 [isolation:isolate] block flex-1 overflow-auto md:hidden">
 			<div class="divide-border/40 divide-y">
 				<ArcaneTableMobileView
 					{table}
@@ -726,7 +729,7 @@
 		</div>
 
 		{#if !withoutPagination}
-			<div class="shrink-0 border-t px-2 py-4">
+			<div class="border-border/50 shrink-0 border-t px-4 py-3">
 				{@render PaginationSnippet()}
 			</div>
 		{/if}
@@ -789,7 +792,7 @@
 		</div>
 
 		{#if !withoutPagination}
-			<div class="border-border/50 shrink-0 border-t px-2 py-4">
+			<div class="border-border/50 shrink-0 border-t px-4 py-3">
 				{@render PaginationSnippet()}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/ui/table/table-cell.svelte
+++ b/frontend/src/lib/components/ui/table/table-cell.svelte
@@ -9,7 +9,7 @@
 	bind:this={ref}
 	data-slot="table-cell"
 	class={cn(
-		'bg-transparent px-4 py-2 align-middle whitespace-nowrap',
+		'bg-transparent px-4 py-3 align-middle whitespace-nowrap',
 		'first:pl-6 last:pr-6 [&:has([role=checkbox])]:pr-0',
 		className
 	)}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the table's actions column from an absolute-positioned, hover-revealed floating button to a proper `sticky right-0` pinned column with an always-visible pill UI, and normalises padding across the toolbar, cells, and pagination footer.

- **Actions column layout overhaul**: the actions cell is now a real sticky column (`sticky right-0 z-10 bg-inherit`) that pins to the right edge during horizontal scroll; `bg-inherit` correctly picks up the row background from `Table.Row`'s explicit `bg-background` for masking. In the virtualised (`table-fixed`) path a fixed `w-24` is used because `w-0` collapses under fixed layout.
- **Global padding normalisation**: toolbar (`px-3/py-2.5` → `px-4/py-3`), table cell (`py-2` → `py-3`), and pagination dividers are made consistent; the scroll containers gain `bg-background/80` as a backdrop for the sticky masking.
- **en.json copy tweak**: template name placeholder changes from "My Nginx Stack" to "My Nginx Project".
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the layout refactor is well-reasoned and the bg-inherit masking chain is correct.

The sticky actions column redesign is sound — bg-inherit reliably picks up the row's opaque bg-background, and the virtualised/non-virtualised width split is correctly handled. The one issue is the header override: tailwind-merge discards z-20 from the table-head base in favour of z-10 from actionsCellClasses, meaning the actions header cell could be painted over by body sticky cells during combined horizontal and vertical scroll.

arcane-table-desktop-view.svelte — specifically the actions header cell z-index override.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Ftable-columns%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftable-columns%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Farcane-table%2Farcane-table-desktop-view.svelte%3A240-243%0AThe%20actions%20header%20cell%20ends%20up%20with%20%60z-10%60%20instead%20of%20%60z-20%60%20due%20to%20tailwind-merge%20resolving%20the%20conflicting%20z-index%20utilities.%20In%20%60table-head.svelte%60%20the%20base%20class%20string%20includes%20%60z-20%60%2C%20but%20since%20%60actionsCellClasses%60%20%28which%20contains%20%60z-10%60%29%20is%20passed%20as%20%60className%60%20and%20comes%20last%20in%20the%20internal%20%60cn%28%29%60%20call%2C%20tailwind-merge%20keeps%20%60z-10%60.%20All%20regular%20header%20cells%20retain%20%60z-20%60%3B%20only%20this%20corner%20cell%20drops.%20When%20the%20table%20is%20scrolled%20both%20horizontally%20and%20vertically%20simultaneously%2C%20body%20sticky%20cells%20%28also%20%60z-10%60%2C%20but%20later%20in%20the%20DOM%29%20will%20paint%20over%20the%20header%20actions%20cell.%20Adding%20%60z-30%60%20to%20the%20override%20keeps%20it%20above%20both%20regular%20header%20cells%20and%20body%20sticky%20cells.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%09class%3D%7Bcn%28%0A%09%09%09%09%09%09%09%09header.column.id%20%3D%3D%3D%20'select'%20%26%26%20selectCellClasses%2C%0A%09%09%09%09%09%09%09%09header.column.id%20%3D%3D%3D%20'actions'%20%26%26%20cn%28actionsCellClasses%2C%20'bg-background%20z-30'%29%0A%09%09%09%09%09%09%09%29%7D%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2928&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fcomponents%2Farcane-table%2Farcane-table-desktop-view.svelte%3A240-243%0AThe%20actions%20header%20cell%20ends%20up%20with%20%60z-10%60%20instead%20of%20%60z-20%60%20due%20to%20tailwind-merge%20resolving%20the%20conflicting%20z-index%20utilities.%20In%20%60table-head.svelte%60%20the%20base%20class%20string%20includes%20%60z-20%60%2C%20but%20since%20%60actionsCellClasses%60%20%28which%20contains%20%60z-10%60%29%20is%20passed%20as%20%60className%60%20and%20comes%20last%20in%20the%20internal%20%60cn%28%29%60%20call%2C%20tailwind-merge%20keeps%20%60z-10%60.%20All%20regular%20header%20cells%20retain%20%60z-20%60%3B%20only%20this%20corner%20cell%20drops.%20When%20the%20table%20is%20scrolled%20both%20horizontally%20and%20vertically%20simultaneously%2C%20body%20sticky%20cells%20%28also%20%60z-10%60%2C%20but%20later%20in%20the%20DOM%29%20will%20paint%20over%20the%20header%20actions%20cell.%20Adding%20%60z-30%60%20to%20the%20override%20keeps%20it%20above%20both%20regular%20header%20cells%20and%20body%20sticky%20cells.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%09class%3D%7Bcn%28%0A%09%09%09%09%09%09%09%09header.column.id%20%3D%3D%3D%20'select'%20%26%26%20selectCellClasses%2C%0A%09%09%09%09%09%09%09%09header.column.id%20%3D%3D%3D%20'actions'%20%26%26%20cn%28actionsCellClasses%2C%20'bg-background%20z-30'%29%0A%09%09%09%09%09%09%09%29%7D%0A%60%60%60%0A%0A&repo=getarcaneapp%2Farcane&pr=2928&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/lib/components/arcane-table/arcane-table-desktop-view.svelte:240-243
The actions header cell ends up with `z-10` instead of `z-20` due to tailwind-merge resolving the conflicting z-index utilities. In `table-head.svelte` the base class string includes `z-20`, but since `actionsCellClasses` (which contains `z-10`) is passed as `className` and comes last in the internal `cn()` call, tailwind-merge keeps `z-10`. All regular header cells retain `z-20`; only this corner cell drops. When the table is scrolled both horizontally and vertically simultaneously, body sticky cells (also `z-10`, but later in the DOM) will paint over the header actions cell. Adding `z-30` to the override keeps it above both regular header cells and body sticky cells.

```suggestion
							class={cn(
								header.column.id === 'select' && selectCellClasses,
								header.column.id === 'actions' && cn(actionsCellClasses, 'bg-background z-30')
							)}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: fix tables rows not flex redering t..."](https://github.com/getarcaneapp/arcane/commit/de101cac6d1b4c28ead05b3c8aed90eb5c4b6dd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37170814)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->