### PR TITLE
docs: add external secrets providers design RFC

### DIFF
--- a/docs/design/external-secrets.md
+++ b/docs/design/external-secrets.md
@@ -1,0 +1,297 @@
+# Design: Agnostic External Secrets Providers
+
+Status: **Draft / RFC**
+Owner: @manawenuz
+Last updated: 2026-06-14
+
+## Summary
+
+Add pluggable **external secrets providers** to Arcane so a Docker Compose project's
+environment can be resolved at deploy time from a secrets manager (Bitwarden Secrets
+Manager / `bws`, Infisical, and later Vault/OpenBao/SOPS) instead of from plaintext on
+disk. Provider credentials are encrypted at rest; resolved secret **values are held in
+memory only and never written to disk**.
+
+The abstraction is provider-neutral; the first two implementations are `bitwarden`
+(speaking the BWS wire protocol natively in Go — works against either a self-hosted
+sidecar or Bitwarden cloud) and `infisical`.
+
+## Goals
+
+- One Go interface, many backends, selected by config.
+- Resolve `${{ secrets.<provider>.<KEY> }}` references in a project's env at deploy time.
+- Credentials encrypted at rest via the existing `pkg/libarcane/crypto` (AES-GCM).
+- Resolved values **never** persisted to disk; injected in-memory into the Compose
+  `Environment` map only.
+- Resilient: per-provider last-known-good cache so a provider/network outage doesn't
+  block a redeploy.
+
+## Non-goals (v1)
+
+- Writing secrets back to a provider from Arcane.
+- Rotation, dynamic/leased secrets, PKI.
+- Per-secret RBAC beyond what the provider already enforces on its access token.
+
+Read-only resolution first; the above are follow-ups.
+
+---
+
+## Architecture
+
+### Provider interface
+
+New package `backend/pkg/secrets`; shared DTOs in `types/secretsprovider/`. Mirror the
+existing pluggable pattern used by `RegistryDaemonClient`
+(`backend/internal/services/container_registry_service.go`).
+
+```go
+package secrets
+
+// Provider is a read-only external secrets backend.
+type Provider interface {
+    // Kind identifies the backend: "bitwarden", "infisical", ...
+    Kind() string
+
+    // Resolve fetches the requested keys for a scope. Returned values are plaintext,
+    // in-memory only: implementations MUST NOT log or persist them.
+    Resolve(ctx context.Context, scope Scope, keys []string) (map[string]string, error)
+
+    // HealthCheck validates credentials/connectivity (used by the "Test connection" UI).
+    HealthCheck(ctx context.Context) error
+}
+
+// Scope is interpreted per provider (e.g. bws: organization+project; infisical: project+env).
+type Scope struct {
+    Project     string
+    Environment string
+    Path        string
+}
+
+// Factory builds a Provider from decrypted, kind-specific config.
+type Factory func(cfg map[string]string) (Provider, error)
+```
+
+Providers register into a config-driven registry (`map[string]Factory`) wired in
+`backend/internal/di` (a `provideSecretsProviders` set), the same way registry/daemon
+getters are wired today.
+
+### Data model (GORM, embed `BaseModel`, migrations for **both** sqlite + postgres)
+
+- `secret_providers`: `id, name, kind, config_json, enabled`.
+  `config_json` holds kind-specific config and is **encrypted at rest** via
+  `pkg/libarcane/crypto.Encrypt` (same path registry tokens use). Decrypted only at
+  resolve time.
+  - bitwarden config: `server_base_url`, `access_token`
+  - infisical config: `site_url`, `client_id`, `client_secret`, `project_id`
+- `project_secret_bindings`: `project_id, provider_id, scope_path, enabled, fail_mode`
+  (`fail_mode` ∈ `fail_closed` | `fail_stale`).
+
+### Reference syntax (declarative, provider-agnostic)
+
+A project declares which env values come from a provider, in the env value itself:
+
+```
+DB_PASSWORD=${{ secrets.bitwarden.DEV_DB_URL }}
+API_KEY=${{ secrets.infisical.STRIPE_KEY }}
+```
+
+`secrets.<providerName>.<KEY>` — `providerName` resolves to a configured provider (scoped
+to the project via a binding); `KEY` is the secret name in that provider.
+
+### Injection seam (single integration point)
+
+Resolution hooks into `backend/pkg/projects/env.go` / `load.go::LoadEnvironment`, **after**
+the existing merge (process env → `.env.global` → project `.env` → `project.env` override)
+and **before** the map is handed to compose-go:
+
+1. Scan the merged env map for `${{ secrets.* }}` references.
+2. Group references by provider; for each, call `Resolve(scope, keys)` once (batched).
+3. Substitute values into the in-memory map.
+4. Hand the map to `docker/compose` as `ConfigDetails.Environment`.
+
+Projects with no references make no provider calls. No other part of the deploy path
+changes.
+
+### Resilience
+
+Each provider wraps a **last-known-good cache** (keyed by provider+scope+key, TTL
+configurable). On a provider/network failure:
+
+- `fail_stale` (default for non-critical): serve cached values, mark deploy as using
+  stale secrets, surface staleness in UI/events.
+- `fail_closed`: abort the deploy with a clear error.
+
+---
+
+## Security requirements (hard)
+
+1. **No plaintext on disk.** Resolved values are injected in-memory only and MUST NOT be
+   written into `.env` / `EffectiveEnvFileName` or any persisted file. This is a
+   deliberate deviation from the current disk-materialization flow.
+2. **No plaintext in logs.** Resolver and providers must never log secret values or
+   provider tokens. Enforced by a unit test.
+3. **Encrypted at rest.** All provider credentials encrypted via the existing AES-GCM
+   helper; decrypted only at resolve time, never returned to API clients.
+4. **Redaction in API/UI/events.** Only key *names* are ever exposed; values are masked.
+5. **Least privilege.** Provider access tokens should be read-only and project-scoped
+   where the backend supports it.
+
+---
+
+## API (Huma v2 typed handlers, registered in `api/api.go`; permissions from `pkg/authz`)
+
+- `GET/POST/PATCH/DELETE  …/secret-providers`            — CRUD (values write-only/masked)
+- `POST  …/secret-providers/{id}/test`                   — HealthCheck
+- `GET/POST/DELETE  …/projects/{id}/secret-bindings`     — bind a provider+scope
+- `GET  …/projects/{id}/secret-refs`                     — dry-run: list `${{ secrets.* }}`
+  refs found and whether each resolves (names only, never values)
+
+## Frontend (`frontend/src/routes/(app)/settings/secret-providers/` + per-project tab)
+
+Follow the registries/authentication settings pattern: Svelte 5 runes, shadcn-svelte,
+`createSettingsForm`, Paraglide i18n, a service extending `BaseAPIService`.
+
+- Settings: list/add/edit providers, "Test connection".
+- Per-project "Secrets" tab: bind provider + scope, preview detected refs + resolve status
+  (names only).
+
+## CLI (`cli/pkg/secrets/`, Cobra)
+
+- `arcane secrets providers ls|add|test`
+- `arcane secrets bind <project>`
+- `arcane secrets check <project>` — dry-run resolve (names only)
+
+---
+
+## Providers
+
+### `bitwarden` (BWS wire protocol, native Go)
+
+Implemented as a native Go HTTP client of the BWS read path — **no `bws` binary
+dependency and no proprietary SDK** (keeps it mergeable and license-clean). Because it
+speaks the wire protocol, the same provider works against **either** a self-hosted sidecar
+**or** Bitwarden cloud. **Correction:** the two differ in **both host and path prefix**, not
+only `server_base_url` — cloud is split-host with no prefixes (`identity.bitwarden.com/connect/token`,
+`api.bitwarden.com/organizations/...`); self-host derives `{base}/identity` and `{base}/api`. The
+provider therefore needs two topology modes. See **[Appendix A](#appendix-a--cloud-vs-self-host-topology)**.
+
+Read-path flow:
+
+1. `POST {base}/identity/connect/token`
+   `grant_type=client_credentials&scope=api.secrets&client_id=<uuid>&client_secret=<secret>`
+   → `{ access_token (bearer), expires_in, token_type, scope, encrypted_payload }`.
+2. Derive the token key from the access token's 16-byte seed:
+   `HKDF-SHA256(ikm=seed, salt="bitwarden-accesstoken", info="sm-access-token", L=64)`
+   → `enc[0:32] || mac[32:64]`.
+3. Decrypt `encrypted_payload` (type-2 EncString `2.iv|ct|mac`, AES-256-CBC + HMAC-SHA-256
+   over `iv‖ct`, PKCS#7) → `{ "encryptionKey": <base64 64-byte org key> }`.
+4. `GET {base}/api/organizations/{org}/secrets` (org from JWT `organization` claim), then
+   `GET {base}/api/secrets/{id}` (or `POST {base}/api/secrets/get-by-ids`) → decrypt the
+   type-2 EncString `key`/`value` fields with the org key.
+
+Access token string format: `0.<client_id>.<client_secret>:<base64(seed16)>`.
+
+### `infisical`
+
+Universal Auth (Client ID/Secret) → REST `GET /api/v3/secrets` for `project_id` +
+environment. Standard bearer flow; no bespoke crypto.
+
+---
+
+## Requirements ON the bws-sidecar server (for the `bitwarden` provider)
+
+These are the server-side contracts the Go provider depends on. (The sidecar's read-path
+MVP already satisfies most.)
+
+1. **Single-host self-hosted topology.** The provider is configured with one
+   `server_base_url` and derives `{base}/identity` and `{base}/api` from it. The server
+   MUST mount identity routes under `/identity` and the SM API under `/api` off that base.
+   *(Confirmed empirically — `bws -u <base>` derives `/identity` + `/api` and the sidecar
+   mounts exactly those; matrix #11 to be marked resolved.)* The sidecar can additionally be
+   configured for **drop-in cloud compatibility** (serving cloud-style unprefixed paths), so a
+   cloud-configured client works against it unchanged — see **[Appendix A](#appendix-a--cloud-vs-self-host-topology)**.
+2. **Frozen read-path contract** with the exact captured JSON shapes:
+   `POST /identity/connect/token`, `GET /api/organizations/{org}/secrets`,
+   `GET /api/secrets/{id}`, `POST /api/secrets/get-by-ids`. Treat these as a stable API.
+3. **HTTPS** with a configurable/served certificate (or run behind a reverse proxy). The
+   provider talks to it over TLS.
+4. **Token provisioning path** (`bws-provision` equivalent) so an operator can mint a
+   read-only `access_token` to paste into the Arcane provider config.
+5. **Cheap health endpoint** (`GET /api/status` or `/alive`) for `HealthCheck()`.
+
+Property worth preserving: the provider being a native protocol client (not a wrapper
+around the sidecar) is exactly what makes it agnostic and upstream-mergeable.
+
+---
+
+## PR slicing (to land incrementally)
+
+1. Interface + DB models + migrations + crypto wiring + resolver seam + tests (no provider
+   yet; resolver is a no-op until a provider is registered).
+2. `bitwarden` provider (+ its own tests, including the crypto chain against a fixture).
+3. `infisical` provider.
+4. API (Huma handlers + authz).
+5. Frontend (settings + per-project tab).
+6. CLI (`arcane secrets`).
+
+## Mergeability checklist
+
+Conventional Commits; Huma typed I/O on Echo (no new API standard); GORM model with
+**sqlite + postgres** migrations; `go test ./...` with in-memory sqlite and interface
+mocks for providers; a test asserting no plaintext secret hits logs; ESLint/Prettier +
+Svelte 5 runes; Paraglide i18n strings.
+
+## Open questions
+
+- Reference syntax: `${{ secrets.x.y }}` vs `arcane+secret://x/y` — pick one and document.
+- Precedence when a key is both in `.env` and referenced — default: explicit ref wins.
+- Cache TTL defaults and whether staleness is per-binding or global.
+
+---
+
+## Appendix A — Cloud vs self-host topology
+
+Added 2026-06-14. Captures a correction and the sidecar capability decided while this PRD was in
+flight (the bws-sidecar implementation has already started; this is an appendix to that work).
+
+### Topologies differ in host *and* path prefix
+Empirically captured (black-box, our own credentials — see the sidecar's
+`docs/03-spec/captures/RESULTS.md`):
+
+| | Identity token endpoint | SM API base |
+|---|---|---|
+| **Cloud** | `https://identity.bitwarden.com/connect/token` (no `/identity`) | `https://api.bitwarden.com/organizations/...`, `/secrets/...` (no `/api`) |
+| **Self-host (sidecar)** | `{base}/identity/connect/token` | `{base}/api/organizations/...`, `{base}/api/secrets/...` |
+
+So "differing only by `server_base_url`" is inaccurate. The `bitwarden` provider config should
+therefore support **either**:
+- a single `server_base_url` (self-host; derive `{base}/identity` + `{base}/api`), **or**
+- explicit `identity_url` + `api_url` (cloud, or any split/advanced deployment).
+
+### What is already 100% cloud-identical
+Crypto chain (HKDF `salt="bitwarden-accesstoken"`, `info="sm-access-token"`, 64-byte split;
+type-2 EncString `2.iv|ct|mac`), the JWT claim shape (`type:ServiceAccount`, `sub≠client_id`,
+`organization`, `scope:["api.secrets"]`), the `encrypted_payload` wrap, and the request/response
+JSON for the read+write endpoints. A client pointed at the sidecar behaves as against cloud through
+all of these.
+
+### Making the sidecar drop-in cloud-compatible (configurable)
+Two pieces close the remaining gap; both are sidecar-side and optional per deployment:
+
+1. **Path topology (the real divergence).** Add `BWS_SIDECAR_COMPAT = both | selfhost | cloud`
+   (default `both`): serve the routes at the prefixed (`/identity`, `/api`) *and* the cloud-style
+   unprefixed paths. With `both`, a client configured for either topology works unchanged. (~small
+   change; planned.)
+2. **Token signing fidelity (optional).** Cloud signs the bearer **RS256** and exposes OIDC
+   discovery + JWKS; the sidecar currently uses **HS256**. This does **not** affect `bws` or this
+   provider — both relay the bearer opaquely and never validate its signature. RS256 + a
+   `/.well-known/openid-configuration` + JWKS endpoint is only needed for a strict
+   signature-validating client; treat as a follow-up.
+
+### Boundary (what "100%" can and cannot mean)
+- Achievable: **wire-compatibility** so any BWS client *pointed at the sidecar's URL* behaves
+  identically to cloud. Not achievable: *being* `identity.bitwarden.com`/`api.bitwarden.com` (DNS +
+  cert chain — the client must be configured to reach the sidecar, or override DNS and trust its cert).
+- Scope: "100%" = the **Secrets Manager / `bws` surface** captured here (identity + projects/secrets
+  read+write), not the entire Bitwarden cloud API (web vault, service-account admin CRUD, billing,
+  events are out of scope).

--- a/docs/design/external-secrets.md
+++ b/docs/design/external-secrets.md
@@ -2,19 +2,19 @@
 
 Status: **Draft / RFC**
 Owner: @manawenuz
-Last updated: 2026-06-14
+Last updated: 2026-06-15
 
 ## Summary
 
 Add pluggable **external secrets providers** to Arcane so a Docker Compose project's
 environment can be resolved at deploy time from a secrets manager (Bitwarden Secrets
-Manager / `bws`, Infisical, and later Vault/OpenBao/SOPS) instead of from plaintext on
-disk. Provider credentials are encrypted at rest; resolved secret **values are held in
+Manager / BWS, Infisical, or HashiCorp Vault) instead of from plaintext on disk.
+Provider credentials are encrypted at rest; resolved secret **values are held in
 memory only and never written to disk**.
 
-The abstraction is provider-neutral; the first two implementations are `bitwarden`
+The abstraction is provider-neutral; the first three implementations are `bitwarden`
 (speaking the BWS wire protocol natively in Go — works against either a self-hosted
-sidecar or Bitwarden cloud) and `infisical`.
+sidecar or Bitwarden cloud), `infisical`, and `vault` (HashiCorp Vault KV v1/v2).
 
 ## Goals
 
@@ -83,6 +83,7 @@ getters are wired today.
   resolve time.
   - bitwarden config: `server_base_url`, `access_token`
   - infisical config: `site_url`, `client_id`, `client_secret`, `project_id`
+  - vault config: `addr`, `token`, `mount` (default `secret`), `kv_version` (`1` or `2`, default `2`), `namespace` (Vault Enterprise, optional)
 - `project_secret_bindings`: `project_id, provider_id, scope_path, enabled, fail_mode`
   (`fail_mode` ∈ `fail_closed` | `fail_stale`).
 
@@ -196,6 +197,34 @@ Access token string format: `0.<client_id>.<client_secret>:<base64(seed16)>`.
 Universal Auth (Client ID/Secret) → REST `GET /api/v3/secrets` for `project_id` +
 environment. Standard bearer flow; no bespoke crypto.
 
+### `vault` (HashiCorp Vault KV)
+
+Targets the Vault KV secrets engine (v1 or v2) via the Vault HTTP API. No proprietary
+SDK dependency — the API is a straightforward REST interface.
+
+Config fields: `addr` (e.g. `https://vault.example.com:8200`), `token` (Vault token;
+AppRole auth is a follow-up), `mount` (KV mount path, default `secret`),
+`kv_version` (`1` or `2`, default `2`), `namespace` (Vault Enterprise namespaces,
+optional).
+
+Read-path flow (KV v2):
+
+1. `GET {addr}/v1/{mount}/data/{scope_path}/{KEY}`
+   `X-Vault-Token: {token}` (and `X-Vault-Namespace: {namespace}` if set)
+   → `{ data: { data: { KEY: "value" }, metadata: { ... } } }`
+
+KV v1 omits the `/data/` infix and the outer `data` wrapper:
+`GET {addr}/v1/{mount}/{scope_path}/{KEY}` → `{ data: { KEY: "value" } }`
+
+The `scope_path` from the project binding maps directly to the Vault path hierarchy,
+allowing per-project or per-environment secret trees (`apps/myapp/prod`, etc.).
+
+Batch reads issue one request per key (Vault KV has no native multi-key GET); a
+follow-up can use `LIST` + filter to reduce round-trips.
+
+`HealthCheck` calls `GET {addr}/v1/sys/health` (returns 200/429/472/501/503 —
+treat 200 and 429 as healthy, anything else or a network error as unhealthy).
+
 ---
 
 ## Requirements ON the bws-sidecar server (for the `bitwarden` provider)
@@ -230,9 +259,10 @@ around the sidecar) is exactly what makes it agnostic and upstream-mergeable.
    yet; resolver is a no-op until a provider is registered).
 2. `bitwarden` provider (+ its own tests, including the crypto chain against a fixture).
 3. `infisical` provider.
