### PR TITLE
fix: tolerate unreadable files when backing up project on save

### DIFF
--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -85,6 +85,11 @@ type stagedDirectorySync struct {
 	syncedFiles     []string
 	serviceCount    int
 	contentsChanged bool
+	// copySkipped holds project-relative paths that could not be read when the
+	// live project directory was copied into the stage (e.g. foreign-owned
+	// bind-mount data). They are absent from the stage, so promotion must
+	// preserve rather than prune them.
+	copySkipped []string
 }
 
 func validateSyncLimits(maxFiles *int, maxTotalSize, maxBinarySize *int64) error {
@@ -1241,10 +1246,20 @@ func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync
 		return nil, err
 	}
 
+	var copySkipped []string
 	if project != nil {
-		if err := projects.CopyDirectoryContents(project.Path, stagePath); err != nil {
+		// Tolerate files Arcane cannot read (e.g. foreign-owned files a container
+		// wrote into the project directory through a relative bind mount). Skipping
+		// them keeps an unrelated unreadable file from aborting the whole sync; the
+		// skipped paths are preserved (not pruned) when the staged tree is mirrored
+		// back over the live project during promotion.
+		copySkipped, err = projects.CopyDirectoryContentsTolerant(project.Path, stagePath)
+		if err != nil {
 			_ = os.RemoveAll(stagePath)
 			return nil, fmt.Errorf("failed to stage current project files: %w", err)
+		}
+		if len(copySkipped) > 0 {
+			slog.WarnContext(ctx, "skipped unreadable files while staging project sync; they will be left untouched on promotion", "projectPath", project.Path, "skipped", copySkipped)
 		}
 	} else if err := s.seedStageEnvFromCandidateDirInternal(ctx, sync, projectsDir, stagePath); err != nil {
 		_ = os.RemoveAll(stagePath)
@@ -1299,6 +1314,7 @@ func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync
 		syncedFiles:     syncedFiles,
 		serviceCount:    serviceCount,
 		contentsChanged: contentsChanged,
+		copySkipped:     copySkipped,
 	}, nil
 }
 
@@ -1760,6 +1776,7 @@ func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Conte
 		return nil, fmt.Errorf("failed to inspect current project directory: %w", err)
 	}
 
+	var backupSkipped []string
 	if existed {
 		projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
 		if err != nil {
@@ -1770,15 +1787,22 @@ func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Conte
 			return nil, fmt.Errorf("failed to create backup directory: %w", err)
 		}
 		defer func() { _ = os.RemoveAll(backupPath) }()
-		if err := projects.CopyDirectoryContents(projectPath, backupPath); err != nil {
+		// Tolerate unreadable files (e.g. foreign-owned bind-mount data) so an
+		// unrelated file can't block the backup; the skipped paths are absent from
+		// the backup and must be preserved, not pruned, when restoring.
+		backupSkipped, err = projects.CopyDirectoryContentsTolerant(projectPath, backupPath)
+		if err != nil {
 			return nil, fmt.Errorf("failed to back up current project directory: %w", err)
+		}
+		if len(backupSkipped) > 0 {
+			slog.WarnContext(ctx, "skipped unreadable files while backing up project for sync; they will be left untouched on rollback", "projectPath", projectPath, "skipped", backupSkipped)
 		}
 	}
 
 	restore := func() {
 		var restoreErr error
 		if existed {
-			restoreErr = projects.MirrorDirectoryContents(backupPath, projectPath)
+			restoreErr = projects.MirrorDirectoryContentsPreserving(backupPath, projectPath, backupSkipped)
 		} else {
 			restoreErr = os.RemoveAll(projectPath)
 		}
@@ -1787,7 +1811,9 @@ func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Conte
 		}
 	}
 
