### PR TITLE
refactor: consolidate duplicated logic in project and notification services

### DIFF
--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -34,105 +34,7 @@ import (
 
 const cgroupCacheTTL = 30 * time.Second
 
-// ============================================================================
-// WebSocket Metrics
-// ============================================================================
-
-// WebSocketMetrics tracks active WebSocket connections and their counts.
-type WebSocketMetrics struct {
-	projectLogsActive   atomic.Int64
-	containerLogsActive atomic.Int64
-	containerStats      atomic.Int64
-	containerExec       atomic.Int64
-	systemStats         atomic.Int64
-	serviceLogsActive   atomic.Int64
-	seq                 atomic.Uint64
-	mu                  sync.RWMutex
-	connections         map[string]systemtypes.WebSocketConnectionInfo
-}
-
-// NewWebSocketMetrics creates a new WebSocketMetrics instance.
-func NewWebSocketMetrics() *WebSocketMetrics {
-	return &WebSocketMetrics{
-		connections: make(map[string]systemtypes.WebSocketConnectionInfo),
-	}
-}
-
-// Snapshot returns a point-in-time copy of the active connection counts.
-func (m *WebSocketMetrics) Snapshot() systemtypes.WebSocketMetricsSnapshot {
-	return systemtypes.WebSocketMetricsSnapshot{
-		ProjectLogsActive:   m.projectLogsActive.Load(),
-		ContainerLogsActive: m.containerLogsActive.Load(),
-		ContainerStats:      m.containerStats.Load(),
-		ContainerExec:       m.containerExec.Load(),
-		SystemStats:         m.systemStats.Load(),
-		ServiceLogsActive:   m.serviceLogsActive.Load(),
-	}
-}
-
-// Connections returns a snapshot of all tracked WebSocket connections.
-func (m *WebSocketMetrics) Connections() []systemtypes.WebSocketConnectionInfo {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	result := make([]systemtypes.WebSocketConnectionInfo, 0, len(m.connections))
-	for _, info := range m.connections {
-		result = append(result, info)
-	}
-	return result
-}
-
-// RegisterConnection adds a connection to the tracker and increments the
-// appropriate kind counter. Returns the assigned connection ID.
-func (m *WebSocketMetrics) RegisterConnection(info systemtypes.WebSocketConnectionInfo) string {
-	if info.ID == "" {
-		info.ID = "ws-" + strconv.FormatUint(m.seq.Add(1), 10)
-	}
-	if info.StartedAt.IsZero() {
-		info.StartedAt = time.Now().UTC()
-	}
-	m.mu.Lock()
-	m.connections[info.ID] = info
-	m.mu.Unlock()
-	m.applyDelta(info.Kind, 1)
-	return info.ID
-}
-
-// UnregisterConnection removes a connection from the tracker and decrements
-// the appropriate kind counter.
-func (m *WebSocketMetrics) UnregisterConnection(id string) {
-	if id == "" {
-		return
-	}
-	var info systemtypes.WebSocketConnectionInfo
-	m.mu.Lock()
-	if existing, ok := m.connections[id]; ok {
-		info = existing
-		delete(m.connections, id)
-	}
-	m.mu.Unlock()
-	if info.Kind != "" {
-		m.applyDelta(info.Kind, -1)
-	}
-}
-
-func (m *WebSocketMetrics) applyDelta(kind string, delta int64) {
-	switch kind {
-	case systemtypes.WSKindProjectLogs:
-		m.projectLogsActive.Add(delta)
-	case systemtypes.WSKindContainerLogs:
-		m.containerLogsActive.Add(delta)
-	case systemtypes.WSKindContainerStats:
-		m.containerStats.Add(delta)
-	case systemtypes.WSKindContainerExec:
-		m.containerExec.Add(delta)
-	case systemtypes.WSKindSystemStats:
-		m.systemStats.Add(delta)
-	case systemtypes.WSKindServiceLogs:
-		m.serviceLogsActive.Add(delta)
-	}
-}
-
-var defaultWebSocketMetrics = NewWebSocketMetrics()
+var defaultWebSocketMetrics = wshub.NewWebSocketMetrics()
 
 // ============================================================================
 // WebSocket Handler
@@ -147,7 +49,7 @@ type WebSocketHandler struct {
 	systemService      *services.SystemService
 	diagnosticsService *services.DiagnosticsService
 	wsUpgrader         websocket.Upgrader
-	wsMetrics          *WebSocketMetrics
+	wsMetrics          *wshub.WebSocketMetrics
 	activeConnections  sync.Map
 	logStreamsMu       sync.Mutex
 	logStreams         map[string]*wsLogStream

--- a/backend/api/ws/handler_test.go
+++ b/backend/api/ws/handler_test.go
@@ -106,7 +106,7 @@ func newTestWSPairInternal(t *testing.T) (clientConn *websocket.Conn, serverConn
 
 func newTestWebSocketHandler() *WebSocketHandler {
 	return &WebSocketHandler{
-		wsMetrics:   NewWebSocketMetrics(),
+		wsMetrics:   wshub.NewWebSocketMetrics(),
 		logStreams:  make(map[string]*wsLogStream),
 		cgroupCache: system.NewCgroupCache(cgroupCacheTTL),
 		gpuMonitor:  system.NewGPUMonitor(false, ""),

--- a/backend/internal/database/database_test.go
+++ b/backend/internal/database/database_test.go
@@ -3,8 +3,10 @@ package database
 import (
 	"context"
 	stdsql "database/sql"
+	"io/fs"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -394,4 +396,89 @@ func assertLegacyMigrationDirtyInternal(t *testing.T, dsn string, expected bool)
 	err = rawDB.QueryRow(`SELECT dirty FROM schema_migrations ORDER BY version DESC LIMIT 1`).Scan(&dirty)
 	require.NoError(t, err)
 	assert.Equal(t, expected, dirty)
+}
+
+// TestSQLiteMigrations_ColumnAddsAreReversible guards against the historical footgun
+// where a SQLite migration adds a column but leaves a no-op '-- +goose Down' (on the
+// mistaken belief that SQLite can't DROP COLUMN). The bundled modernc SQLite supports
+// DROP COLUMN, so every column-adding migration must reverse itself — otherwise a
+// down/up round-trip fails with a duplicate-column error. See 059_add_api_key_kind.sql
+// for the expected pattern.
+func TestSQLiteMigrations_ColumnAddsAreReversible(t *testing.T) {
+	migrationsFS, err := embeddedMigrationFSInternal(dbProviderSQLite)
+	require.NoError(t, err)
+
+	entries, err := fs.ReadDir(migrationsFS, ".")
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+
+		content, err := fs.ReadFile(migrationsFS, entry.Name())
+		require.NoError(t, err)
+
+		up, down := gooseUpDownSectionsInternal(string(content))
+		if !strings.Contains(strings.ToUpper(up), "ADD COLUMN") {
+			continue
+		}
+
+		assert.True(t, sectionHasSQLInternal(down),
+			"migration %s adds a column but its '-- +goose Down' has no SQL; add the reversing "+
+				"ALTER TABLE ... DROP COLUMN (modernc SQLite supports it). A no-op Down breaks "+
+				"down/up round-trips with a duplicate-column error.", entry.Name())
+	}
+}
+
+// TestSQLiteMigrations_DownUpRoundTrip migrates fully up, downgrades to just below
+// 029_add_ssh_host_key_verification (whose Down was previously a no-op), then migrates
+// back up. It proves that Down block executes cleanly (DROP COLUMN) and that re-applying
+// the Up does not fail with a duplicate-column error.
+//
+// The target stops at 28 rather than below 007 because downgrading past version 25 hits
+// a separate, pre-existing problem: 025's Down drops a column from api_keys while a
+// foreign key still references it, which SQLite rejects. That is unrelated to the no-op
+// Down fixes here and is tracked separately.
+func TestSQLiteMigrations_DownUpRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	rawDB, dsn := newSQLiteSQLDBInternal(t, t.TempDir(), "arcane-roundtrip.db")
+
+	require.NoError(t, migrateDatabaseInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{}))
+
+	const belowFixedVersion = int64(28)
+	require.NoError(t, migrateDatabaseToVersionInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{AllowDowngrade: true}, belowFixedVersion))
+	assert.Equal(t, belowFixedVersion, readGooseSQLiteVersionInternal(t, dsn))
+
+	// Re-up: a no-op Down would have left the column in place, so this would fail
+	// with "duplicate column name".
+	require.NoError(t, migrateDatabaseInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{}))
+
+	highestVersion, err := getHighestEmbeddedMigrationVersionInternal("sqlite")
+	require.NoError(t, err)
+	assert.Equal(t, highestVersion, readGooseSQLiteVersionInternal(t, dsn))
+}
+
+// gooseUpDownSectionsInternal splits a goose migration into the text before the
+// '-- +goose Down' marker (the Up section) and the text after it (the Down section).
+func gooseUpDownSectionsInternal(content string) (up, down string) {
+	const downMarker = "-- +goose Down"
+	idx := strings.Index(content, downMarker)
+	if idx < 0 {
+		return content, ""
+	}
+	return content[:idx], content[idx+len(downMarker):]
+}
+
+// sectionHasSQLInternal reports whether a migration section contains at least one
+// non-comment, non-blank line (i.e. an actual statement rather than only comments).
+func sectionHasSQLInternal(section string) bool {
+	for _, line := range strings.Split(section, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		return true
+	}
+	return false
 }

--- a/backend/internal/services/build_service.go
+++ b/backend/internal/services/build_service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	buildtypes "github.com/getarcaneapp/arcane/types/v2/builds"
 	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
-	dockerregistry "github.com/moby/moby/api/types/registry"
 	"gorm.io/gorm"
 )
 
@@ -55,30 +54,13 @@ func NewBuildService(
 		gitRepository:   gitRepository,
 		eventService:    eventService,
 	}
-	svc.builder = libbuild.NewBuilder(svc, dockerService, svc)
+	// ContainerRegistryService already implements buildtypes.RegistryAuthProvider, so the
+	// builder consumes it directly instead of through forwarding methods on BuildService.
+	// Its auth methods are nil-receiver safe, so a nil registryService (which satisfies the
+	// interface as a typed-nil pointer) returns empty auth instead of panicking.
+	svc.builder = libbuild.NewBuilder(svc, dockerService, registryService)
 
 	return svc