-4. API (Huma handlers + authz).
-5. Frontend (settings + per-project tab).
-6. CLI (`arcane secrets`).
+4. `vault` provider (KV v2 + v1; token auth; `HealthCheck` via `sys/health`).
+5. API (Huma handlers + authz).
+6. Frontend (settings + per-project tab).
+7. CLI (`arcane secrets`).
 
 ## Mergeability checklist
 


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's main branch

## What This PR Implements

This PR adds a design document (RFC) only, with no code changes. It proposes pluggable external secrets providers so a Compose project environment can be resolved at deploy time from a secrets manager (Bitwarden Secrets Manager and Infisical first, Vault, OpenBao and SOPS later) instead of from plaintext on disk.

The document defines a single provider interface with multiple backends selected by config, a provider-agnostic reference syntax embedded in env values, an injection seam in the environment loader, encryption of provider credentials at rest using the existing AES-GCM crypto helper, and a hard requirement that resolved values stay in memory and never reach disk or logs. It also lays out a six-step incremental delivery plan so the feature can land in small reviewable slices.

Opening this as an RFC first to gather maintainer feedback on the interface, the reference syntax choice, and the security model before any implementation PRs.

Fixes:

## Changes Made

Added docs/design/external-secrets.md describing the architecture, data model, security requirements, API surface, the bitwarden and infisical providers, and the incremental delivery plan. No source code is touched.

