### PR TITLE
fix: scope environment access tokens to their environment

### DIFF
--- a/backend/api/middleware/auth.go
+++ b/backend/api/middleware/auth.go
@@ -154,17 +154,17 @@ func tryApiKeyAuthInternal(ctx huma.Context, apiKeyService *services.ApiKeyServi
 	return user, key, true
 }
 
-func tryEnvironmentAccessTokenAuthInternal(ctx huma.Context, resolver environmentAccessTokenResolver, token string) (*models.User, bool) {
+func tryEnvironmentAccessTokenAuthInternal(ctx huma.Context, resolver environmentAccessTokenResolver, token string) (*models.User, *models.Environment, bool) {
 	if resolver == nil || strings.TrimSpace(token) == "" {
-		return nil, false
+		return nil, nil, false
 	}
 
 	env, err := resolver.ResolveEnvironmentByAccessToken(ctx.Context(), token)
 	if err != nil || env == nil {
-		return nil, false
+		return nil, nil, false
 	}
 
-	return createEnvironmentSudoUserInternal(env), true
+	return createEnvironmentUserInternal(env), env, true
 }
 
 // tryAgentAuthInternal checks if the request is from an authenticated agent.
@@ -207,7 +207,7 @@ func createAgentSudoUserInternal() *models.User {
 	}
 }
 