-	if err := projects.MirrorDirectoryContents(stage.stagePath, projectPath); err != nil {
+	// Preserve files skipped while staging: they remain in the live project but are
+	// absent from the stage, so a plain mirror would prune them.
+	if err := projects.MirrorDirectoryContentsPreserving(stage.stagePath, projectPath, stage.copySkipped); err != nil {
 		restore()
 		return nil, fmt.Errorf("failed to promote staged project directory: %w", err)
 	}

--- a/backend/internal/services/gitops_sync_service_unix_test.go
+++ b/backend/internal/services/gitops_sync_service_unix_test.go
@@ -1,0 +1,96 @@
+//go:build unix
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGitOpsSyncService_SyncProjectDirectory_PreservesUnreadableBindMountData verifies
+// that re-syncing an existing GitOps project tolerates a foreign-owned unreadable file
+// inside the project directory (e.g. data a container wrote through a relative bind
+// mount, owned by another UID with restrictive perms). The sync must succeed instead
+// of aborting on the permission error while staging/backing up, and the unreadable
+// file must be left untouched rather than pruned when the staged tree is promoted.
+func TestGitOpsSyncService_SyncProjectDirectory_PreservesUnreadableBindMountData(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+
+	projectPath := filepath.Join(projectsDir, "demo-project")
+	writeFileInternal(t, projectPath, "docker-compose.yaml", []byte(`services:
+  app:
+    image: nginx:1.26-alpine
+`))
+
+	// A container wrote a foreign-owned, unreadable file into a relative bind-mount
+	// directory inside the project. Arcane's PUID cannot read it.
+	secretPath := filepath.Join(projectPath, "data", "secret.bin")
+	require.NoError(t, os.MkdirAll(filepath.Dir(secretPath), 0o755))
+	require.NoError(t, os.WriteFile(secretPath, []byte("supersecret"), 0o644))
+	require.NoError(t, os.Chmod(secretPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(secretPath, 0o644) })
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-unreadable-bindmount"},
+		Name:      "demo-project",
+		DirName:   new("demo-project"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	oldSyncedFilesJSON, err := json.Marshal([]string{"docker-compose.yaml"})
+	require.NoError(t, err)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-unreadable-bindmount"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		ProjectID:     &project.ID,
+		SyncDirectory: true,
+		SyncedFiles:   new(string(oldSyncedFilesJSON)),
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{
+			RelativePath: "docker-compose.yaml",
+			Content: []byte(`services:
+  app:
+    image: nginx:1.27-alpine
+`),
+		},
+	}
+
+	updatedProject, _, created, _, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.NoError(t, err)
+	require.NotNil(t, updatedProject)
+	require.False(t, created)
+
+	// The unreadable foreign file survived promotion untouched (preserved, not pruned).
+	require.NoError(t, os.Chmod(secretPath, 0o644))
+	secretBytes, err := os.ReadFile(secretPath)
+	require.NoError(t, err)
+	assert.Equal(t, "supersecret", string(secretBytes))
+
+	// The managed compose file was still updated by the sync.
+	composeBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "docker-compose.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(composeBytes), "nginx:1.27-alpine")
+}

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -2875,8 +2875,9 @@ func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, na
 	}
 
 	backupPath := ""
