### PR TITLE
fix: swarm node agents never move out of pending

### DIFF
--- a/backend/internal/services/swarm_service.go
+++ b/backend/internal/services/swarm_service.go
@@ -659,10 +659,17 @@ func (s *SwarmService) buildNodeAgentStatusInternal(nodeID string, env *models.E
 		return swarmtypes.NodeAgentStatus{State: swarmtypes.NodeAgentStateNone}
 	}
 
+	// An agent is live when it holds an open tunnel or has checked in via the poll
+	// control plane recently. lastHeartbeat/lastPollAt are only populated from the
+	// in-memory runtime registries when activity is fresh, so their presence is
+	// current evidence — unlike env.Status, which poll-mode agents never advance
+	// out of "pending" (HandlePoll updates the registry, not the persisted record).
+	live := runtime.connected || runtime.lastHeartbeat != nil || runtime.lastPollAt != nil
+
 	status := swarmtypes.NodeAgentStatus{
 		State:         swarmtypes.NodeAgentStateOffline,
 		EnvironmentID: &env.ID,
-		Connected:     &runtime.connected,
+		Connected:     &live,
 		LastHeartbeat: runtime.lastHeartbeat,
 		LastPollAt:    runtime.lastPollAt,
 	}
@@ -676,6 +683,8 @@ func (s *SwarmService) buildNodeAgentStatusInternal(nodeID string, env *models.E
 		}
 	}
 
+	// A live tunnel with a completed identity probe lets us authoritatively detect
+	// a node-ID mismatch (only tunnel mode can probe identity).
 	if runtime.connected && runtime.identity != nil {
 		if !runtime.identity.SwarmActive || strings.TrimSpace(runtime.identity.SwarmNodeID) != strings.TrimSpace(nodeID) {
 			status.State = swarmtypes.NodeAgentStateMismatched
@@ -685,7 +694,17 @@ func (s *SwarmService) buildNodeAgentStatusInternal(nodeID string, env *models.E
 		return status
 	}
 
-	if env.Status == string(models.EnvironmentStatusPending) || (env.LastSeen == nil && runtime.lastHeartbeat == nil && runtime.lastPollAt == nil) {
+	// Poll-mode agents (and tunnels without a completed probe) can't be identity-
+	// verified live, but a fresh check-in proves the agent mapped to this node is
+	// reachable. The node-to-env mapping was established by Arcane at deploy time,
+	// so report it as connected instead of masking it behind a stale env.Status.
+	if live {
+		status.State = swarmtypes.NodeAgentStateConnected
+		return status
+	}
+
+	// No live evidence: an unpaired agent stays pending; one seen before is offline.
+	if env.Status == string(models.EnvironmentStatusPending) || env.LastSeen == nil {
 		status.State = swarmtypes.NodeAgentStatePending
 		return status
 	}

--- a/backend/internal/services/swarm_service_test.go
+++ b/backend/internal/services/swarm_service_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
@@ -252,6 +253,61 @@ func TestSwarmService_ScaleService_HandlesServiceModesInternal(t *testing.T) {
 			require.Equal(t, []string{"updated"}, resp.Warnings)
 			require.Equal(t, 1, updateCalls)
 			tt.assertMode(t, updatedSpec.Mode)
+		})
+	}
+}
+
+// TestSwarmService_BuildNodeAgentStatusInternal covers the state classification.
+// The regression case is a poll-mode agent: its persisted env.Status never leaves
+// "pending" (HandlePoll only updates the in-memory poll registry), so a fresh
+// lastPollAt must still resolve to "connected" rather than "pending".
+func TestSwarmService_BuildNodeAgentStatusInternal(t *testing.T) {
+	const nodeID = "node-abc"
+	now := time.Now()
+	svc := &SwarmService{}
+
+	tests := []struct {
+		name    string
+		env     *models.Environment
+		runtime swarmNodeAgentRuntime
+		want    swarmtypes.NodeAgentState
+	}{
+		{
+			name:    "poll-mode check-in reports connected despite stale pending status",
+			env:     &models.Environment{Status: string(models.EnvironmentStatusPending)},
+			runtime: swarmNodeAgentRuntime{lastPollAt: &now},
+			want:    swarmtypes.NodeAgentStateConnected,
+		},
+		{
+			name:    "no runtime activity and never paired stays pending",
+			env:     &models.Environment{Status: string(models.EnvironmentStatusPending)},
+			runtime: swarmNodeAgentRuntime{},
+			want:    swarmtypes.NodeAgentStatePending,
+		},
+		{
+			name:    "tunnel with mismatched identity reports mismatched",
+			env:     &models.Environment{Status: string(models.EnvironmentStatusOnline)},
+			runtime: swarmNodeAgentRuntime{connected: true, identity: &SwarmNodeIdentity{SwarmNodeID: "other-node", SwarmActive: true}},
+			want:    swarmtypes.NodeAgentStateMismatched,
+		},
+		{
+			name:    "tunnel connected without identity probe reports connected",
+			env:     &models.Environment{Status: string(models.EnvironmentStatusPending)},
+			runtime: swarmNodeAgentRuntime{connected: true},
+			want:    swarmtypes.NodeAgentStateConnected,
+		},
+		{
+			name:    "previously seen agent with no activity reports offline",
+			env:     &models.Environment{Status: string(models.EnvironmentStatusOnline), LastSeen: &now},
+			runtime: swarmNodeAgentRuntime{},
+			want:    swarmtypes.NodeAgentStateOffline,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := svc.buildNodeAgentStatusInternal(nodeID, tt.env, tt.runtime)
+			require.Equal(t, tt.want, got.State)
 		})
 	}
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2522

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where swarm node agents in poll mode were permanently stuck in the `pending` state. The root cause was that `HandlePoll` updates only the in-memory registry, never the persisted `env.Status`, so the old path that gated "connected" on `env.Status` advancing past "pending" never fired for poll-mode agents.

- Introduces a `live` flag derived from in-memory runtime evidence (`connected`, `lastHeartbeat`, `lastPollAt`) and uses it as the primary gate for returning `NodeAgentStateConnected`, ahead of any `env.Status` check.
- Updates the `Connected` field on the returned status to reflect `live` (broader than just tunnel connectivity) and simplifies the pending/offline fallthrough to only apply when all live evidence is absent.
- Adds a table-driven test covering the regression case and four related state transitions, including the previously-flagged "tunnel connected without identity probe" path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is contained to a single pure-function state classifier, backed by targeted tests that cover the regression and edge cases.

The fix correctly prioritises in-memory liveness evidence over stale persisted status, the control flow is easy to follow, and all reachable branches are now exercised by the new test suite. No state is mutated, no concurrency is introduced, and the related website repo shows no direct consumers of the Connected field that could be broken by its broadened semantics.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: swarm node agents never move out of..."](https://github.com/getarcaneapp/arcane/commit/e1496b9afa285908397b572b1e75b12991b739bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38749992)</sub>

<!-- /greptile_comment -->