### PR TITLE
fix: fix dind path mappings for projects and swarm

### DIFF
--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -1656,7 +1656,7 @@ func (s *GitOpsSyncService) validateDirectorySyncStageInternal(ctx context.Conte
 		return 0, err
 	}
 
-	pathMapper := s.projectService.getPathMapper(ctx)
+	pathMapper := s.projectService.getPathMapperInternal(ctx)
 
 	autoInjectEnv := s.settingsService.GetBoolSetting(ctx, "autoInjectEnv", false)
 	project, err := projects.LoadComposeProjectLenient(

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -99,7 +99,7 @@ func (s *ProjectService) resolveRegistryCredentialsInternal(ctx context.Context)
 	return credentials, nil
 }
 
-func (s *ProjectService) getPathMapper(ctx context.Context) *projects.PathMapper {
+func (s *ProjectService) getPathMapperInternal(ctx context.Context) *projects.PathMapper {
 	configuredPath := s.settingsService.GetStringSetting(ctx, "projectsDirectory", "/app/data/projects")
 
 	var containerDir, hostDir string
@@ -124,29 +124,32 @@ func (s *ProjectService) getPathMapper(ctx context.Context) *projects.PathMapper
 		containerDirResolved = "/app/data/projects"
 	}
 
-	// If hostDir not obtained from mapping, attempt auto-discovery from Docker mounts
-	if hostDir == "" && s.dockerService != nil {
+	// Explicit "container:host" mapping: honor the user-declared prefix directly.
+	if strings.TrimSpace(hostDir) != "" {
+		hostDirResolved := filepath.Clean(strings.TrimSpace(hostDir))
+		pm := projects.NewPathMapper(containerDirResolved, hostDirResolved)
+		if !pm.IsNonMatchingMount() {
+			return nil
+		}
+		return pm
+	}
+
+	// Auto-discovery: resolve each bind-mount source against Arcane's real container
+	// mount table (longest-prefix match) so independently bind-mounted project
+	// directories map to their own host path instead of a single projects-root prefix.
+	if s.dockerService != nil {
 		if dockerCli, derr := s.dockerService.GetClient(ctx); derr == nil {
-			absContainerDir, _ := filepath.Abs(containerDirResolved)
-			if discovery, aerr := dockerutil.GetHostPathForContainerPath(ctx, dockerCli, absContainerDir); aerr == nil && discovery != "" {
-				hostDir = discovery
-				slog.DebugContext(ctx, "Auto-discovered host path for projects", "container", absContainerDir, "host", hostDir)
+			if mounts, merr := dockerutil.GetCurrentContainerMounts(ctx, dockerCli); merr == nil && len(mounts) > 0 {
+				pm := projects.NewPathMapperFromMounts(mounts)
+				if !pm.IsNonMatchingMount() {
+					return nil
+				}
+				return pm
 			}
 		}
 	}
 
-	// Clean host directory
-	hostDirResolved := strings.TrimSpace(hostDir)
-	if hostDirResolved != "" {
-		hostDirResolved = filepath.Clean(hostDirResolved)
-	}
-
-	pm := projects.NewPathMapper(containerDirResolved, hostDirResolved)
-	if !pm.IsNonMatchingMount() {
-		return nil
-	}
-
-	return pm
+	return nil
 }
 
 func (s *ProjectService) getProjectsDirectoryInternal(ctx context.Context) (string, error) {
@@ -501,7 +504,7 @@ func (s *ProjectService) loadComposeProjectForProjectInternal(ctx context.Contex
 		projectsDirectory = "/app/data/projects"
 	}
 
-	pathMapper := s.getPathMapper(ctx)
+	pathMapper := s.getPathMapperInternal(ctx)
 
 	composeProject, loadErr := projects.LoadComposeProject(ctx, composeFileFullPath, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if loadErr != nil {
@@ -2760,7 +2763,7 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, u
 		projectsDirectory = "/app/data/projects"
 	}
 
-	pathMapper := s.getPathMapper(ctx)
+	pathMapper := s.getPathMapperInternal(ctx)
 
 	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, normalizeComposeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if lerr != nil {
@@ -4478,7 +4481,7 @@ func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context,
 		return 0, nil, pErr
 	}
 
-	pathMapper := s.getPathMapper(ctx)
+	pathMapper := s.getPathMapperInternal(ctx)
 
 	normName := normalizeComposeProjectName(dirName)
 	autoInjectEnv := utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)

--- a/backend/internal/services/swarm_service.go
+++ b/backend/internal/services/swarm_service.go
@@ -2259,29 +2259,32 @@ func (s *SwarmService) getPathMapperInternal(ctx context.Context) *appfs.PathMap
 		containerDirResolved = defaultSwarmStackSourceRootDir
 	}
 
-	// If hostDir not obtained from mapping, attempt auto-discovery from Docker mounts
-	if hostDir == "" && s.dockerService != nil {
+	// Explicit "container:host" mapping: honor the user-declared prefix directly.
+	if strings.TrimSpace(hostDir) != "" {
+		hostDirResolved := filepath.Clean(strings.TrimSpace(hostDir))
+		pm := appfs.NewPathMapper(containerDirResolved, hostDirResolved)
+		if !pm.IsNonMatchingMount() {
+			return nil
+		}
+		return pm
+	}
+
+	// Auto-discovery: resolve each bind-mount source against Arcane's real container
+	// mount table (longest-prefix match) so an independently bind-mounted stack
+	// directory maps to its own host path instead of a single sources-root prefix.
+	if s.dockerService != nil {
 		if dockerCli, derr := s.dockerService.GetClient(ctx); derr == nil {
-			absContainerDir, _ := filepath.Abs(containerDirResolved)
-			if discovery, aerr := dockerutil.GetHostPathForContainerPath(ctx, dockerCli, absContainerDir); aerr == nil && discovery != "" {
-				hostDir = discovery
-				slog.DebugContext(ctx, "Auto-discovered host path for swarm stack sources", "container", absContainerDir, "host", hostDir)
+			if mounts, merr := dockerutil.GetCurrentContainerMounts(ctx, dockerCli); merr == nil && len(mounts) > 0 {
+				pm := appfs.NewPathMapperFromMounts(mounts)
+				if !pm.IsNonMatchingMount() {
+					return nil
+				}
+				return pm
 			}
 		}
 	}
 
-	// Clean host directory
-	hostDirResolved := strings.TrimSpace(hostDir)
-	if hostDirResolved != "" {
-		hostDirResolved = filepath.Clean(hostDirResolved)
-	}
-
-	pm := appfs.NewPathMapper(containerDirResolved, hostDirResolved)
-	if !pm.IsNonMatchingMount() {
-		return nil
-	}
-
-	return pm
+	return nil
 }
 
 func (s *SwarmService) ensureSwarmManagerInternal(ctx context.Context) error {

--- a/backend/pkg/dockerutil/mount_utils.go
+++ b/backend/pkg/dockerutil/mount_utils.go
@@ -12,59 +12,53 @@ import (
 	"github.com/moby/moby/client"
 )
 
-// GetHostPathForContainerPath attempts to discover the host-side path for a given container path
-// by inspecting the container itself. This is useful for Docker-in-Docker scenarios
-// where the application needs to know host paths for volume mapping.
-func GetHostPathForContainerPath(ctx context.Context, dockerCli *client.Client, containerPath string) (string, error) {
+// GetCurrentContainerMounts inspects Arcane's own container and returns its bind and
+// named-volume mounts as projects.HostMount entries. It returns no mounts when Arcane is
+// not running in a container (or the daemon is unreachable). This is the basis for
+// Docker-in-Docker host-path resolution.
+func GetCurrentContainerMounts(ctx context.Context, dockerCli *client.Client) ([]projects.HostMount, error) {
 	if dockerCli == nil {
-		return "", nil // No docker client, can't discover
+		return nil, nil // No docker client, can't discover
 	}
 
-	// 1. Prefer robust current-container detection and fall back to hostname.
+	// Prefer robust current-container detection and fall back to hostname.
 	inspectTarget, err := getCurrentContainerInspectTargetInternal(GetCurrentContainerID, os.Hostname)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// 2. Inspect self
 	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerCli, inspectTarget, client.ContainerInspectOptions{})
 	if err != nil {
 		// Not running in a container or can't reach docker daemon
+		return nil, err
+	}
+
+	mounts := make([]projects.HostMount, 0, len(inspect.Container.Mounts))
+	for i := range inspect.Container.Mounts {
+		m := &inspect.Container.Mounts[i]
+		if m.Type != mounttypes.TypeBind && m.Type != mounttypes.TypeVolume {
+			continue
+		}
+		if strings.TrimSpace(m.Source) == "" || strings.TrimSpace(m.Destination) == "" {
+			continue
+		}
+		mounts = append(mounts, projects.HostMount{Destination: m.Destination, Source: m.Source})
+	}
+	return mounts, nil
+}
+
+// GetHostPathForContainerPath attempts to discover the host-side path for a given container path
+// by inspecting the container itself. This is useful for Docker-in-Docker scenarios
+// where the application needs to know host paths for volume mapping. It returns an empty
+// string when the path is not covered by any of Arcane's mounts.
+func GetHostPathForContainerPath(ctx context.Context, dockerCli *client.Client, containerPath string) (string, error) {
+	mounts, err := GetCurrentContainerMounts(ctx, dockerCli)
+	if err != nil {
 		return "", err
 	}
 
-	// 3. Find mount point for the target path
-	// We want to find the mount that most specifically matches our path
-	var bestMatch *containertypes.MountPoint
-	for i := range inspect.Container.Mounts {
-		m := &inspect.Container.Mounts[i]
-		if strings.HasPrefix(containerPath, m.Destination) {
-			if bestMatch == nil || len(m.Destination) > len(bestMatch.Destination) {
-				bestMatch = m
-			}
-		}
-	}
-
-	if bestMatch != nil && (bestMatch.Type == mounttypes.TypeBind || bestMatch.Type == mounttypes.TypeVolume) {
-		// Calculate the relative path from mount destination to target path
-		rel := strings.TrimPrefix(containerPath, bestMatch.Destination)
-		rel = strings.TrimPrefix(rel, "/") // Ensure no double slash
-
-		hostPath := bestMatch.Source
-		if rel != "" {
-			// Determine path separator from the host path
-			separator := "/"
-			if projects.IsWindowsDrivePath(hostPath) && strings.Contains(hostPath, "\\") {
-				separator = "\\"
-				rel = strings.ReplaceAll(rel, "/", "\\")
-			}
-
-			if !strings.HasSuffix(hostPath, separator) {
-				hostPath += separator
-			}
-			hostPath += rel
-		}
-		return hostPath, nil
+	if host, ok := projects.ResolveHostPath(mounts, containerPath); ok {
+		return host, nil
 	}
 
 	return "", nil

--- a/backend/pkg/projects/path_mapper.go
+++ b/backend/pkg/projects/path_mapper.go
@@ -8,11 +8,21 @@ import (
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 )
 
+// HostMount is one container→host mount (bind or named volume) from Arcane's own
+// container. It is used for longest-prefix host-path resolution in Docker-in-Docker
+// setups, where independently bind-mounted project directories each map to their own
+// host path rather than a single projects-root prefix.
+type HostMount struct {
+	Destination string // container-side mount path, e.g. "/app/data/projects/homeassistant"
+	Source      string // host-side path, e.g. "/home/user/homeassistant"
+}
+
 // PathMapper handles translation between container and host paths
 type PathMapper struct {
-	containerPrefix string // e.g., "/app/data/projects"
-	hostPrefix      string // e.g., "D:/self-hosted/arcane/projects"
-	isNonMatching   bool   // true if paths differ
+	containerPrefix string      // e.g., "/app/data/projects" (single-prefix mode)
+	hostPrefix      string      // e.g., "D:/self-hosted/arcane/projects" (single-prefix mode)
+	isNonMatching   bool        // true if a translation can occur
+	mounts          []HostMount // when set, sources resolve by longest-prefix match (auto-discovery mode)
 }
 
 // NewPathMapper creates a new path mapper
@@ -31,10 +41,82 @@ func NewPathMapper(containerDir, hostDir string) *PathMapper {
 	}
 }
 
+// NewPathMapperFromMounts creates a path mapper that resolves each source against the
+// given container mount table by longest-prefix match, instead of a single
+// container→host prefix. This is used for Docker-in-Docker auto-discovery so that an
+// independently bind-mounted project directory maps to its real host path.
+func NewPathMapperFromMounts(mounts []HostMount) *PathMapper {
+	nonMatching := false
+	for i := range mounts {
+		if filepath.Clean(mounts[i].Source) != filepath.Clean(mounts[i].Destination) {
+			nonMatching = true
+			break
+		}
+	}
+
+	return &PathMapper{
+		mounts:        mounts,
+		isNonMatching: nonMatching,
+	}
+}
+
+// ResolveHostPath returns the host-side path for containerPath by selecting the
+// longest-prefix mount whose Destination contains it and appending the trailing relative
+// segment to that mount's Source. ok is false when no mount contains the path.
+func ResolveHostPath(mounts []HostMount, containerPath string) (string, bool) {
+	cleaned := filepath.Clean(containerPath)
+
+	var (
+		bestSource string
+		bestRel    string
+		bestLen    = -1
+	)
+	for i := range mounts {
+		dest := filepath.Clean(mounts[i].Destination)
+		rel, err := filepath.Rel(dest, cleaned)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			continue
+		}
+		if len(dest) > bestLen {
+			bestLen = len(dest)
+			bestSource = mounts[i].Source
+			bestRel = rel
+		}
+	}
+	if bestLen < 0 {
+		return "", false
+	}
+
+	host := bestSource
+	if bestRel != "." {
+		// Mirror the separator handling used for Windows hosts: keep backslashes when the
+		// host source is a Windows drive path, otherwise use forward slashes.
+		separator := "/"
+		if IsWindowsDrivePath(host) && strings.Contains(host, "\\") {
+			separator = "\\"
+			bestRel = strings.ReplaceAll(bestRel, "/", "\\")
+		}
+		if !strings.HasSuffix(host, separator) {
+			host += separator
+		}
+		host += bestRel
+	}
+	return host, true
+}
+
 // ContainerToHost translates a container path to host path
 func (pm *PathMapper) ContainerToHost(containerPath string) (string, error) {
 	if !pm.IsNonMatchingMount() {
 		return containerPath, nil // No translation needed
+	}
+
+	// Auto-discovery mode: resolve against Arcane's real mount table so nested,
+	// independently bind-mounted directories map to their own host path.
+	if len(pm.mounts) > 0 {
+		if host, ok := ResolveHostPath(pm.mounts, containerPath); ok {
+			return host, nil
+		}
+		return filepath.Clean(containerPath), nil // outside all mounts: leave unchanged
 	}
 
 	cleaned := filepath.Clean(containerPath)

--- a/backend/pkg/projects/path_mapper_test.go
+++ b/backend/pkg/projects/path_mapper_test.go
@@ -36,6 +36,43 @@ func TestPathMapper_PathTraversalPrevention(t *testing.T) {
 	assert.Equal(t, "/app/etc/passwd", result)
 }
 
+func TestPathMapper_FromMounts_NestedIndependentMount(t *testing.T) {
+	// Reproduces the nested independent-mount bug: a project directory is bind-mounted
+	// into Arcane's projects directory from an unrelated host path.
+	pm := NewPathMapperFromMounts([]HostMount{
+		{Destination: "/app/data", Source: "/home/user/.arcane/data"},
+		{Destination: "/app/data/projects/homeassistant", Source: "/home/user/homeassistant"},
+	})
+	require.True(t, pm.IsNonMatchingMount())
+
+	// Independently-mounted project resolves to its own host path (longest-prefix wins).
+	got, err := pm.ContainerToHost("/app/data/projects/homeassistant/service_postgresql/postgres_data")
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/homeassistant/service_postgresql/postgres_data", got)
+
+	// A project without its own mount still re-bases under /app/data.
+	got, err = pm.ContainerToHost("/app/data/projects/other/data")
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/.arcane/data/projects/other/data", got)
+}
+
+func TestPathMapper_FromMounts_NoMatchAndMatchingMounts(t *testing.T) {
+	pm := NewPathMapperFromMounts([]HostMount{
+		{Destination: "/app/data", Source: "/host/data"},
+	})
+
+	// Path outside every mount is returned unchanged.
+	got, err := pm.ContainerToHost("/etc/hosts")
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/hosts", got)
+
+	// A table whose mounts all match (source == destination) needs no translation.
+	matching := NewPathMapperFromMounts([]HostMount{
+		{Destination: "/var/run/docker.sock", Source: "/var/run/docker.sock"},
+	})
+	assert.False(t, matching.IsNonMatchingMount())
+}
+
 func TestPathMapper_TranslateVolumeSources(t *testing.T) {
 	pm := NewPathMapper("/app/data/projects", "C:/User/arcane/projects")
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2932

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Docker-in-Docker path mapping for projects and swarm stacks by replacing the old single-prefix auto-discovery with a longest-prefix mount-table lookup. It also renames `getPathMapper` to `getPathMapperInternal` for consistency with the project's naming convention.

- **`path_mapper.go`**: Adds `HostMount` type, `NewPathMapperFromMounts`, and `ResolveHostPath` (longest-prefix match across all container mounts) so independently bind-mounted project directories resolve to their own host path instead of always rebasing under a single projects root.
- **`mount_utils.go`**: Refactors `GetHostPathForContainerPath` to delegate to a new `GetCurrentContainerMounts` function that returns all bind/volume mounts for the running container; the path-resolution logic is consolidated in `ResolveHostPath`.
- **`project_service.go` / `swarm_service.go`**: Updates `getPathMapperInternal` (renamed from `getPathMapper`) to use the new mount-table mapper for auto-discovery, falling back to `nil` (no translation) only when no mounts are returned or all mounts have matching source/destination.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes correctly fix the core DinD path-mapping bug and are well-tested.

The refactor is narrow and well-targeted: the new mount-table approach is logically correct (uses filepath.Rel for proper prefix detection, applies a longest-prefix tie-breaker, and handles the Windows separator edge case), the old getPathMapper→getPathMapperInternal rename satisfies the project convention, and two new test cases cover both the happy path and the edge cases (matching mounts, paths outside all mounts). No new unexported functions lack the Internal suffix, and appfs in swarm_service.go is just an alias for the same projects package, so NewPathMapperFromMounts is already available there.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/project_service.go`, line 102 ([link](https://github.com/getarcaneapp/arcane/blob/a7765008847da7410cbdbdc5835da5fe56dc6d4a/backend/internal/services/project_service.go#L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unexported function missing `Internal` suffix**

   The team convention requires all unexported functions to carry an `Internal` suffix, yet `getPathMapper` does not. Its counterpart in `swarm_service.go` is already named `getPathMapperInternal` — renaming this one would make the two services consistent and satisfy the project-wide rule.

   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 102
   
   Comment:
   **Unexported function missing `Internal` suffix**
   
   The team convention requires all unexported functions to carry an `Internal` suffix, yet `getPathMapper` does not. Its counterpart in `swarm_service.go` is already named `getPathMapperInternal` — renaming this one would make the two services consistent and satisfy the project-wide rule.
   
   **Rule Used:** What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fpath-mappings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpath-mappings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20102%0A%0AComment%3A%0A**Unexported%20function%20missing%20%60Internal%60%20suffix**%0A%0AThe%20team%20convention%20requires%20all%20unexported%20functions%20to%20carry%20an%20%60Internal%60%20suffix%2C%20yet%20%60getPathMapper%60%20does%20not.%20Its%20counterpart%20in%20%60swarm_service.go%60%20is%20already%20named%20%60getPathMapperInternal%60%20%E2%80%94%20renaming%20this%20one%20would%20make%20the%20two%20services%20consistent%20and%20satisfy%20the%20project-wide%20rule.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2939&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%20102%0A%0AComment%3A%0A**Unexported%20function%20missing%20%60Internal%60%20suffix**%0A%0AThe%20team%20convention%20requires%20all%20unexported%20functions%20to%20carry%20an%20%60Internal%60%20suffix%2C%20yet%20%60getPathMapper%60%20does%20not.%20Its%20counterpart%20in%20%60swarm_service.go%60%20is%20already%20named%20%60getPathMapperInternal%60%20%E2%80%94%20renaming%20this%20one%20would%20make%20the%20two%20services%20consistent%20and%20satisfy%20the%20project-wide%20rule.%0A%0A**Rule%20Used%3A**%20What%3A%20All%20unexported%20functions%20must%20have%20the%20%22Inte...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D306fc233-4d2f-4ac4-bdf7-8059588e8a43%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2939&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: fix dind path mappings for projects..."](https://github.com/getarcaneapp/arcane/commit/28cd36d85d13e0e6169a80c4e7a5b873a7440c2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37498161)</sub>

<!-- /greptile_comment -->