## Testing Done

Documentation only, so no runtime testing applies. Verified the markdown renders correctly and that internal references are consistent.

## AI Tool Used (if applicable)

Claude Code (Claude Opus 4.8) was used to study existing codebase patterns and to draft this design document. The author reviewed and edited the content before submission. Per AI_POLICY.md, any follow-up implementation PRs will be verified in the development environment with human testing before they are opened.

## Additional Context

This is the first item in the delivery plan and intentionally contains no code. Subsequent PRs will implement the interface, the data model and migrations, the resolver seam, and then individual providers, each as its own focused PR.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a documentation-only RFC (`docs/design/external-secrets.md`) proposing pluggable external secrets providers for Arcane, enabling Docker Compose project environments to be resolved at deploy time from Bitwarden Secrets Manager or Infisical instead of from plaintext on disk.

- **Architecture:** A single `Provider` interface with `Resolve`/`HealthCheck` methods, a `${{ secrets.<provider>.<KEY> }}` reference syntax embedded in env values, and a resolver seam injected into the existing `LoadEnvironment` path after the `.env` merge and before compose-go receives the map.
- **Security model:** Provider credentials are AES-GCM encrypted at rest; resolved values are held in memory only and must never reach disk or logs; a last-known-good cache provides resilience with `fail_stale` / `fail_closed` modes per binding.
- **Delivery plan:** Six incremental PRs \u2014 interface + DB models first, then each provider, then API, frontend, and CLI.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as documentation, but two design gaps should be closed before the first implementation PR opens to avoid a security-violating cache implementation or implementer confusion over the reference syntax.

