### PR TITLE
fix: add missing healthcheck cli command

### DIFF
--- a/backend/cli/health.go
+++ b/backend/cli/health.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultHealthTimeout = 5 * time.Second
+	defaultHealthPort    = "3552"
+	healthHost           = "127.0.0.1"
+	healthPath           = "/api/health"
+)
+
+var healthTimeout time.Duration
+
+var HealthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Check API health",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.Load()
+		timeout := healthTimeout
+		if timeout <= 0 {
+			timeout = defaultHealthTimeout
+		}
+
+		if err := runHealthCommandInternal(cmd.Context(), cfg, timeout); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func buildHealthURLInternal(cfg *config.Config) (string, error) {
+	if cfg == nil {
+		return "", errors.New("health config is nil")
+	}
+
+	port := strings.TrimSpace(cfg.Port)
+	if port == "" {
+		port = defaultHealthPort
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", fmt.Errorf("invalid health port %q: %w", port, err)
+	}
+
+	hostPort := net.JoinHostPort(healthHost, port)
+
+	u := &url.URL{
+		Scheme: "http",
+		Host:   hostPort,
+		Path:   healthPath,
+	}
+
+	return u.String(), nil
+}
+
+func runHealthCommandInternal(ctx context.Context, cfg *config.Config, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultHealthTimeout
+	}
+
+	healthURL, err := buildHealthURLInternal(cfg)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodHead, healthURL, nil)
+	if err != nil {
+		return fmt.Errorf("health check request creation failed: %w", err)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("health check request failed: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("health check failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func init() {
+	HealthCmd.Flags().DurationVar(&healthTimeout, "timeout", defaultHealthTimeout, "Health check timeout (e.g. 5s)")
+	rootCmd.AddCommand(HealthCmd)
+}

--- a/backend/cli/health_test.go
+++ b/backend/cli/health_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
+)
+
+func TestBuildHealthURLInternalDefaults(t *testing.T) {
+	t.Run("default_port", func(t *testing.T) {
+		cfg := &config.Config{}
+		healthURL, err := buildHealthURLInternal(cfg)
+		if err != nil {
+			t.Fatalf("build health URL failed: %v", err)
+		}
+
+		if !strings.HasPrefix(healthURL, "http://127.0.0.1:3552") {
+			t.Fatalf("unexpected health URL: %s", healthURL)
+		}
+		if !strings.HasSuffix(healthURL, "/api/health") {
+			t.Fatalf("expected health URL path /api/health, got: %s", healthURL)
+		}
+	})
+
+	t.Run("explicit_port", func(t *testing.T) {
+		cfg := &config.Config{Port: "8443"}
+		healthURL, err := buildHealthURLInternal(cfg)
+		if err != nil {
+			t.Fatalf("build health URL failed: %v", err)
+		}
+		if !strings.HasPrefix(healthURL, "http://127.0.0.1:8443") {
+			t.Fatalf("unexpected health URL: %s", healthURL)
+		}
+	})
+}
+
+func TestBuildHealthURLInternalInvalidPort(t *testing.T) {
+	cfg := &config.Config{Port: "invalid-port"}
+	_, err := buildHealthURLInternal(cfg)
+	if err == nil {
+		t.Fatal("expected invalid health URL port to fail")
+	}
+}
+
+func TestRunHealthCommandInternal(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("expected HEAD request, got: %s", r.Method)
+		}
+		if r.URL.Path != "/api/health" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	_, port, ok := strings.Cut(strings.TrimPrefix(s.URL, "http://"), ":")
+	if !ok {
+		t.Fatalf("failed to parse port from %s", s.URL)
+	}
+	if strings.Contains(port, "/") {
+		port = strings.SplitN(port, "/", 2)[0]
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		t.Fatalf("invalid port in test server URL %q: %v", s.URL, err)
+	}
+
+	cfg := &config.Config{Port: port}
+	if err := runHealthCommandInternal(context.Background(), cfg, 2*time.Second); err != nil {
+		t.Fatalf("health command failed: %v", err)
+	}
+}
+
+func TestRunHealthCommandInternalNon2xx(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer s.Close()
+
+	_, port, ok := strings.Cut(strings.TrimPrefix(s.URL, "http://"), ":")
+	if !ok {
+		t.Fatalf("failed to parse port from %s", s.URL)
+	}
+	if strings.Contains(port, "/") {
+		port = strings.SplitN(port, "/", 2)[0]
+	}
+
+	cfg := &config.Config{Port: port}
+	err := runHealthCommandInternal(context.Background(), cfg, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected non-2xx response to fail")
+	}
+	if !strings.Contains(err.Error(), "health check failed with status") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunHealthCommandInternalConnectionFailure(t *testing.T) {
+	err := runHealthCommandInternal(context.Background(), &config.Config{Port: "1"}, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected connection failure")
+	}
+}
+
+func TestRunHealthCommandInternalDefaultTimeoutFallback(t *testing.T) {
+	err := runHealthCommandInternal(context.Background(), &config.Config{Port: "1"}, 0)
+	if err == nil {
+		t.Fatal("expected connection failure")
+	}
+	if !strings.Contains(err.Error(), "health check request failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ensure timeout path is exercised by checking the string formatting path.
+	if !strings.Contains(fmt.Sprint(defaultHealthTimeout), "5s") {
+		t.Fatalf("unexpected default timeout: %s", defaultHealthTimeout)
+	}
+}

--- a/docker/examples/compose.basic.yaml
+++ b/docker/examples/compose.basic.yaml
@@ -25,12 +25,7 @@ services:
     cgroup: host
     healthcheck:
       test:
-        [
-          "CMD",
-          "curl",
-          "-fsS",
-          "http://localhost:3552/api/health",
-        ]
+        ["CMD", "./arcane", "health", "--timeout", "2s"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/docker/examples/compose.proxy.yaml
+++ b/docker/examples/compose.proxy.yaml
@@ -58,12 +58,7 @@ services:
       - docker-socket-proxy
     healthcheck:
       test:
-        [
-          "CMD",
-          "curl",
-          "-fsS",
-          "http://localhost:3552/api/health",
-        ]
+        ["CMD", "./arcane", "health", "--timeout", "2s"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2927

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a native `arcane health` CLI sub-command (and accompanying tests) that performs an HTTP HEAD request to the local API, then updates the Docker Compose example files to replace the curl-based healthcheck with `./arcane health --timeout 2s`.

- **New CLI command** (`backend/cli/health.go`): builds the health URL from the loaded config, fires a HEAD request with a configurable timeout (defaulting to 5 s), and returns a non-zero exit code on non-2xx responses. The explicit `--timeout 2s` flag in the Compose files ensures the HTTP client finishes within Docker's 3 s window.
- **Tests** (`backend/cli/health_test.go`): cover the happy path, non-2xx, connection failure, and timeout-fallback cases using `httptest.NewServer`.
- **Compose files**: both `compose.basic.yaml` and `compose.proxy.yaml` swap out the curl dependency for the self-contained `arcane health` command.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new health command is well-tested, timeout alignment in Compose is correct, and no logic errors were found.

The change adds a straightforward CLI command with good test coverage and the Docker Compose files correctly use --timeout 2s to fit within the 3s Docker healthcheck window. No correctness defects were found in the changed code paths.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add missing healthcheck cli command"](https://github.com/getarcaneapp/arcane/commit/636c93ebd32ce6dce407423382454f4e813f4509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37263633)</sub>

<!-- /greptile_comment -->