### PR TITLE
fix: fix broken git sync bindings to recover properly

### DIFF
--- a/backend/api/handlers/projects.go
+++ b/backend/api/handlers/projects.go
@@ -874,10 +874,12 @@ func (h *ProjectHandler) DestroyProject(ctx context.Context, input *DestroyProje
 		return nil, err
 	}
 
-	removeFiles := false
+	removeFiles := true
 	removeVolumes := false
 	if input.Body != nil {
-		removeFiles = input.Body.RemoveFiles
+		if input.Body.RemoveFiles != nil {
+			removeFiles = *input.Body.RemoveFiles
+		}
 		removeVolumes = input.Body.RemoveVolumes
 		slog.DebugContext(ctx, "DestroyProject handler received body",
 			"removeFiles", removeFiles,

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1588,6 +1588,21 @@ func (e *GitOpsSyncPerformError) Error() string {
 	return "Failed to perform GitOps sync"
 }
 
+type GitOpsSyncProjectBindingBrokenError struct {
+	Err error
+}
+
+func (e *GitOpsSyncProjectBindingBrokenError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("GitOps sync project binding broken: %v", e.Err)
+	}
+	return "GitOps sync project binding broken"
+}
+
+func (e *GitOpsSyncProjectBindingBrokenError) Unwrap() error {
+	return e.Err
+}
+
 type GitOpsSyncStatusError struct {
 	Err error
 }

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -116,6 +116,10 @@ func megabytesToBytes(value int) int64 {
 	return int64(value) * 1024 * 1024
 }
 
+func hasEstablishedProjectBindingInternal(sync *models.GitOpsSync) bool {
+	return sync != nil && sync.ProjectID != nil && strings.TrimSpace(*sync.ProjectID) != ""
+}
+
 func NewGitOpsSyncService(db *database.DB, repoService *GitRepositoryService, projectService *ProjectService, swarmService *SwarmService, eventService *EventService, settingsService *SettingsService) *GitOpsSyncService {
 	return &GitOpsSyncService{
 		db:              db,
@@ -166,7 +170,7 @@ func (s *GitOpsSyncService) buildSyncJobInternal(syncID, environmentID string, i
 			return schedule
 		},
 		RunFn: func(ctx context.Context) {
-			sync, err := s.GetSyncByID(ctx, environmentID, syncID)
+			sync, err := s.getSyncRecordByIDInternal(ctx, environmentID, syncID)
 			if err != nil {
 				slog.DebugContext(ctx, "gitops auto-sync skipped; sync not found", "syncId", syncID, "error", err)
 				return
@@ -352,20 +356,39 @@ func (s *GitOpsSyncService) getFilteredSyncCounts(query *gorm.DB) (gitops.SyncCo
 }
 
 func (s *GitOpsSyncService) GetSyncByID(ctx context.Context, environmentID, id string) (*models.GitOpsSync, error) {
+	sync, err := s.getSyncByIDInternal(ctx, environmentID, id, true)
+	if err != nil {
+		var notFound *models.NotFoundError
+		if errors.As(err, &notFound) {
+			slog.WarnContext(ctx, "GitOps sync not found", "syncID", id, "environmentID", environmentID)
+			return nil, err
+		}
+		slog.ErrorContext(ctx, "Failed to get GitOps sync", "syncID", id, "environmentID", environmentID, "error", err)
+		return nil, err
+	}
+	return sync, nil
+}
+
+func (s *GitOpsSyncService) getSyncByIDInternal(ctx context.Context, environmentID, id string, preloadAssociations bool) (*models.GitOpsSync, error) {
 	var sync models.GitOpsSync
-	q := s.db.WithContext(ctx).Preload("Repository").Preload("Project").Where("id = ?", id)
+	q := s.db.WithContext(ctx).Where("id = ?", id)
+	if preloadAssociations {
+		q = q.Preload("Repository").Preload("Project")
+	}
 	if environmentID != "" {
 		q = q.Where("environment_id = ?", environmentID)
 	}
 	if err := q.First(&sync).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			slog.WarnContext(ctx, "GitOps sync not found", "syncID", id, "environmentID", environmentID)
-			return nil, errors.New("sync not found")
+			return nil, &models.NotFoundError{Message: "GitOps sync not found"}
 		}
-		slog.ErrorContext(ctx, "Failed to get GitOps sync", "syncID", id, "environmentID", environmentID, "error", err)
 		return nil, fmt.Errorf("failed to get sync: %w", err)
 	}
 	return &sync, nil
+}
+
+func (s *GitOpsSyncService) getSyncRecordByIDInternal(ctx context.Context, environmentID, id string) (*models.GitOpsSync, error) {
+	return s.getSyncByIDInternal(ctx, environmentID, id, false)
 }
 
 func (s *GitOpsSyncService) CreateSync(ctx context.Context, environmentID string, req gitops.CreateSyncRequest, actor models.User) (*models.GitOpsSync, error) {
@@ -561,7 +584,7 @@ func (s *GitOpsSyncService) UpdateSync(ctx context.Context, environmentID, id st
 
 func (s *GitOpsSyncService) DeleteSync(ctx context.Context, environmentID, id string, actor models.User) error {
 	// Get sync info before deleting
-	sync, err := s.GetSyncByID(ctx, environmentID, id)
+	sync, err := s.getSyncRecordByIDInternal(ctx, environmentID, id)
 	if err != nil {
 		return err
 	}
@@ -719,6 +742,13 @@ func (s *GitOpsSyncService) performDirectorySync(ctx context.Context, sync *mode
 
 	project, syncedFiles, _, contentsChanged, err := s.syncProjectDirectoryInternal(ctx, sync, syncFiles, actor)
 	if err != nil {
+		var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+		if errors.As(err, &bindingErr) {
+			errMsg := bindingErr.Error()
+			result.Message = "GitOps project binding broken"
+			result.Error = new(errMsg)
+			return result, bindingErr
+		}
 		return result, s.failSync(ctx, id, result, sync, actor, "Failed to sync project directory", err.Error())
 	}
 
@@ -1041,6 +1071,38 @@ func (s *GitOpsSyncService) failSync(ctx context.Context, id string, result *git
 	return fmt.Errorf("%s", errMsg)
 }
 
+func (s *GitOpsSyncService) disableAutoSyncForBrokenBindingInternal(ctx context.Context, sync *models.GitOpsSync) {
+	if sync == nil || sync.ID == "" {
+		return
+	}
+	if err := s.db.WithContext(ctx).
+		Model(&models.GitOpsSync{}).
+		Where("id = ?", sync.ID).
+		Update("auto_sync", false).Error; err != nil {
+		slog.ErrorContext(ctx, "Failed to disable GitOps auto-sync after broken project binding", "syncId", sync.ID, "error", err)
+	}
+	sync.AutoSync = false
+	s.unregisterSyncJobInternal(ctx, sync.ID)
+}
+
+func (s *GitOpsSyncService) failSyncAndDisableAutoSyncInternal(ctx context.Context, id string, result *gitops.SyncResult, sync *models.GitOpsSync, actor models.User, message string, failure error) error {
+	errMsg := failure.Error()
+	_ = s.failSync(ctx, id, result, sync, actor, message, errMsg)
+	s.disableAutoSyncForBrokenBindingInternal(ctx, sync)
+	return failure
+}
+
+func (s *GitOpsSyncService) recordBrokenProjectBindingInternal(ctx context.Context, sync *models.GitOpsSync, actor models.User, err error) {
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	if !errors.As(err, &bindingErr) || sync == nil {
+		return
+	}
+	errMsg := bindingErr.Error()
+	s.updateSyncStatus(ctx, sync.ID, "failed", errMsg, "")
+	s.logSyncError(ctx, sync, actor, errMsg)
+	s.disableAutoSyncForBrokenBindingInternal(ctx, sync)
+}
+
 func (s *GitOpsSyncService) createProjectForSyncInternal(ctx context.Context, sync *models.GitOpsSync, id string, composeContent string, envContent *string, result *gitops.SyncResult, actor models.User) (*models.Project, error) {
 	project, err := s.projectService.CreateProject(ctx, sync.ProjectName, composeContent, envContent, nil, actor)
 	if err != nil {
@@ -1079,8 +1141,11 @@ func (s *GitOpsSyncService) getOrCreateProjectInternal(ctx context.Context, sync
 			return nil, s.failSync(ctx, id, result, sync, actor, "Failed to load existing project", lookupErr.Error())
 		}
 		if !found {
-			slog.WarnContext(ctx, "Existing project not found, will create new one", "projectId", *sync.ProjectID)
-			project = nil
+			err := &common.GitOpsSyncProjectBindingBrokenError{
+				Err: fmt.Errorf("sync %s references missing project %s", sync.ID, *sync.ProjectID),
+			}
+			slog.WarnContext(ctx, "Existing project not found; GitOps project binding is broken", "projectId", *sync.ProjectID, "syncId", sync.ID)
+			return nil, s.failSyncAndDisableAutoSyncInternal(ctx, id, result, sync, actor, "GitOps project binding broken", err)
 		}
 	}
 
@@ -1204,6 +1269,7 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sync *models.GitOpsSync, syncFiles []projects.SyncFile, actor models.User) (*models.Project, []string, bool, bool, error) {
 	stage, err := s.stageDirectorySyncInternal(ctx, sync, syncFiles)
 	if err != nil {
+		s.recordBrokenProjectBindingInternal(ctx, sync, actor, err)
 		return nil, nil, false, false, err
 	}
 	defer func() {
@@ -1551,7 +1617,7 @@ func (s *GitOpsSyncService) findUniqueProjectDirectoryCandidateInternal(ctx cont
 	case 1:
 		return matches[0], nil
 	default:
-		return "", fmt.Errorf("multiple project directories match sync %s; refusing automatic relink", sync.ID)
+		return "", fmt.Errorf("multiple candidate project directories match sync %s; refusing automatic relink", sync.ID)
 	}
 }
 
@@ -1623,7 +1689,8 @@ func (s *GitOpsSyncService) getDirectorySyncProjectInternal(ctx context.Context,
 		return nil, nil
 	}
 
-	if sync.ProjectID != nil && *sync.ProjectID != "" {
+	establishedBinding := hasEstablishedProjectBindingInternal(sync)
+	if establishedBinding {
 		project, found, err := s.lookupProjectByIDInternal(ctx, *sync.ProjectID)
 		if err != nil {
 			return nil, err
@@ -1643,6 +1710,11 @@ func (s *GitOpsSyncService) getDirectorySyncProjectInternal(ctx context.Context,
 
 	project, err := s.findRecoverableManagedProjectInternal(ctx, sync)
 	if err != nil {
+		if establishedBinding {
+			return nil, &common.GitOpsSyncProjectBindingBrokenError{
+				Err: fmt.Errorf("sync %s references missing project %s: %w", sync.ID, *sync.ProjectID, err),
+			}
+		}
 		return nil, err
 	}
 	if project != nil {
@@ -1654,10 +1726,21 @@ func (s *GitOpsSyncService) getDirectorySyncProjectInternal(ctx context.Context,
 
 	project, err = s.recoverProjectFromDirectoryCandidateInternal(ctx, sync)
 	if err != nil {
+		if establishedBinding {
+			return nil, &common.GitOpsSyncProjectBindingBrokenError{
+				Err: fmt.Errorf("sync %s references missing project %s: %w", sync.ID, *sync.ProjectID, err),
+			}
+		}
 		return nil, err
 	}
 	if project != nil {
 		return project, nil
+	}
+
+	if establishedBinding {
+		return nil, &common.GitOpsSyncProjectBindingBrokenError{
+			Err: fmt.Errorf("sync %s references missing project %s: no unique recovery candidate was found", sync.ID, *sync.ProjectID),
+		}
 	}
 
 	return nil, nil

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -8,11 +8,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	git "github.com/getarcaneapp/arcane/backend/v2/pkg/gitutil"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
+	gitopstypes "github.com/getarcaneapp/arcane/types/v2/gitops"
+	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -31,9 +34,26 @@ func setupGitOpsSyncDirectoryTestService(t *testing.T) (*GitOpsSyncService, *dat
 	projectsDir := t.TempDir()
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
-	projectService := NewProjectService(db, settingsService, nil, nil, nil, nil, config.Load())
+	eventService := NewEventService(db, config.Load(), nil)
+	projectService := NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load())
 
-	return NewGitOpsSyncService(db, nil, projectService, nil, nil, settingsService), db, projectsDir
+	return NewGitOpsSyncService(db, nil, projectService, nil, eventService, settingsService), db, projectsDir
+}
+
+type gitOpsSyncTestSchedulerInternal struct {
+	removed []string
+}
+
+func (s *gitOpsSyncTestSchedulerInternal) AddJob(_ context.Context, _ schedulertypes.Job) error {
+	return nil
+}
+
+func (s *gitOpsSyncTestSchedulerInternal) RemoveJob(_ context.Context, name string) {
+	s.removed = append(s.removed, name)
+}
+
+func (s *gitOpsSyncTestSchedulerInternal) HasJob(_ string) bool {
+	return false
 }
 
 func writeFileInternal(t *testing.T, rootDir, relativePath string, content []byte) {
@@ -42,6 +62,39 @@ func writeFileInternal(t *testing.T, rootDir, relativePath string, content []byt
 	targetPath := filepath.Join(rootDir, relativePath)
 	require.NoError(t, os.MkdirAll(filepath.Dir(targetPath), 0o755))
 	require.NoError(t, os.WriteFile(targetPath, content, 0o644))
+}
+
+func TestGitOpsSyncService_GetSyncByID_ReturnsNotFoundError(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupGitOpsSyncDirectoryTestService(t)
+
+	_, err := svc.GetSyncByID(ctx, "0", "missing-sync")
+
+	var notFound *models.NotFoundError
+	require.ErrorAs(t, err, &notFound)
+}
+
+func TestGitOpsSyncService_DeleteSync_DeletesStaleProjectReference(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-delete-stale-project"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		ProjectID:     ptr("missing-project"),
+		SyncInterval:  60,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	require.NoError(t, svc.DeleteSync(ctx, "0", sync.ID, models.User{}))
+
+	var count int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", sync.ID).Count(&count).Error)
+	assert.Zero(t, count)
 }
 
 func TestGitOpsSyncService_SyncProjectDirectory_CreatesProjectPreservingRepoLayout(t *testing.T) {
@@ -528,6 +581,160 @@ func TestGitOpsSyncService_ReconcileDirectorySyncProjectsOnStartup_SkipsAmbiguou
 	require.NoError(t, db.First(&storedSync, "id = ?", sync.ID).Error)
 	require.NotNil(t, storedSync.ProjectID)
 	assert.Equal(t, "missing-project", *storedSync.ProjectID)
+}
+
+func TestGitOpsSyncService_SyncProjectDirectory_FailsWhenBoundProjectMissing(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+	testScheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, testScheduler)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-missing-bound-project"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		ProjectID:     ptr("missing-project"),
+		SyncDirectory: true,
+		AutoSync:      true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{
+			RelativePath: "docker-compose.yaml",
+			Content: []byte(`services:
+  app:
+    image: nginx:alpine
+`),
+		},
+	}
+
+	project, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.Error(t, err)
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	require.ErrorAs(t, err, &bindingErr)
+	require.Nil(t, project)
+	assert.Nil(t, syncedFiles)
+	assert.False(t, created)
+	assert.False(t, changed)
+
+	var projectCount int64
+	require.NoError(t, db.Model(&models.Project{}).Count(&projectCount).Error)
+	assert.Zero(t, projectCount)
+
+	_, statErr := os.Stat(filepath.Join(projectsDir, "demo-project"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	var storedSync models.GitOpsSync
+	require.NoError(t, db.First(&storedSync, "id = ?", sync.ID).Error)
+	assert.False(t, storedSync.AutoSync)
+	require.NotNil(t, storedSync.LastSyncStatus)
+	assert.Equal(t, "failed", *storedSync.LastSyncStatus)
+	require.NotNil(t, storedSync.LastSyncError)
+	assert.Contains(t, *storedSync.LastSyncError, "project binding")
+	assert.Contains(t, testScheduler.removed, gitOpsSyncJobNameInternal(sync.ID))
+}
+
+func TestGitOpsSyncService_SyncProjectDirectory_DisablesAutoSyncWhenBoundProjectRecoveryAmbiguous(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+	testScheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, testScheduler)
+
+	for _, dirName := range []string{"Radarr-3", "Radarr-30"} {
+		projectPath := filepath.Join(projectsDir, dirName)
+		require.NoError(t, os.MkdirAll(projectPath, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectPath, "radarr.yaml"), []byte("services:\n  app:\n    image: lscr.io/linuxserver/radarr:latest\n"), 0o644))
+	}
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-directory-ambiguous-bound-project"},
+		Name:          "radarr-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/media/radarr.yaml",
+		ProjectName:   "Radarr",
+		ProjectID:     ptr("missing-project"),
+		SyncDirectory: true,
+		AutoSync:      true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{
+			RelativePath: "radarr.yaml",
+			Content:      []byte("services:\n  app:\n    image: lscr.io/linuxserver/radarr:latest\n"),
+		},
+	}
+
+	project, syncedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	require.Error(t, err)
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	require.ErrorAs(t, err, &bindingErr)
+	require.Nil(t, project)
+	assert.Nil(t, syncedFiles)
+	assert.False(t, created)
+	assert.False(t, changed)
+
+	var projectCount int64
+	require.NoError(t, db.Model(&models.Project{}).Count(&projectCount).Error)
+	assert.Zero(t, projectCount)
+
+	var storedSync models.GitOpsSync
+	require.NoError(t, db.First(&storedSync, "id = ?", sync.ID).Error)
+	assert.False(t, storedSync.AutoSync)
+	require.NotNil(t, storedSync.LastSyncStatus)
+	assert.Equal(t, "failed", *storedSync.LastSyncStatus)
+	require.NotNil(t, storedSync.LastSyncError)
+	assert.Contains(t, *storedSync.LastSyncError, "multiple candidate project directories")
+	assert.Contains(t, testScheduler.removed, gitOpsSyncJobNameInternal(sync.ID))
+}
+
+func TestGitOpsSyncService_GetOrCreateProjectInternal_FailsWhenBoundProjectMissing(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+	testScheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, testScheduler)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-file-missing-bound-project"},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		RepositoryID:  "repo-1",
+		ComposePath:   "apps/demo/docker-compose.yaml",
+		ProjectName:   "demo-project",
+		ProjectID:     ptr("missing-project"),
+		AutoSync:      true,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	result := &gitopstypes.SyncResult{}
+	project, err := svc.getOrCreateProjectInternal(ctx, sync, sync.ID, "services:\n  app:\n    image: nginx:alpine\n", nil, result, models.User{})
+	require.Error(t, err)
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	require.ErrorAs(t, err, &bindingErr)
+	require.Nil(t, project)
+
+	var projectCount int64
+	require.NoError(t, db.Model(&models.Project{}).Count(&projectCount).Error)
+	assert.Zero(t, projectCount)
+
+	_, statErr := os.Stat(filepath.Join(projectsDir, "demo-project"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+	_, statErr = os.Stat(filepath.Join(projectsDir, "demo-project-1"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	var storedSync models.GitOpsSync
+	require.NoError(t, db.First(&storedSync, "id = ?", sync.ID).Error)
+	assert.False(t, storedSync.AutoSync)
+	require.NotNil(t, storedSync.LastSyncStatus)
+	assert.Equal(t, "failed", *storedSync.LastSyncStatus)
+	require.NotNil(t, storedSync.LastSyncError)
+	assert.Contains(t, *storedSync.LastSyncError, "project binding")
+	assert.Contains(t, testScheduler.removed, gitOpsSyncJobNameInternal(sync.ID))
 }
 
 func TestEnvContentChangedInternal(t *testing.T) {

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -2187,7 +2187,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent
 	return proj, nil
 }
 
-func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, removeFiles, removeVolumes bool, user models.User) error {
+func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, removeFiles bool, removeVolumes bool, user models.User) error {
 	slog.DebugContext(ctx, "DestroyProject service called",
 		"projectID", projectID,
 		"removeFiles", removeFiles,
@@ -2228,8 +2228,6 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 			return fmt.Errorf("failed to remove project files: %w", err)
 		}
 		slog.InfoContext(ctx, "Project files removed successfully", "path", proj.Path)
-	} else {
-		slog.DebugContext(ctx, "Skipping file removal (removeFiles=false)", "path", proj.Path)
 	}
 
 	if err := s.db.WithContext(ctx).Delete(proj).Error; err != nil {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -74,8 +74,70 @@ func setupProjectTestDB(t *testing.T) *database.DB {
 	return &database.DB{DB: db}
 }
 
+func setupProjectDestroyTestServiceInternal(t *testing.T) (*ProjectService, *database.DB, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsDir := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
+
+	eventService := NewEventService(db, config.Load(), nil)
+	return NewProjectService(db, settingsService, eventService, nil, nil, nil, config.Load()), db, projectsDir
+}
+
 func newProjectImagePullServer(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse) *httptest.Server {
 	return newProjectImagePullServerWithObserverInternal(t, inspectByRef, nil)
+}
+
+func TestProjectService_DestroyProject_RemovesFilesWhenRequested(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupProjectDestroyTestServiceInternal(t)
+
+	projectPath := filepath.Join(projectsDir, "demo-remove")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project-data.txt"), []byte("keep until destroy\n"), 0o644))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "project-destroy-remove-files"},
+		Name:      "demo-remove",
+		DirName:   ptr("demo-remove"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	require.NoError(t, svc.DestroyProject(ctx, project.ID, true, false, models.User{}))
+
+	_, statErr := os.Stat(projectPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestProjectService_DestroyProject_PreservesFilesWhenRequested(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupProjectDestroyTestServiceInternal(t)
+
+	projectPath := filepath.Join(projectsDir, "demo-preserve")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	projectDataPath := filepath.Join(projectPath, "project-data.txt")
+	require.NoError(t, os.WriteFile(projectDataPath, []byte("preserve on destroy\n"), 0o644))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "project-destroy-preserve-files"},
+		Name:      "demo-preserve",
+		DirName:   ptr("demo-preserve"),
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	require.NoError(t, svc.DestroyProject(ctx, project.ID, false, false, models.User{}))
+
+	assert.DirExists(t, projectPath)
+	assert.FileExists(t, projectDataPath)
 }
 
 func newProjectImagePullServerWithObserverInternal(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse, onPull func(fullRef string, authHeader string)) *httptest.Server {

--- a/frontend/src/lib/components/action-buttons.svelte
+++ b/frontend/src/lib/components/action-buttons.svelte
@@ -151,11 +151,11 @@
 
 	const removeMutation = createMutation(() => ({
 		mutationKey: ['action', 'remove', type, id],
-		mutationFn: ({ removeFiles, removeVolumes }: { removeFiles: boolean; removeVolumes: boolean }) =>
+		mutationFn: ({ removeVolumes }: { removeVolumes: boolean }) =>
 			tryCatch(
 				type === 'container'
 					? containerService.deleteContainer(id, { volumes: removeVolumes })
-					: projectService.destroyProject(id, removeVolumes, removeFiles)
+					: projectService.destroyProject(id, removeVolumes)
 			),
 		onMutate: () => setLoading('remove', true),
 		onSettled: () => setLoading('remove', false)
@@ -245,10 +245,9 @@
 					label: type === 'project' ? m.compose_destroy() : m.common_remove(),
 					destructive: true,
 					action: async (checkboxStates) => {
-						const removeFiles = checkboxStates['removeFiles'] === true;
 						const removeVolumes = checkboxStates['removeVolumes'] === true;
 
-						const result = await removeMutation.mutateAsync({ removeFiles, removeVolumes });
+						const result = await removeMutation.mutateAsync({ removeVolumes });
 						handleApiResultWithCallbacks({
 							result,
 							message: m.common_action_failed_with_type({
@@ -263,7 +262,6 @@
 					}
 				},
 				checkboxes: [
-					{ id: 'removeFiles', label: m.confirm_remove_project_files(), initialState: false },
 					{
 						id: 'removeVolumes',
 						label: m.confirm_remove_volumes_warning(),

--- a/frontend/src/lib/services/project-service.ts
+++ b/frontend/src/lib/services/project-service.ts
@@ -257,13 +257,12 @@ class ProjectService extends BaseAPIService {
 		await this.streamProjectPull(projectId, onLine);
 	}
 
-	async destroyProject(projectName: string, removeVolumes = false, removeFiles = false): Promise<void> {
+	async destroyProject(projectName: string, removeVolumes = false): Promise<void> {
 		const envId = await environmentStore.getCurrentEnvironmentId();
 		await this.handleResponse(
 			this.api.delete(`/environments/${envId}/projects/${projectName}/destroy`, {
 				data: {
-					removeVolumes,
-					removeFiles
+					removeVolumes
 				}
 			})
 		);

--- a/frontend/src/routes/(app)/projects/projects-table.actions.ts
+++ b/frontend/src/routes/(app)/projects/projects-table.actions.ts
@@ -129,11 +129,6 @@ export function createProjectActions({
 					id: 'volumes',
 					label: m.confirm_remove_volumes_warning(),
 					initialState: false
-				},
-				{
-					id: 'files',
-					label: m.confirm_remove_project_files(),
-					initialState: false
 				}
 			],
 			confirm: {
@@ -141,11 +136,10 @@ export function createProjectActions({
 				destructive: true,
 				action: async (result: DestroyConfirmResult) => {
 					const removeVolumes = !!(result?.checkboxes?.volumes ?? result?.volumes);
-					const removeFiles = !!(result?.checkboxes?.files ?? result?.files);
 					actionStatus[id] = 'destroying';
 
 					await handleApiResultWithCallbacks({
-						result: await tryCatch(projectService.destroyProject(id, removeVolumes, removeFiles)),
+						result: await tryCatch(projectService.destroyProject(id, removeVolumes)),
 						message: m.compose_destroy_failed(),
 						setLoadingState: (value) => {
 							actionStatus[id] = value ? 'destroying' : '';

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -231,7 +231,6 @@ async function destroyCurrentProjectViaUI(page: Page) {
 
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
-	await dialog.getByLabel(/Remove project files/i).check();
 	await dialog.getByRole('button', { name: 'Destroy', exact: true }).click();
 
 	await page.waitForURL(ROUTES.page, { timeout: 10000 });
@@ -260,7 +259,6 @@ async function destroyProjectByNameViaUI(page: Page, projectName: string) {
 
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
-	await dialog.getByLabel(/Remove project files/i).check();
 	await dialog.getByRole('button', { name: 'Destroy', exact: true }).click();
 
 	await expect(page.locator('tbody tr').filter({ hasText: projectName })).toHaveCount(0, {
@@ -276,8 +274,7 @@ async function destroyProjectByIdViaAPI(page: Page, projectId: string) {
 	await page.request
 		.delete(`/api/environments/0/projects/${encodeURIComponent(projectId)}/destroy`, {
 			data: {
-				removeVolumes: false,
-				removeFiles: true
+				removeVolumes: false
 			}
 		})
 		.catch(() => undefined);

--- a/types/project/project.go
+++ b/types/project/project.go
@@ -610,10 +610,10 @@ type Details struct {
 
 // Destroy is used to destroy a project.
 type Destroy struct {
-	// RemoveFiles indicates if project files should be removed.
+	// RemoveFiles indicates if project files should be removed. Defaults to true when omitted.
 	//
 	// Required: false
-	RemoveFiles bool `json:"removeFiles,omitempty"`
+	RemoveFiles *bool `json:"removeFiles,omitempty"`
 
 	// RemoveVolumes indicates if project volumes should be removed.
 	//


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2978

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes broken GitOps sync bindings by detecting when a sync's stored project ID no longer exists and responding gracefully: it marks the sync as failed, logs the event, and disables auto-sync to prevent repeated futile runs. The `removeFiles` default is also flipped to `true` (always remove on destroy) using a `*bool` pointer so callers can still opt out explicitly.

- **Binding-broken recovery**: Three new helpers (`disableAutoSyncForBrokenBindingInternal`, `failSyncAndDisableAutoSyncInternal`, `recordBrokenProjectBindingInternal`) cleanly separate the "record failure + stop scheduler" concern from the sync flow. Both the directory-sync and single-file-sync paths propagate `GitOpsSyncProjectBindingBrokenError` up to `PerformSync` without double-recording.
- **Preload refactor**: `GetSyncByID` is split into `getSyncByIDInternal(preload bool)` so internal callers (scheduler job, `DeleteSync`) skip unnecessary association loads. The prior duplication flagged in review is resolved.
- **UI change**: The "Remove project files" checkbox is removed from the destroy dialog; files are always removed unless the API caller explicitly sends `removeFiles: false`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the binding-broken detection and auto-sync disabling logic is well-structured and covered by new tests.

The core sync paths are clean — no double-recording of failures, DB status and scheduler state are updated exactly once per broken-binding event. The one design concern (transient infrastructure errors during recovery being treated the same as confirmed missing-project errors) is unlikely to cause observable problems given how the recovery flow is sequenced, and does not leave data in an incorrect state.

backend/internal/services/gitops_sync_service.go — specifically the error-wrapping in getDirectorySyncProjectInternal for recovery-path errors when an established binding exists.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: fix broken git sync bindings to rec..."](https://github.com/getarcaneapp/arcane/commit/103b0155ee2771f7b334af6185024e15b023ea7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39912946)</sub>

<!-- /greptile_comment -->