-func createEnvironmentSudoUserInternal(env *models.Environment) *models.User {
+func createEnvironmentUserInternal(env *models.Environment) *models.User {
 	return &models.User{
 		BaseModel: models.BaseModel{ID: "environment:" + env.ID},
 		Username:  env.Name,
@@ -238,12 +238,12 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 		}
 
 		if reqs.apiKeyAuth && ctx.Header(pkgutils.HeaderApiKey) != "" {
-			handleApiKeyAuthInternal(api, ctx, apiKeyService, permResolver, envTokenResolver, next)
+			handleApiKeyAuthInternal(api, ctx, authService, apiKeyService, permResolver, envTokenResolver, reqs.bearerAuth, next)
 			return
 		}
 
-		if user, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(pkgutils.HeaderAgentToken)); ok {
-			newCtx := setUserInContextWithSudoInternal(ctx.Context(), user)
+		if user, env, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(pkgutils.HeaderAgentToken)); ok {
+			newCtx := setUserInContextInternal(ctx.Context(), user, authz.EnvironmentPermissionSet(env.ID))
 			next(huma.WithContext(ctx, newCtx))
 			return
 		}
@@ -289,9 +289,10 @@ func opportunisticBearerAuthInternal(ctx huma.Context, authService *services.Aut
 	return huma.WithContext(ctx, newCtx)
 }
 
-// handleApiKeyAuthInternal handles the API-key-present branch. If validation
-// fails, it writes 401 directly — Bearer is not attempted as fallback.
-func handleApiKeyAuthInternal(api huma.API, ctx huma.Context, apiKeyService *services.ApiKeyService, permResolver PermissionResolver, envTokenResolver environmentAccessTokenResolver, next func(huma.Context)) {
+// handleApiKeyAuthInternal handles the API-key-present branch. Invalid user
+// keys fail closed; only recognized environment tokens defer to bearer auth
+// when both credentials are present on a bearer-capable operation.
+func handleApiKeyAuthInternal(api huma.API, ctx huma.Context, authService *services.AuthService, apiKeyService *services.ApiKeyService, permResolver PermissionResolver, envTokenResolver environmentAccessTokenResolver, allowBearerFallback bool, next func(huma.Context)) {
 	if user, key, ok := tryApiKeyAuthInternal(ctx, apiKeyService); ok {
 		// Personal keys inherit the owner's role permissions (same resolution
 		// as session auth); scoped keys are limited to their own grants.
@@ -305,8 +306,17 @@ func handleApiKeyAuthInternal(api huma.API, ctx huma.Context, apiKeyService *ser
 		next(huma.WithContext(ctx, newCtx))
 		return
 	}
-	if user, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(pkgutils.HeaderApiKey)); ok {
-		newCtx := setUserInContextWithSudoInternal(ctx.Context(), user)
+	if user, env, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(pkgutils.HeaderApiKey)); ok {
+		if allowBearerFallback && extractBearerTokenInternal(ctx) != "" {
+			nextCtx, handled := handleBearerAuthInternal(api, ctx, authService, permResolver)
+			if handled {
+				if nextCtx != nil {
+					next(nextCtx)
+				}
+				return
+			}
+		}
+		newCtx := setUserInContextInternal(ctx.Context(), user, authz.EnvironmentPermissionSet(env.ID))
 		next(huma.WithContext(ctx, newCtx))
 		return
 	}
@@ -412,8 +422,8 @@ func setUserInContextInternal(ctx context.Context, user *models.User, ps *authz.
 }
 
 // setUserInContextWithSudoInternal attaches a sudo PermissionSet (bypasses
-// every check) plus the user. Used by the agent token and environment
-// access token paths, which are infrastructure-level and not per-user.
+// every check) plus the user. Used by the agent token path, which is
+// infrastructure-level and not per-user.
 func setUserInContextWithSudoInternal(ctx context.Context, user *models.User) context.Context {
 	return setUserInContextInternal(ctx, user, authz.SudoPermissionSet())
 }

--- a/backend/api/middleware/auth_test.go
+++ b/backend/api/middleware/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/types/v2/auth"
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/golang-jwt/jwt/v5"
@@ -38,6 +39,45 @@ func (r testEnvironmentAccessResolver) ResolveEnvironmentByAccessToken(_ context
 		return r.env, nil
 	}
 	return nil, context.Canceled
+}
+
+type staticPermissionResolverInternal struct {
+	ps *authz.PermissionSet
+}
+
+func (r staticPermissionResolverInternal) ResolvePermissions(_ context.Context, _ *models.User) (*authz.PermissionSet, error) {
+	return r.ps, nil
+}
+
+func (r staticPermissionResolverInternal) ResolveApiKeyPermissions(_ context.Context, _ string) (*authz.PermissionSet, error) {
+	return r.ps, nil
+}
+
+func mintAuthBridgeTestTokenInternal(t *testing.T, userSvc *services.UserService, sessionSvc *services.SessionService, jwtSecret string, userID string) string {
+	t.Helper()
+
+	_, err := userSvc.CreateUser(context.Background(), &models.User{
+		BaseModel: models.BaseModel{ID: userID},
+		Username:  userID,
+	})
+	require.NoError(t, err)
+
+	exp := time.Now().Add(5 * time.Minute)
+	session, _, err := sessionSvc.CreateSession(context.Background(), userID, exp, auth.SessionMeta{})
+	require.NoError(t, err)
+
+	claims := jwt.MapClaims{
+		"jti":      userID,
+		"sub":      "access",
+		"iat":      time.Now().Unix(),
+		"exp":      exp.Unix(),
+		"sid":      session.ID,
+		"user_id":  userID,
+		"username": userID,
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(jwtSecret))
+	require.NoError(t, err)
+	return token
 }
 
 func TestNewAuthBridge_AcceptsEnvironmentAccessTokenViaAPIKey(t *testing.T) {
@@ -74,6 +114,13 @@ func TestNewAuthBridge_AcceptsEnvironmentAccessTokenViaAPIKey(t *testing.T) {
 		require.Equal(t, "environment:env-self", user.ID)
 		require.Equal(t, "Self Target", user.Username)
 
+		ps, ok := PermissionsFromContext(ctx)
+		require.True(t, ok)
+		require.True(t, ps.Allows(authz.PermContainersStart, "env-self"))
+		require.False(t, ps.Allows(authz.PermContainersStart, "env-other"))
+		require.False(t, ps.Allows(authz.PermUsersList, ""))
+		require.False(t, ps.IsGlobalAdmin())
+
 		resp := &secureOutput{}
 		resp.Body.UserID = user.ID
 		return resp, nil
@@ -87,6 +134,71 @@ func TestNewAuthBridge_AcceptsEnvironmentAccessTokenViaAPIKey(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "environment:env-self")
+}
+
+func TestNewAuthBridge_UsesBearerWhenLoopbackProxySendsEnvironmentAccessToken(t *testing.T) {
+	db := setupAuthMiddlewareTestDBInternal(t)
+	userSvc := services.NewUserService(db)
+	sessionSvc := services.NewSessionService(db)
+
+	jwtSecret := "test-secret-please-do-not-use-in-prod"
+	authSvc := services.NewAuthService(userSvc, nil, nil, sessionSvc, nil, jwtSecret, &config.Config{JWTRefreshExpiry: 24 * time.Hour})
+	bearerToken := mintAuthBridgeTestTokenInternal(t, userSvc, sessionSvc, jwtSecret, "u-loopback")
+
+	ps := authz.NewPermissionSet()
+	ps.AddEnv("0", authz.PermContainersStart)
+
+	envToken := "remote-env-access-token"
+	router := echo.New()
+	apiGroup := router.Group("/api")
+
+	humaConfig := huma.DefaultConfig("test", "1.0.0")
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"BearerAuth": {Type: "http", Scheme: "bearer"},
+		"ApiKeyAuth": {Type: "apiKey", In: "header", Name: "X-API-Key"},
+	}
+
+	api := humaecho.NewWithGroup(router, apiGroup, humaConfig)
+	api.UseMiddleware(NewAuthBridge(api, authSvc, nil, staticPermissionResolverInternal{ps: ps}, testEnvironmentAccessResolver{
+		env: &models.Environment{
+			BaseModel:   models.BaseModel{ID: "remote-env"},
+			Name:        "Remote Env",
+			AccessToken: &envToken,
+		},
+	}, &config.Config{}))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "loopback-start",
+		Method:      http.MethodPost,
+		Path:        "/environments/{id}/containers/{cid}/start",
+		Security: []map[string][]string{
+			{"BearerAuth": {}},
+			{"ApiKeyAuth": {}},
+		},
+		Middlewares: RequirePermission(api, authz.PermContainersStart),
+	}, func(ctx context.Context, _ *struct {
+		ID  string `path:"id"`
+		CID string `path:"cid"`
+	}) (*secureOutput, error) {
+		user, ok := GetCurrentUserFromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, "u-loopback", user.ID)
+
+		resp := &secureOutput{}
+		resp.Body.UserID = user.ID
+		return resp, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/environments/0/containers/c/start", nil)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	req.Header.Set("X-API-Key", envToken)
+	req.Header.Set("X-Arcane-Agent-Token", envToken)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "u-loopback")
 }
 
 // A valid API key presented to a BearerAuth-only operation must be rejected:

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -120,8 +120,8 @@ func createAuthValidatorInternal(appServices *di.Services) middleware.AuthValida
 			}
 			// Environment bootstrap key (user_id = NULL): used by the proxy when forwarding
 			// requests to a remote env whose apiUrl resolves back to this manager.
