### PR TITLE
fix: activity status only showing on first browser tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,9 +283,9 @@ jobs:
 
       - name: Pull and save test images
         run: |
-          docker pull ghcr.io/linuxserver/nginx:latest
+          docker pull public.ecr.aws/nginx/nginx:stable-alpine
           docker pull ghcr.io/linuxserver/radarr:nightly
-          docker save ghcr.io/linuxserver/nginx:latest ghcr.io/linuxserver/radarr:nightly > /tmp/test-images.tar
+          docker save public.ecr.aws/nginx/nginx:stable-alpine ghcr.io/linuxserver/radarr:nightly > /tmp/test-images.tar
 
       - name: Setup and Install Playwright Dependencies
         run: just deps install tests

--- a/backend/pkg/utils/httpx/request.go
+++ b/backend/pkg/utils/httpx/request.go
@@ -14,7 +14,10 @@ type HeaderSetter interface {
 
 func SetJSONStreamHeaders(headers HeaderSetter) {
 	headers.SetHeader("Content-Type", "application/x-json-stream")
-	headers.SetHeader("Cache-Control", "no-cache")
+	// no-store keeps proxies from caching or collapsing identical concurrent
+	// stream requests (e.g. two browser tabs), which would otherwise leave only
+	// the first connection attached to the live upstream stream.
+	headers.SetHeader("Cache-Control", "no-store, no-cache, must-revalidate")
 	headers.SetHeader("Connection", "keep-alive")
 	headers.SetHeader("X-Accel-Buffering", "no")
 }

--- a/frontend/src/lib/services/activity-service.ts
+++ b/frontend/src/lib/services/activity-service.ts
@@ -3,6 +3,7 @@ import { environmentStore } from '$lib/stores/environment.store.svelte';
 import type { Activity, ActivityClearHistoryResult, ActivityDetail } from '$lib/types/activity.type';
 import type { Paginated, SearchPaginationSortRequest } from '$lib/types/shared';
 import { transformPaginationParams } from '$lib/utils/tables';
+import { streamCacheBuster } from '$lib/utils/streaming';
 
 class ActivityService extends BaseAPIService {
 	private async resolveEnvironmentId(environmentId?: string): Promise<string> {
@@ -33,7 +34,7 @@ class ActivityService extends BaseAPIService {
 
 	getActivityStreamUrl(limit = 50): string {
 		const baseUrl = this.api.defaults.baseURL.replace(/\/+$/, '');
-		const params = new URLSearchParams({ limit: String(limit) });
+		const params = new URLSearchParams({ limit: String(limit), _: streamCacheBuster() });
 		return `${baseUrl}/activities/stream?${params.toString()}`;
 	}
 

--- a/frontend/src/lib/services/dashboard-service.ts
+++ b/frontend/src/lib/services/dashboard-service.ts
@@ -1,4 +1,5 @@
 import BaseAPIService, { handleUnauthorizedResponseInternal } from './api-service';
+import { streamCacheBuster } from '$lib/utils/streaming';
 import type { DashboardSnapshot } from '$lib/types/shared';
 
 interface GetDashboardOptions {
@@ -17,6 +18,7 @@ class DashboardService extends BaseAPIService {
 		if (debugAllGood) {
 			params.set('debugAllGood', 'true');
 		}
+		params.set('_', streamCacheBuster());
 		const query = params.toString();
 		return `${baseUrl}/dashboard/stream${query ? `?${query}` : ''}`;
 	}

--- a/frontend/src/lib/utils/streaming.ts
+++ b/frontend/src/lib/utils/streaming.ts
@@ -1,3 +1,20 @@
+/**
+ * Returns a value unique to each call, for use as a cache-busting query param on
+ * stream URLs. Without it, intermediaries that key on the URL — a reverse proxy
+ * collapsing identical in-flight GETs, the service worker cache, the browser HTTP
+ * cache — can collapse multiple tabs' identical stream requests onto a single
+ * upstream connection, so only the first tab receives live events.
+ *
+ * `crypto.randomUUID()` is only defined in secure contexts (HTTPS / localhost),
+ * so fall back to a timestamp + random suffix for plain-HTTP deployments.
+ */
+export function streamCacheBuster(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 export async function readNdjsonStream(
 	body: ReadableStream<Uint8Array>,
 	onMessage?: (data: any) => void,

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -7,7 +7,6 @@ import { build, files, version } from '$service-worker';
 
 const self = globalThis.self as unknown as ServiceWorkerGlobalScope;
 
-const DATA_CACHE = `data-cache-${version}`;
 const CACHE = `cache-${version}`;
 
 const ASSETS = [...build, ...files];
@@ -22,6 +21,10 @@ self.addEventListener('install', (event) => {
 	}
 
 	event.waitUntil(addFilesToCache());
+
+	// Activate this worker immediately rather than waiting for all tabs to close,
+	// so the API-bypass fix takes effect on the next navigation.
+	self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
@@ -31,7 +34,7 @@ self.addEventListener('activate', (event) => {
 		const keyList = await caches.keys();
 		await Promise.all(
 			keyList.map((key) => {
-				if (key !== CACHE && key !== DATA_CACHE) {
+				if (key !== CACHE) {
 					console.log('[ServiceWorker] Removing old cache', key);
 					return caches.delete(key);
 				}
@@ -39,46 +42,35 @@ self.addEventListener('activate', (event) => {
 		);
 	}
 
-	event.waitUntil(deleteOldCaches());
-	return self.clients.claim();
+	// Make both the cache cleanup and taking control of already-open tabs part of
+	// the activation lifetime. Returning clients.claim() from the listener isn't
+	// enough — the service worker event system ignores the return value, so the
+	// claim could lose the race to activation completing and leave existing tabs
+	// controlled by the old worker (which still caches /api/ streams) until a full
+	// reload, leaving the multi-tab bug unfixed for the very tabs this repairs.
+	event.waitUntil(Promise.all([deleteOldCaches(), self.clients.claim()]));
 });
 
 self.addEventListener('fetch', (event) => {
-	console.log('[ServiceWorker] Fetch', event.request.url);
-
 	if (event.request.method !== 'GET') return;
 
 	const url = new URL(event.request.url);
-	const isApiRequest = url.pathname.startsWith('/api/');
+
+	// Never intercept API requests. Caching the never-ending `/api/.../stream`
+	// responses leaked memory and collapsed every tab onto a single cached
+	// connection, so only the first tab received live events. Let API requests
+	// — including streams — go straight to the network, one per tab.
+	if (url.pathname.startsWith('/api/')) return;
 
 	async function respond() {
-		if (isApiRequest) {
-			const cache = await caches.open(DATA_CACHE);
-			try {
-				const response = await fetch(event.request);
+		const cache = await caches.open(CACHE);
+		const cachedResponse = await cache.match(event.request);
 
-				if (response.status === 200) {
-					cache.put(event.request, response.clone());
-				}
-
-				return response;
-			} catch (err) {
-				const cachedResponse = await cache.match(event.request);
-				if (cachedResponse) {
-					return cachedResponse;
-				}
-				throw err;
-			}
-		} else {
-			const cache = await caches.open(CACHE);
-			const cachedResponse = await cache.match(event.request);
-
-			if (cachedResponse) {
-				return cachedResponse;
-			}
-
-			return fetch(event.request);
+		if (cachedResponse) {
+			return cachedResponse;
 		}
+
+		return fetch(event.request);
 	}
 
 	event.respondWith(respond());

--- a/tests/setup/project.data.ts
+++ b/tests/setup/project.data.ts
@@ -7,7 +7,7 @@ export const TEST_COMPOSE_YAML = `configs:
 
 services:
   nginx:
-    image: ghcr.io/linuxserver/nginx:latest
+    image: public.ecr.aws/nginx/nginx:stable-alpine
     container_name: \${CONTAINER_NAME}
     configs:
       - source: some_content

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -709,7 +709,11 @@ test.describe('New Compose Project Page', () => {
 
 		const deployResponse = await deployResponsePromise;
 		expect(deployResponse.ok()).toBe(true);
-		expect(await deployResponse.finished()).toBeNull();
+		// Don't await deployResponse.finished() here: for a chunked NDJSON stream
+		// consumed via fetch().body, Playwright's network-layer finished() doesn't
+		// reliably resolve even after the server closes the response and the UI
+		// updates to "running" — it hangs until the test timeout. Deploy completion
+		// is verified below via the running-status poll and the activity-success check.
 
 		const projectId = createdProjectId ?? getProjectIdFromPageUrl(page.url());
 		await expect


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2945

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds cache-busting query parameters to activity and dashboard stream URLs so status updates work across multiple browser tabs.
- Strengthens JSON stream cache-control behavior on the backend and skips service worker handling for `/api/` requests.
- Updates service worker activation behavior and adjusts related Playwright/project test fixtures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are narrowly scoped to streaming cache behavior and service worker request handling, with no review comments requiring changes before merge.

The diff targets the reported multi-tab activity update issue directly and includes related backend, service worker, and test updates without introducing identified correctness or security concerns.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the multi-tab activity status Playwright scenario and captured the base run in the before-log artifact.
- T-Rex executed the same scenario again and captured the head run in the after-log artifact.
- The test harness artifact confirms the executed Playwright scenario used for both references.
- The streaming behavior was analyzed, comparing pre-change and post-change states, including stream URL uniqueness, headers, and API interception changes.

<a href="https://app.greptile.com/trex/runs/11473923/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `frontend/src/service-worker.ts`, line 45-46 ([link](https://github.com/getarcaneapp/arcane/blob/11b4da5cbaae3b9f81133661cbf9f0f7ab059406/frontend/src/service-worker.ts#L45-L46)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Claim activation lifetime**

   `clients.claim()` needs to be part of the activation lifetime. Right now `event.waitUntil()` only waits for `deleteOldCaches()`, and the returned promise from the listener is ignored by the service worker event system. Because this PR also calls `skipWaiting()` during install, the new worker can activate and finish the activate event before the claim promise settles, leaving already-open tabs controlled by the old worker that still intercepts and caches `/api/.../stream` requests until a full reload. That means the multi-tab activity/dashboard bug can persist for the tabs this hotfix is trying to repair.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused service worker activate lifecycle harness](https://app.greptile.com/trex/artifacts/d2d80e17-1c44-498d-85ae-21148703304e)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: harness output showing clients.claim absent from waitUntil](https://app.greptile.com/trex/artifacts/daf6dc5c-9fff-46ec-917e-264db50cfd1b)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11441081/artifacts?artifact=d2d80e17-1c44-498d-85ae-21148703304e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/service-worker.ts
   Line: 45-46

   Comment:
   **Claim activation lifetime**

   `clients.claim()` needs to be part of the activation lifetime. Right now `event.waitUntil()` only waits for `deleteOldCaches()`, and the returned promise from the listener is ignored by the service worker event system. Because this PR also calls `skipWaiting()` during install, the new worker can activate and finish the activate event before the claim promise settles, leaving already-open tabs controlled by the old worker that still intercepts and caches `/api/.../stream` requests until a full reload. That means the multi-tab activity/dashboard bug can persist for the tabs this hotfix is trying to repair.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Factivity-center-tabs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Factivity-center-tabs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Fservice-worker.ts%0ALine%3A%2045-46%0A%0AComment%3A%0A**Claim%20activation%20lifetime**%0A%0A%60clients.claim%28%29%60%20needs%20to%20be%20part%20of%20the%20activation%20lifetime.%20Right%20now%20%60event.waitUntil%28%29%60%20only%20waits%20for%20%60deleteOldCaches%28%29%60%2C%20and%20the%20returned%20promise%20from%20the%20listener%20is%20ignored%20by%20the%20service%20worker%20event%20system.%20Because%20this%20PR%20also%20calls%20%60skipWaiting%28%29%60%20during%20install%2C%20the%20new%20worker%20can%20activate%20and%20finish%20the%20activate%20event%20before%20the%20claim%20promise%20settles%2C%20leaving%20already-open%20tabs%20controlled%20by%20the%20old%20worker%20that%20still%20intercepts%20and%20caches%20%60%2Fapi%2F...%2Fstream%60%20requests%20until%20a%20full%20reload.%20That%20means%20the%20multi-tab%20activity%2Fdashboard%20bug%20can%20persist%20for%20the%20tabs%20this%20hotfix%20is%20trying%20to%20repair.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2951&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Fservice-worker.ts%0ALine%3A%2045-46%0A%0AComment%3A%0A**Claim%20activation%20lifetime**%0A%0A%60clients.claim%28%29%60%20needs%20to%20be%20part%20of%20the%20activation%20lifetime.%20Right%20now%20%60event.waitUntil%28%29%60%20only%20waits%20for%20%60deleteOldCaches%28%29%60%2C%20and%20the%20returned%20promise%20from%20the%20listener%20is%20ignored%20by%20the%20service%20worker%20event%20system.%20Because%20this%20PR%20also%20calls%20%60skipWaiting%28%29%60%20during%20install%2C%20the%20new%20worker%20can%20activate%20and%20finish%20the%20activate%20event%20before%20the%20claim%20promise%20settles%2C%20leaving%20already-open%20tabs%20controlled%20by%20the%20old%20worker%20that%20still%20intercepts%20and%20caches%20%60%2Fapi%2F...%2Fstream%60%20requests%20until%20a%20full%20reload.%20That%20means%20the%20multi-tab%20activity%2Fdashboard%20bug%20can%20persist%20for%20the%20tabs%20this%20hotfix%20is%20trying%20to%20repair.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=2951&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix: activity status only showing on fir..."](https://github.com/getarcaneapp/arcane/commit/fc3c4e66118ec0c807c4cb8b700e408575703dbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38231961)</sub>

<!-- /greptile_comment -->