### PR TITLE
fix: dashboard prune counts may be inconsistient

### DIFF
--- a/backend/internal/services/system_service.go
+++ b/backend/internal/services/system_service.go
@@ -171,7 +171,12 @@ func (s *SystemService) runSystemPruneInternal(ctx context.Context, req system.P
 			localResult := &system.PruneAllResult{}
 			if err := s.pruneBuildCacheInternal(groupCtx, *req.BuildCache, localResult); err != nil {
 				slog.WarnContext(groupCtx, "Build cache pruning encountered an error", "error", err.Error())
-				// Build cache errors are often non-critical, but we log them
+				// Surface the failure like every other prune type so a build cache that
+				// could not be reclaimed is reported instead of silently left behind.
+				mu.Lock()
+				result.Errors = append(result.Errors, fmt.Sprintf("Build cache pruning failed: %v", err))
+				result.Success = false
+				mu.Unlock()
 			} else {
 				mu.Lock()
 				result.SpaceReclaimed += localResult.SpaceReclaimed

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -13,7 +13,9 @@
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { m } from '$lib/paraglide/messages';
+	import { settingsService } from '$lib/services/settings-service';
 	import { systemService } from '$lib/services/system-service';
+	import { activityStore } from '$lib/stores/activity.store.svelte';
 	import { dashboardStore } from '$lib/stores/dashboard.store.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { hasAnyPermission, hasPermission } from '$lib/utils/auth';
@@ -28,6 +30,7 @@
 	import type { Environment } from '$lib/types/environment';
 	import type { DockerInfo } from '$lib/types/docker';
 	import type { PruneType, SystemPruneRequest } from '$lib/types/automation';
+	import type { Settings } from '$lib/types/settings';
 	import { extractApiErrorMessage, handleApiResultWithCallbacks } from '$lib/utils/api';
 	import { capitalizeFirstLetter } from '$lib/utils/formatting';
 	import { tryCatch } from '$lib/utils/api';
@@ -74,7 +77,10 @@
 	let isRefreshing = $state(false);
 	let isPruneDialogOpen = $state(false);
 	let pruneEnvironment = $state<DashboardEnvironmentOverview | null>(null);
+	let pruneDefaults = $state<Settings | null>(null);
+	let pruneDefaultsLoadingId = $state<string | null>(null);
 	let pruningEnvironmentId = $state<string | null>(null);
+	let pendingPruneActivityId = $state<string | null>(null);
 	let reloadVersion = $state(0);
 	let liveStatsByEnvironmentId = $state<Record<string, EnvironmentLiveStatsState>>({});
 	let upgradeDialogOpenById = $state<Record<string, boolean>>({});
@@ -354,6 +360,24 @@
 		});
 	});
 
+	// A prune runs as a background activity; once the streamed activity reaches a
+	// terminal state, refresh so the dashboard reflects the post-prune resource counts.
+	// A plain (non-reactive) guard dedupes so the refresh fires once per activity
+	// without writing $state inside the effect.
+	let refreshedPruneActivityId: string | null = null;
+	$effect(() => {
+		const id = pendingPruneActivityId;
+		if (!id || id === refreshedPruneActivityId) {
+			return;
+		}
+
+		const status = activityStore.getActivity(id)?.status;
+		if (status === 'success' || status === 'failed' || status === 'cancelled') {
+			refreshedPruneActivityId = id;
+			void refreshOverview();
+		}
+	});
+
 	onMount(() => {
 		void dashboardStore.start({ debugAllGood });
 	});
@@ -587,9 +611,9 @@
 				id: `${item.environment.id}-prune`,
 				action: 'prune',
 				label: m.quick_actions_prune_system(),
-				loading: pruningEnvironmentId === item.environment.id,
-				disabled: !canPruneEnvironment(item) || !!pruningEnvironmentId,
-				onclick: () => openPruneDialog(item),
+				loading: pruningEnvironmentId === item.environment.id || pruneDefaultsLoadingId === item.environment.id,
+				disabled: !canPruneEnvironment(item) || !!pruningEnvironmentId || !!pruneDefaultsLoadingId,
+				onclick: () => void openPruneDialog(item),
 				icon: TrashIcon
 			});
 		}
