### PR TITLE
fix: add missing decyrption fucntions for notification providers

### DIFF
--- a/backend/internal/services/notification_service.go
+++ b/backend/internal/services/notification_service.go
@@ -2611,6 +2611,12 @@ func (s *NotificationService) sendSignalPruneNotification(ctx context.Context, e
 	if err := s.unmarshalConfigInternal(config, &signalConfig); err != nil {
 		return err
 	}
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
+		return err
+	}
 
 	message := notifications.BuildPruneReportNotificationMessage(notifications.MessageFormatPlain, environmentName, result)
 
@@ -2620,6 +2626,9 @@ func (s *NotificationService) sendSignalPruneNotification(ctx context.Context, e
 func (s *NotificationService) sendSlackPruneNotification(ctx context.Context, environmentName string, result *system.PruneAllResult, config models.JSON) error {
 	var slackConfig models.SlackConfig
 	if err := s.unmarshalConfigInternal(config, &slackConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&slackConfig.Token); err != nil {
 		return err
 	}
 
@@ -2633,6 +2642,9 @@ func (s *NotificationService) sendNtfyPruneNotification(ctx context.Context, env
 	if err := s.unmarshalConfigInternal(config, &ntfyConfig); err != nil {
 		return err
 	}
+	if err := notifications.DecryptStringCredential(&ntfyConfig.Password); err != nil {
+		return err
+	}
 
 	message := notifications.BuildPruneReportNotificationMessage(notifications.MessageFormatPlain, environmentName, result)
 
@@ -2642,6 +2654,9 @@ func (s *NotificationService) sendNtfyPruneNotification(ctx context.Context, env
 func (s *NotificationService) sendPushoverPruneNotification(ctx context.Context, environmentName string, result *system.PruneAllResult, config models.JSON) error {
 	var pushoverConfig models.PushoverConfig
 	if err := s.unmarshalConfigInternal(config, &pushoverConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&pushoverConfig.Token); err != nil {
 		return err
 	}
 
@@ -2675,6 +2690,9 @@ func (s *NotificationService) sendGotifyPruneNotification(ctx context.Context, e
 func (s *NotificationService) sendMatrixPruneNotification(ctx context.Context, environmentName string, result *system.PruneAllResult, config models.JSON) error {
 	var matrixConfig models.MatrixConfig
 	if err := s.unmarshalConfigInternal(config, &matrixConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&matrixConfig.Password); err != nil {
 		return err
 	}
 
@@ -2809,6 +2827,12 @@ func (s *NotificationService) sendSignalAutoHealNotification(ctx context.Context
 	if err := s.unmarshalConfigInternal(config, &signalConfig); err != nil {
 		return err
 	}
+	if err := notifications.DecryptStringCredential(&signalConfig.Password); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&signalConfig.Token); err != nil {
+		return err
+	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatPlain, environmentName, containerName)
 	return notifications.SendSignal(ctx, signalConfig, message)
 }
@@ -2816,6 +2840,9 @@ func (s *NotificationService) sendSignalAutoHealNotification(ctx context.Context
 func (s *NotificationService) sendSlackAutoHealNotification(ctx context.Context, environmentName, containerName string, config models.JSON) error {
 	var slackConfig models.SlackConfig
 	if err := s.unmarshalConfigInternal(config, &slackConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&slackConfig.Token); err != nil {
 		return err
 	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatSlack, environmentName, containerName)
@@ -2827,6 +2854,9 @@ func (s *NotificationService) sendNtfyAutoHealNotification(ctx context.Context, 
 	if err := s.unmarshalConfigInternal(config, &ntfyConfig); err != nil {
 		return err
 	}
+	if err := notifications.DecryptStringCredential(&ntfyConfig.Password); err != nil {
+		return err
+	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatPlain, environmentName, containerName)
 	return notifications.SendNtfy(ctx, ntfyConfig, message)
 }
@@ -2834,6 +2864,9 @@ func (s *NotificationService) sendNtfyAutoHealNotification(ctx context.Context, 
 func (s *NotificationService) sendPushoverAutoHealNotification(ctx context.Context, environmentName, containerName string, config models.JSON) error {
 	var pushoverConfig models.PushoverConfig
 	if err := s.unmarshalConfigInternal(config, &pushoverConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&pushoverConfig.Token); err != nil {
 		return err
 	}
 	if pushoverConfig.Title == "" {
@@ -2861,6 +2894,9 @@ func (s *NotificationService) sendGotifyAutoHealNotification(ctx context.Context
 func (s *NotificationService) sendMatrixAutoHealNotification(ctx context.Context, environmentName, containerName string, config models.JSON) error {
 	var matrixConfig models.MatrixConfig
 	if err := s.unmarshalConfigInternal(config, &matrixConfig); err != nil {
+		return err
+	}
+	if err := notifications.DecryptStringCredential(&matrixConfig.Password); err != nil {
 		return err
 	}
 	message := notifications.BuildAutoHealNotificationMessage(notifications.MessageFormatPlain, environmentName, containerName)


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2987

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds missing `DecryptStringCredential` calls to the prune-report and auto-heal notification senders for Signal, Slack, Ntfy, Pushover, and Matrix providers. Without these calls, encrypted credentials stored in the database were passed raw to the sender functions, causing authentication failures for those notification channels in those two event contexts.

- Adds decryption of the correct credential fields for each provider (e.g., `Password`+`Token` for Signal, `Token` for Slack/Pushover, `Password` for Ntfy/Matrix) across all 10 affected functions, matching the contract established by the `Prepare*Config` helpers in `config_credentials.go`.
- The other event types (image update, container update, vulnerability) already used the `Prepare*Config` helpers which include decryption internally, so they were not affected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it adds previously-missing decryption calls without touching any shared logic, and each added call matches what the corresponding Prepare*Config helper in config_credentials.go already does for the same provider.

The fix is narrow and mechanical: insert DecryptStringCredential for the right field in each of the ten affected functions, consistent with how other event-type senders for the same providers already worked. The decrypted fields match the model definitions and the existing helper functions. No other logic is changed.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add missing decyrption fucntions fo..."](https://github.com/getarcaneapp/arcane/commit/37968445ef41645d3c8e22e3b457185c44409a84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38746829)</sub>

<!-- /greptile_comment -->