-			if _, err := appServices.ApiKey.GetEnvironmentByApiKey(ctx, apiKey); err == nil {
-				return authz.SudoPermissionSet(), true
+			if envID, err := appServices.ApiKey.GetEnvironmentByApiKey(ctx, apiKey); err == nil && envID != nil {
+				return authz.EnvironmentPermissionSet(*envID), true
 			}
 			return nil, false
 		}

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -180,7 +180,7 @@ func (m *AuthMiddleware) managerAuth(ctx context.Context, c echo.Context, next e
 	req := c.Request()
 	if agentToken := req.Header.Get(pkgutils.HeaderAgentToken); agentToken != "" {
 		if env, ok := m.resolveEnvironmentAccessToken(ctx, agentToken); ok {
-			environmentSudoInternal(c, env)
+			environmentScopedInternal(c, env)
 			return next(c)
 		}
 	}
@@ -273,7 +273,7 @@ func (m *AuthMiddleware) apiKeyHeaderAuth(ctx context.Context, c echo.Context, n
 		}
 	}
 	if env, ok := m.resolveEnvironmentAccessToken(ctx, apiKey); ok {
-		environmentSudoInternal(c, env)
+		environmentScopedInternal(c, env)
 		return next(c)
 	}
 	return c.JSON(http.StatusUnauthorized, models.APIError{
@@ -341,14 +341,14 @@ func agentSudoInternal(c echo.Context) {
 	c.Set(echoCtxKeyAuthMethod, "agent_token")
 }
 
-func environmentSudoInternal(c echo.Context, env *models.Environment) {
+func environmentScopedInternal(c echo.Context, env *models.Environment) {
 	envUser := &models.User{
 		BaseModel: models.BaseModel{ID: "environment:" + env.ID},
 		Username:  env.Name,
 	}
 	c.Set(echoCtxKeyUserID, envUser.ID)
 	c.Set(echoCtxKeyCurrentUser, envUser)
-	c.Set(echoCtxKeyUserPermissions, authz.SudoPermissionSet())
+	c.Set(echoCtxKeyUserPermissions, authz.EnvironmentPermissionSet(env.ID))
 	c.Set(echoCtxKeyAuthMethod, "environment_access_token")
 }
 

--- a/backend/internal/middleware/auth_middleware_test.go
+++ b/backend/internal/middleware/auth_middleware_test.go
@@ -122,6 +122,13 @@ func TestAuthMiddleware_ManagerAuthAcceptsEnvironmentAccessTokenViaAPIKey(t *tes
 		require.Equal(t, "Self Target", user.Username)
 		require.Equal(t, "environment_access_token", c.Get("authMethod"))
 
+		ps, ok := c.Get("userPermissions").(*authz.PermissionSet)
+		require.True(t, ok)
+		require.True(t, ps.Allows(authz.PermContainersStart, "env-self"))
+		require.False(t, ps.Allows(authz.PermContainersStart, "env-other"))
+		require.False(t, ps.Allows(authz.PermUsersList, ""))
+		require.False(t, ps.IsGlobalAdmin())
+
 		return c.JSON(http.StatusOK, map[string]any{"userId": user.ID})
 	})
 

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -51,8 +51,8 @@ type EnvResolver func(ctx context.Context, id string) (string, *string, bool, er
 // AuthValidator validates authentication for a request and resolves the
 // caller's effective permission set. The boolean result reports whether the
 // request is authenticated; the permission set is used to authorize proxied
-// requests against the target environment. Sudo permission sets (environment
-// access tokens, internal agent proxies) bypass authorization.
+// requests against the target environment. Sudo permission sets (internal
+// agent proxies) bypass authorization.
 type AuthValidator func(ctx context.Context, c echo.Context) (*authz.PermissionSet, bool)
 
 // EnvironmentMiddleware proxies requests for remote environments to their respective agents.
@@ -181,10 +181,9 @@ func (m *EnvironmentMiddleware) Handle(c echo.Context, next echo.HandlerFunc) er
 // required for the (method, path) is looked up in the matcher and evaluated
 // against the caller's permission set for the target environment.
 //
-// Sudo callers (environment access tokens and internal agent proxies) bypass
-// the check. Requests whose (method, path) has no known permission mapping are
-// denied (default-deny), so a newly added proxied route cannot silently bypass
-// authorization before it is mapped.
+// Sudo callers bypass the check. Requests whose (method, path) has no known
+// permission mapping are denied (default-deny), so a newly added proxied route
+// cannot silently bypass authorization before it is mapped.
 func (m *EnvironmentMiddleware) proxyPermissionDenied(c echo.Context, ps *authz.PermissionSet, envID string) bool {
 	if m.matcher == nil {
 		return false

--- a/backend/pkg/authz/permission_set.go
+++ b/backend/pkg/authz/permission_set.go
@@ -7,8 +7,7 @@ import "strings"
 //
 // Global permissions apply to every environment and to org-level endpoints.
 // PerEnv permissions apply only when the caller is acting on that specific
-// environment. Sudo bypasses all checks (used for the agent token and the
-// per-environment access token paths).
+// environment. Sudo bypasses all checks (used for the agent token path).
 type PermissionSet struct {
 	Global map[string]struct{}
 	PerEnv map[string]map[string]struct{}
@@ -67,10 +66,25 @@ func (ps *PermissionSet) IsGlobalAdmin() bool {
 }
 
 // SudoPermissionSet returns a PermissionSet that allows every action. Used for
-// the agent token and environment access token paths, which bypass per-user
-// permission resolution entirely.
+// the agent token path, which bypasses per-user permission resolution entirely.
 func SudoPermissionSet() *PermissionSet {
 	return &PermissionSet{Sudo: true}
+}
+
+// EnvironmentPermissionSet returns the effective permission set for a
+// per-environment access token. It grants every environment-scoped permission
+// only for envID and no global or sudo permissions.
+func EnvironmentPermissionSet(envID string) *PermissionSet {
+	ps := NewPermissionSet()
+	if envID == "" {
+		return ps
+	}
+	for _, p := range AllPermissions() {
+		if IsEnvScoped(p) {
+			ps.AddEnv(envID, p)
+		}
+	}
+	return ps
 }
 
 // NewPermissionSet builds an empty PermissionSet ready for population.

--- a/backend/pkg/authz/permission_set_test.go
+++ b/backend/pkg/authz/permission_set_test.go
@@ -85,6 +85,28 @@ func TestSudoAllowsEverything(t *testing.T) {
 	}
 }
 
+func TestEnvironmentPermissionSetScopesToOwnEnvironment(t *testing.T) {
+	ps := EnvironmentPermissionSet("env-A")
+
+	if !ps.Allows(PermContainersStart, "env-A") {
+		t.Fatal("environment token should allow env-scoped permissions for its own env")
+	}
+	if ps.Allows(PermContainersStart, "env-B") {
+		t.Fatal("environment token must not allow env-scoped permissions for another env")
+	}
+	if ps.Allows(PermUsersList, "") {
+		t.Fatal("environment token must not allow org-level permissions")
+	}
+	if ps.IsGlobalAdmin() {
+		t.Fatal("environment token must not be global admin")
+	}
+
+	empty := EnvironmentPermissionSet("")
+	if empty.Allows(PermContainersStart, "env-A") {
+		t.Fatal("environment token with empty env id must deny env-scoped permissions")
+	}
+}
+
 func TestEnvIDFromPath(t *testing.T) {
 	cases := map[string]string{
 		"/environments/abc-123/containers":     "abc-123",


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scopes environment access tokens to their own environment rather than granting them a full sudo bypass. Environment tokens now receive `EnvironmentPermissionSet(envID)` — all env-scoped permissions for that specific environment, and no global or sudo permissions.

- `EnvironmentPermissionSet` is introduced in `permission_set.go`, granting every `IsEnvScoped` permission for the given env ID and nothing else.
- All three token-handling paths (Huma auth bridge `X-Api-Key`, Huma auth bridge `X-Arcane-Agent-Token`, and the Echo `AuthValidator` in `router_bootstrap.go`) are updated to use the new scoped set.
- A bearer-fallback path is added to `handleApiKeyAuthInternal` so that loopback proxy requests — which carry both the env access token and the original user's JWT — continue to authenticate as the real user rather than as the environment.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three token-handling paths are consistently updated and both previously raised concerns are addressed.

The permission-scoping change is complete and consistent across the Huma bridge, the Echo auth middleware, and the router bootstrap validator. The loopback proxy scenario (bearer token present alongside an env access token) is now correctly handled by the new bearer-fallback path in `handleApiKeyAuthInternal`, and a dedicated integration test validates the exact flow. The stale comment about sudo env tokens was also cleaned up. No partial updates or missed call sites were found.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/middleware/environment_middleware.go`, line 52-57 ([link](https://github.com/getarcaneapp/arcane/blob/076d39164e06e3b693e46292c2a727e46d0958c5/backend/internal/middleware/environment_middleware.go#L52-L57)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment on `AuthValidator` type**

   The parenthetical in this comment still lists environment access tokens as a sudo bypass: "Sudo permission sets (environment access tokens, internal agent proxies) bypass authorization." After this PR, environment access tokens are no longer granted `Sudo: true` — they receive a scoped `EnvironmentPermissionSet` and go through the normal `proxyPermissionDenied` check. Only the agent token path retains sudo. The comment should be updated to match the new reality, e.g. "Sudo permission sets (internal agent proxies) bypass authorization."

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/middleware/environment_middleware.go
   Line: 52-57

   Comment:
   **Stale comment on `AuthValidator` type**

   The parenthetical in this comment still lists environment access tokens as a sudo bypass: "Sudo permission sets (environment access tokens, internal agent proxies) bypass authorization." After this PR, environment access tokens are no longer granted `Sudo: true` — they receive a scoped `EnvironmentPermissionSet` and go through the normal `proxyPermissionDenied` check. Only the agent token path retains sudo. The comment should be updated to match the new reality, e.g. "Sudo permission sets (internal agent proxies) bypass authorization."

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fenv-token-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fenv-token-scope%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%0ALine%3A%2052-57%0A%0AComment%3A%0A**Stale%20comment%20on%20%60AuthValidator%60%20type**%0A%0AThe%20parenthetical%20in%20this%20comment%20still%20lists%20environment%20access%20tokens%20as%20a%20sudo%20bypass%3A%20%22Sudo%20permission%20sets%20%28environment%20access%20tokens%2C%20internal%20agent%20proxies%29%20bypass%20authorization.%22%20After%20this%20PR%2C%20environment%20access%20tokens%20are%20no%20longer%20granted%20%60Sudo%3A%20true%60%20%E2%80%94%20they%20receive%20a%20scoped%20%60EnvironmentPermissionSet%60%20and%20go%20through%20the%20normal%20%60proxyPermissionDenied%60%20check.%20Only%20the%20agent%20token%20path%20retains%20sudo.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20reality%2C%20e.g.%20%22Sudo%20permission%20sets%20%28internal%20agent%20proxies%29%20bypass%20authorization.%22%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%0ALine%3A%2052-57%0A%0AComment%3A%0A**Stale%20comment%20on%20%60AuthValidator%60%20type**%0A%0AThe%20parenthetical%20in%20this%20comment%20still%20lists%20environment%20access%20tokens%20as%20a%20sudo%20bypass%3A%20%22Sudo%20permission%20sets%20%28environment%20access%20tokens%2C%20internal%20agent%20proxies%29%20bypass%20authorization.%22%20After%20this%20PR%2C%20environment%20access%20tokens%20are%20no%20longer%20granted%20%60Sudo%3A%20true%60%20%E2%80%94%20they%20receive%20a%20scoped%20%60EnvironmentPermissionSet%60%20and%20go%20through%20the%20normal%20%60proxyPermissionDenied%60%20check.%20Only%20the%20agent%20token%20path%20retains%20sudo.%20The%20comment%20should%20be%20updated%20to%20match%20the%20new%20reality%2C%20e.g.%20%22Sudo%20permission%20sets%20%28internal%20agent%20proxies%29%20bypass%20authorization.%22%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `backend/api/middleware/auth.go`, line 294-312 ([link](https://github.com/getarcaneapp/arcane/blob/7dff167e7a9bd6915e19cb393b82c23347a60d6b/backend/api/middleware/auth.go#L294-L312)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **HTTP proxy loopback regression — env token preempts user JWT**

   When the proxy forwards a request to a non-edge environment whose `apiUrl` resolves back to this same manager (the scenario described in the `router_bootstrap.go` comment), `ApplyAgentTokenHeaders` sets **both** `X-Api-Key` and `X-Arcane-Agent-Token` to the remote env's access token on the outbound request — while the original user's `Authorization: Bearer` JWT is also forwarded by `SetAuthHeader`.

   When that loopback request arrives, the proxy middleware short-circuits (`envID == localID`) and the Huma auth bridge runs. Because `X-Api-Key != ""` satisfies `reqs.apiKeyAuth`, `handleApiKeyAuthInternal` fires before the bearer path. Inside it, `tryApiKeyAuthInternal` fails (env token is not a user key), then `tryEnvironmentAccessTokenAuthInternal` succeeds and returns `EnvironmentPermissionSet("remote-env-ID")`. The bearer JWT is never evaluated.

   The handler then checks `ps.Allows(perm, LOCAL_DOCKER_ENVIRONMENT_ID)`, which is `false` because the scoped set only covers `remote-env-ID`. Every env-scoped operation on the local environment returns 403. With the old sudo grant this worked transparently — the regression is silent and affects the deployment pattern explicitly documented in the `router_bootstrap.go` comment.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/api/middleware/auth.go
   Line: 294-312

   Comment:
   **HTTP proxy loopback regression — env token preempts user JWT**

   When the proxy forwards a request to a non-edge environment whose `apiUrl` resolves back to this same manager (the scenario described in the `router_bootstrap.go` comment), `ApplyAgentTokenHeaders` sets **both** `X-Api-Key` and `X-Arcane-Agent-Token` to the remote env's access token on the outbound request — while the original user's `Authorization: Bearer` JWT is also forwarded by `SetAuthHeader`.

   When that loopback request arrives, the proxy middleware short-circuits (`envID == localID`) and the Huma auth bridge runs. Because `X-Api-Key != ""` satisfies `reqs.apiKeyAuth`, `handleApiKeyAuthInternal` fires before the bearer path. Inside it, `tryApiKeyAuthInternal` fails (env token is not a user key), then `tryEnvironmentAccessTokenAuthInternal` succeeds and returns `EnvironmentPermissionSet("remote-env-ID")`. The bearer JWT is never evaluated.

   The handler then checks `ps.Allows(perm, LOCAL_DOCKER_ENVIRONMENT_ID)`, which is `false` because the scoped set only covers `remote-env-ID`. Every env-scoped operation on the local environment returns 403. With the old sudo grant this worked transparently — the regression is silent and affects the deployment pattern explicitly documented in the `router_bootstrap.go` comment.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fenv-token-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fenv-token-scope%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fmiddleware%2Fauth.go%0ALine%3A%20294-312%0A%0AComment%3A%0A**HTTP%20proxy%20loopback%20regression%20%E2%80%94%20env%20token%20preempts%20user%20JWT**%0A%0AWhen%20the%20proxy%20forwards%20a%20request%20to%20a%20non-edge%20environment%20whose%20%60apiUrl%60%20resolves%20back%20to%20this%20same%20manager%20%28the%20scenario%20described%20in%20the%20%60router_bootstrap.go%60%20comment%29%2C%20%60ApplyAgentTokenHeaders%60%20sets%20**both**%20%60X-Api-Key%60%20and%20%60X-Arcane-Agent-Token%60%20to%20the%20remote%20env's%20access%20token%20on%20the%20outbound%20request%20%E2%80%94%20while%20the%20original%20user's%20%60Authorization%3A%20Bearer%60%20JWT%20is%20also%20forwarded%20by%20%60SetAuthHeader%60.%0A%0AWhen%20that%20loopback%20request%20arrives%2C%20the%20proxy%20middleware%20short-circuits%20%28%60envID%20%3D%3D%20localID%60%29%20and%20the%20Huma%20auth%20bridge%20runs.%20Because%20%60X-Api-Key%20!%3D%20%22%22%60%20satisfies%20%60reqs.apiKeyAuth%60%2C%20%60handleApiKeyAuthInternal%60%20fires%20before%20the%20bearer%20path.%20Inside%20it%2C%20%60tryApiKeyAuthInternal%60%20fails%20%28env%20token%20is%20not%20a%20user%20key%29%2C%20then%20%60tryEnvironmentAccessTokenAuthInternal%60%20succeeds%20and%20returns%20%60EnvironmentPermissionSet%28%22remote-env-ID%22%29%60.%20The%20bearer%20JWT%20is%20never%20evaluated.%0A%0AThe%20handler%20then%20checks%20%60ps.Allows%28perm%2C%20LOCAL_DOCKER_ENVIRONMENT_ID%29%60%2C%20which%20is%20%60false%60%20because%20the%20scoped%20set%20only%20covers%20%60remote-env-ID%60.%20Every%20env-scoped%20operation%20on%20the%20local%20environment%20returns%20403.%20With%20the%20old%20sudo%20grant%20this%20worked%20transparently%20%E2%80%94%20the%20regression%20is%20silent%20and%20affects%20the%20deployment%20pattern%20explicitly%20documented%20in%20the%20%60router_bootstrap.go%60%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fapi%2Fmiddleware%2Fauth.go%0ALine%3A%20294-312%0A%0AComment%3A%0A**HTTP%20proxy%20loopback%20regression%20%E2%80%94%20env%20token%20preempts%20user%20JWT**%0A%0AWhen%20the%20proxy%20forwards%20a%20request%20to%20a%20non-edge%20environment%20whose%20%60apiUrl%60%20resolves%20back%20to%20this%20same%20manager%20%28the%20scenario%20described%20in%20the%20%60router_bootstrap.go%60%20comment%29%2C%20%60ApplyAgentTokenHeaders%60%20sets%20**both**%20%60X-Api-Key%60%20and%20%60X-Arcane-Agent-Token%60%20to%20the%20remote%20env's%20access%20token%20on%20the%20outbound%20request%20%E2%80%94%20while%20the%20original%20user's%20%60Authorization%3A%20Bearer%60%20JWT%20is%20also%20forwarded%20by%20%60SetAuthHeader%60.%0A%0AWhen%20that%20loopback%20request%20arrives%2C%20the%20proxy%20middleware%20short-circuits%20%28%60envID%20%3D%3D%20localID%60%29%20and%20the%20Huma%20auth%20bridge%20runs.%20Because%20%60X-Api-Key%20!%3D%20%22%22%60%20satisfies%20%60reqs.apiKeyAuth%60%2C%20%60handleApiKeyAuthInternal%60%20fires%20before%20the%20bearer%20path.%20Inside%20it%2C%20%60tryApiKeyAuthInternal%60%20fails%20%28env%20token%20is%20not%20a%20user%20key%29%2C%20then%20%60tryEnvironmentAccessTokenAuthInternal%60%20succeeds%20and%20returns%20%60EnvironmentPermissionSet%28%22remote-env-ID%22%29%60.%20The%20bearer%20JWT%20is%20never%20evaluated.%0A%0AThe%20handler%20then%20checks%20%60ps.Allows%28perm%2C%20LOCAL_DOCKER_ENVIRONMENT_ID%29%60%2C%20which%20is%20%60false%60%20because%20the%20scoped%20set%20only%20covers%20%60remote-env-ID%60.%20Every%20env-scoped%20operation%20on%20the%20local%20environment%20returns%20403.%20With%20the%20old%20sudo%20grant%20this%20worked%20transparently%20%E2%80%94%20the%20regression%20is%20silent%20and%20affects%20the%20deployment%20pattern%20explicitly%20documented%20in%20the%20%60router_bootstrap.go%60%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: scope environment access tokens to ..."](https://github.com/getarcaneapp/arcane/commit/a1519e8a26d3325992ec44fc3a84ab7a7d283fd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39825085)</sub>

<!-- /greptile_comment -->