### PR TITLE
fix(projects): skip unreadable subdirectories during discovery (#3043)

### DIFF
--- a/backend/pkg/projects/discovery.go
+++ b/backend/pkg/projects/discovery.go
@@ -1,7 +1,10 @@
 package projects
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -125,6 +128,15 @@ func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, 
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
+		// A subdirectory we lack permission to read (e.g. a root-owned
+		// lost+found on a mounted volume) should be skipped rather than
+		// aborting discovery of sibling projects. The projects root itself
+		// is still surfaced as a hard error, since being unable to read it
+		// makes discovery impossible.
+		if !isRoot && errors.Is(err, fs.ErrPermission) {
+			slog.Debug("Skipping unreadable project subdirectory", "path", path, "error", err)
+			return nil
+		}
 		return err
 	}
 

--- a/backend/pkg/projects/discovery_unix_test.go
+++ b/backend/pkg/projects/discovery_unix_test.go
@@ -1,0 +1,39 @@
+//go:build unix
+
+package projects
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscoverProjectDirectories_SkipsUnreadableSubdirectory verifies that an
+// unreadable subdirectory (such as a root-owned lost+found on a mounted
+// volume) is skipped during discovery instead of aborting the entire scan, so
+// that sibling projects are still found.
+func TestDiscoverProjectDirectories_SkipsUnreadableSubdirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+
+	root := t.TempDir()
+
+	// A valid project sits next to an unreadable system directory.
+	writeComposeFileInternal(t, filepath.Join(root, "app"))
+
+	unreadable := filepath.Join(root, "lost+found")
+	require.NoError(t, os.MkdirAll(unreadable, 0o755))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
+	require.NoError(t, err)
+
+	names := discoveredNamesInternal(discovered)
+	assert.Equal(t, []string{"app"}, names,
+		"the valid sibling project must be discovered even though a sibling directory is unreadable")
+}


### PR DESCRIPTION
## What & why

Closes #3043.

When Arcane runs as a non-root user and its projects root sits on a mounted volume, the volume often contains a root-owned `lost+found` directory (`drwx------ root:root`). During initial project discovery, `os.ReadDir` on that directory returns a permission error which propagated all the way up and **aborted the entire scan**, so no sibling projects were discovered.

## Root cause

In `backend/pkg/projects/discovery.go`, `walkProjectDirectoriesInternal` returned the `os.ReadDir` error unconditionally (the exact spot @Jannes-Dailidow pointed to, L126–129):

```go
entries, err := os.ReadDir(path)
if err != nil {
    return err
}
```

A permission error on one subdirectory therefore cancelled discovery of every other project.

## Fix

Skip a subdirectory that fails with a permission error and continue scanning, logging at debug level. This mirrors the existing `"Skipping unreadable project subdirectory"` handling already used in `fs_util.go`. The projects **root** itself still surfaces the error, since being unable to read it makes discovery impossible.

```go
if !isRoot && errors.Is(err, fs.ErrPermission) {
    slog.Debug("Skipping unreadable project subdirectory", "path", path, "error", err)
    return nil
}
return err
```

## How it was tested

Added `TestDiscoverProjectDirectories_SkipsUnreadableSubdirectory` (in a new `discovery_unix_test.go`, `//go:build unix`), following the existing `TestCopyDirectoryContentsTolerant_SkipsUnreadableFile` pattern (skips when euid==0, `chmod 0o000` + `t.Cleanup`). It creates a valid project beside an unreadable `lost+found` and asserts the valid project is still discovered.

- The test **fails before** the change (`open .../lost+found: permission denied`) and **passes after**.
- `go test ./pkg/projects/` — full package passes.
- `go vet ./pkg/projects/` — clean.
- `gofmt` — clean.

## AI disclosure

Per Arcane's [AI Usage Policy](https://github.com/getarcaneapp/arcane/blob/main/AI_POLICY.md): this change was produced with **Claude Code (Claude Opus)**, operating autonomously. The change was reproduced, implemented, and verified end-to-end via the Go test suite (`go test`, `go vet`, `gofmt`) on a Unix host; it is a backend-only logic fix with no frontend impact.

AI-Agent: THSort-Agent (autonomous agent operated by Taimur) — https://thsort.github.io

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes project discovery tolerate unreadable child directories. The main changes are:

- Adds permission-error handling for non-root `os.ReadDir` failures.
- Keeps unreadable project roots as hard errors.
- Adds a Unix regression test for an unreadable `lost+found` sibling.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is localized to project discovery, but it can still silently omit nested projects when an unreadable grouping directory is encountered.

The implementation addresses the reported unreadable leaf-directory case and includes a focused Unix regression test, while the remaining edge case affects completeness of discovery results rather than broad runtime stability.

backend/pkg/projects/discovery.go
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a base-mode discovery with a readable app and an unreadable lost+found; permission denied was returned and no discoveries were reported.
- Ran a head-mode discovery with the same setup; the run completed with err=\<nil\> and discovered DirName:\\"app\\".
- Ran a head-mode discovery with an unreadable root; permission denied was reported and the process exited with the expected error surfaced.

<a href="https://app.greptile.com/trex/runs/12628415/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fdiscovery-skip-unreadable-subdir%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdiscovery-skip-unreadable-subdir%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Fprojects%2Fdiscovery.go%3A136-138%0A**Unreadable%20Parents%20Hide%20Projects**%0A%0AWhen%20a%20non-root%20directory%20is%20an%20unreadable%20grouping%20folder%20rather%20than%20a%20leaf%20like%20%60lost%2Bfound%60%2C%20this%20branch%20returns%20success%20and%20skips%20the%20whole%20subtree.%20A%20valid%20project%20under%20that%20folder%20is%20then%20omitted%20from%20discovery%20without%20an%20error%2C%20so%20callers%20receive%20a%20partial%20project%20list%20that%20looks%20complete.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3076&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Fpkg%2Fprojects%2Fdiscovery.go%3A136-138%0A**Unreadable%20Parents%20Hide%20Projects**%0A%0AWhen%20a%20non-root%20directory%20is%20an%20unreadable%20grouping%20folder%20rather%20than%20a%20leaf%20like%20%60lost%2Bfound%60%2C%20this%20branch%20returns%20success%20and%20skips%20the%20whole%20subtree.%20A%20valid%20project%20under%20that%20folder%20is%20then%20omitted%20from%20discovery%20without%20an%20error%2C%20so%20callers%20receive%20a%20partial%20project%20list%20that%20looks%20complete.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3076&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/pkg/projects/discovery.go:136-138
**Unreadable Parents Hide Projects**

When a non-root directory is an unreadable grouping folder rather than a leaf like `lost+found`, this branch returns success and skips the whole subtree. A valid project under that folder is then omitted from discovery without an error, so callers receive a partial project list that looks complete.

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(projects): skip unreadable subdirect..."](https://github.com/getarcaneapp/arcane/commit/a8ac2c30c3b48da02f82ed2d5daadb224de29bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40505579)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->