### PR TITLE
feat(dashboard): optimal stale-while-revalidate cache for system stats

### DIFF
--- a/frontend/src/lib/stores/system-stats-cache.store.svelte.ts
+++ b/frontend/src/lib/stores/system-stats-cache.store.svelte.ts
@@ -1,3 +1,4 @@
+import { setContext, getContext } from 'svelte';
 import type { SystemStats } from '$lib/types/shared';
 
 type CachedStats = {
@@ -6,9 +7,10 @@ type CachedStats = {
 };
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_CONTEXT_KEY = Symbol('system-stats-cache');
 
-function createSystemStatsCacheStore() {
-	let cache: Record<string, CachedStats> = {};
+export function createSystemStatsCacheStore() {
+	let cache = $state<Record<string, CachedStats>>({});
 
 	return {
 		get(environmentId: string): SystemStats | null {
@@ -32,4 +34,14 @@ function createSystemStatsCacheStore() {
 	};
 }
 
-export const systemStatsCacheStore = createSystemStatsCacheStore();
+export type SystemStatsCacheStore = ReturnType<typeof createSystemStatsCacheStore>;
+
+export function setSystemStatsCacheContext(): SystemStatsCacheStore {
+	const store = createSystemStatsCacheStore();
+	setContext(CACHE_CONTEXT_KEY, store);
+	return store;
+}
+
+export function getSystemStatsCacheContext(): SystemStatsCacheStore {
+	return getContext<SystemStatsCacheStore>(CACHE_CONTEXT_KEY);
+}

--- a/frontend/src/lib/stores/system-stats-cache.store.svelte.ts
+++ b/frontend/src/lib/stores/system-stats-cache.store.svelte.ts
@@ -1,0 +1,35 @@
+import type { SystemStats } from '$lib/types/shared';
+
+type CachedStats = {
+	stats: SystemStats;
+	timestamp: number;
+};
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function createSystemStatsCacheStore() {
+	let cache: Record<string, CachedStats> = {};
+
+	return {
+		get(environmentId: string): SystemStats | null {
+			const entry = cache[environmentId];
+			if (!entry) return null;
+			if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+				delete cache[environmentId];
+				return null;
+			}
+			return entry.stats;
+		},
+		set(environmentId: string, stats: SystemStats) {
+			cache[environmentId] = {
+				stats,
+				timestamp: Date.now()
+			};
+		},
+		clear() {
+			cache = {};
+		}
+	};
+}
+
+export const systemStatsCacheStore = createSystemStatsCacheStore();

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -11,10 +11,13 @@
 	import { getEffectiveNavigationSettings, navigationSettingsOverridesStore } from '$lib/utils/navigation';
 	import { browser } from '$app/env';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { setSystemStatsCacheContext } from '$lib/stores/system-stats-cache.store.svelte';
 	import { navigationItems, getManagementItems, filterByPermissions, type NavigationItem } from '$lib/config/navigation-config';
 	import { isEditableTarget, matchesShortcutEvent } from '$lib/utils/navigation';
 	import { cn } from '$lib/utils';
 	let { data, children }: LayoutProps = $props();
+
+	setSystemStatsCacheContext();
 
 	const versionInformation = $derived(data.versionInformation);
 	const user = $derived(data.user);

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -18,6 +18,7 @@
 	import { activityStore } from '$lib/stores/activity.store.svelte';
 	import { dashboardStore } from '$lib/stores/dashboard.store.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { systemStatsCacheStore } from '$lib/stores/system-stats-cache.store.svelte';
 	import { hasAnyPermission, hasPermission } from '$lib/utils/auth';
 	import type { SystemStats } from '$lib/types/shared';
 	import type {
@@ -150,11 +151,12 @@
 		};
 	}
 
-	function createEmptyLiveStatsState(): EnvironmentLiveStatsState {
+	function createEmptyLiveStatsState(environmentId: string): EnvironmentLiveStatsState {
+		const cached = systemStatsCacheStore.get(environmentId);
 		return {
-			stats: null,
-			loading: true,
-			hasLoaded: false,
+			stats: cached,
+			loading: !cached,
+			hasLoaded: !!cached,
 			client: null
 		};
 	}
@@ -166,7 +168,7 @@
 		}
 
 		if (!liveStatsByEnvironmentId[environment.id]) {
-			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState();
+			liveStatsByEnvironmentId[environment.id] = createEmptyLiveStatsState(environment.id);
 		}
 
 		const liveStatsState = liveStatsByEnvironmentId[environment.id];
@@ -190,6 +192,7 @@
 				liveStatsState.stats = stats;
 				liveStatsState.hasLoaded = true;
 				liveStatsState.loading = false;
+				systemStatsCacheStore.set(environment.id, stats);
 			},
 			onError: (error) => {
 				console.error(`Stats websocket error for environment ${environment.id}:`, error);

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -18,7 +18,7 @@
 	import { activityStore } from '$lib/stores/activity.store.svelte';
 	import { dashboardStore } from '$lib/stores/dashboard.store.svelte';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
-	import { systemStatsCacheStore } from '$lib/stores/system-stats-cache.store.svelte';
+	import { getSystemStatsCacheContext } from '$lib/stores/system-stats-cache.store.svelte';
 	import { hasAnyPermission, hasPermission } from '$lib/utils/auth';
 	import type { SystemStats } from '$lib/types/shared';
 	import type {
@@ -65,6 +65,8 @@
 		debugAllGood?: boolean;
 		debugUpgrade?: boolean;
 	} = $props();
+
+	const systemStatsCacheStore = getSystemStatsCacheContext();
 
 	const emptySnapshotSettings: DashboardSnapshot['settings'] = {};
 


### PR DESCRIPTION
This PR extracts the stale-while-revalidate cache from the bugfix PR #3024 into its own dedicated feature, using Svelte 5 store patterns to ensure state is safely encapsulated.

### Changes
- Introduces `system-stats-cache.store.svelte.ts` which provides a clean API for caching system metrics with a configurable TTL (currently 5 minutes).
- Refactors `dashboard-all-environments-view.svelte` to read from and write to this store instead of a module-level variable.

This provides the optimal UX by preventing skeleton flashes during menu navigation, while respecting SvelteKit architecture best practices.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds stale-while-revalidate caching for dashboard system stats. The main changes are:

- Adds a context-scoped `systemStatsCacheStore` with TTL-based cached stats.
- Initializes the cache context from the app layout.
- Seeds dashboard live stats from cached values and refreshes them from WebSocket updates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are focused on dashboard stats caching and do not introduce identified merge-blocking concerns.

The reviewed changes are small, localized, and align with the stated cache behavior without identified correctness or security issues.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to start the app environment by running docker-compose up -d --build, but the command failed because docker was not found.
- The setup attempt was repeated, and it again failed at the same step due to the missing Docker engine.
- Because the app server never started, no valid before/after UI video or dashboard screenshot could be produced.
- A cache contract probe was run to evaluate head versus base cache behavior, showing that base initially had no system-stats-cache.store.svelte.ts and no dashboard cache references, and after the probe the head passes the cache contract with expected results: same-env cache hit, different-env null, a valid timestamp at 5 minutes, null after TTL, context store reuse, and dashboard cached state initialized with loading false and hasLoaded true, with fresh stats overwriting the cache.

<a href="https://app.greptile.com/trex/runs/12338132/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): address greptile code re..."](https://github.com/getarcaneapp/arcane/commit/3cbf449b01a35c446b99de9961accf11b6d31df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39921906)</sub>

<!-- /greptile_comment -->