The reference syntax is used consistently throughout the document body but simultaneously listed as an unresolved open question. More critically, the last-known-good cache is described as holding plaintext resolved values with no explicit in-memory-only constraint, which directly conflicts with the hard no-plaintext-on-disk security requirement; a GORM-backed implementation would silently violate it.

docs/design/external-secrets.md — the Resilience section (cache storage medium) and the Open questions section (reference syntax decision) need updates before implementation begins.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Cache storage gap (plaintext-at-rest risk):** The resilience section specifies a last-known-good cache for resolved secret values without constraining it to in-memory storage. Security requirement #1 prohibits resolved values from being written to disk; an implementer choosing a GORM-backed persistent cache would violate this silently. The document must explicitly require the cache to be in-memory only.
- No hardcoded secrets, injection risks, or auth/authz bypasses were identified in this documentation-only PR.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22docs%2Fexternal-secrets-rfc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fexternal-secrets-rfc%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A240%0A**Reference%20syntax%20is%20already%20committed%20but%20still%20listed%20as%20open**%0A%0AThe%20%22Open%20questions%22%20section%20asks%20to%20pick%20between%20%60%24%7B%7B%20secrets.x.y%20%7D%7D%60%20and%20%60arcane%2Bsecret%3A%2F%2Fx%2Fy%60%2C%20but%20the%20entire%20document%20body%20%E2%80%94%20Goals%2C%20Reference%20syntax%20section%2C%20example%20%60.env%60%20snippets%2C%20injection%20seam%20steps%2C%20and%20the%20%60secret-refs%60%20API%20endpoint%20%E2%80%94%20has%20already%20committed%20to%20the%20%60%24%7B%7B%20secrets.%3Cprovider%3E.%3CKEY%3E%20%7D%7D%60%20form.%20An%20implementer%20starting%20PR%20%232%20%28Bitwarden%20provider%29%20or%20PR%20%231%20%28resolver%20seam%29%20will%20find%20conflicting%20signals%20and%20may%20not%20know%20whether%20this%20is%20genuinely%20open%20or%20accidentally%20left%20in.%20This%20open%20question%20should%20be%20struck%20and%20replaced%20with%20a%20record%20of%20the%20decision%2C%20or%20it%20should%20be%20clearly%20flagged%20as%20%22resolved%3A%20using%20%60%24%7B%7B%20%7D%7D%60%22%20to%20avoid%20ambiguity%20in%20follow-up%20PRs.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A117-122%0A**Last-known-good%20cache%20storage%20medium%20is%20unspecified%2C%20creating%20a%20potential%20security-requirement%20conflict**%0A%0AThe%20resilience%20section%20describes%20a%20%22last-known-good%20cache%20%28keyed%20by%20provider%2Bscope%2Bkey%2C%20TTL%20configurable%29%22%20that%20holds%20resolved%20secret%20values%20%28plaintext%29.%20Security%20requirement%20%231%20says%20those%20values%20must%20never%20be%20written%20to%20disk.%20If%20an%20implementer%20builds%20this%20cache%20against%20the%20project's%20existing%20SQLite%2FPostgres%20GORM%20store%20%E2%80%94%20a%20natural%20choice%20for%20cross-restart%20resilience%20%E2%80%94%20they%20would%20silently%20violate%20that%20requirement.%20The%20document%20needs%20to%20explicitly%20say%20the%20cache%20must%20be%20**in-memory%20only%20and%20process-scoped**%2C%20and%20it%20should%20acknowledge%20the%20consequence%3A%20after%20a%20process%20restart%20with%20an%20unreachable%20provider%2C%20%60fail_stale%60%20behaves%20identically%20to%20%60fail_closed%60%20because%20the%20in-process%20cache%20is%20empty.%20That's%20a%20meaningful%20operational%20trade-off%20that%20belongs%20in%20the%20spec%20before%20implementation%20begins.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A117-122%0A**%60fail_stale%60%20default%20has%20no%20defined%20maximum%20staleness%2C%20allowing%20indefinitely-old%20secrets**%0A%0A%60fail_stale%60%20is%20marked%20as%20the%20default%20for%20non-critical%20bindings%2C%20with%20%22TTL%20configurable%22%20as%20the%20only%20guard.%20Without%20a%20hard%20default%20TTL%20%28or%20an%20explicit%20warning%20when%20the%20cache%20is%20older%20than%20N%20hours%2Fdays%29%2C%20a%20deployment%20could%20proceed%20using%20credentials%20fetched%20weeks%20ago%3A%20a%20rotated%20token%2C%20a%20revoked%20key%2C%20or%20a%20deleted%20secret%20would%20silently%20%22succeed%22%20until%20the%20cache%20is%20invalidated.%20The%20%22Open%20questions%22%20section%20flags%20TTL%20defaults%20but%20doesn't%20give%20a%20proposed%20safe%20default.%20Before%20PR%20%231%20lands%2C%20the%20document%20should%20name%20a%20concrete%20default%20%28e.g.%2024%20h%29%20and%20specify%20whether%20an%20expired-but-still-cached%20entry%20is%20treated%20as%20missing%20%28%E2%86%92%20%60fail_closed%60%20behaviour%29%20or%20as%20valid%20until%20replaced.%0A%0A&repo=getarcaneapp%2Farcane&pr=2936&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A240%0A**Reference%20syntax%20is%20already%20committed%20but%20still%20listed%20as%20open**%0A%0AThe%20%22Open%20questions%22%20section%20asks%20to%20pick%20between%20%60%24%7B%7B%20secrets.x.y%20%7D%7D%60%20and%20%60arcane%2Bsecret%3A%2F%2Fx%2Fy%60%2C%20but%20the%20entire%20document%20body%20%E2%80%94%20Goals%2C%20Reference%20syntax%20section%2C%20example%20%60.env%60%20snippets%2C%20injection%20seam%20steps%2C%20and%20the%20%60secret-refs%60%20API%20endpoint%20%E2%80%94%20has%20already%20committed%20to%20the%20%60%24%7B%7B%20secrets.%3Cprovider%3E.%3CKEY%3E%20%7D%7D%60%20form.%20An%20implementer%20starting%20PR%20%232%20%28Bitwarden%20provider%29%20or%20PR%20%231%20%28resolver%20seam%29%20will%20find%20conflicting%20signals%20and%20may%20not%20know%20whether%20this%20is%20genuinely%20open%20or%20accidentally%20left%20in.%20This%20open%20question%20should%20be%20struck%20and%20replaced%20with%20a%20record%20of%20the%20decision%2C%20or%20it%20should%20be%20clearly%20flagged%20as%20%22resolved%3A%20using%20%60%24%7B%7B%20%7D%7D%60%22%20to%20avoid%20ambiguity%20in%20follow-up%20PRs.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A117-122%0A**Last-known-good%20cache%20storage%20medium%20is%20unspecified%2C%20creating%20a%20potential%20security-requirement%20conflict**%0A%0AThe%20resilience%20section%20describes%20a%20%22last-known-good%20cache%20%28keyed%20by%20provider%2Bscope%2Bkey%2C%20TTL%20configurable%29%22%20that%20holds%20resolved%20secret%20values%20%28plaintext%29.%20Security%20requirement%20%231%20says%20those%20values%20must%20never%20be%20written%20to%20disk.%20If%20an%20implementer%20builds%20this%20cache%20against%20the%20project's%20existing%20SQLite%2FPostgres%20GORM%20store%20%E2%80%94%20a%20natural%20choice%20for%20cross-restart%20resilience%20%E2%80%94%20they%20would%20silently%20violate%20that%20requirement.%20The%20document%20needs%20to%20explicitly%20say%20the%20cache%20must%20be%20**in-memory%20only%20and%20process-scoped**%2C%20and%20it%20should%20acknowledge%20the%20consequence%3A%20after%20a%20process%20restart%20with%20an%20unreachable%20provider%2C%20%60fail_stale%60%20behaves%20identically%20to%20%60fail_closed%60%20because%20the%20in-process%20cache%20is%20empty.%20That's%20a%20meaningful%20operational%20trade-off%20that%20belongs%20in%20the%20spec%20before%20implementation%20begins.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fdesign%2Fexternal-secrets.md%3A117-122%0A**%60fail_stale%60%20default%20has%20no%20defined%20maximum%20staleness%2C%20allowing%20indefinitely-old%20secrets**%0A%0A%60fail_stale%60%20is%20marked%20as%20the%20default%20for%20non-critical%20bindings%2C%20with%20%22TTL%20configurable%22%20as%20the%20only%20guard.%20Without%20a%20hard%20default%20TTL%20%28or%20an%20explicit%20warning%20when%20the%20cache%20is%20older%20than%20N%20hours%2Fdays%29%2C%20a%20deployment%20could%20proceed%20using%20credentials%20fetched%20weeks%20ago%3A%20a%20rotated%20token%2C%20a%20revoked%20key%2C%20or%20a%20deleted%20secret%20would%20silently%20%22succeed%22%20until%20the%20cache%20is%20invalidated.%20The%20%22Open%20questions%22%20section%20flags%20TTL%20defaults%20but%20doesn't%20give%20a%20proposed%20safe%20default.%20Before%20PR%20%231%20lands%2C%20the%20document%20should%20name%20a%20concrete%20default%20%28e.g.%2024%20h%29%20and%20specify%20whether%20an%20expired-but-still-cached%20entry%20is%20treated%20as%20missing%20%28%E2%86%92%20%60fail_closed%60%20behaviour%29%20or%20as%20valid%20until%20replaced.%0A%0A&repo=getarcaneapp%2Farcane&pr=2936&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/design/external-secrets.md:240
**Reference syntax is already committed but still listed as open**

