### PR TITLE
chore: recommend sherlock extension and add PR checklist item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ## Checklist
 
 - [ ] This PR is **not** opened from my fork’s `main` branch
+- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)
 
 ## What This PR Implements
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["actboy168.tasks", "svelte.svelte-vscode", "golang.go"]
+  "recommendations": ["actboy168.tasks", "svelte.svelte-vscode", "golang.go", "inlang.vs-code-extension"]
 }


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

As discussed in #3029, this PR provides a softer, standard approach to ensure no hardcoded strings slip into future PRs without enforcing rigid CI checks.

1. **Suggest installing the [Sherlock VS Code extension](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension)**: Added `"inlang.vs-code-extension"` to `.vscode/extensions.json`. It natively highlights hardcoded UI strings in `.svelte` files and provides a "Quick Fix" to extract them to `en.json` directly within the editor.
2. **Add a line to the PR Template**: Added `- [ ] All new user-facing strings are translated via Paraglide (m.*())` to the `.github/PULL_REQUEST_TEMPLATE.md`. This reminds contributors to double-check their work and guides AI reviewers to systematically verify it without running any custom validation script.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds lightweight i18n guidance for contributors. The main changes are:

- Added a PR checklist item for Paraglide-translated user-facing strings.
- Added the Sherlock/Inlang VS Code extension to workspace recommendations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are limited to contributor guidance and editor recommendations, with no runtime application behavior affected.

Only documentation-like repository metadata is changed, and no blocking issues were identified.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the pre-change JSON validation command to inspect the initial state.
- I ran the post-change JSON validation command to verify the updated state after changes.

<a href="https://app.greptile.com/trex/runs/12515669/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(i18n): recommend sherlock extensio..."](https://github.com/getarcaneapp/arcane/commit/cfd0706914945926fa18176e244838af943dc106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40286625)</sub>

<!-- /greptile_comment -->