### PR TITLE
fix: use correct disabletlsverification parameter for ntfy

### DIFF
--- a/backend/pkg/utils/notifications/ntfy_sender.go
+++ b/backend/pkg/utils/notifications/ntfy_sender.go
@@ -78,7 +78,7 @@ func BuildNtfyURL(config models.NtfyConfig) (string, error) {
 	}
 
 	if config.DisableTLSVerification {
-		q.Set("disabletls", "yes")
+		q.Set("disabletlsverification", "yes")
 	}
 
 	u.RawQuery = q.Encode()

--- a/backend/pkg/utils/notifications/ntfy_sender_test.go
+++ b/backend/pkg/utils/notifications/ntfy_sender_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
@@ -111,7 +112,7 @@ func TestBuildNtfyURL(t *testing.T) {
 			},
 			wantErr: false,
 			check: func(url string) bool {
-				return url == "ntfy://user:pass@ntfy.example.com:8080/test?cache=no&disabletls=yes&firebase=no&icon=https%3A%2F%2Fexample.com%2Ficon.png&priority=max&tags=urgent&title=Arcane+Alert"
+				return url == "ntfy://user:pass@ntfy.example.com:8080/test?cache=no&disabletlsverification=yes&firebase=no&icon=https%3A%2F%2Fexample.com%2Ficon.png&priority=max&tags=urgent&title=Arcane+Alert"
 			},
 		},
 	}
@@ -127,4 +128,22 @@ func TestBuildNtfyURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildNtfyURLDisableTLSVerificationUsesCertificateVerificationFlag(t *testing.T) {
+	gotURL, err := BuildNtfyURL(models.NtfyConfig{
+		Host:                   "ntfy.example.com",
+		Topic:                  "alerts",
+		Cache:                  true,
+		Firebase:               true,
+		DisableTLSVerification: true,
+	})
+	require.NoError(t, err)
+
+	parsedURL, err := url.Parse(gotURL)
+	require.NoError(t, err)
+
+	query := parsedURL.Query()
+	assert.Equal(t, "yes", query.Get("disabletlsverification"))
+	assert.Empty(t, query.Get("disabletls"))
 }

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -472,7 +472,7 @@ func NewDetailSummary(src *image.InspectResponse) DetailSummary {
 			}
 		}
 		out.Config.WorkingDir = src.Config.WorkingDir
-		out.Config.ArgsEscaped = src.Config.ArgsEscaped
+		out.Config.ArgsEscaped = src.Config.ArgsEscaped //nolint:staticcheck,nolintlint // Mirror Docker inspect data; deprecated only for new image builders.
 	}
 
 	out.Architecture = src.Architecture


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3077

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the ntfy notification URL parameter for disabling TLS certificate verification. The main changes are:

- Updates the ntfy Shoutrrr query key from `disabletls` to `disabletlsverification`.
- Adds a regression test that checks the new key is present and the old key is absent.
- Adds a scoped lint suppression explaining the intentional Docker inspect `ArgsEscaped` copy.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to the ntfy query parameter fix and a targeted regression test.

No issues were identified in the modified files, and the tests directly cover the intended parameter behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after ntfy-disabletlsverification runtime test logs to verify the parameter correction from disabletls=yes to disabletlsverification=yes and the absence of disabletls.

<a href="https://app.greptile.com/trex/runs/12717783/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use correct disabletlsverification ..."](https://github.com/getarcaneapp/arcane/commit/d39f7f02909123550dc4ad517307eb9b7abee8cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40690321)</sub>

<!-- /greptile_comment -->