+	var backupSkipped []string
 	if len(fileChanges) > 0 {
-		backupPath, err = s.backupProjectDirectoryInternal(projectsDirectory, proj.Path)
+		backupPath, backupSkipped, err = s.backupProjectDirectoryInternal(ctx, projectsDirectory, proj.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -2905,7 +2906,7 @@ func (s *ProjectService) UpdateProject(ctx context.Context, projectID string, na
 		return nil
 	}); err != nil {
 		if backupPath != "" {
-			if restoreErr := s.restoreProjectDirectoryBackupInternal(ctx, projectsDirectory, proj.Path, backupPath); restoreErr != nil {
+			if restoreErr := s.restoreProjectDirectoryBackupInternal(ctx, projectsDirectory, proj.Path, backupPath, backupSkipped); restoreErr != nil {
 				slog.WarnContext(ctx, "failed to restore project files after update failure", "projectID", projectID, "error", restoreErr)
 			}
 		}
@@ -3088,34 +3089,41 @@ func wrapProjectFileErrorInternal(err error) error {
 	}
 }
 
-func (s *ProjectService) backupProjectDirectoryInternal(projectsDirectory, projectPath string) (string, error) {
+func (s *ProjectService) backupProjectDirectoryInternal(ctx context.Context, projectsDirectory, projectPath string) (string, []string, error) {
 	projectAbs, err := filepath.Abs(projectPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve project path: %w", err)
+		return "", nil, fmt.Errorf("failed to resolve project path: %w", err)
 	}
 	projectAbs = filepath.Clean(projectAbs)
 
 	rootAbs, err := filepath.Abs(projectsDirectory)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve projects directory: %w", err)
+		return "", nil, fmt.Errorf("failed to resolve projects directory: %w", err)
 	}
 	rootAbs = filepath.Clean(rootAbs)
 	if !projects.IsSafeSubdirectory(rootAbs, projectAbs) || projectAbs == rootAbs {
-		return "", errors.New("project path is outside projects directory")
+		return "", nil, errors.New("project path is outside projects directory")
 	}
 
 	backupPath, err := os.MkdirTemp(projectsDirectory, ".project-update-backup-*")
 	if err != nil {
-		return "", fmt.Errorf("failed to create project backup directory: %w", err)
+		return "", nil, fmt.Errorf("failed to create project backup directory: %w", err)
 	}
-	if err := projects.CopyDirectoryContents(projectAbs, backupPath); err != nil {
+	// Tolerate files Arcane cannot read (e.g. foreign-owned secrets): skip them
+	// in the backup so an unrelated unreadable file can't block the whole save.
+	// The skipped paths are returned so the rollback restore can preserve them.
+	skipped, err := projects.CopyDirectoryContentsTolerant(projectAbs, backupPath)
+	if err != nil {
 		_ = os.RemoveAll(backupPath)
-		return "", fmt.Errorf("failed to backup project files: %w", err)
+		return "", nil, fmt.Errorf("failed to backup project files: %w", err)
 	}
-	return backupPath, nil
+	if len(skipped) > 0 {
+		slog.WarnContext(ctx, "skipped unreadable files while backing up project; they will be left untouched on rollback", "projectPath", projectAbs, "skipped", skipped)
+	}
+	return backupPath, skipped, nil
 }
 
-func (s *ProjectService) restoreProjectDirectoryBackupInternal(ctx context.Context, projectsDirectory, projectPath, backupPath string) error {
+func (s *ProjectService) restoreProjectDirectoryBackupInternal(ctx context.Context, projectsDirectory, projectPath, backupPath string, skipped []string) error {
 	projectAbs, err := filepath.Abs(projectPath)
 	if err != nil {
 		return fmt.Errorf("failed to resolve project path: %w", err)
@@ -3132,13 +3140,13 @@ func (s *ProjectService) restoreProjectDirectoryBackupInternal(ctx context.Conte
 	}
 
 	slog.DebugContext(ctx, "restoring project directory backup", "path", projectAbs, "backup", backupPath)
-	if err := os.RemoveAll(projectAbs); err != nil {
-		return fmt.Errorf("failed to remove failed project directory state: %w", err)
-	}
 	if err := os.MkdirAll(projectAbs, common.DirPerm); err != nil {
 		return fmt.Errorf("failed to recreate project directory: %w", err)
 	}
-	if err := projects.CopyDirectoryContents(backupPath, projectAbs); err != nil {
+	// Mirror the backup back over the live directory rather than wiping it: files
+	// that were skipped during backup (unreadable, e.g. foreign-owned secrets)
+	// are absent from the backup and must be preserved, not deleted.
+	if err := projects.MirrorDirectoryContentsPreserving(backupPath, projectAbs, skipped); err != nil {
 		return fmt.Errorf("failed to restore project backup: %w", err)
 	}
 	return nil

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -402,6 +402,28 @@ func RemoveStaleComposeFiles(projectPath, composeFileName string, syncedFiles []
 }
 
 func CopyDirectoryContents(srcDir, destDir string) error {
+	return copyDirectoryContentsInternal(srcDir, destDir, nil)
+}
+
+// CopyDirectoryContentsTolerant copies srcDir into destDir like
+// CopyDirectoryContents, except that files (or whole subdirectories) which
+// cannot be read because of a permission error are skipped instead of aborting
+// the copy. The skipped entries' project-relative paths are returned sorted so
+// callers can avoid deleting them on a later restore. Any non-permission error
+// still aborts the copy.
+func CopyDirectoryContentsTolerant(srcDir, destDir string) (skipped []string, err error) {
+	err = copyDirectoryContentsInternal(srcDir, destDir, func(relPath string) {
+		skipped = append(skipped, relPath)
+	})
+	slices.Sort(skipped)
+	return skipped, err
+}
+
+// copyDirectoryContentsInternal copies srcDir into destDir. When skipUnreadable
+// is non-nil and a file or subdirectory cannot be read because of a permission
+// error, the offending project-relative path is reported via skipUnreadable and
+// the copy continues; otherwise the error aborts the copy.
+func copyDirectoryContentsInternal(srcDir, destDir string, skipUnreadable func(relPath string)) error {
 	srcRoot, err := os.OpenRoot(srcDir)
 	if err != nil {
 		return err
@@ -416,7 +438,7 @@ func CopyDirectoryContents(srcDir, destDir string) error {
 
 	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			return walkErr
+			return handleCopyWalkErrorInternal(srcDir, path, d, walkErr, skipUnreadable)
 		}
 		if path == srcDir {
 			return nil
@@ -434,36 +456,67 @@ func CopyDirectoryContents(srcDir, destDir string) error {
 			return nil
 		}
 
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		content, err := srcRoot.ReadFile(relPath)
-		if err != nil {
-			return err
-		}
-
-		if err := destRoot.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
-			return err
-		}
-
-		return destRoot.WriteFile(relPath, content, info.Mode())
+		return copyRegularFileInternal(srcRoot, destRoot, relPath, d, skipUnreadable)
 	})
 }
 
-// MirrorDirectoryContents makes destDir match srcDir while updating files and
-// directories in place, so existing inodes (and therefore container bind
-// mounts into destDir) stay valid. Entries missing from srcDir or whose type
-// differs are removed, then srcDir is copied over the result.
-func MirrorDirectoryContents(srcDir, destDir string) error {
-	if err := pruneDirectoryContentsInternal(srcDir, destDir); err != nil {
+func handleCopyWalkErrorInternal(srcDir, path string, d os.DirEntry, walkErr error, skipUnreadable func(relPath string)) error {
+	// An unreadable subdirectory surfaces here as a permission error on the
+	// directory entry itself.
+	if skipUnreadable == nil || !errors.Is(walkErr, os.ErrPermission) {
+		return walkErr
+	}
+	if relPath, relErr := filepath.Rel(srcDir, path); relErr == nil {
+		skipUnreadable(relPath)
+	}
+	if d != nil && d.IsDir() {
+		return filepath.SkipDir
+	}
+	return nil
+}
+
+func copyRegularFileInternal(srcRoot, destRoot *os.Root, relPath string, d os.DirEntry, skipUnreadable func(relPath string)) error {
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+
+	content, err := srcRoot.ReadFile(relPath)
+	if err != nil {
+		if skipUnreadable != nil && errors.Is(err, os.ErrPermission) {
+			skipUnreadable(relPath)
+			return nil
+		}
+		return err
+	}
+
+	if err := destRoot.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
+		return err
+	}
+
+	return destRoot.WriteFile(relPath, content, info.Mode())
+}
+
+// MirrorDirectoryContentsPreserving makes destDir match srcDir while updating
+// files and directories in place, so existing inodes (and therefore container
+// bind mounts into destDir) stay valid. Entries missing from srcDir or whose
+// type differs are removed, then srcDir is copied over the result. It never
+// prunes a destDir entry whose project-relative path is listed in preserve, nor
+// any directory that still contains a preserved entry. It is used when
+// restoring a backup that intentionally omits files the caller could not read:
+// those files must survive the restore rather than be deleted.
+func MirrorDirectoryContentsPreserving(srcDir, destDir string, preserve []string) error {
+	preserveSet := make(map[string]struct{}, len(preserve))
+	for _, p := range preserve {
+		preserveSet[filepath.Clean(p)] = struct{}{}
+	}
+	if err := pruneDirectoryContentsInternal(srcDir, destDir, preserveSet); err != nil {
 		return err
 	}
 	return CopyDirectoryContents(srcDir, destDir)
 }
 
-func pruneDirectoryContentsInternal(srcDir, destDir string) error {
+func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]struct{}) error {
 	srcRoot, err := os.OpenRoot(srcDir)
 	if err != nil {
 		return err
@@ -489,12 +542,27 @@ func pruneDirectoryContentsInternal(srcDir, destDir string) error {
 			return err
 		}
 
+		// Never delete a preserved entry.
+		if _, ok := preserve[relPath]; ok {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		srcInfo, err := srcRoot.Lstat(relPath)
 		if err == nil && srcInfo.Mode()&os.ModeType == d.Type() {
 			return nil
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
+		}
+
+		// This entry is absent from (or type-changed vs) the source, so it would
+		// normally be pruned. If it is a directory that still contains a preserved
+		// entry, descend and prune its other children instead of removing it whole.
+		if d.IsDir() && hasPreservedDescendantInternal(relPath, preserve) {
+			return nil
 		}
 
 		if err := destRoot.RemoveAll(relPath); err != nil {
@@ -505,6 +573,18 @@ func pruneDirectoryContentsInternal(srcDir, destDir string) error {
 		}
 		return nil
 	})
+}
+
+// hasPreservedDescendantInternal reports whether any preserved path lives under
+// dir, so the prune knows to descend into dir rather than remove it wholesale.
+func hasPreservedDescendantInternal(dir string, preserve map[string]struct{}) bool {
+	prefix := dir + string(filepath.Separator)
+	for p := range preserve {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // CreateUniqueDir creates a unique directory within the allowed projectsRoot.

--- a/backend/pkg/projects/fs_util_unix_test.go
+++ b/backend/pkg/projects/fs_util_unix_test.go
@@ -21,7 +21,7 @@ func inodeOfInternal(t *testing.T, path string) uint64 {
 	return stat.Ino
 }
 
-func TestMirrorDirectoryContents_PreservesInodesAndPrunes(t *testing.T) {
+func TestMirrorDirectoryContentsPreserving_PreservesInodesAndPrunes(t *testing.T) {
 	dst := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dst, "site"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dst, "site", "index.html"), []byte("old"), 0o644))
@@ -38,7 +38,7 @@ func TestMirrorDirectoryContents_PreservesInodesAndPrunes(t *testing.T) {
 	siteIno := inodeOfInternal(t, filepath.Join(dst, "site"))
 	indexIno := inodeOfInternal(t, filepath.Join(dst, "site", "index.html"))
 
-	require.NoError(t, MirrorDirectoryContents(src, dst))
+	require.NoError(t, MirrorDirectoryContentsPreserving(src, dst, nil))
 
 	assert.Equal(t, rootIno, inodeOfInternal(t, dst))
 	assert.Equal(t, siteIno, inodeOfInternal(t, filepath.Join(dst, "site")))
@@ -54,4 +54,62 @@ func TestMirrorDirectoryContents_PreservesInodesAndPrunes(t *testing.T) {
 	envContent, err := os.ReadFile(filepath.Join(dst, ".env"))
 	require.NoError(t, err)
 	assert.Equal(t, "KEY=1", string(envContent))
+}
+
+func TestCopyDirectoryContentsTolerant_SkipsUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "compose.yaml"), []byte("services: {}"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "secrets"), 0o755))
+	secretPath := filepath.Join(src, "secrets", "token.txt")
+	require.NoError(t, os.WriteFile(secretPath, []byte("supersecret"), 0o644))
+	require.NoError(t, os.Chmod(secretPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(secretPath, 0o644) })
+
+	dst := t.TempDir()
+	skipped, err := CopyDirectoryContentsTolerant(src, dst)
+	require.NoError(t, err)
+
+	// The readable file is copied through.
+	content, err := os.ReadFile(filepath.Join(dst, "compose.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "services: {}", string(content))
+
+	// The unreadable file is reported and not copied.
+	assert.Equal(t, []string{filepath.Join("secrets", "token.txt")}, skipped)
+	assert.NoFileExists(t, filepath.Join(dst, "secrets", "token.txt"))
+}
+
+func TestMirrorDirectoryContentsPreserving_KeepsSkippedFile(t *testing.T) {
+	// Simulates the project-update rollback: the backup omits a file Arcane
+	// could not read, so restoring must preserve that file while still reverting
+	// Arcane-managed files and pruning stragglers left by the failed update.
+	backup := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(backup, ".env"), []byte("KEY=original"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(backup, "secrets"), 0o755))
+	// The backup intentionally does NOT contain secrets/token.txt (it was skipped).
+
+	live := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(live, ".env"), []byte("KEY=changed"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(live, "secrets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(live, "secrets", "token.txt"), []byte("supersecret"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(live, "straggler.txt"), []byte("partial write"), 0o644))
+
+	require.NoError(t, MirrorDirectoryContentsPreserving(backup, live, []string{filepath.Join("secrets", "token.txt")}))
+
+	// The skipped (preserved) file survives untouched.
+	secretContent, err := os.ReadFile(filepath.Join(live, "secrets", "token.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "supersecret", string(secretContent))
+
+	// The Arcane-managed file is reverted to the backed-up version.
+	envContent, err := os.ReadFile(filepath.Join(live, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, "KEY=original", string(envContent))
+
+	// The straggler created during the failed update is pruned.
+	assert.NoFileExists(t, filepath.Join(live, "straggler.txt"))
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2995

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash that occurred when Arcane tried to back up or stage a project directory that contained files it couldn't read — for example, data written by a container through a relative bind mount, owned by a different UID with restrictive permissions. The fix introduces tolerant copy and mirror primitives that skip unreadable entries instead of aborting, track the skipped paths, and then preserve (rather than prune) those paths when the staged or backed-up tree is promoted back to the live directory.

- Adds `CopyDirectoryContentsTolerant` (skips permission-denied files/directories, returns their relative paths) and `MirrorDirectoryContentsPreserving` (mirrors without pruning a caller-supplied preserve list) in `fs_util.go`.
- Updates both the project-save backup/restore flow (`project_service.go`) and the GitOps sync staging/promotion flow (`gitops_sync_service.go`) to use the tolerant variants and thread skipped-path lists through to the restore/promotion step.
- Adds unix-only unit tests for the new primitives and an end-to-end integration test that creates a 0-permission bind-mount file inside a project and verifies a sync succeeds while leaving the file untouched.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a focused, well-scoped fix with a clear failure scenario and test coverage at both the unit and integration levels.

The tolerant copy path falls back to the existing error-return behavior for any non-permission error, so the blast radius of the change is narrow. The prune logic correctly descends into directories that contain preserved descendants rather than skipping them entirely, meaning stale files from a failed update are still cleaned up. The skipped-path lists are threaded end-to-end through staging→promotion and backup→restore without leaking across call paths. The old `RemoveAll`-then-copy restore strategy is replaced by a mirror that uses the same prune+copy primitive the rest of the codebase already relied on, so unreadable files that were absent from the backup are simply left in place. Tests cover the unreadable-file case, the straggler-pruning case, and the full sync round-trip.

No files require special attention. All changed files are self-contained and well-tested.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: tolerate unreadable files when back..."](https://github.com/getarcaneapp/arcane/commit/7eaaff41f85e3227b45110a7078d56c0871adf56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39168215)</sub>

<!-- /greptile_comment -->