### PR TITLE
fix: (dashboard): immediately display initial snapshot on mount

### DIFF
--- a/frontend/src/lib/stores/dashboard.store.svelte.ts
+++ b/frontend/src/lib/stores/dashboard.store.svelte.ts
@@ -384,7 +384,9 @@ function createDashboardStore() {
 			debugAllGood = nextDebugAllGood;
 			await environmentStore.ready;
 			reconcileEnvironmentsInternal();
-			void connectStreamInternal(nextGenerationInternal());
+			const generation = nextGenerationInternal();
+			void refreshInternal();
+			void connectStreamInternal(generation);
 			unsubscribeEnvironment = environmentStore.subscribeSelected(() => {
 				reconcileEnvironmentsInternal();
 			});

--- a/frontend/src/lib/stores/dashboard.store.svelte.ts
+++ b/frontend/src/lib/stores/dashboard.store.svelte.ts
@@ -195,9 +195,9 @@ function createDashboardStore() {
 		}
 	}
 
-	async function refreshInternal() {
+	async function refreshInternal(generation = streamGeneration) {
 		reconcileEnvironmentsInternal();
-		await Promise.all(Object.keys(_environmentStates).map((environmentId) => refreshEnvironmentInternal(environmentId)));
+		await Promise.all(Object.keys(_environmentStates).map((environmentId) => refreshEnvironmentInternal(environmentId, generation)));
 	}
 
 	async function connectStreamInternal(generation: number) {
@@ -385,7 +385,7 @@ function createDashboardStore() {
 			await environmentStore.ready;
 			reconcileEnvironmentsInternal();
 			const generation = nextGenerationInternal();
-			void refreshInternal();
+			void refreshInternal(generation);
 			void connectStreamInternal(generation);
 			unsubscribeEnvironment = environmentStore.subscribeSelected(() => {
 				reconcileEnvironmentsInternal();

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -1,3 +1,10 @@
+<script module lang="ts">
+	import type { SystemStats } from '$lib/types/shared';
+	type CachedStats = { stats: SystemStats; timestamp: number };
+	const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+	const cachedStatsByEnvironmentId: Record<string, CachedStats> = {};
+</script>
+
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -19,7 +26,6 @@
 	import { dashboardStore } from '$lib/stores/dashboard.store.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { hasAnyPermission, hasPermission } from '$lib/utils/auth';
-	import type { SystemStats } from '$lib/types/shared';
 	import type {
 		DashboardActionItem,
 		DashboardEnvironmentCardState,
@@ -150,11 +156,18 @@
 		};
 	}
 
-	function createEmptyLiveStatsState(): EnvironmentLiveStatsState {
+	function createEmptyLiveStatsState(environmentId: string): EnvironmentLiveStatsState {
+		const cached = cachedStatsByEnvironmentId[environmentId];
+		const isValid = cached && Date.now() - cached.timestamp < CACHE_TTL_MS;
+		if (cached && !isValid) {
+			delete cachedStatsByEnvironmentId[environmentId];
+		}
+		const stats = isValid ? cached.stats : null;
+
 		return {
-			stats: null,
-			loading: true,
-			hasLoaded: false,
+			stats,
+			loading: !stats,
+			hasLoaded: !!stats,
 			client: null
 		};
 	}
@@ -166,7 +179,7 @@
 		}
 
 		if (!liveStatsByEnvironmentId[environment.id]) {
-			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState();
+			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState(environment.id);
 		}
 
 		const liveStatsState = liveStatsByEnvironmentId[environment.id];
@@ -190,6 +203,7 @@
 				liveStatsState.stats = stats;
 				liveStatsState.hasLoaded = true;
 				liveStatsState.loading = false;
+				cachedStatsByEnvironmentId[environment.id] = { stats, timestamp: Date.now() };
 			},
 			onError: (error) => {
 				console.error(`Stats websocket error for environment ${environment.id}:`, error);

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -1,9 +1,4 @@
-<script module lang="ts">
-	import type { SystemStats } from '$lib/types/shared';
-	type CachedStats = { stats: SystemStats; timestamp: number };
-	const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-	const cachedStatsByEnvironmentId: Record<string, CachedStats> = {};
-</script>
+
 
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
@@ -156,18 +151,11 @@
 		};
 	}
 
-	function createEmptyLiveStatsState(environmentId: string): EnvironmentLiveStatsState {
-		const cached = cachedStatsByEnvironmentId[environmentId];
-		const isValid = cached && Date.now() - cached.timestamp < CACHE_TTL_MS;
-		if (cached && !isValid) {
-			delete cachedStatsByEnvironmentId[environmentId];
-		}
-		const stats = isValid ? cached.stats : null;
-
+	function createEmptyLiveStatsState(): EnvironmentLiveStatsState {
 		return {
-			stats,
-			loading: !stats,
-			hasLoaded: !!stats,
+			stats: null,
+			loading: true,
+			hasLoaded: false,
 			client: null
 		};
 	}
@@ -179,7 +167,7 @@
 		}
 
 		if (!liveStatsByEnvironmentId[environment.id]) {
-			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState(environment.id);
+			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState();
 		}
 
 		const liveStatsState = liveStatsByEnvironmentId[environment.id];
@@ -203,7 +191,6 @@
 				liveStatsState.stats = stats;
 				liveStatsState.hasLoaded = true;
 				liveStatsState.loading = false;
-				cachedStatsByEnvironmentId[environment.id] = { stats, timestamp: Date.now() };
 			},
 			onError: (error) => {
 				console.error(`Stats websocket error for environment ${environment.id}:`, error);

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -792,38 +792,21 @@
 
 		{#if boardSummaryLoading}
 			<div class="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
-				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
-					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
-						<EnvironmentsIcon class="size-3.5" />
-						<span>{m.environments_title()}</span>
+				{#each [
+					{ icon: EnvironmentsIcon, label: m.environments_title() },
+					{ icon: ContainersIcon, label: m.containers_title() },
+					{ icon: ImagesIcon, label: m.images_title() },
+					{ icon: VolumesIcon, label: m.dashboard_all_storage_title() }
+				] as tile (tile.label)}
+					<div class="border-border/50 bg-background/50 rounded-xl border p-3">
+						<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
+							<tile.icon class="size-3.5" />
+							<span>{tile.label}</span>
+						</div>
+						<Skeleton class="mt-2 h-7 w-12" />
+						<Skeleton class="mt-1.5 h-3.5 w-28" />
 					</div>
-					<Skeleton class="mt-2 h-7 w-10" />
-					<Skeleton class="mt-1.5 h-3.5 w-28" />
-				</div>
-				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
-					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
-						<ContainersIcon class="size-3.5" />
-						<span>{m.containers_title()}</span>
-					</div>
-					<Skeleton class="mt-2 h-7 w-10" />
-					<Skeleton class="mt-1.5 h-3.5 w-28" />
-				</div>
-				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
-					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
-						<ImagesIcon class="size-3.5" />
-						<span>{m.images_title()}</span>
-					</div>
-					<Skeleton class="mt-2 h-7 w-10" />
-					<Skeleton class="mt-1.5 h-3.5 w-28" />
-				</div>
-				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
-					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
-						<VolumesIcon class="size-3.5" />
-						<span>{m.dashboard_all_storage_title()}</span>
-					</div>
-					<Skeleton class="mt-2 h-7 w-16" />
-					<Skeleton class="mt-1.5 h-3.5 w-28" />
-				</div>
+				{/each}
 			</div>
 		{:else}
 			{@const summary = boardState.summary}

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -792,13 +792,38 @@
 
 		{#if boardSummaryLoading}
 			<div class="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
-				{#each [1, 2, 3, 4] as tile (tile)}
-					<div class="border-border/50 bg-background/50 rounded-xl border p-3">
-						<Skeleton class="h-3 w-24" />
-						<Skeleton class="mt-2 h-7 w-16" />
-						<Skeleton class="mt-1.5 h-3.5 w-32" />
+				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
+					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
+						<EnvironmentsIcon class="size-3.5" />
+						<span>{m.environments_title()}</span>
 					</div>
-				{/each}
+					<Skeleton class="mt-2 h-7 w-10" />
+					<Skeleton class="mt-1.5 h-3.5 w-28" />
+				</div>
+				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
+					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
+						<ContainersIcon class="size-3.5" />
+						<span>{m.containers_title()}</span>
+					</div>
+					<Skeleton class="mt-2 h-7 w-10" />
+					<Skeleton class="mt-1.5 h-3.5 w-28" />
+				</div>
+				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
+					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
+						<ImagesIcon class="size-3.5" />
+						<span>{m.images_title()}</span>
+					</div>
+					<Skeleton class="mt-2 h-7 w-10" />
+					<Skeleton class="mt-1.5 h-3.5 w-28" />
+				</div>
+				<div class="border-border/50 bg-background/50 rounded-xl border p-3">
+					<div class="text-muted-foreground flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
+						<VolumesIcon class="size-3.5" />
+						<span>{m.dashboard_all_storage_title()}</span>
+					</div>
+					<Skeleton class="mt-2 h-7 w-16" />
+					<Skeleton class="mt-1.5 h-3.5 w-28" />
+				</div>
 			</div>
 		{:else}
 			{@const summary = boardState.summary}


### PR DESCRIPTION
Fixes #2996.

This PR fixes the long skeleton loading screen on the dashboard. Previously, the fast REST response was incorrectly discarded as stale because the stream connection had immediately bumped the generation counter. Incrementing the stream generation counter *before* executing the initial REST snapshot fetch ensures the response is accepted and displayed instantly.

It also introduces an in-memory cache for system metrics to prevent skeletons from flashing when navigating between tabs.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR resolves a long skeleton loading screen on the dashboard by ensuring the initial REST snapshot is accepted rather than discarded as stale. It also adds a 5-minute in-memory cache for system metrics to avoid skeleton flashes when navigating between tabs.

- **`dashboard.store.svelte.ts`**: On `start()`, `nextGenerationInternal()` is now called once and the same generation token is passed to both `refreshInternal(generation)` and `connectStreamInternal(generation)`. Previously, only `connectStreamInternal` was invoked on start (bumping the generation), which caused any concurrent REST fetch that used the old generation to be silently dropped by `isCurrentGenerationInternal`.
- **`dashboard-all-environments-view.svelte`**: A module-level `cachedStatsByEnvironmentId` map stores the latest `SystemStats` per environment with a timestamp; `createEmptyLiveStatsState` seeds the initial live-stats object from the cache when valid, skipping the loading skeleton entirely. The `boardSummaryLoading` skeleton tiles are also improved to show meaningful labels instead of blank placeholders.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are minimal and targeted, with no regressions to the stream reconnect or refresh paths.

Both changed files have clean, well-reasoned logic. The generation-sharing fix in the store directly resolves the root cause without touching unrelated paths. The component-level cache is guarded by a TTL and correctly seeds the initial state. No data-loss, race, or auth concerns were identified in the diff.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/api/handlers/auth.go`, line 107-110 ([link](https://github.com/getarcaneapp/arcane/blob/000b4f125e4ea2284a870c68b4ab25a3a859bf55/backend/api/handlers/auth.go#L107-L110)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **File-size guard uses the client-declared `Content-Length` part header**

   `fileHeader.Size` is populated from the `Content-Length` header of the individual multipart part, which is set by the client. A client that omits that header causes Go's `multipart` reader to set `Size` to the actual bytes read (safe), but a client that declares a size smaller than the real payload causes the reader to stop early, potentially truncating data without triggering the guard. Measuring the size after reading (`len(buf.Bytes())`) would be more reliable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/handlers/auth.go
   Line: 107-110

   Comment:
   **File-size guard uses the client-declared `Content-Length` part header**

   `fileHeader.Size` is populated from the `Content-Length` header of the individual multipart part, which is set by the client. A client that omits that header causes Go's `multipart` reader to set `Size` to the actual bytes read (safe), but a client that declares a size smaller than the real payload causes the reader to stop early, potentially truncating data without triggering the guard. Measuring the size after reading (`len(buf.Bytes())`) would be more reliable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix-issue-2996-dashboard-loading%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-issue-2996-dashboard-loading%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fauth.go%0ALine%3A%20107-110%0A%0AComment%3A%0A**File-size%20guard%20uses%20the%20client-declared%20%60Content-Length%60%20part%20header**%0A%0A%60fileHeader.Size%60%20is%20populated%20from%20the%20%60Content-Length%60%20header%20of%20the%20individual%20multipart%20part%2C%20which%20is%20set%20by%20the%20client.%20A%20client%20that%20omits%20that%20header%20causes%20Go's%20%60multipart%60%20reader%20to%20set%20%60Size%60%20to%20the%20actual%20bytes%20read%20%28safe%29%2C%20but%20a%20client%20that%20declares%20a%20size%20smaller%20than%20the%20real%20payload%20causes%20the%20reader%20to%20stop%20early%2C%20potentially%20truncating%20data%20without%20triggering%20the%20guard.%20Measuring%20the%20size%20after%20reading%20%28%60len%28buf.Bytes%28%29%29%60%29%20would%20be%20more%20reliable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3024&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fhandlers%2Fauth.go%0ALine%3A%20107-110%0A%0AComment%3A%0A**File-size%20guard%20uses%20the%20client-declared%20%60Content-Length%60%20part%20header**%0A%0A%60fileHeader.Size%60%20is%20populated%20from%20the%20%60Content-Length%60%20header%20of%20the%20individual%20multipart%20part%2C%20which%20is%20set%20by%20the%20client.%20A%20client%20that%20omits%20that%20header%20causes%20Go's%20%60multipart%60%20reader%20to%20set%20%60Size%60%20to%20the%20actual%20bytes%20read%20%28safe%29%2C%20but%20a%20client%20that%20declares%20a%20size%20smaller%20than%20the%20real%20payload%20causes%20the%20reader%20to%20stop%20early%2C%20potentially%20truncating%20data%20without%20triggering%20the%20guard.%20Measuring%20the%20size%20after%20reading%20%28%60len%28buf.Bytes%28%29%29%60%29%20would%20be%20more%20reliable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3024&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): properly pin REST snapsh..."](https://github.com/getarcaneapp/arcane/commit/a6f3f2cd0dbd753f9ae411fc32bb98c162f65233) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39581206)</sub>

<!-- /greptile_comment -->