### PR TITLE
fix: send notifications on a context detached from the completed activity

### DIFF
--- a/backend/api/env_scoped_permission_test.go
+++ b/backend/api/env_scoped_permission_test.go
@@ -41,11 +41,6 @@ func TestEnvScopedOperationsDeclarePermission(t *testing.T) {
 			if op.Security != nil && len(op.Security) == 0 {
 				continue
 			}
-			// Operations registered with RegisterWithoutPermission are
-			// intentionally permission-free (auth-only) and carry a marker.
-			if _, ok := op.Metadata[authz.MetaProxyNoPermission]; ok {
-				continue
-			}
 			perm, ok := op.Metadata[authz.MetaRequiredPermission].(string)
 			if !ok || perm == "" {
 				missing = append(missing, method+" "+path)

--- a/backend/api/middleware/role.go
+++ b/backend/api/middleware/role.go
@@ -35,23 +35,6 @@ func RegisterWithPermission[I, O any](api huma.API, op huma.Operation, perm stri
 	huma.Register(api, op, handler)
 }
 
-// RegisterWithoutPermission registers an environment-scoped Huma operation that
-// requires authentication but no specific permission. It records a metadata
-// marker (authz.MetaProxyNoPermission) so the remote environment proxy allows
-// the operation for any authenticated caller instead of denying it by default,
-// and so the env-scoped permission guard test recognizes the operation as
-// intentionally permission-free.
-//
-// Use this ONLY for intentionally low-sensitivity endpoints (for example a
-// health check). Operations that act on resources must use RegisterWithPermission.
-func RegisterWithoutPermission[I, O any](api huma.API, op huma.Operation, handler func(context.Context, *I) (*O, error)) {
-	if op.Metadata == nil {
-		op.Metadata = map[string]any{}
-	}
-	op.Metadata[authz.MetaProxyNoPermission] = true
-	huma.Register(api, op, handler)
-}
-
 // RequirePermission returns a per-operation Huma middleware that rejects
 // callers lacking `perm`. For env-scoped permissions, the env ID is extracted
 // from the request path (/environments/{id}/...). For org-level permissions,

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -1287,6 +1287,12 @@ func (s *ImageUpdateService) sendBatchImageUpdateNotificationsInternal(ctx conte
 		return
 	}
 
+	// completeImageUpdateActivityInternal cancels the activity-tracked ctx before
+	// we reach here, so detach from that cancellation (mirrors the helper it uses)
+	// — otherwise the unnotified-updates query dies with "context canceled" and no
+	// notification is ever dispatched.
+	ctx = utils.ActivityRuntimeContext(ctx, nil)
+
 	notifCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -1298,6 +1298,40 @@ func TestImageUpdateService_MarkUpdatesAsNotified_EmptyList(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestImageUpdateService_SendBatchNotifications_DetachesCanceledContext guards the
+// regression where completeImageUpdateActivityInternal cancels the activity-tracked
+// ctx before the batch notification step runs, killing the unnotified-updates query
+// with "context canceled" so notifications were never dispatched (issue #2920).
+func TestImageUpdateService_SendBatchNotifications_DetachesCanceledContext(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.NotificationSettings{}))
+
+	notif := NewNotificationService(db, nil, nil)
+	svc := NewImageUpdateService(db, nil, nil, nil, nil, notif, nil)
+
+	rec := models.ImageUpdateRecord{
+		ID:               "sha256:img1",
+		Repository:       "test/repo",
+		Tag:              "latest",
+		HasUpdate:        true,
+		NotificationSent: false,
+	}
+	require.NoError(t, db.Create(&rec).Error)
+
+	// Simulate the post-activity-completion state: the tracked ctx is already canceled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	svc.sendBatchImageUpdateNotificationsInternal(ctx)
+
+	// With no providers configured the send is a no-op success, so the record being
+	// marked notified proves GetUnnotifiedUpdates + MarkUpdatesAsNotified ran despite
+	// the canceled parent ctx.
+	var reloaded models.ImageUpdateRecord
+	require.NoError(t, db.First(&reloaded, "id = ?", "sha256:img1").Error)
+	assert.True(t, reloaded.NotificationSent)
+}
+
 func TestImageUpdateService_GetUpdateSummaryForImageIDs_FiltersToLiveImages(t *testing.T) {
 	ctx := context.Background()
 	db := setupImageUpdateTestDB(t)

--- a/backend/pkg/authz/permission_matcher_huma.go
+++ b/backend/pkg/authz/permission_matcher_huma.go
@@ -14,12 +14,6 @@ import (
 // to an agent.
 const MetaRequiredPermission = "arcane:requiredPermission"
 
-// MetaProxyNoPermission is the huma.Operation.Metadata key that marks an
-// environment-scoped operation as intentionally requiring no specific
-// permission (only authentication). The remote environment proxy allows such
-// operations for any authenticated caller instead of denying them by default.
-const MetaProxyNoPermission = "arcane:proxyNoPermission"
-
 const envPathPrefixInternal = "/environments/{id}"
 
 // CollectFromHumaAPI walks every operation registered on humaAPI and records,
@@ -52,12 +46,10 @@ func (m *PermissionMatcher) CollectFromHumaAPI(humaAPI huma.API) {
 				continue
 			}
 			// An environment-scoped operation that declares no required
-			// permission is only allowed through the proxy when it is
-			// intentionally permission-free: either an explicitly public
-			// endpoint (empty Security) or one registered with
-			// RegisterWithoutPermission. Anything else is left unmapped and
-			// denied by default.
-			if isPublicOperationInternal(op) || isProxyNoPermissionInternal(op) {
+			// permission is only allowed through the proxy when it is an
+			// explicitly public endpoint (empty Security). Anything else is
+			// left unmapped and denied by default.
+			if isPublicOperationInternal(op) {
 				m.AddPublic(method, suffix)
 			}
 		}
@@ -93,17 +85,6 @@ func requiredPermissionInternal(op *huma.Operation) (string, bool) {
 // requirement and is therefore NOT public.
 func isPublicOperationInternal(op *huma.Operation) bool {
 	return op.Security != nil && len(op.Security) == 0
-}
-
-// isProxyNoPermissionInternal reports whether op is marked as intentionally
-// requiring no specific permission (only authentication) via the
-// MetaProxyNoPermission metadata key set by RegisterWithoutPermission.
-func isProxyNoPermissionInternal(op *huma.Operation) bool {
-	if op.Metadata == nil {
-		return false
-	}
-	v, ok := op.Metadata[MetaProxyNoPermission].(bool)
-	return ok && v
 }
 
 func operationsByMethodInternal(item *huma.PathItem) map[string]*huma.Operation {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2920
 
## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where `sendBatchImageUpdateNotificationsInternal` received an already-cancelled context because `completeImageUpdateActivityInternal` cancels the activity-tracked context before returning, causing the unnotified-updates query to fail immediately with "context canceled" and silently drop all notifications.

- The fix inserts `ctx = utils.ActivityRuntimeContext(ctx, nil)` at the top of `sendBatchImageUpdateNotificationsInternal`, which calls `context.WithoutCancel` to detach from the cancelled parent while preserving its values — this matches the identical pattern used in `completeImageUpdateActivityInternal` (line 159) and other post-activity work across the codebase.
- A new regression test exercises the exact failure path by passing a pre-cancelled context and asserting that the record's `NotificationSent` field is flipped to `true`, confirming both the DB query and the mark step executed successfully.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-liner fix backed by a purpose-built regression test, and the helper it uses is already established across the codebase.

The fix is minimal, well-commented, and follows the exact same pattern used by completeImageUpdateActivityInternal and a dozen other call sites. The new test directly exercises the failure scenario by passing a pre-cancelled context and verifying the DB write still succeeds. No other code paths are touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: send notifications on a context det..."](https://github.com/getarcaneapp/arcane/commit/9b0f4c2a602c19ba18c5cbf22e4cc6556a1dc58c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38538002)</sub>

<!-- /greptile_comment -->