@@ -643,13 +667,28 @@
 		return m.dashboard_all_images_tracked_summary({ count: summary.totalImages });
 	}
 
-	function openPruneDialog(item: DashboardEnvironmentOverview) {
-		if (!canPruneEnvironment(item)) {
+	async function openPruneDialog(item: DashboardEnvironmentOverview) {
+		if (!canPruneEnvironment(item) || pruneDefaultsLoadingId) {
 			return;
 		}
 
+		const environmentId = item.environment.id;
 		pruneEnvironment = item;
-		isPruneDialogOpen = true;
+		pruneDefaultsLoadingId = environmentId;
+		try {
+			// Pre-fill the dialog with this environment's configured prune defaults.
+			pruneDefaults = await settingsService.getSettingsForEnvironment(environmentId);
+		} catch {
+			// Fall back to the dialog's built-in defaults if settings can't be loaded.
+			pruneDefaults = null;
+		} finally {
+			pruneDefaultsLoadingId = null;
+		}
+
+		// Guard against the selection changing while the fetch was in flight.
+		if (pruneEnvironment?.environment.id === environmentId) {
+			isPruneDialogOpen = true;
+		}
 	}
 
 	function closePruneDialog() {
@@ -659,6 +698,7 @@
 
 		isPruneDialogOpen = false;
 		pruneEnvironment = null;
+		pruneDefaults = null;
 	}
 
 	async function confirmPrune(pruneRequest: SystemPruneRequest) {
@@ -690,8 +730,10 @@
 			onSuccess: async (data) => {
 				isPruneDialogOpen = false;
 				pruneEnvironment = null;
+				pruneDefaults = null;
+				const activityId = extractActivityId(data);
 				const toastOptions = {
-					...(activityToastOptions(extractActivityId(data)) ?? {}),
+					...(activityToastOptions(activityId) ?? {}),
 					description: targetEnvironment.environment.name
 				};
 				if (selectedTypes.length === 1) {
@@ -699,7 +741,14 @@
 				} else {
 					toast.success(m.dashboard_prune_success_many({ types: typesString }), toastOptions);
 				}
-				await refreshOverview();
+				// The prune runs as a background activity, so refresh once it actually
+				// completes — refreshing now would capture pre-prune state. Fall back to
+				// an immediate refresh when no activity id is returned.
+				if (activityId) {
+					pendingPruneActivityId = activityId;
+				} else {
+					await refreshOverview();
+				}
 			}
 		});
 	}
@@ -1069,6 +1118,7 @@
 <PruneConfirmationDialog
 	open={isPruneDialogOpen}
 	isPruning={!!pruningEnvironmentId}
+	defaults={pruneDefaults}
 	onConfirm={confirmPrune}
 	onCancel={closePruneDialog}
 />


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes dashboard prune counts being stale by deferring the overview refresh until the background prune activity reaches a terminal state, rather than refreshing immediately after the API call returns (when Docker hasn't reclaimed anything yet). The backend half aligns build-cache error handling with every other prune type by recording failures into `result.Errors` instead of swallowing them.

- **Backend** (`system_service.go`): Build cache pruning errors now set `result.Success = false` and append to `result.Errors`, matching the pattern already used for image, volume, and network pruning.
- **Frontend** (`dashboard-all-environments-view.svelte`): The `$effect` watches the live activity stream via `activityStore.getActivity` and fires `refreshOverview()` once the prune activity reaches `success`/`failed`/`cancelled`; a plain (non-reactive) `refreshedPruneActivityId` guard prevents duplicate refreshes without writing `$state` inside the effect. The dialog also now pre-fetches per-environment prune defaults before opening.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the backend change is a straightforward error-surfacing fix with no new logic, and the frontend deferred-refresh approach is correctly guarded against duplicate fires and concurrent prunes.

Both changes are narrowly scoped and follow existing patterns in the codebase. The $effect guard correctly uses a non-reactive local variable to deduplicate refreshes, the async openPruneDialog is properly guarded against race conditions via pruneEnvironment identity check, and the backend error recording mirrors the already-proven pattern for images/volumes/networks.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: dashboard prune counts may be incon..."](https://github.com/getarcaneapp/arcane/commit/6160831a0c0852d616480b273e746dc62d67945d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38818791)</sub>

<!-- /greptile_comment -->