-}
-
-func (s *BuildService) GetRegistryAuthForImage(ctx context.Context, imageRef string) (string, error) {
-	if s.registryService == nil {
-		return "", nil
-	}
-	return s.registryService.GetRegistryAuthForImage(ctx, imageRef)
-}
-
-func (s *BuildService) GetRegistryAuthForHost(ctx context.Context, registryHost string) (string, error) {
-	if s.registryService == nil {
-		return "", nil
-	}
-	return s.registryService.GetRegistryAuthForHost(ctx, registryHost)
-}
-
-func (s *BuildService) GetAllRegistryAuthConfigs(ctx context.Context) (map[string]dockerregistry.AuthConfig, error) {
-	if s.registryService == nil {
-		return nil, nil
-	}
-	return s.registryService.GetAllRegistryAuthConfigs(ctx)
 }
 
 func (s *BuildService) BuildSettings() buildtypes.BuildSettings {

--- a/backend/internal/services/build_service_test.go
+++ b/backend/internal/services/build_service_test.go
@@ -21,65 +21,6 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestBuildService_GetRegistryAuthForHost_UsesDatabaseCredentials(t *testing.T) {
-	_, db := setupImageServiceAuthTest(t)
-	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
-
-	svc := &BuildService{registryService: NewContainerRegistryService(db, nil, nil)}
-
-	auth, err := svc.GetRegistryAuthForHost(context.Background(), "registry-1.docker.io")
-	require.NoError(t, err)
-	require.NotEmpty(t, auth)
-
-	cfg := decodeRegistryAuth(t, auth)
-	assert.Equal(t, "docker-user", cfg.Username)
-	assert.Equal(t, "docker-token", cfg.Password)
-	assert.Equal(t, "https://index.docker.io/v1/", cfg.ServerAddress)
-}
-
-func TestBuildService_GetRegistryAuthForImage_UsesHostLookup(t *testing.T) {
-	_, db := setupImageServiceAuthTest(t)
-	createTestPullRegistry(t, db, "https://ghcr.io", "gh-user", "gh-token")
-
-	svc := &BuildService{registryService: NewContainerRegistryService(db, nil, nil)}
-
-	auth, err := svc.GetRegistryAuthForImage(context.Background(), "ghcr.io/getarcaneapp/arcane:latest")
-	require.NoError(t, err)
-	require.NotEmpty(t, auth)
-
-	cfg := decodeRegistryAuth(t, auth)
-	assert.Equal(t, "gh-user", cfg.Username)
-	assert.Equal(t, "gh-token", cfg.Password)
-	assert.Equal(t, "ghcr.io", cfg.ServerAddress)
-}
-
-func TestBuildService_GetAllRegistryAuthConfigs_UsesDatabaseCredentials(t *testing.T) {
-	_, db := setupImageServiceAuthTest(t)
-	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
-
-	svc := &BuildService{registryService: NewContainerRegistryService(db, nil, nil)}
-
-	authConfigs, err := svc.GetAllRegistryAuthConfigs(context.Background())
-	require.NoError(t, err)
-	require.NotNil(t, authConfigs)
-
-	dockerCfg, ok := authConfigs["docker.io"]
-	require.True(t, ok)
-	assert.Equal(t, "docker-user", dockerCfg.Username)
-	assert.Equal(t, "docker-token", dockerCfg.Password)
-	assert.Equal(t, "https://index.docker.io/v1/", dockerCfg.ServerAddress)
-	assert.Equal(t, dockerCfg, authConfigs["registry-1.docker.io"])
-	assert.Equal(t, dockerCfg, authConfigs["index.docker.io"])
-}
-
-func TestBuildService_GetAllRegistryAuthConfigs_NoRegistryService(t *testing.T) {
-	svc := &BuildService{}
-
-	authConfigs, err := svc.GetAllRegistryAuthConfigs(context.Background())
-	require.NoError(t, err)
-	assert.Nil(t, authConfigs)
-}
-
 func TestBuildService_ResolveBuildRequest_PassesThroughLocalContext(t *testing.T) {
 	contextDir := t.TempDir()
 	svc := &BuildService{

--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -312,7 +312,14 @@ func (s *ContainerRegistryService) GetEnabledRegistries(ctx context.Context) ([]
 }
 
 // GetRegistryAuthForImage returns X-Registry-Auth for the image's registry host.
+//
+// The registry-auth methods tolerate a nil receiver: callers such as BuildService may
+// hold no registry service, and are wired in as a buildtypes.RegistryAuthProvider where a
+// typed-nil pointer would otherwise satisfy the interface's nil checks and panic on use.
 func (s *ContainerRegistryService) GetRegistryAuthForImage(ctx context.Context, imageRef string) (string, error) {
+	if s == nil {
+		return "", nil
+	}
 	registryHost, err := utilsregistry.GetRegistryAddress(imageRef)
 	if err != nil {
 		return "", err
@@ -322,6 +329,9 @@ func (s *ContainerRegistryService) GetRegistryAuthForImage(ctx context.Context, 
 
 // GetRegistryAuthForHost returns X-Registry-Auth for a configured and enabled registry.
 func (s *ContainerRegistryService) GetRegistryAuthForHost(ctx context.Context, registryHost string) (string, error) {
+	if s == nil {
+		return "", nil
+	}
 	normalizedRegistryHost := utilsregistry.NormalizeRegistryForComparison(registryHost)
 	if normalizedRegistryHost == "" {
 		return "", nil
@@ -344,6 +354,9 @@ func (s *ContainerRegistryService) GetRegistryAuthForHost(ctx context.Context, r
 }
 
 func (s *ContainerRegistryService) GetAllRegistryAuthConfigs(ctx context.Context) (map[string]dockerregistry.AuthConfig, error) {
+	if s == nil {
+		return nil, nil
+	}
 	registries, err := s.GetEnabledRegistries(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/internal/services/container_registry_service_test.go
+++ b/backend/internal/services/container_registry_service_test.go
@@ -141,6 +141,53 @@ func TestContainerRegistryService_GetAllRegistryAuthConfigs_SkipsInvalidEntries(
 	assert.Equal(t, "registry.example.com", exampleCfg.ServerAddress)
 }
 
+func TestContainerRegistryService_GetRegistryAuthForHost_UsesDatabaseCredentials(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
+
+	svc := NewContainerRegistryService(db, nil, nil)
+	auth, err := svc.GetRegistryAuthForHost(context.Background(), "registry-1.docker.io")
+	require.NoError(t, err)
+	require.NotEmpty(t, auth)
+
+	cfg := decodeRegistryAuth(t, auth)
+	assert.Equal(t, "docker-user", cfg.Username)
+	assert.Equal(t, "docker-token", cfg.Password)
+	assert.Equal(t, "https://index.docker.io/v1/", cfg.ServerAddress)
+}
+
+func TestContainerRegistryService_GetRegistryAuthForImage_UsesHostLookup(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	createTestPullRegistry(t, db, "https://ghcr.io", "gh-user", "gh-token")
+
+	svc := NewContainerRegistryService(db, nil, nil)
+	auth, err := svc.GetRegistryAuthForImage(context.Background(), "ghcr.io/getarcaneapp/arcane:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, auth)
+
+	cfg := decodeRegistryAuth(t, auth)
+	assert.Equal(t, "gh-user", cfg.Username)
+	assert.Equal(t, "gh-token", cfg.Password)
+	assert.Equal(t, "ghcr.io", cfg.ServerAddress)
+}
+
+func TestContainerRegistryService_NilService_RegistryAuthMethodsReturnEmpty(t *testing.T) {
+	var svc *ContainerRegistryService
+	ctx := context.Background()
+
+	authConfigs, err := svc.GetAllRegistryAuthConfigs(ctx)
+	require.NoError(t, err)
+	require.Nil(t, authConfigs)
+
+	authForHost, err := svc.GetRegistryAuthForHost(ctx, "registry-1.docker.io")
+	require.NoError(t, err)
+	require.Empty(t, authForHost)
+
+	authForImage, err := svc.GetRegistryAuthForImage(ctx, "ghcr.io/getarcaneapp/arcane:latest")
+	require.NoError(t, err)
+	require.Empty(t, authForImage)
+}
+
 func TestContainerRegistryService_GetRegistryPullUsage_AnonymousDockerHubLimit(t *testing.T) {
 	_, db := setupImageServiceAuthTest(t)
 	require.NoError(t, db.WithContext(context.Background()).Create(&models.ContainerRegistry{

--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -680,7 +679,7 @@ func (s *NotificationService) sendDiscordNotification(ctx context.Context, envir
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 
@@ -715,7 +714,7 @@ func (s *NotificationService) sendTelegramNotification(ctx context.Context, envi
 		return errors.New("no telegram chat IDs configured")
 	}
 
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 
@@ -764,7 +763,7 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, environ
 		}
 	}
 
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -843,7 +842,7 @@ func (s *NotificationService) sendDiscordContainerUpdateNotification(ctx context
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 
@@ -880,7 +879,7 @@ func (s *NotificationService) sendTelegramContainerUpdateNotification(ctx contex
 		return errors.New("no telegram chat IDs configured")
 	}
 
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 
@@ -931,7 +930,7 @@ func (s *NotificationService) sendEmailContainerUpdateNotification(ctx context.C
 		}
 	}
 
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -1287,7 +1286,7 @@ func (s *NotificationService) sendTestEmail(ctx context.Context, environmentName
 		}
 	}
 
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -1444,11 +1443,11 @@ func (s *NotificationService) sendBatchImageUpdateNotificationForTargetInternal(
 }
 
 func (s *NotificationService) sendBatchDiscordNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	discordConfig, err := decodeNotificationConfigInternal[models.DiscordConfig](config, "discord")
+	discordConfig, err := notifications.DecodeConfig[models.DiscordConfig](config, "discord")
 	if err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 
@@ -1475,7 +1474,7 @@ func (s *NotificationService) sendBatchTelegramNotification(ctx context.Context,
 		return fmt.Errorf("failed to unmarshal telegram config: %w", err)
 	}
 
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 
@@ -1523,7 +1522,7 @@ func (s *NotificationService) sendBatchEmailNotification(ctx context.Context, en
 		}
 	}
 
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -1630,10 +1629,10 @@ func (s *NotificationService) sendSignalNotification(ctx context.Context, enviro
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
 		return err
 	}
 
@@ -1684,10 +1683,10 @@ func (s *NotificationService) sendSignalContainerUpdateNotification(ctx context.
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
 		return err
 	}
 
@@ -1727,10 +1726,10 @@ func (s *NotificationService) sendBatchSignalNotification(ctx context.Context, e
 		return errors.New("signal cannot use both basic auth and token authentication simultaneously")
 	}
 
-	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
 		return err
 	}
 
@@ -1748,7 +1747,7 @@ func (s *NotificationService) sendBatchSignalNotification(ctx context.Context, e
 }
 
 func (s *NotificationService) sendSlackNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	slackConfig, err := prepareSlackConfigInternal(config, "Slack", true)
+	slackConfig, err := notifications.PrepareSlackConfig(config, "Slack", true)
 	if err != nil {
 		return err
 	}
@@ -1768,7 +1767,7 @@ func (s *NotificationService) sendSlackNotification(ctx context.Context, environ
 }
 
 func (s *NotificationService) sendSlackContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	slackConfig, err := prepareSlackConfigInternal(config, "Slack", true)
+	slackConfig, err := notifications.PrepareSlackConfig(config, "Slack", true)
 	if err != nil {
 		return err
 	}
@@ -1790,7 +1789,7 @@ func (s *NotificationService) sendSlackContainerUpdateNotification(ctx context.C
 }
 
 func (s *NotificationService) sendBatchSlackNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	slackConfig, err := prepareSlackConfigInternal(config, "slack", false)
+	slackConfig, err := notifications.PrepareSlackConfig(config, "slack", false)
 	if err != nil {
 		return err
 	}
@@ -1809,7 +1808,7 @@ func (s *NotificationService) sendBatchSlackNotification(ctx context.Context, en
 }
 
 func (s *NotificationService) sendNtfyNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	ntfyConfig, err := prepareNtfyConfigInternal(config, "Ntfy", true)
+	ntfyConfig, err := notifications.PrepareNtfyConfig(config, "Ntfy", true)
 	if err != nil {
 		return err
 	}
@@ -1829,7 +1828,7 @@ func (s *NotificationService) sendNtfyNotification(ctx context.Context, environm
 }
 
 func (s *NotificationService) sendNtfyContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	ntfyConfig, err := prepareNtfyConfigInternal(config, "Ntfy", true)
+	ntfyConfig, err := notifications.PrepareNtfyConfig(config, "Ntfy", true)
 	if err != nil {
 		return err
 	}
@@ -1851,7 +1850,7 @@ func (s *NotificationService) sendNtfyContainerUpdateNotification(ctx context.Co
 }
 
 func (s *NotificationService) sendBatchNtfyNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	ntfyConfig, err := prepareNtfyConfigInternal(config, "ntfy", false)
+	ntfyConfig, err := notifications.PrepareNtfyConfig(config, "ntfy", false)
 	if err != nil {
 		return err
 	}
@@ -1870,7 +1869,7 @@ func (s *NotificationService) sendBatchNtfyNotification(ctx context.Context, env
 }
 
 func (s *NotificationService) sendPushoverNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	pushoverConfig, err := preparePushoverConfigInternal(config, "Pushover")
+	pushoverConfig, err := notifications.PreparePushoverConfig(config, "Pushover")
 	if err != nil {
 		return err
 	}
@@ -1897,7 +1896,7 @@ func (s *NotificationService) sendPushoverNotification(ctx context.Context, envi
 }
 
 func (s *NotificationService) sendPushoverContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	pushoverConfig, err := preparePushoverConfigInternal(config, "Pushover")
+	pushoverConfig, err := notifications.PreparePushoverConfig(config, "Pushover")
 	if err != nil {
 		return err
 	}
@@ -1926,7 +1925,7 @@ func (s *NotificationService) sendPushoverContainerUpdateNotification(ctx contex
 }
 
 func (s *NotificationService) sendBatchPushoverNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	pushoverConfig, err := preparePushoverConfigInternal(config, "pushover")
+	pushoverConfig, err := notifications.PreparePushoverConfig(config, "pushover")
 	if err != nil {
 		return err
 	}
@@ -2069,7 +2068,7 @@ func (s *NotificationService) sendEmailVulnerabilityNotification(ctx context.Con
 			return fmt.Errorf("invalid to address %s: %w", addr, err)
 		}
 	}
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 	htmlBody, _, err := s.renderVulnerabilitySummaryEmailTemplate(environmentName, payload)
@@ -2095,7 +2094,7 @@ func (s *NotificationService) sendDiscordVulnerabilityNotification(ctx context.C
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
 		return errors.New("discord webhook ID or token not configured")
 	}
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 	message := notifications.BuildVulnerabilitySummaryNotificationMessage(
@@ -2128,7 +2127,7 @@ func (s *NotificationService) sendTelegramVulnerabilityNotification(ctx context.
 	if len(telegramConfig.ChatIDs) == 0 {
 		return errors.New("no telegram chat IDs configured")
 	}
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 	if telegramConfig.ParseMode == "" {
@@ -2161,10 +2160,10 @@ func (s *NotificationService) sendSignalVulnerabilityNotification(ctx context.Co
 	if signalConfig.Host == "" || signalConfig.Port == 0 || signalConfig.Source == "" || len(signalConfig.Recipients) == 0 {
 		return errors.New("signal not fully configured")
 	}
-	if err := decryptStringCredentialInternal(&signalConfig.Password); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&signalConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
 		return err
 	}
 	message := notifications.BuildVulnerabilitySummaryNotificationMessage(
@@ -2183,7 +2182,7 @@ func (s *NotificationService) sendSignalVulnerabilityNotification(ctx context.Co
 }
 
 func (s *NotificationService) sendSlackVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	slackConfig, err := prepareSlackConfigInternal(config, "Slack", true)
+	slackConfig, err := notifications.PrepareSlackConfig(config, "Slack", true)
 	if err != nil {
 		return err
 	}
@@ -2195,7 +2194,7 @@ func (s *NotificationService) sendSlackVulnerabilityNotification(ctx context.Con
 }
 
 func (s *NotificationService) sendNtfyVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	ntfyConfig, err := prepareNtfyConfigInternal(config, "Ntfy", true)
+	ntfyConfig, err := notifications.PrepareNtfyConfig(config, "Ntfy", true)
 	if err != nil {
 		return err
 	}
@@ -2207,7 +2206,7 @@ func (s *NotificationService) sendNtfyVulnerabilityNotification(ctx context.Cont
 }
 
 func (s *NotificationService) sendPushoverVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	pushoverConfig, err := preparePushoverConfigInternal(config, "Pushover")
+	pushoverConfig, err := notifications.PreparePushoverConfig(config, "Pushover")
 	if err != nil {
 		return err
 	}
@@ -2225,7 +2224,7 @@ func (s *NotificationService) sendPushoverVulnerabilityNotification(ctx context.
 }
 
 func (s *NotificationService) sendGotifyVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	gotifyConfig, err := prepareGotifyConfigInternal(config, "Gotify")
+	gotifyConfig, err := notifications.PrepareGotifyConfig(config, "Gotify")
 	if err != nil {
 		return err
 	}
@@ -2240,7 +2239,7 @@ func (s *NotificationService) sendGotifyVulnerabilityNotification(ctx context.Co
 }
 
 func (s *NotificationService) sendMatrixVulnerabilityNotification(ctx context.Context, environmentName string, payload VulnerabilityNotificationPayload, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config)
+	matrixConfig, err := notifications.PrepareMatrixConfig(config)
 	if err != nil {
 		return err
 	}
@@ -2308,7 +2307,7 @@ func (s *NotificationService) sendBatchGenericNotification(ctx context.Context, 
 }
 
 func (s *NotificationService) sendGotifyNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	gotifyConfig, err := prepareGotifyConfigInternal(config, "Gotify")
+	gotifyConfig, err := notifications.PrepareGotifyConfig(config, "Gotify")
 	if err != nil {
 		return err
 	}
@@ -2328,7 +2327,7 @@ func (s *NotificationService) sendGotifyNotification(ctx context.Context, enviro
 }
 
 func (s *NotificationService) sendGotifyContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	gotifyConfig, err := prepareGotifyConfigInternal(config, "Gotify")
+	gotifyConfig, err := notifications.PrepareGotifyConfig(config, "Gotify")
 	if err != nil {
 		return err
 	}
@@ -2350,7 +2349,7 @@ func (s *NotificationService) sendGotifyContainerUpdateNotification(ctx context.
 }
 
 func (s *NotificationService) sendBatchGotifyNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	gotifyConfig, err := prepareGotifyConfigInternal(config, "gotify")
+	gotifyConfig, err := notifications.PrepareGotifyConfig(config, "gotify")
 	if err != nil {
 		return err
 	}
@@ -2369,7 +2368,7 @@ func (s *NotificationService) sendBatchGotifyNotification(ctx context.Context, e
 }
 
 func (s *NotificationService) sendMatrixNotification(ctx context.Context, environmentName, imageRef string, updateInfo *imageupdate.Response, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config)
+	matrixConfig, err := notifications.PrepareMatrixConfig(config)
 	if err != nil {
 		return err
 	}
@@ -2389,7 +2388,7 @@ func (s *NotificationService) sendMatrixNotification(ctx context.Context, enviro
 }
 
 func (s *NotificationService) sendMatrixContainerUpdateNotification(ctx context.Context, environmentName, containerName, imageRef, oldDigest, newDigest string, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config)
+	matrixConfig, err := notifications.PrepareMatrixConfig(config)
 	if err != nil {
 		return err
 	}
@@ -2411,7 +2410,7 @@ func (s *NotificationService) sendMatrixContainerUpdateNotification(ctx context.
 }
 
 func (s *NotificationService) sendBatchMatrixNotification(ctx context.Context, environmentName string, updates map[string]*imageupdate.Response, config models.JSON) error {
-	matrixConfig, err := prepareMatrixConfigInternal(config)
+	matrixConfig, err := notifications.PrepareMatrixConfig(config)
 	if err != nil {
 		return err
 	}
@@ -2522,7 +2521,7 @@ func (s *NotificationService) sendDiscordPruneNotification(ctx context.Context, 
 		return errors.New("discord webhook ID or token not configured")
 	}
 
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 
@@ -2545,7 +2544,7 @@ func (s *NotificationService) sendTelegramPruneNotification(ctx context.Context,
 		return errors.New("telegram bot token or chat IDs not configured")
 	}
 
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 
@@ -2572,7 +2571,7 @@ func (s *NotificationService) sendEmailPruneNotification(ctx context.Context, en
 		return err
 	}
 
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 
@@ -2660,7 +2659,7 @@ func (s *NotificationService) sendGotifyPruneNotification(ctx context.Context, e
 	if err := s.unmarshalConfigInternal(config, &gotifyConfig); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&gotifyConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&gotifyConfig.Token); err != nil {
 		return err
 	}
 
@@ -2760,7 +2759,7 @@ func (s *NotificationService) sendDiscordAutoHealNotification(ctx context.Contex
 	if discordConfig.WebhookID == "" || discordConfig.Token == "" {
 		return errors.New("discord webhook ID or token not configured")
 	}
-	if err := decryptStringCredentialInternal(&discordConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&discordConfig.Token); err != nil {
 		return err
 	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatMarkdown, environmentName, containerName)
@@ -2775,7 +2774,7 @@ func (s *NotificationService) sendEmailAutoHealNotification(ctx context.Context,
 	if err := s.validateEmailConfigInternal(&emailConfig); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&emailConfig.SMTPPassword); err != nil {
+	if err := notifications.DecryptStringCredential(&emailConfig.SMTPPassword); err != nil {
 		return err
 	}
 	subject := notifications.BuildEmailSubject(environmentName, fmt.Sprintf("Auto Heal: Container '%s' Restarted", containerName))
@@ -2795,7 +2794,7 @@ func (s *NotificationService) sendTelegramAutoHealNotification(ctx context.Conte
 	if telegramConfig.BotToken == "" || len(telegramConfig.ChatIDs) == 0 {
 		return errors.New("telegram bot token or chat IDs not configured")
 	}
-	if err := decryptStringCredentialInternal(&telegramConfig.BotToken); err != nil {
+	if err := notifications.DecryptStringCredential(&telegramConfig.BotToken); err != nil {
 		return err
 	}
 	if telegramConfig.ParseMode == "" {
@@ -2849,7 +2848,7 @@ func (s *NotificationService) sendGotifyAutoHealNotification(ctx context.Context
 	if err := s.unmarshalConfigInternal(config, &gotifyConfig); err != nil {
 		return err
 	}
-	if err := decryptStringCredentialInternal(&gotifyConfig.Token); err != nil {
+	if err := notifications.DecryptStringCredential(&gotifyConfig.Token); err != nil {
 		return err
 	}
 	if gotifyConfig.Title == "" {
@@ -2890,18 +2889,6 @@ func (s *NotificationService) unmarshalConfigInternal(config models.JSON, dest a
 	return nil
 }
 
-func decodeNotificationConfigInternal[T any](config models.JSON, providerName string) (T, error) {
-	var out T
-	configBytes, err := json.Marshal(config)
-	if err != nil {
-		return out, fmt.Errorf("failed to marshal %s config: %w", providerName, err)
-	}
-	if err := json.Unmarshal(configBytes, &out); err != nil {
-		return out, fmt.Errorf("failed to unmarshal %s config: %w", providerName, err)
-	}
-	return out, nil
-}
-
 func (s *NotificationService) validateEmailConfigInternal(config *models.EmailConfig) error {
 	if config.SMTPHost == "" || config.SMTPPort == 0 {
 		return errors.New("SMTP host or port not configured")
@@ -2910,93 +2897,6 @@ func (s *NotificationService) validateEmailConfigInternal(config *models.EmailCo
 		return errors.New("no recipient email addresses configured")
 	}
 	return nil
-}
-
-func decryptStringCredentialInternal(value *string) error {
-	if *value == "" {
-		return nil
-	}
-
-	decrypted, err := crypto.Decrypt(*value)
-	if err != nil {
-		if isPlausibleEncryptedCredentialInternal(*value) {
-			return fmt.Errorf("failed to decrypt notification credential: %w", err)
-		}
-		slog.Warn("Failed to decrypt notification credential, using raw legacy value", "error", err)
-		return nil
-	}
-	*value = decrypted
-	return nil
-}
-
-func isPlausibleEncryptedCredentialInternal(value string) bool {
-	data, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return false
-	}
-	const minAESGCMCiphertextSize = 12 + 16
-	return len(data) >= minAESGCMCiphertextSize
-}
-
-func prepareSlackConfigInternal(config models.JSON, providerName string, requireToken bool) (models.SlackConfig, error) {
-	slackConfig, err := decodeNotificationConfigInternal[models.SlackConfig](config, providerName)
-	if err != nil {
-		return models.SlackConfig{}, err
-	}
-	if requireToken && slackConfig.Token == "" {
-		return models.SlackConfig{}, errors.New("slack token not configured")
-	}
-	if err := decryptStringCredentialInternal(&slackConfig.Token); err != nil {
-		return models.SlackConfig{}, err
-	}
-	return slackConfig, nil
-}
-
-func prepareNtfyConfigInternal(config models.JSON, providerName string, requireTopic bool) (models.NtfyConfig, error) {
-	ntfyConfig, err := decodeNotificationConfigInternal[models.NtfyConfig](config, providerName)
-	if err != nil {
-		return models.NtfyConfig{}, err
-	}
-	if requireTopic && ntfyConfig.Topic == "" {
-		return models.NtfyConfig{}, errors.New("ntfy topic is required")
-	}
-	if err := decryptStringCredentialInternal(&ntfyConfig.Password); err != nil {
-		return models.NtfyConfig{}, err
-	}
-	return ntfyConfig, nil
-}
-
-func preparePushoverConfigInternal(config models.JSON, providerName string) (models.PushoverConfig, error) {
-	pushoverConfig, err := decodeNotificationConfigInternal[models.PushoverConfig](config, providerName)
-	if err != nil {
-		return models.PushoverConfig{}, err
-	}
-	if err := decryptStringCredentialInternal(&pushoverConfig.Token); err != nil {
-		return models.PushoverConfig{}, err
-	}
-	return pushoverConfig, nil
-}
-
-func prepareGotifyConfigInternal(config models.JSON, providerName string) (models.GotifyConfig, error) {
-	gotifyConfig, err := decodeNotificationConfigInternal[models.GotifyConfig](config, providerName)
-	if err != nil {
-		return models.GotifyConfig{}, err
-	}
-	if err := decryptStringCredentialInternal(&gotifyConfig.Token); err != nil {
-		return models.GotifyConfig{}, err
-	}
-	return gotifyConfig, nil
-}
-
-func prepareMatrixConfigInternal(config models.JSON) (models.MatrixConfig, error) {
-	matrixConfig, err := decodeNotificationConfigInternal[models.MatrixConfig](config, "Matrix")
-	if err != nil {
-		return models.MatrixConfig{}, err
-	}
-	if err := decryptStringCredentialInternal(&matrixConfig.Password); err != nil {
-		return models.MatrixConfig{}, err
-	}
-	return matrixConfig, nil
 }
 
 func buildVulnerabilitySummaryMessageInternal(format notifications.MessageFormat, environmentName string, payload VulnerabilityNotificationPayload) string {

--- a/backend/internal/services/notification_service_test.go
+++ b/backend/internal/services/notification_service_test.go
@@ -442,7 +442,7 @@ func TestNotificationCredentialInternal_KeepsPlaintextLegacyValues(t *testing.T)
 
 	value := "discord-webhook-token/plaintext"
 
-	require.NoError(t, decryptStringCredentialInternal(&value))
+	require.NoError(t, notifications.DecryptStringCredential(&value))
 	require.Equal(t, "discord-webhook-token/plaintext", value)
 }
 
@@ -452,7 +452,7 @@ func TestNotificationCredentialInternal_DecryptsEncryptedValues(t *testing.T) {
 	encrypted, err := crypto.Encrypt("gotify-application-token")
 	require.NoError(t, err)
 
-	require.NoError(t, decryptStringCredentialInternal(&encrypted))
+	require.NoError(t, notifications.DecryptStringCredential(&encrypted))
 	require.Equal(t, "gotify-application-token", encrypted)
 }
 
@@ -467,7 +467,7 @@ func TestNotificationCredentialInternal_ReturnsErrorForCorruptedCiphertext(t *te
 	ciphertext[len(ciphertext)-1] ^= 0xff
 	corrupted := base64.StdEncoding.EncodeToString(ciphertext)
 
-	require.Error(t, decryptStringCredentialInternal(&corrupted))
+	require.Error(t, notifications.DecryptStringCredential(&corrupted))
 }
 
 func TestNotificationCredentialInternal_LeavesEmptyValuesEmpty(t *testing.T) {
@@ -475,7 +475,7 @@ func TestNotificationCredentialInternal_LeavesEmptyValuesEmpty(t *testing.T) {
 
 	value := ""
 
-	require.NoError(t, decryptStringCredentialInternal(&value))
+	require.NoError(t, notifications.DecryptStringCredential(&value))
 	require.Empty(t, value)
 }
 

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2488,7 +2487,7 @@ func serviceSelected(selected map[string]struct{}, name string) bool {
 func ensureServiceImage(projectID, projectName, serviceName string, svc composetypes.ServiceConfig) (string, composetypes.ServiceConfig, bool) {
 	imageName := strings.TrimSpace(svc.Image)
 	if imageName == "" {
-		imageName = buildLocalImageTag(projectID, projectName, serviceName)
+		imageName = projects.BuildLocalImageTag(projectID, projectName, serviceName)
 		svc.Image = imageName
 		return imageName, svc, true
 	}
@@ -2582,17 +2581,6 @@ func resolveDockerfilePathInternal(svc composetypes.ServiceConfig) string {
 	return dockerfilePath
 }
 
-func buildArgsFromCompose(args map[string]*string) map[string]string {
-	buildArgs := map[string]string{}
-	for key, value := range args {
-		if value == nil {
-			continue
-		}
-		buildArgs[key] = *value
-	}
-	return buildArgs
-}
-
 func (s *ProjectService) resolveEffectiveBuildProvider(override string) string {
 	provider := strings.ToLower(strings.TrimSpace(override))
 	if provider != "" {
@@ -2608,86 +2596,6 @@ func (s *ProjectService) resolveEffectiveBuildProvider(override string) string {
 	}
 
 	return provider
-}
-
-func labelsFromCompose(labels composetypes.Labels) map[string]string {
-	if len(labels) == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, len(labels))
-	maps.Copy(out, labels)
-
-	return out
-}
-
-func ulimitsFromCompose(ulimits map[string]*composetypes.UlimitsConfig) map[string]string {
-	if len(ulimits) == 0 {
-		return nil
-	}
-
-	out := make(map[string]string, len(ulimits))
-	for name, cfg := range ulimits {
-		if cfg == nil {
-			continue
-		}
-
-		switch {
-		case cfg.Single > 0:
-			out[name] = strconv.Itoa(cfg.Single)
-		case cfg.Soft > 0 || cfg.Hard > 0:
-			out[name] = fmt.Sprintf("%d:%d", cfg.Soft, cfg.Hard)
-		}
-	}
-
-	if len(out) == 0 {
-		return nil
-	}
-
-	return out
-}
-
-func mergeBuildTags(primaryImage string, composeTags []string) []string {
-	seen := map[string]struct{}{}
-	merged := make([]string, 0, len(composeTags)+1)
-
-	appendTag := func(tag string) {
-		tag = strings.TrimSpace(tag)
-		if tag == "" {
-			return
-		}
-		if _, ok := seen[tag]; ok {
-			return
-		}
-		seen[tag] = struct{}{}
-		merged = append(merged, tag)
-	}
-
-	appendTag(primaryImage)
-	for _, tag := range composeTags {
-		appendTag(tag)
-	}
-
-	return merged
-}
-
-func buildPlatformsFromCompose(svc composetypes.ServiceConfig) []string {
-	platforms := make([]string, 0, len(svc.Build.Platforms)+1)
-	for _, platform := range svc.Build.Platforms {
-		platform = strings.TrimSpace(platform)
-		if platform == "" {
-			continue
-		}
-		platforms = append(platforms, platform)
-	}
-
-	if len(platforms) == 0 {
-		if servicePlatform := strings.TrimSpace(svc.Platform); servicePlatform != "" {
-			platforms = append(platforms, servicePlatform)
-		}
-	}
-
-	return platforms
 }
 
 func (s *ProjectService) prepareServiceBuildRequest(
@@ -2736,10 +2644,10 @@ func (s *ProjectService) prepareServiceBuildRequest(
 		ContextDir:       contextDir,
 		Dockerfile:       dockerfilePath,
 		DockerfileInline: dockerfileInline,
-		Tags:             mergeBuildTags(imageName, updatedSvc.Build.Tags),
+		Tags:             projects.MergeBuildTags(imageName, updatedSvc.Build.Tags),
 		Target:           strings.TrimSpace(updatedSvc.Build.Target),
-		BuildArgs:        buildArgsFromCompose(updatedSvc.Build.Args),
-		Labels:           labelsFromCompose(updatedSvc.Build.Labels),
+		BuildArgs:        projects.BuildArgsFromCompose(updatedSvc.Build.Args),
+		Labels:           projects.LabelsFromCompose(updatedSvc.Build.Labels),
 		CacheFrom:        append([]string(nil), updatedSvc.Build.CacheFrom...),
 		CacheTo:          append([]string(nil), updatedSvc.Build.CacheTo...),
 		NoCache:          updatedSvc.Build.NoCache,
@@ -2747,14 +2655,14 @@ func (s *ProjectService) prepareServiceBuildRequest(
 		Network:          strings.TrimSpace(updatedSvc.Build.Network),
 		Isolation:        strings.TrimSpace(updatedSvc.Build.Isolation),
 		ShmSize:          int64(updatedSvc.Build.ShmSize),
-		Ulimits:          ulimitsFromCompose(updatedSvc.Build.Ulimits),
+		Ulimits:          projects.UlimitsFromCompose(updatedSvc.Build.Ulimits),
 		Entitlements: append(
 			[]string(nil),
 			updatedSvc.Build.Entitlements...,
 		),
 		Privileged: updatedSvc.Build.Privileged,
 		ExtraHosts: updatedSvc.Build.ExtraHosts.AsList(":"),
-		Platforms:  buildPlatformsFromCompose(updatedSvc),
+		Platforms:  projects.BuildPlatformsFromCompose(updatedSvc),
 		Provider:   effectiveProvider,
 	}
 	if options.Push != nil {
@@ -2829,42 +2737,6 @@ func (s *ProjectService) buildProjectServicesInternal(ctx context.Context, proje
 	}
 
 	return nil
-}
-
-func buildLocalImageTag(projectID, projectName, serviceName string) string {
-	shortID := strings.TrimSpace(projectID)
-	if len(shortID) > 8 {
-		shortID = shortID[:8]
-	}
-	projectPart := sanitizeImageComponent(projectName)
-	if projectPart == "" {
-		projectPart = "project"
-	}
-	servicePart := sanitizeImageComponent(serviceName)
-	if servicePart == "" {
-		servicePart = "service"
-	}
-
-	return fmt.Sprintf("arcane.local/%s-%s/%s:latest", projectPart, shortID, servicePart)
-}
-
-func sanitizeImageComponent(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	if value == "" {
-		return ""
-	}
-	return strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z':
-			return r
-		case r >= '0' && r <= '9':
-			return r
-		case r == '-' || r == '_' || r == '.':
-			return r
-		default:
-			return '-'
-		}
-	}, value)
 }
 
 func (s *ProjectService) RestartProject(ctx context.Context, projectID string, user models.User) error {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -3216,11 +3216,6 @@ func TestProjectService_MapProjectToDto_SetsRedeployDisabledFromRuntimeServices(
 	}
 }
 
-func TestProjectService_MergeBuildTags(t *testing.T) {
-	tags := mergeBuildTags("example/app:latest", []string{"example/app:sha", "example/app:latest", " "})
-	assert.Equal(t, []string{"example/app:latest", "example/app:sha"}, tags)
-}
-
 func TestProjectService_ListProjects_WithDerivedStatusFilter_AllowsAllPageSizeSentinel(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -3256,33 +3251,6 @@ func TestProjectService_ListProjects_WithDerivedStatusFilter_AllowsAllPageSizeSe
 	require.Len(t, items, 25)
 	assert.Equal(t, "stopped-00", items[0].Name)
 	assert.Equal(t, "stopped-24", items[len(items)-1].Name)
-}
-
-func TestProjectService_BuildPlatformsFromCompose(t *testing.T) {
-	t.Run("uses service platform when build platforms missing", func(t *testing.T) {
-		svc := composetypes.ServiceConfig{
-			Platform: "linux/amd64",
-			Build: &composetypes.BuildConfig{
-				Context: ".",
-			},
-		}
-
-		platforms := buildPlatformsFromCompose(svc)
-		assert.Equal(t, []string{"linux/amd64"}, platforms)
-	})
-
-	t.Run("keeps explicit build platforms", func(t *testing.T) {
-		svc := composetypes.ServiceConfig{
-			Platform: "linux/amd64",
-			Build: &composetypes.BuildConfig{
-				Context:   ".",
-				Platforms: []string{"linux/arm64"},
-			},
-		}
-
-		platforms := buildPlatformsFromCompose(svc)
-		assert.Equal(t, []string{"linux/arm64"}, platforms)
-	})
 }
 
 func TestProjectService_PrepareServiceBuildRequest_MapsComposeFields(t *testing.T) {

--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -16,6 +16,7 @@ import (
 	dockerutils "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
+	vuln "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/vuln"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
@@ -301,10 +302,10 @@ func resolveSystemUpgraderRuntimeOptionsInternal(
 	isRunningInDocker func() bool,
 ) (upgraderRuntimeOptionsInternal, error) {
 	options := upgraderRuntimeOptionsInternal{
-		ContainerEnv: buildTrivyDockerHostEnvInternal(dockerHost),
+		ContainerEnv: vuln.BuildDockerHostEnv(dockerHost),
 	}
 
-	scheme, socketPath, err := parseTrivyDockerHostInternal(dockerHost)
+	scheme, socketPath, err := vuln.ParseDockerHost(dockerHost)
 	if err != nil {
 		return upgraderRuntimeOptionsInternal{}, fmt.Errorf("resolve docker host %q: %w", dockerHost, err)
 	}

--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,10 +11,8 @@ import (
 	"log/slog"
 	"math"
 	"net"
-	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,6 +26,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
+	vuln "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/vuln"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2/vulnerability"
@@ -36,7 +34,6 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	imagetypes "github.com/moby/moby/api/types/image"
 	mounttypes "github.com/moby/moby/api/types/mount"
-	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	libupdater "go.getarcane.app/updater/pkg/labels"
 	"gorm.io/gorm"
@@ -49,28 +46,24 @@ const (
 	DefaultArcaneToolsImage = "ghcr.io/getarcaneapp/tools:latest"
 	// DefaultTrivyImage preserves the existing setting name, but now points at
 	// the shared Arcane tools image that includes the Trivy binary.
-	DefaultTrivyImage                        = DefaultArcaneToolsImage
-	DefaultTrivyNetworkMode                  = "bridge"
-	trivyCacheVolumeName                     = "arcane-trivy-cache"
-	trivyCacheMountTarget                    = "/root/.cache"
-	trivyCacheSlotRootDir                    = trivyCacheMountTarget + "/arcane-scan-slots"
-	scanStaleTimeout                         = 30 * time.Minute
-	defaultTrivyCPULimitCores                = 1.0
-	defaultTrivyMemoryLimitMB          int64 = 0
-	trivyNanoCPUsPerCore                     = int64(1_000_000_000)
-	trivyBytesPerMB                          = int64(1024 * 1024)
-	trivyErrorExcerptSize                    = int64(32 * 1024)
-	defaultScanSaveRetryAttempts             = 3
-	defaultScanSaveRetryDelay                = 200 * time.Millisecond
-	defaultScanSaveRetryMaxDelay             = 2 * time.Second
-	trivyOutputPathPrefix                    = "/tmp/arcane-trivy-result-"
-	defaultDockerHostURI                     = "unix:///var/run/docker.sock"
-	DefaultTrivyDBRepository                 = "ghcr.io/getarcaneapp/trivy-db:2"
-	DefaultTrivyJavaDBRepository             = "ghcr.io/getarcaneapp/trivy-java-db:1"
-	DefaultTrivyChecksBundleRepository       = "ghcr.io/getarcaneapp/trivy-checks:1"
-	trivyRegistryConfigDir                   = "/tmp/arcane-registry-auth"
-	trivyRegistryConfigCopyDest              = "/tmp"
-	trivyRegistryConfigTarName               = "arcane-registry-auth/config.json"
+	DefaultTrivyImage                  = DefaultArcaneToolsImage
+	DefaultTrivyNetworkMode            = "bridge"
+	trivyCacheVolumeName               = "arcane-trivy-cache"
+	trivyCacheMountTarget              = "/root/.cache"
+	trivyCacheSlotRootDir              = trivyCacheMountTarget + "/arcane-scan-slots"
+	scanStaleTimeout                   = 30 * time.Minute
+	defaultTrivyCPULimitCores          = 1.0
+	defaultTrivyMemoryLimitMB    int64 = 0
+	trivyNanoCPUsPerCore               = int64(1_000_000_000)
+	trivyBytesPerMB                    = int64(1024 * 1024)
+	trivyErrorExcerptSize              = int64(32 * 1024)
+	defaultScanSaveRetryAttempts       = 3
+	defaultScanSaveRetryDelay          = 200 * time.Millisecond
+	defaultScanSaveRetryMaxDelay       = 2 * time.Second
+	trivyOutputPathPrefix              = "/tmp/arcane-trivy-result-"
+	trivyRegistryConfigDir             = "/tmp/arcane-registry-auth"
+	trivyRegistryConfigCopyDest        = "/tmp"
+	trivyRegistryConfigTarName         = "arcane-registry-auth/config.json"
 )
 
 type trivyRuntimeOptions struct {
@@ -255,36 +248,6 @@ func NewVulnerabilityService(db *database.DB, dockerService *DockerClientService
 	}
 }
 
-func buildDockerConfigJSONInternal(authConfigs map[string]dockerregistry.AuthConfig) ([]byte, error) {
-	if len(authConfigs) == 0 {
-		return nil, nil
-	}
-
-	type authEntry struct {
-		Auth string `json:"auth"`
-	}
-
-	auths := make(map[string]authEntry, len(authConfigs))
-	for host, cfg := range authConfigs {
-		host = strings.TrimSpace(host)
-		if host == "" || cfg.Username == "" || cfg.Password == "" {
-			continue
-		}
-
-		auths[host] = authEntry{
-			Auth: base64.StdEncoding.EncodeToString([]byte(cfg.Username + ":" + cfg.Password)),
-		}
-	}
-
-	if len(auths) == 0 {
-		return nil, nil
-	}
-
-	return json.Marshal(struct {
-		Auths map[string]authEntry `json:"auths"`
-	}{Auths: auths})
-}
-
 func (s *VulnerabilityService) buildTrivyRegistryConfigInternal(ctx context.Context) []byte {
 	if s.registryService == nil {
 		return nil
@@ -296,7 +259,7 @@ func (s *VulnerabilityService) buildTrivyRegistryConfigInternal(ctx context.Cont
 		return nil
 	}
 
-	configJSON, err := buildDockerConfigJSONInternal(authConfigs)
+	configJSON, err := vuln.BuildDockerConfigJSON(authConfigs)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to build trivy registry config; continuing anonymously", "error", err)
 		return nil
@@ -1555,8 +1518,8 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 
 	execCmd := make([]string, 0, 16)
 	execCmd = append(execCmd, "trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout)
-	execCmd = append(execCmd, trivyScanCacheBackendArgsInternal()...)
-	execCmd = append(execCmd, trivyDefaultRepositoryArgsInternal()...)
+	execCmd = append(execCmd, vuln.ScanCacheBackendArgs()...)
+	execCmd = append(execCmd, vuln.DefaultRepositoryArgs()...)
 	execCmd = append(execCmd, imageName)
 
 	execCfg := client.ExecCreateOptions{
@@ -1801,57 +1764,11 @@ func (s *VulnerabilityService) GetTrivyVersion(ctx context.Context) string {
 		return ""
 	}
 
-	return parseTrivyVersion(readTempFileExcerptInternal(stdoutFile))
-}
-
-func parseTrivyVersion(output string) string {
-	output = strings.TrimSpace(output)
-	if output == "" {
-		return ""
-	}
-	lines := strings.SplitSeq(output, "\n")
-	for line := range lines {
-		if after, ok := strings.CutPrefix(line, "Version:"); ok {
-			return strings.TrimSpace(after)
-		}
-	}
-	return strings.TrimSpace(output)
+	return vuln.ParseVersion(readTempFileExcerptInternal(stdoutFile))
 }
 
 func (s *VulnerabilityService) getTrivyImageRef() string {
 	return DefaultTrivyImage
-}
-
-func normalizeTrivyNetworkModeInternal(networkMode string) string {
-	return strings.TrimSpace(networkMode)
-}
-
-func parseTrivySecurityOptsInternal(value string) []string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-
-	value = strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(value)
-	parts := strings.FieldsFunc(value, func(r rune) bool {
-		return r == ',' || r == '\n'
-	})
-	if len(parts) == 0 {
-		return nil
-	}
-
-	opts := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if opt := strings.TrimSpace(part); opt != "" {
-			opts = append(opts, opt)
-		}
-	}
-
-	if len(opts) == 0 {
-		return nil
-	}
-
-	return opts
 }
 
 func (s *VulnerabilityService) getConfiguredTrivyNetworkModeInternal() string {
@@ -1864,7 +1781,7 @@ func (s *VulnerabilityService) getConfiguredTrivyNetworkModeInternal() string {
 		return ""
 	}
 
-	return normalizeTrivyNetworkModeInternal(cfg.TrivyNetwork.Value)
+	return vuln.NormalizeNetworkMode(cfg.TrivyNetwork.Value)
 }
 
 func (s *VulnerabilityService) getEffectiveDockerHostInternal() string {
@@ -1882,46 +1799,7 @@ func (s *VulnerabilityService) getEffectiveDockerHostInternal() string {
 		}
 	}
 
-	return defaultDockerHostURI
-}
-
-func parseTrivyDockerHostInternal(dockerHost string) (scheme string, socketPath string, err error) {
-	dockerHost = strings.TrimSpace(dockerHost)
-	if dockerHost == "" {
-		dockerHost = defaultDockerHostURI
-	}
-
-	if strings.HasPrefix(dockerHost, "/") {
-		return "unix", dockerHost, nil
-	}
-
-	parsed, err := url.Parse(dockerHost)
-	if err != nil {
-		return "", "", fmt.Errorf("parse docker host %q: %w", dockerHost, err)
-	}
-
-	scheme = strings.ToLower(strings.TrimSpace(parsed.Scheme))
-	switch scheme {
-	case "unix":
-		socketPath = strings.TrimSpace(parsed.Path)
-		if socketPath == "" {
-			return "", "", fmt.Errorf("docker host %q is missing a unix socket path", dockerHost)
-		}
-		return scheme, socketPath, nil
-	case "tcp", "http", "https":
-		return scheme, "", nil
-	default:
-		return "", "", fmt.Errorf("unsupported docker host scheme %q", scheme)
-	}
-}
-
-func buildTrivyDockerHostEnvInternal(dockerHost string) []string {
-	dockerHost = strings.TrimSpace(dockerHost)
-	if dockerHost == "" {
-		return nil
-	}
-
-	return []string{"DOCKER_HOST=" + dockerHost}
+	return vuln.DefaultDockerHostURI
 }
 
 func resolveTrivyUnixSocketSourceInternal(
@@ -2029,7 +1907,7 @@ func selectTrivyAutoNetworkModeInternal(inspect *containertypes.InspectResponse)
 	}
 
 	if inspect.HostConfig != nil {
-		networkMode := normalizeTrivyNetworkModeInternal(string(inspect.HostConfig.NetworkMode))
+		networkMode := vuln.NormalizeNetworkMode(string(inspect.HostConfig.NetworkMode))
 		if networkMode != "" && networkMode != "default" && networkMode != DefaultTrivyNetworkMode &&
 			!containertypes.NetworkMode(networkMode).IsContainer() {
 			return networkMode
@@ -2039,7 +1917,7 @@ func selectTrivyAutoNetworkModeInternal(inspect *containertypes.InspectResponse)
 	if inspect.NetworkSettings != nil && len(inspect.NetworkSettings.Networks) > 0 {
 		networkNames := make([]string, 0, len(inspect.NetworkSettings.Networks))
 		for networkName := range inspect.NetworkSettings.Networks {
-			networkName = normalizeTrivyNetworkModeInternal(networkName)
+			networkName = vuln.NormalizeNetworkMode(networkName)
 			if networkName != "" {
 				networkNames = append(networkNames, networkName)
 			}
@@ -2063,7 +1941,7 @@ func selectTrivyAutoNetworkModeInternal(inspect *containertypes.InspectResponse)
 	}
 
 	if inspect.HostConfig != nil {
-		networkMode := normalizeTrivyNetworkModeInternal(string(inspect.HostConfig.NetworkMode))
+		networkMode := vuln.NormalizeNetworkMode(string(inspect.HostConfig.NetworkMode))
 		if networkMode != "" && networkMode != "default" && !containertypes.NetworkMode(networkMode).IsContainer() {
 			return networkMode
 		}
@@ -2092,12 +1970,12 @@ func (s *VulnerabilityService) resolveTrivyRuntimeOptionsInternal(ctx context.Co
 	}
 
 	dockerHost := s.getEffectiveDockerHostInternal()
-	scheme, socketPath, err := parseTrivyDockerHostInternal(dockerHost)
+	scheme, socketPath, err := vuln.ParseDockerHost(dockerHost)
 	if err != nil {
 		return trivyRuntimeOptions{}, fmt.Errorf("failed to resolve trivy docker host: %w", err)
 	}
 
-	options.ContainerEnv = buildTrivyDockerHostEnvInternal(dockerHost)
+	options.ContainerEnv = vuln.BuildDockerHostEnv(dockerHost)
 	if scheme != "unix" {
 		return options, nil
 	}
@@ -2136,7 +2014,7 @@ func (s *VulnerabilityService) getTrivyRuntimeSecurityInternal() ([]string, bool
 		return nil, false
 	}
 
-	return parseTrivySecurityOptsInternal(cfg.TrivySecurityOpts.Value), cfg.TrivyPrivileged.IsTrue()
+	return vuln.ParseSecurityOpts(cfg.TrivySecurityOpts.Value), cfg.TrivyPrivileged.IsTrue()
 }
 
 func (s *VulnerabilityService) getTrivyScanTimeoutArg() string {
@@ -2277,29 +2155,6 @@ func cleanupTempFiles(ctx context.Context, tempFiles []string) {
 
 // trivyScanCacheBackendArgsForArchInternal returns extra Trivy flags that switch
 // the scan cache to Trivy's documented in-memory backend on 32-bit architectures.
-// The default BoltDB-backed cache can fail with ENOMEM on arm/v7 and 386 because
-// Go's heap reservations fragment the limited 32-bit virtual address space.
-func trivyScanCacheBackendArgsForArchInternal(arch string) []string {
-	switch arch {
-	case "arm", "386", "mips", "mipsle":
-		return []string{"--cache-backend", "memory"}
-	default:
-		return nil
-	}
-}
-
-func trivyScanCacheBackendArgsInternal() []string {
-	return trivyScanCacheBackendArgsForArchInternal(runtime.GOARCH)
-}
-
-func trivyDefaultRepositoryArgsInternal() []string {
-	return []string{
-		"--db-repository", DefaultTrivyDBRepository,
-		"--java-db-repository", DefaultTrivyJavaDBRepository,
-		"--checks-bundle-repository", DefaultTrivyChecksBundleRepository,
-	}
-}
-
 func (s *VulnerabilityService) buildTrivyCommandArgs(
 	ctx context.Context,
 	imageName string,
@@ -2309,8 +2164,8 @@ func (s *VulnerabilityService) buildTrivyCommandArgs(
 	outputPath string,
 ) ([]string, []string) {
 	cmdArgs := []string{"image", "--format", "json", "--quiet", "--timeout", s.getTrivyScanTimeoutArg()}
-	cmdArgs = append(cmdArgs, trivyScanCacheBackendArgsInternal()...)
-	cmdArgs = append(cmdArgs, trivyDefaultRepositoryArgsInternal()...)
+	cmdArgs = append(cmdArgs, vuln.ScanCacheBackendArgs()...)
+	cmdArgs = append(cmdArgs, vuln.DefaultRepositoryArgs()...)
 	var tempFiles []string
 
 	if strings.TrimSpace(configContent) != "" {
@@ -2338,18 +2193,6 @@ func (s *VulnerabilityService) buildTrivyCommandArgs(
 	cmdArgs = append(cmdArgs, imageName)
 
 	return cmdArgs, tempFiles
-}
-
-func buildTrivyContainerConfig(trivyImage string, cmdArgs []string, env []string) *containertypes.Config {
-	return &containertypes.Config{
-		Image:      trivyImage,
-		Entrypoint: []string{"trivy"},
-		Cmd:        cmdArgs,
-		Env:        append([]string(nil), env...),
-		Labels: map[string]string{
-			libarcane.InternalResourceLabel: "true",
-		},
-	}
 }
 
 func buildTrivyBatchHostConfigInternal(
@@ -2407,7 +2250,7 @@ func buildTrivyHostConfig(
 }
 
 func selectDefaultTrivyNetworkModeInternal(networkMode string) string {
-	networkMode = normalizeTrivyNetworkModeInternal(networkMode)
+	networkMode = vuln.NormalizeNetworkMode(networkMode)
 	if networkMode == "" {
 		return DefaultTrivyNetworkMode
 	}
@@ -3447,7 +3290,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 		env = append(env, "DOCKER_CONFIG="+trivyRegistryConfigDir)
 	}
 
-	config := buildTrivyContainerConfig(trivyImage, cmdArgs, env)
+	config := vuln.BuildContainerConfig(trivyImage, cmdArgs, env)
 	resources, cpuSet, applyLimits := s.getTrivyContainerResourceOptionsInternal(ctx, dockerClient)
 	securityOpts, privileged := s.getTrivyRuntimeSecurityInternal()
 	hostConfig := buildTrivyHostConfig(

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,86 +15,16 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
+	vuln "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/vuln"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/vulnerability"
 	glsqlite "github.com/glebarez/sqlite"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
-	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
-
-func TestBuildDockerConfigJSONInternal(t *testing.T) {
-	tests := []struct {
-		name      string
-		auths     map[string]dockerregistry.AuthConfig
-		wantAuths map[string]string
-	}{
-		{
-			name: "nil map",
-		},
-		{
-			name:  "empty map",
-			auths: map[string]dockerregistry.AuthConfig{},
-		},
-		{
-			name: "one registry",
-			auths: map[string]dockerregistry.AuthConfig{
-				"registry.example.com": {Username: "user", Password: "pass"},
-			},
-			wantAuths: map[string]string{
-				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
-			},
-		},
-		{
-			name: "skips blank credentials",
-			auths: map[string]dockerregistry.AuthConfig{
-				"registry.example.com": {Username: "user", Password: "pass"},
-				"blank-user.example":   {Username: "", Password: "pass"},
-				"blank-pass.example":   {Username: "user", Password: ""},
-				"   ":                  {Username: "user", Password: "pass"},
-			},
-			wantAuths: map[string]string{
-				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
-			},
-		},
-		{
-			name: "two registries",
-			auths: map[string]dockerregistry.AuthConfig{
-				"registry-a.example.com": {Username: "user-a", Password: "pass-a"},
-				"registry-b.example.com": {Username: "user-b", Password: "pass-b"},
-			},
-			wantAuths: map[string]string{
-				"registry-a.example.com": base64.StdEncoding.EncodeToString([]byte("user-a:pass-a")),
-				"registry-b.example.com": base64.StdEncoding.EncodeToString([]byte("user-b:pass-b")),
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildDockerConfigJSONInternal(tt.auths)
-			require.NoError(t, err)
-			if len(tt.wantAuths) == 0 {
-				require.Nil(t, got)
-				return
-			}
-
-			var parsed struct {
-				Auths map[string]struct {
-					Auth string `json:"auth"`
-				} `json:"auths"`
-			}
-			require.NoError(t, json.Unmarshal(got, &parsed))
-			require.Len(t, parsed.Auths, len(tt.wantAuths))
-			for host, want := range tt.wantAuths {
-				require.Equal(t, want, parsed.Auths[host].Auth)
-			}
-		})
-	}
-}
 
 func TestIsExpectedDockerStreamEndErrorInternal(t *testing.T) {
 	tests := []struct {
@@ -367,49 +296,11 @@ func TestBuildTrivyCommandArgs_IncludesDefaultRepositories(t *testing.T) {
 	cmdArgs, _ := svc.buildTrivyCommandArgs(context.Background(), "alpine:3.20", "", "", "", "/tmp/out.json")
 
 	require.Contains(t, cmdArgs, "--db-repository")
-	require.Contains(t, cmdArgs, DefaultTrivyDBRepository)
+	require.Contains(t, cmdArgs, vuln.DefaultDBRepository)
 	require.Contains(t, cmdArgs, "--java-db-repository")
-	require.Contains(t, cmdArgs, DefaultTrivyJavaDBRepository)
+	require.Contains(t, cmdArgs, vuln.DefaultJavaDBRepository)
 	require.Contains(t, cmdArgs, "--checks-bundle-repository")
-	require.Contains(t, cmdArgs, DefaultTrivyChecksBundleRepository)
-}
-
-func TestTrivyScanCacheBackendArgsForArch(t *testing.T) {
-	memoryBackend := []string{"--cache-backend", "memory"}
-
-	tests := []struct {
-		arch string
-		want []string
-	}{
-		{"arm", memoryBackend},
-		{"386", memoryBackend},
-		{"mips", memoryBackend},
-		{"mipsle", memoryBackend},
-		{"amd64", nil},
-		{"arm64", nil},
-		{"ppc64le", nil},
-		{"s390x", nil},
-		{"", nil},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.arch, func(t *testing.T) {
-			got := trivyScanCacheBackendArgsForArchInternal(tt.arch)
-			require.Equal(t, tt.want, got)
-			require.NotContains(t, got, "--db-backend")
-		})
-	}
-}
-
-func TestBuildTrivyContainerConfig_IncludesEnv(t *testing.T) {
-	config := buildTrivyContainerConfig(
-		DefaultTrivyImage,
-		[]string{"image", "alpine:3.20"},
-		[]string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"},
-	)
-
-	require.Equal(t, []string{"trivy"}, config.Entrypoint)
-	require.Equal(t, []string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"}, config.Env)
+	require.Contains(t, cmdArgs, vuln.DefaultChecksBundleRepository)
 }
 
 func TestBuildTrivyHostConfig_ExcludesResourcesWhenLimitsDisabled(t *testing.T) {
@@ -484,27 +375,6 @@ func TestBuildTrivyHostConfig_UsesCPUSetAndClearsNanoCPUs(t *testing.T) {
 	require.Equal(t, resources.MemorySwap, hostConfig.MemorySwap)
 }
 
-func TestParseTrivySecurityOptsInternal(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-		want  []string
-	}{
-		{name: "empty", value: "", want: nil},
-		{name: "whitespace only", value: " \n\t ", want: nil},
-		{name: "single", value: "label=disable", want: []string{"label=disable"}},
-		{name: "comma separated", value: "label=disable,label=type:container_runtime_t", want: []string{"label=disable", "label=type:container_runtime_t"}},
-		{name: "newline separated", value: "label=disable\nlabel=type:container_runtime_t", want: []string{"label=disable", "label=type:container_runtime_t"}},
-		{name: "mixed whitespace", value: " label=disable,\n\n  label=type:container_runtime_t \r\n privileged=true ", want: []string{"label=disable", "label=type:container_runtime_t", "privileged=true"}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, parseTrivySecurityOptsInternal(tt.value))
-		})
-	}
-}
-
 func TestBuildTrivyHostConfig_AppliesRuntimeSecurity(t *testing.T) {
 	hostConfig := buildTrivyHostConfig(
 		"cache-volume",
@@ -572,48 +442,10 @@ func TestApplyTrivyRuntimeSecurityInternal(t *testing.T) {
 	require.True(t, hostConfig.Privileged)
 }
 
-func TestNormalizeTrivyNetworkModeInternal(t *testing.T) {
-	require.Equal(t, "", normalizeTrivyNetworkModeInternal(""))
-	require.Equal(t, "", normalizeTrivyNetworkModeInternal(" \t\n "))
-	require.Equal(t, "arcane-external", normalizeTrivyNetworkModeInternal("arcane-external"))
-}
-
 func TestSelectDefaultTrivyNetworkModeInternal(t *testing.T) {
 	require.Equal(t, DefaultTrivyNetworkMode, selectDefaultTrivyNetworkModeInternal(""))
 	require.Equal(t, DefaultTrivyNetworkMode, selectDefaultTrivyNetworkModeInternal(" \t\n "))
 	require.Equal(t, "arcane-external", selectDefaultTrivyNetworkModeInternal("arcane-external"))
-}
-
-func TestParseTrivyDockerHostInternal(t *testing.T) {
-	tests := []struct {
-		name           string
-		dockerHost     string
-		wantScheme     string
-		wantSocketPath string
-		wantErr        string
-	}{
-		{name: "default unix", dockerHost: "", wantScheme: "unix", wantSocketPath: "/var/run/docker.sock"},
-		{name: "explicit unix", dockerHost: "unix:///run/user/1000/podman/podman.sock", wantScheme: "unix", wantSocketPath: "/run/user/1000/podman/podman.sock"},
-		{name: "tcp host", dockerHost: "tcp://docker-socket-proxy:2375", wantScheme: "tcp"},
-		{name: "http host", dockerHost: "http://docker-socket-proxy:2375", wantScheme: "http"},
-		{name: "https host", dockerHost: "https://docker.example.com", wantScheme: "https"},
-		{name: "unsupported scheme", dockerHost: "ssh://docker.example.com", wantErr: "unsupported docker host scheme"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scheme, socketPath, err := parseTrivyDockerHostInternal(tt.dockerHost)
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.wantScheme, scheme)
-			require.Equal(t, tt.wantSocketPath, socketPath)
-		})
-	}
 }
 
 func TestResolveTrivyUnixSocketSourceInternal(t *testing.T) {

--- a/backend/pkg/libarcane/vuln/trivy.go
+++ b/backend/pkg/libarcane/vuln/trivy.go
@@ -1,0 +1,195 @@
+// Package vuln provides stateless helpers for building and parsing the Trivy
+// scanner invocations used by the vulnerability service. Functions here have no
+// dependency on database or service state so they can be unit-tested in isolation.
+package vuln
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
+	containertypes "github.com/moby/moby/api/types/container"
+	dockerregistry "github.com/moby/moby/api/types/registry"
+)
+
+const (
+	// DefaultDockerHostURI is the fallback Docker endpoint used when none is configured.
+	DefaultDockerHostURI = "unix:///var/run/docker.sock"
+
+	// DefaultDBRepository / DefaultJavaDBRepository / DefaultChecksBundleRepository are the
+	// Arcane-mirrored Trivy database locations passed to the scanner.
+	DefaultDBRepository           = "ghcr.io/getarcaneapp/trivy-db:2"
+	DefaultJavaDBRepository       = "ghcr.io/getarcaneapp/trivy-java-db:1"
+	DefaultChecksBundleRepository = "ghcr.io/getarcaneapp/trivy-checks:1"
+)
+
+// ParseVersion extracts the version string from `trivy --version` output. It
+// returns the value after a "Version:" prefix when present, otherwise the
+// trimmed output as-is.
+func ParseVersion(output string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return ""
+	}
+	lines := strings.SplitSeq(output, "\n")
+	for line := range lines {
+		if after, ok := strings.CutPrefix(line, "Version:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return strings.TrimSpace(output)
+}
+
+// NormalizeNetworkMode trims a configured Trivy network mode.
+func NormalizeNetworkMode(networkMode string) string {
+	return strings.TrimSpace(networkMode)
+}
+
+// ParseSecurityOpts splits a comma- or newline-separated list of security options
+// into a cleaned slice, returning nil when there are no non-empty entries.
+func ParseSecurityOpts(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+
+	value = strings.NewReplacer("\r\n", "\n", "\r", "\n").Replace(value)
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == '\n'
+	})
+	if len(parts) == 0 {
+		return nil
+	}
+
+	opts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if opt := strings.TrimSpace(part); opt != "" {
+			opts = append(opts, opt)
+		}
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+
+	return opts
+}
+
+// ParseDockerHost validates and decomposes a Docker host URI into its scheme and,
+// for unix sockets, the socket path. An empty host falls back to DefaultDockerHostURI.
+func ParseDockerHost(dockerHost string) (scheme string, socketPath string, err error) {
+	dockerHost = strings.TrimSpace(dockerHost)
+	if dockerHost == "" {
+		dockerHost = DefaultDockerHostURI
+	}
+
+	if strings.HasPrefix(dockerHost, "/") {
+		return "unix", dockerHost, nil
+	}
+
+	parsed, err := url.Parse(dockerHost)
+	if err != nil {
+		return "", "", fmt.Errorf("parse docker host %q: %w", dockerHost, err)
+	}
+
+	scheme = strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	switch scheme {
+	case "unix":
+		socketPath = strings.TrimSpace(parsed.Path)
+		if socketPath == "" {
+			return "", "", fmt.Errorf("docker host %q is missing a unix socket path", dockerHost)
+		}
+		return scheme, socketPath, nil
+	case "tcp", "http", "https":
+		return scheme, "", nil
+	default:
+		return "", "", fmt.Errorf("unsupported docker host scheme %q", scheme)
+	}
+}
+
+// BuildDockerHostEnv returns the DOCKER_HOST environment entry for a non-empty host.
+func BuildDockerHostEnv(dockerHost string) []string {
+	dockerHost = strings.TrimSpace(dockerHost)
+	if dockerHost == "" {
+		return nil
+	}
+
+	return []string{"DOCKER_HOST=" + dockerHost}
+}
+
+// ScanCacheBackendArgsForArch returns the Trivy cache-backend flags for a GOARCH.
+// The default BoltDB-backed cache can fail with ENOMEM on arm/v7 and 386 because
+// Go's heap reservations fragment the limited 32-bit virtual address space.
+func ScanCacheBackendArgsForArch(arch string) []string {
+	switch arch {
+	case "arm", "386", "mips", "mipsle":
+		return []string{"--cache-backend", "memory"}
+	default:
+		return nil
+	}
+}
+
+// ScanCacheBackendArgs returns the cache-backend flags for the running architecture.
+func ScanCacheBackendArgs() []string {
+	return ScanCacheBackendArgsForArch(runtime.GOARCH)
+}
+
+// DefaultRepositoryArgs returns the Trivy DB repository flags pointing at the
+// Arcane-mirrored databases.
+func DefaultRepositoryArgs() []string {
+	return []string{
+		"--db-repository", DefaultDBRepository,
+		"--java-db-repository", DefaultJavaDBRepository,
+		"--checks-bundle-repository", DefaultChecksBundleRepository,
+	}
+}
+
+// BuildDockerConfigJSON encodes registry auth configs into a docker config.json
+// payload (base64 user:password under each host). It returns (nil, nil) when there
+// are no usable credentials.
+func BuildDockerConfigJSON(authConfigs map[string]dockerregistry.AuthConfig) ([]byte, error) {
+	if len(authConfigs) == 0 {
+		return nil, nil
+	}
+
+	type authEntry struct {
+		Auth string `json:"auth"`
+	}
+
+	auths := make(map[string]authEntry, len(authConfigs))
+	for host, cfg := range authConfigs {
+		host = strings.TrimSpace(host)
+		if host == "" || cfg.Username == "" || cfg.Password == "" {
+			continue
+		}
+
+		auths[host] = authEntry{
+			Auth: base64.StdEncoding.EncodeToString([]byte(cfg.Username + ":" + cfg.Password)),
+		}
+	}
+
+	if len(auths) == 0 {
+		return nil, nil
+	}
+
+	return json.Marshal(struct {
+		Auths map[string]authEntry `json:"auths"`
+	}{Auths: auths})
+}
+
+// BuildContainerConfig assembles the container.Config for a Trivy scan container.
+func BuildContainerConfig(trivyImage string, cmdArgs []string, env []string) *containertypes.Config {
+	return &containertypes.Config{
+		Image:      trivyImage,
+		Entrypoint: []string{"trivy"},
+		Cmd:        cmdArgs,
+		Env:        append([]string(nil), env...),
+		Labels: map[string]string{
+			libarcane.InternalResourceLabel: "true",
+		},
+	}
+}

--- a/backend/pkg/libarcane/vuln/trivy_test.go
+++ b/backend/pkg/libarcane/vuln/trivy_test.go
@@ -1,0 +1,193 @@
+package vuln
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	dockerregistry "github.com/moby/moby/api/types/registry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVersion(t *testing.T) {
+	require.Equal(t, "", ParseVersion(""))
+	require.Equal(t, "0.50.1", ParseVersion("Version: 0.50.1\nVulnerability DB:\n  Version: 2"))
+	require.Equal(t, "raw-output", ParseVersion("raw-output"))
+}
+
+func TestBuildDockerConfigJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		auths     map[string]dockerregistry.AuthConfig
+		wantAuths map[string]string
+	}{
+		{
+			name: "nil map",
+		},
+		{
+			name:  "empty map",
+			auths: map[string]dockerregistry.AuthConfig{},
+		},
+		{
+			name: "one registry",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry.example.com": {Username: "user", Password: "pass"},
+			},
+			wantAuths: map[string]string{
+				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			},
+		},
+		{
+			name: "skips blank credentials",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry.example.com": {Username: "user", Password: "pass"},
+				"blank-user.example":   {Username: "", Password: "pass"},
+				"blank-pass.example":   {Username: "user", Password: ""},
+				"   ":                  {Username: "user", Password: "pass"},
+			},
+			wantAuths: map[string]string{
+				"registry.example.com": base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			},
+		},
+		{
+			name: "two registries",
+			auths: map[string]dockerregistry.AuthConfig{
+				"registry-a.example.com": {Username: "user-a", Password: "pass-a"},
+				"registry-b.example.com": {Username: "user-b", Password: "pass-b"},
+			},
+			wantAuths: map[string]string{
+				"registry-a.example.com": base64.StdEncoding.EncodeToString([]byte("user-a:pass-a")),
+				"registry-b.example.com": base64.StdEncoding.EncodeToString([]byte("user-b:pass-b")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildDockerConfigJSON(tt.auths)
+			require.NoError(t, err)
+			if len(tt.wantAuths) == 0 {
+				require.Nil(t, got)
+				return
+			}
+
+			var parsed struct {
+				Auths map[string]struct {
+					Auth string `json:"auth"`
+				} `json:"auths"`
+			}
+			require.NoError(t, json.Unmarshal(got, &parsed))
+			require.Len(t, parsed.Auths, len(tt.wantAuths))
+			for host, want := range tt.wantAuths {
+				require.Equal(t, want, parsed.Auths[host].Auth)
+			}
+		})
+	}
+}
+
+func TestScanCacheBackendArgsForArch(t *testing.T) {
+	memoryBackend := []string{"--cache-backend", "memory"}
+
+	tests := []struct {
+		arch string
+		want []string
+	}{
+		{"arm", memoryBackend},
+		{"386", memoryBackend},
+		{"mips", memoryBackend},
+		{"mipsle", memoryBackend},
+		{"amd64", nil},
+		{"arm64", nil},
+		{"ppc64le", nil},
+		{"s390x", nil},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			got := ScanCacheBackendArgsForArch(tt.arch)
+			require.Equal(t, tt.want, got)
+			require.NotContains(t, got, "--db-backend")
+		})
+	}
+}
+
+func TestDefaultRepositoryArgs(t *testing.T) {
+	args := DefaultRepositoryArgs()
+	require.Contains(t, args, "--db-repository")
+	require.Contains(t, args, DefaultDBRepository)
+	require.Contains(t, args, "--java-db-repository")
+	require.Contains(t, args, DefaultJavaDBRepository)
+	require.Contains(t, args, "--checks-bundle-repository")
+	require.Contains(t, args, DefaultChecksBundleRepository)
+}
+
+func TestBuildContainerConfig_IncludesEnv(t *testing.T) {
+	config := BuildContainerConfig(
+		"ghcr.io/getarcaneapp/tools:latest",
+		[]string{"image", "alpine:3.20"},
+		[]string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"},
+	)
+
+	require.Equal(t, []string{"trivy"}, config.Entrypoint)
+	require.Equal(t, []string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"}, config.Env)
+}
+
+func TestParseSecurityOpts(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "empty", value: "", want: nil},
+		{name: "whitespace only", value: " \n\t ", want: nil},
+		{name: "single", value: "label=disable", want: []string{"label=disable"}},
+		{name: "comma separated", value: "label=disable,label=type:container_runtime_t", want: []string{"label=disable", "label=type:container_runtime_t"}},
+		{name: "newline separated", value: "label=disable\nlabel=type:container_runtime_t", want: []string{"label=disable", "label=type:container_runtime_t"}},
+		{name: "mixed whitespace", value: " label=disable,\n\n  label=type:container_runtime_t \r\n privileged=true ", want: []string{"label=disable", "label=type:container_runtime_t", "privileged=true"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ParseSecurityOpts(tt.value))
+		})
+	}
+}
+
+func TestNormalizeNetworkMode(t *testing.T) {
+	require.Equal(t, "", NormalizeNetworkMode(""))
+	require.Equal(t, "", NormalizeNetworkMode(" \t\n "))
+	require.Equal(t, "arcane-external", NormalizeNetworkMode("arcane-external"))
+}
+
+func TestParseDockerHost(t *testing.T) {
+	tests := []struct {
+		name           string
+		dockerHost     string
+		wantScheme     string
+		wantSocketPath string
+		wantErr        string
+	}{
+		{name: "default unix", dockerHost: "", wantScheme: "unix", wantSocketPath: "/var/run/docker.sock"},
+		{name: "explicit unix", dockerHost: "unix:///run/user/1000/podman/podman.sock", wantScheme: "unix", wantSocketPath: "/run/user/1000/podman/podman.sock"},
+		{name: "tcp host", dockerHost: "tcp://docker-socket-proxy:2375", wantScheme: "tcp"},
+		{name: "http host", dockerHost: "http://docker-socket-proxy:2375", wantScheme: "http"},
+		{name: "https host", dockerHost: "https://docker.example.com", wantScheme: "https"},
+		{name: "unsupported scheme", dockerHost: "ssh://docker.example.com", wantErr: "unsupported docker host scheme"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme, socketPath, err := ParseDockerHost(tt.dockerHost)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantScheme, scheme)
+			require.Equal(t, tt.wantSocketPath, socketPath)
+		})
+	}
+}

--- a/backend/pkg/libarcane/ws/metrics.go
+++ b/backend/pkg/libarcane/ws/metrics.go
@@ -1,0 +1,104 @@
+package ws
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	systemtypes "github.com/getarcaneapp/arcane/types/v2/system"
+)
+
+// WebSocketMetrics tracks active WebSocket connections and their counts.
+type WebSocketMetrics struct {
+	projectLogsActive   atomic.Int64
+	containerLogsActive atomic.Int64
+	containerStats      atomic.Int64
+	containerExec       atomic.Int64
+	systemStats         atomic.Int64
+	serviceLogsActive   atomic.Int64
+	seq                 atomic.Uint64
+	mu                  sync.RWMutex
+	connections         map[string]systemtypes.WebSocketConnectionInfo
+}
+
+// NewWebSocketMetrics creates a new WebSocketMetrics instance.
+func NewWebSocketMetrics() *WebSocketMetrics {
+	return &WebSocketMetrics{
+		connections: make(map[string]systemtypes.WebSocketConnectionInfo),
+	}
+}
+
+// Snapshot returns a point-in-time copy of the active connection counts.
+func (m *WebSocketMetrics) Snapshot() systemtypes.WebSocketMetricsSnapshot {
+	return systemtypes.WebSocketMetricsSnapshot{
+		ProjectLogsActive:   m.projectLogsActive.Load(),
+		ContainerLogsActive: m.containerLogsActive.Load(),
+		ContainerStats:      m.containerStats.Load(),
+		ContainerExec:       m.containerExec.Load(),
+		SystemStats:         m.systemStats.Load(),
+		ServiceLogsActive:   m.serviceLogsActive.Load(),
+	}
+}
+
+// Connections returns a snapshot of all tracked WebSocket connections.
+func (m *WebSocketMetrics) Connections() []systemtypes.WebSocketConnectionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]systemtypes.WebSocketConnectionInfo, 0, len(m.connections))
+	for _, info := range m.connections {
+		result = append(result, info)
+	}
+	return result
+}
+
+// RegisterConnection adds a connection to the tracker and increments the
+// appropriate kind counter. Returns the assigned connection ID.
+func (m *WebSocketMetrics) RegisterConnection(info systemtypes.WebSocketConnectionInfo) string {
+	if info.ID == "" {
+		info.ID = "ws-" + strconv.FormatUint(m.seq.Add(1), 10)
+	}
+	if info.StartedAt.IsZero() {
+		info.StartedAt = time.Now().UTC()
+	}
+	m.mu.Lock()
+	m.connections[info.ID] = info
+	m.mu.Unlock()
+	m.applyDelta(info.Kind, 1)
+	return info.ID
+}
+
+// UnregisterConnection removes a connection from the tracker and decrements
+// the appropriate kind counter.
+func (m *WebSocketMetrics) UnregisterConnection(id string) {
+	if id == "" {
+		return
+	}
+	var info systemtypes.WebSocketConnectionInfo
+	m.mu.Lock()
+	if existing, ok := m.connections[id]; ok {
+		info = existing
+		delete(m.connections, id)
+	}
+	m.mu.Unlock()
+	if info.Kind != "" {
+		m.applyDelta(info.Kind, -1)
+	}
+}
+
+func (m *WebSocketMetrics) applyDelta(kind string, delta int64) {
+	switch kind {
+	case systemtypes.WSKindProjectLogs:
+		m.projectLogsActive.Add(delta)
+	case systemtypes.WSKindContainerLogs:
+		m.containerLogsActive.Add(delta)
+	case systemtypes.WSKindContainerStats:
+		m.containerStats.Add(delta)
+	case systemtypes.WSKindContainerExec:
+		m.containerExec.Add(delta)
+	case systemtypes.WSKindSystemStats:
+		m.systemStats.Add(delta)
+	case systemtypes.WSKindServiceLogs:
+		m.serviceLogsActive.Add(delta)
+	}
+}

--- a/backend/pkg/projects/build_translation.go
+++ b/backend/pkg/projects/build_translation.go
@@ -1,0 +1,147 @@
+package projects
+
+import (
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+)
+
+// BuildArgsFromCompose flattens compose build args into a string map, dropping nil values.
+func BuildArgsFromCompose(args map[string]*string) map[string]string {
+	buildArgs := map[string]string{}
+	for key, value := range args {
+		if value == nil {
+			continue
+		}
+		buildArgs[key] = *value
+	}
+	return buildArgs
+}
+
+// LabelsFromCompose copies compose labels into a plain map, returning nil when empty.
+func LabelsFromCompose(labels composetypes.Labels) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(labels))
+	maps.Copy(out, labels)
+
+	return out
+}
+
+// UlimitsFromCompose renders compose ulimits as Docker-style "soft:hard" (or single) strings.
+func UlimitsFromCompose(ulimits map[string]*composetypes.UlimitsConfig) map[string]string {
+	if len(ulimits) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(ulimits))
+	for name, cfg := range ulimits {
+		if cfg == nil {
+			continue
+		}
+
+		switch {
+		case cfg.Single > 0:
+			out[name] = strconv.Itoa(cfg.Single)
+		case cfg.Soft > 0 || cfg.Hard > 0:
+			out[name] = fmt.Sprintf("%d:%d", cfg.Soft, cfg.Hard)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// MergeBuildTags combines a primary image tag with compose tags, trimming blanks
+// and de-duplicating while preserving order (primary first).
+func MergeBuildTags(primaryImage string, composeTags []string) []string {
+	seen := map[string]struct{}{}
+	merged := make([]string, 0, len(composeTags)+1)
+
+	appendTag := func(tag string) {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			return
+		}
+		if _, ok := seen[tag]; ok {
+			return
+		}
+		seen[tag] = struct{}{}
+		merged = append(merged, tag)
+	}
+
+	appendTag(primaryImage)
+	for _, tag := range composeTags {
+		appendTag(tag)
+	}
+
+	return merged
+}
+
+// BuildPlatformsFromCompose returns the build platforms for a service, falling
+// back to the service platform when no build platforms are declared.
+func BuildPlatformsFromCompose(svc composetypes.ServiceConfig) []string {
+	platforms := make([]string, 0, len(svc.Build.Platforms)+1)
+	for _, platform := range svc.Build.Platforms {
+		platform = strings.TrimSpace(platform)
+		if platform == "" {
+			continue
+		}
+		platforms = append(platforms, platform)
+	}
+
+	if len(platforms) == 0 {
+		if servicePlatform := strings.TrimSpace(svc.Platform); servicePlatform != "" {
+			platforms = append(platforms, servicePlatform)
+		}
+	}
+
+	return platforms
+}
+
+// BuildLocalImageTag derives a deterministic local image tag for a built service.
+func BuildLocalImageTag(projectID, projectName, serviceName string) string {
+	shortID := strings.TrimSpace(projectID)
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	projectPart := SanitizeImageComponent(projectName)
+	if projectPart == "" {
+		projectPart = "project"
+	}
+	servicePart := SanitizeImageComponent(serviceName)
+	if servicePart == "" {
+		servicePart = "service"
+	}
+
+	return fmt.Sprintf("arcane.local/%s-%s/%s:latest", projectPart, shortID, servicePart)
+}
+
+// SanitizeImageComponent lowercases a value and replaces characters that are
+// invalid in an image reference component with '-'.
+func SanitizeImageComponent(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_' || r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, value)
+}

--- a/backend/pkg/projects/build_translation_test.go
+++ b/backend/pkg/projects/build_translation_test.go
@@ -1,0 +1,40 @@
+package projects
+
+import (
+	"testing"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeBuildTags(t *testing.T) {
+	tags := MergeBuildTags("example/app:latest", []string{"example/app:sha", "example/app:latest", " "})
+	assert.Equal(t, []string{"example/app:latest", "example/app:sha"}, tags)
+}
+
+func TestBuildPlatformsFromCompose(t *testing.T) {
+	t.Run("uses service platform when build platforms missing", func(t *testing.T) {
+		svc := composetypes.ServiceConfig{
+			Platform: "linux/amd64",
+			Build: &composetypes.BuildConfig{
+				Context: ".",
+			},
+		}
+
+		platforms := BuildPlatformsFromCompose(svc)
+		assert.Equal(t, []string{"linux/amd64"}, platforms)
+	})
+
+	t.Run("keeps explicit build platforms", func(t *testing.T) {
+		svc := composetypes.ServiceConfig{
+			Platform: "linux/amd64",
+			Build: &composetypes.BuildConfig{
+				Context:   ".",
+				Platforms: []string{"linux/arm64"},
+			},
+		}
+
+		platforms := BuildPlatformsFromCompose(svc)
+		assert.Equal(t, []string{"linux/arm64"}, platforms)
+	})
+}

--- a/backend/pkg/utils/notifications/config_credentials.go
+++ b/backend/pkg/utils/notifications/config_credentials.go
@@ -1,0 +1,119 @@
+package notifications
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/crypto"
+)
+
+// DecodeConfig round-trips a provider config (models.JSON) into a typed struct T.
+func DecodeConfig[T any](config models.JSON, providerName string) (T, error) {
+	var out T
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		return out, fmt.Errorf("failed to marshal %s config: %w", providerName, err)
+	}
+	if err := json.Unmarshal(configBytes, &out); err != nil {
+		return out, fmt.Errorf("failed to unmarshal %s config: %w", providerName, err)
+	}
+	return out, nil
+}
+
+// DecryptStringCredential decrypts an encrypted credential in place. A value that
+// fails to decrypt but is not plausibly ciphertext is treated as a legacy raw value.
+func DecryptStringCredential(value *string) error {
+	if *value == "" {
+		return nil
+	}
+
+	decrypted, err := crypto.Decrypt(*value)
+	if err != nil {
+		if isPlausibleEncryptedCredentialInternal(*value) {
+			return fmt.Errorf("failed to decrypt notification credential: %w", err)
+		}
+		slog.Warn("Failed to decrypt notification credential, using raw legacy value", "error", err)
+		return nil
+	}
+	*value = decrypted
+	return nil
+}
+
+func isPlausibleEncryptedCredentialInternal(value string) bool {
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	const minAESGCMCiphertextSize = 12 + 16
+	return len(data) >= minAESGCMCiphertextSize
+}
+
+// PrepareSlackConfig decodes and decrypts a Slack provider config.
+func PrepareSlackConfig(config models.JSON, providerName string, requireToken bool) (models.SlackConfig, error) {
+	slackConfig, err := DecodeConfig[models.SlackConfig](config, providerName)
+	if err != nil {
+		return models.SlackConfig{}, err
+	}
+	if requireToken && slackConfig.Token == "" {
+		return models.SlackConfig{}, errors.New("slack token not configured")
+	}
+	if err := DecryptStringCredential(&slackConfig.Token); err != nil {
+		return models.SlackConfig{}, err
+	}
+	return slackConfig, nil
+}
+
+// PrepareNtfyConfig decodes and decrypts an ntfy provider config.
+func PrepareNtfyConfig(config models.JSON, providerName string, requireTopic bool) (models.NtfyConfig, error) {
+	ntfyConfig, err := DecodeConfig[models.NtfyConfig](config, providerName)
+	if err != nil {
+		return models.NtfyConfig{}, err
+	}
+	if requireTopic && ntfyConfig.Topic == "" {
+		return models.NtfyConfig{}, errors.New("ntfy topic is required")
+	}
+	if err := DecryptStringCredential(&ntfyConfig.Password); err != nil {
+		return models.NtfyConfig{}, err
+	}
+	return ntfyConfig, nil
+}
+
+// PreparePushoverConfig decodes and decrypts a Pushover provider config.
+func PreparePushoverConfig(config models.JSON, providerName string) (models.PushoverConfig, error) {
+	pushoverConfig, err := DecodeConfig[models.PushoverConfig](config, providerName)
+	if err != nil {
+		return models.PushoverConfig{}, err
+	}
+	if err := DecryptStringCredential(&pushoverConfig.Token); err != nil {
+		return models.PushoverConfig{}, err
+	}
+	return pushoverConfig, nil
+}
+
+// PrepareGotifyConfig decodes and decrypts a Gotify provider config.
+func PrepareGotifyConfig(config models.JSON, providerName string) (models.GotifyConfig, error) {
+	gotifyConfig, err := DecodeConfig[models.GotifyConfig](config, providerName)
+	if err != nil {
+		return models.GotifyConfig{}, err
+	}
+	if err := DecryptStringCredential(&gotifyConfig.Token); err != nil {
+		return models.GotifyConfig{}, err
+	}
+	return gotifyConfig, nil
+}
+
+// PrepareMatrixConfig decodes and decrypts a Matrix provider config.
+func PrepareMatrixConfig(config models.JSON) (models.MatrixConfig, error) {
+	matrixConfig, err := DecodeConfig[models.MatrixConfig](config, "Matrix")
+	if err != nil {
+		return models.MatrixConfig{}, err
+	}
+	if err := DecryptStringCredential(&matrixConfig.Password); err != nil {
+		return models.MatrixConfig{}, err
+	}
+	return matrixConfig, nil
+}

--- a/backend/resources/migrations/sqlite/007_add_user_oidc_tokens.sql
+++ b/backend/resources/migrations/sqlite/007_add_user_oidc_tokens.sql
@@ -4,5 +4,6 @@ ALTER TABLE users ADD COLUMN oidc_refresh_token TEXT;
 ALTER TABLE users ADD COLUMN oidc_access_token_expires_at DATETIME;
 
 -- +goose Down
--- SQLite cannot DROP COLUMN directly. No-op down migration.
--- To rollback manually, recreate the users table without these columns and copy data back.
+ALTER TABLE users DROP COLUMN oidc_access_token;
+ALTER TABLE users DROP COLUMN oidc_refresh_token;
+ALTER TABLE users DROP COLUMN oidc_access_token_expires_at;

--- a/backend/resources/migrations/sqlite/009_add_image_update_auth_fields.sql
+++ b/backend/resources/migrations/sqlite/009_add_image_update_auth_fields.sql
@@ -5,4 +5,7 @@ ALTER TABLE image_updates ADD COLUMN auth_registry TEXT;
 ALTER TABLE image_updates ADD COLUMN used_credential INTEGER DEFAULT 0;
 
 -- +goose Down
--- no-op: dropping columns in SQLite requires table rebuild; intentionally left empty
+ALTER TABLE image_updates DROP COLUMN auth_method;
+ALTER TABLE image_updates DROP COLUMN auth_username;
+ALTER TABLE image_updates DROP COLUMN auth_registry;
+ALTER TABLE image_updates DROP COLUMN used_credential;

--- a/backend/resources/migrations/sqlite/012_add_user_locale.sql
+++ b/backend/resources/migrations/sqlite/012_add_user_locale.sql
@@ -2,4 +2,4 @@
 ALTER TABLE users ADD COLUMN locale TEXT;
 
 -- +goose Down
--- SQLite down migration: to rollback, recreate the users table without the 'locale' column and copy data back.
+ALTER TABLE users DROP COLUMN locale;

--- a/backend/resources/migrations/sqlite/029_add_ssh_host_key_verification.sql
+++ b/backend/resources/migrations/sqlite/029_add_ssh_host_key_verification.sql
@@ -4,6 +4,4 @@
 ALTER TABLE git_repositories ADD COLUMN ssh_host_key_verification TEXT NOT NULL DEFAULT 'accept_new';
 
 -- +goose Down
--- SQLite doesn't support DROP COLUMN directly, but we can recreate the table
--- For simplicity, we'll just leave the column in place (it's harmless)
--- In production, you'd want to recreate the table without this column
+ALTER TABLE git_repositories DROP COLUMN ssh_host_key_verification;

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -74,6 +74,8 @@
 	let scanRequestedAtByImage = $state<Record<string, string>>({});
 	let scanPollTimeout: ReturnType<typeof setTimeout> | null = null;
 	let scanPollInFlight = false;
+	// Set once on destroy so an in-flight poll can't re-arm a timer on a dead component.
+	let destroyed = false;
 	const SCAN_POLL_INTERVAL_MS = 4000;
 
 	async function refreshImages(options: SearchPaginationSortRequest = requestOptions) {
@@ -258,6 +260,7 @@
 		scanPollInFlight = true;
 		try {
 			const response = await vulnerabilityService.getScanSummaries(imageIds);
+			if (destroyed) return;
 			const summaries = response?.summaries ?? {};
 
 			if (Object.keys(summaries).length > 0 && images.data?.length) {
@@ -295,7 +298,7 @@
 			console.error('Failed to poll vulnerability summaries:', error);
 		} finally {
 			scanPollInFlight = false;
-			if (getScanningImageIds().length > 0) {
+			if (!destroyed && getScanningImageIds().length > 0) {
 				scheduleBatchScanPolling();
 			}
 		}
@@ -320,6 +323,7 @@
 	});
 
 	onDestroy(() => {
+		destroyed = true;
 		stopBatchScanPolling();
 	});
 

--- a/frontend/src/routes/(app)/images/vulnerabilities/+page.svelte
+++ b/frontend/src/routes/(app)/images/vulnerabilities/+page.svelte
@@ -28,6 +28,8 @@
 	let scanProgress = $state({ current: 0, total: 0 });
 	let activeTab = $state('vulnerabilities');
 	let scanPollTimeout: ReturnType<typeof setTimeout> | null = null;
+	// Set once on destroy so an in-flight poll tick can't re-arm a timer on a dead component.
+	let destroyed = false;
 
 	// Ignored vulnerabilities state
 	let ignoredVulnerabilities = $state<Paginated<IgnoredVulnerability>>({
@@ -102,6 +104,7 @@
 		stopScanPolling();
 
 		const tick = async () => {
+			if (destroyed) return;
 			if (attempts >= MAX_ATTEMPTS) {
 				stopScanPolling();
 				return;
@@ -114,6 +117,7 @@
 			}
 
 			await refreshAll();
+			if (destroyed) return;
 
 			const currentScanned = summary?.scannedImages ?? 0;
 			const currentTotal = summary?.totalImages ?? targetTotal;
@@ -181,7 +185,10 @@
 
 	useEnvironmentRefresh(refreshAll);
 
-	$effect(() => () => stopScanPolling());
+	$effect(() => () => {
+		destroyed = true;
+		stopScanPolling();
+	});
 
 	async function scanAllImages() {
 		if (isLoading.scanningAll) return;


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates duplicated logic across `project_service.go`, `notification_service.go`, and `vulnerability_service.go` into purpose-built packages (`pkg/projects`, `pkg/utils/notifications`, `pkg/libarcane/vuln`, `pkg/libarcane/ws`). It also replaces no-op SQLite DOWN migrations with proper `DROP COLUMN` statements and adds a round-trip migration test to guard against regressions.

- **Backend refactor**: Private helper functions have been lifted into testable, importable packages. Nil-receiver guards were added to `ContainerRegistryService`'s auth methods, allowing `BuildService` to wire the registry service directly rather than through forwarding wrappers.
- **Migrations**: Four SQLite migration files (007, 009, 012, 029) now have real `DOWN` sections; a new `TestSQLiteMigrations_DownUpRoundTrip` test verifies the critical one (029) executes cleanly.
- **Frontend**: A `destroyed` flag is added to both `image-table.svelte` and `vulnerabilities/+page.svelte` to prevent in-flight poll callbacks from rescheduling timers after component teardown.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor is a mechanical move of logic into well-tested packages, the nil-receiver fix correctly addresses the previous registry auth concern, and the migration DOWN sections are straightforward DROP COLUMN statements.

All moved functions are exact semantic copies of the originals. The nil-receiver guards on ContainerRegistryService and the accompanying test (TestContainerRegistryService_NilService_RegistryAuthMethodsReturnEmpty) properly close the gap. The migration changes are minimal and verified by new tests. The only finding is a naming convention nit in the new ws package.

backend/pkg/libarcane/ws/metrics.go — the unexported applyDelta method should carry the Internal suffix to match the project convention followed everywhere else in this PR.
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: consolidate duplicated logic i..."](https://github.com/getarcaneapp/arcane/commit/1110ec25d7498c0000e2905325b2b8c7b221b57d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37445759)</sub>

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->