### PR TITLE
fix: environment update context deadline, and out of bounds text in dialog

### DIFF
--- a/backend/internal/services/system_upgrade_service.go
+++ b/backend/internal/services/system_upgrade_service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	vuln "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/vuln"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/remenv"
 	"github.com/getarcaneapp/arcane/types/v2/version"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
@@ -680,7 +681,7 @@ func (s *SystemUpgradeService) upgradeAgentInternal(ctx context.Context, env *En
 	err := env.ProxyJSONRequest(versionCtx, envID, http.MethodGet, "/api/app-version", nil, &info)
 	cancel()
 	if err != nil {
-		result.Status = models.EnvironmentUpdateResultStatusSkippedOffline
+		result.Status = updateAllAgentFailureStatusInternal(err)
 		result.Error = truncateUpdateAllErrorInternal(err)
 		return
 	}
@@ -712,6 +713,26 @@ func (s *SystemUpgradeService) upgradeAgentInternal(ctx context.Context, env *En
 		// Upgrade fired but the new version was not confirmed within the wait window.
 		result.Status = models.EnvironmentUpdateResultStatusTriggered
 	}
+}
+
+// updateAllAgentFailureStatusInternal classifies a failed agent pre-check. An
+// environment we actually reached but whose request failed or timed out is a real
+// failure, not an offline skip: poll-mode agents connect on demand, so a slow
+// tunnel round-trip surfaces here as a deadline even though the agent is online.
+// Only errors that look like the environment was never reachable (no tunnel,
+// connection refused, DNS failure, …) stay an offline skip.
+func updateAllAgentFailureStatusInternal(err error) models.EnvironmentUpdateResultStatus {
+	// The tunnel/connection was established but the request did not finish: it
+	// either timed out or was canceled (e.g. the parent context was aborted).
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return models.EnvironmentUpdateResultStatusFailed
+	}
+	// The environment answered with a non-success status — reached, not offline.
+	var statusErr *remenv.StatusError
+	if errors.As(err, &statusErr) {
+		return models.EnvironmentUpdateResultStatusFailed
+	}
+	return models.EnvironmentUpdateResultStatusSkippedOffline
 }
 
 // confirmAgentUpgradedInternal polls the agent's version until it changes from the

--- a/backend/internal/services/system_upgrade_service_test.go
+++ b/backend/internal/services/system_upgrade_service_test.go
@@ -3,9 +3,12 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/remenv"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
@@ -270,4 +273,31 @@ func TestResolveSystemUpgraderRuntimeOptionsInternal_UnixDockerHostResolutionErr
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "resolve unix socket source")
+}
+
+// TestUpdateAllAgentFailureStatus verifies that a reachable-but-failed agent (e.g.
+// a poll-mode environment whose tunnel round-trip timed out) is reported as a real
+// failure rather than mislabeled "offline — skipped".
+func TestUpdateAllAgentFailureStatus(t *testing.T) {
+	// Mirrors the real wrapping: executeRemoteRequest -> TransportError ->
+	// "tunnel request failed" -> context.DeadlineExceeded.
+	tunnelTimeout := fmt.Errorf("failed to send request to environment oracle-cloud: %w",
+		&remenv.TransportError{Err: fmt.Errorf("tunnel request failed: %w", context.DeadlineExceeded)})
+
+	tests := []struct {
+		name string
+		err  error
+		want models.EnvironmentUpdateResultStatus
+	}{
+		{"tunnel request timed out", tunnelTimeout, models.EnvironmentUpdateResultStatusFailed},
+		{"request canceled mid-flight", fmt.Errorf("tunnel request failed: %w", context.Canceled), models.EnvironmentUpdateResultStatusFailed},
+		{"non-success status from agent", &remenv.StatusError{StatusCode: 502}, models.EnvironmentUpdateResultStatusFailed},
+		{"agent never connected", &remenv.TransportError{Err: errors.New("edge agent is not connected")}, models.EnvironmentUpdateResultStatusSkippedOffline},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, updateAllAgentFailureStatusInternal(tt.err))
+		})
+	}
 }

--- a/frontend/src/routes/(app)/environments/update-all-dialog.svelte
+++ b/frontend/src/routes/(app)/environments/update-all-dialog.svelte
@@ -225,14 +225,14 @@
 										{/if}
 									</span>
 
-									<div class="flex min-w-0 flex-1 flex-col">
-										<span class="truncate font-medium">{result.environmentName}</span>
+									<div class="min-w-0 flex-1">
+										<span class="block truncate font-medium">{result.environmentName}</span>
 										{#if result.status === 'updating'}
 											<div class="bg-muted mt-1.5 h-1 overflow-hidden rounded-full">
 												<div class="update-all-capbar bg-primary h-full rounded-full"></div>
 											</div>
 										{:else if result.error}
-											<span class="text-muted-foreground truncate text-xs">{result.error}</span>
+											<span class="text-muted-foreground block truncate text-xs" title={result.error}>{result.error}</span>
 										{/if}
 									</div>
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two separate bugs: a backend misclassification where poll-mode environments whose tunnel round-trip timed out were incorrectly labeled `skipped_offline` instead of `failed`, and a frontend layout issue where the environment name and error message in the update-all dialog overflowed instead of truncating.

- Introduces `updateAllAgentFailureStatusInternal` to distinguish reachable-but-failed environments (deadline, cancel, non-2xx) from genuinely unreachable ones, and adds a table-driven test covering four representative error paths.
- Fixes the Svelte dialog by making the name and error `<span>` elements block-level so `truncate` works correctly, and adds a `title` attribute on the error span for full-text hover access.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; changes are well-scoped and well-tested.

The backend change is targeted and backed by a new test suite. The frontend change is a straightforward CSS/attribute fix. The one gap (DecodeError not yet classified as Failed) is an edge case that was equally unhandled before this PR and does not regress existing behavior.

No files require special attention, though reviewers may want to consider extending updateAllAgentFailureStatusInternal to cover the DecodeError case.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: environment update context deadline..."](https://github.com/getarcaneapp/arcane/commit/a56c604e50aaaf3117f833186cb342d655bb7714) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38924526)</sub>

<!-- /greptile_comment -->