The "Open questions" section asks to pick between `${{ secrets.x.y }}` and `arcane+secret://x/y`, but the entire document body — Goals, Reference syntax section, example `.env` snippets, injection seam steps, and the `secret-refs` API endpoint — has already committed to the `${{ secrets.<provider>.<KEY> }}` form. An implementer starting PR #2 (Bitwarden provider) or PR #1 (resolver seam) will find conflicting signals and may not know whether this is genuinely open or accidentally left in. This open question should be struck and replaced with a record of the decision, or it should be clearly flagged as "resolved: using `${{ }}`" to avoid ambiguity in follow-up PRs.

### Issue 2 of 3
docs/design/external-secrets.md:117-122
**Last-known-good cache storage medium is unspecified, creating a potential security-requirement conflict**

The resilience section describes a "last-known-good cache (keyed by provider+scope+key, TTL configurable)" that holds resolved secret values (plaintext). Security requirement #1 says those values must never be written to disk. If an implementer builds this cache against the project's existing SQLite/Postgres GORM store — a natural choice for cross-restart resilience — they would silently violate that requirement. The document needs to explicitly say the cache must be **in-memory only and process-scoped**, and it should acknowledge the consequence: after a process restart with an unreachable provider, `fail_stale` behaves identically to `fail_closed` because the in-process cache is empty. That's a meaningful operational trade-off that belongs in the spec before implementation begins.

### Issue 3 of 3
docs/design/external-secrets.md:117-122
**`fail_stale` default has no defined maximum staleness, allowing indefinitely-old secrets**

`fail_stale` is marked as the default for non-critical bindings, with "TTL configurable" as the only guard. Without a hard default TTL (or an explicit warning when the cache is older than N hours/days), a deployment could proceed using credentials fetched weeks ago: a rotated token, a revoked key, or a deleted secret would silently "succeed" until the cache is invalidated. The "Open questions" section flags TTL defaults but doesn't give a proposed safe default. Before PR #1 lands, the document should name a concrete default (e.g. 24 h) and specify whether an expired-but-still-cached entry is treated as missing (→ `fail_closed` behaviour) or as valid until replaced.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add external secrets providers des..."](https://github.com/getarcaneapp/arcane/commit/3a0ffc7cf34b6ba7582ed0d3c9839099c7973154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37476034)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->