### PR TITLE
docs: add nested compose troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 For setup instructions, configuration details, and development guides, visit the **[official documentation site](https://getarcane.app)**.
 
+Troubleshooting nested Docker Compose discovery? See [Nested compose file discovery troubleshooting](docs/nested-compose-troubleshooting.md).
+
 ## Sponsors
 
 This project is supported by the following amazing people:

--- a/docs/nested-compose-troubleshooting.md
+++ b/docs/nested-compose-troubleshooting.md
@@ -1,0 +1,48 @@
+# Nested compose file discovery troubleshooting
+
+Arcane discovers projects by scanning the configured projects directory for compose files. Use this checklist when a compose file in a nested folder does not appear in the Projects list or does not update after you edit it.
+
+## Expected project layout
+
+A project is a directory that contains one supported compose file. Nested projects are supported when they are inside the configured projects directory and within the scan depth.
+
+```text
+/app/data/projects/
+├── media/
+│   └── compose.yaml
+└── homelab/
+    └── monitoring/
+        └── docker-compose.yml
+```
+
+Supported default compose filenames are `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`, `podman-compose.yaml`, and `podman-compose.yml`. Arcane can also detect a single custom `.yaml` or `.yml` file when it has compose root keys, but using one of the default names avoids ambiguity. Avoid keeping two custom compose-looking YAML files in the same project directory because Arcane may refuse to choose between them.
+
+## Scan depth and directories
+
+`PROJECTS_DIRECTORY` controls the root Arcane scans. In the official container this defaults to `/app/data/projects`, so host paths must be mounted into that location or configured to match the mount target. `PROJECT_SCAN_MAX_DEPTH` controls how many directory levels under `PROJECTS_DIRECTORY` Arcane scans and watches. The default is `3`; increase it if your compose file is deeper than that.
+
+Examples:
+
+- `/app/data/projects/blog/compose.yaml` is depth 1.
+- `/app/data/projects/homelab/monitoring/docker-compose.yml` is depth 2.
+- `/app/data/projects/a/b/c/d/compose.yaml` is depth 4 and needs `PROJECT_SCAN_MAX_DEPTH=4` or higher.
+
+After changing `PROJECTS_DIRECTORY`, `PROJECT_SCAN_MAX_DEPTH`, or `FOLLOW_PROJECT_SYMLINKS`, restart Arcane so the filesystem watcher is recreated with the new settings. If the UI still shows stale data after a move or rename, restart Arcane or trigger a project rescan by touching the compose file inside the configured directory.
+
+## Symlinks and mounts
+
+Arcane only follows symlinked project directories when `FOLLOW_PROJECT_SYMLINKS` is enabled in settings/configuration. If the nested compose path is a symlink target, enable that option and restart Arcane. If Arcane runs in Docker, verify the path you see on the host is also mounted at the same effective location inside the Arcane container; a compose file that exists only on the host cannot be discovered from inside the container.
+
+Keep local templates outside `PROJECTS_DIRECTORY`. Arcane disables the templates watcher when the templates directory overlaps the projects directory to avoid treating templates as projects, and overlapping paths can make discovery confusing.
+
+## Quick diagnostics
+
+Run these checks from the host running Arcane:
+
+```bash
+docker exec <arcane-container> printenv PROJECTS_DIRECTORY PROJECT_SCAN_MAX_DEPTH FOLLOW_PROJECT_SYMLINKS
+docker exec <arcane-container> sh -lc 'find "$PROJECTS_DIRECTORY" -maxdepth "${PROJECT_SCAN_MAX_DEPTH:-3}" -type f \( -name compose.yaml -o -name compose.yml -o -name docker-compose.yaml -o -name docker-compose.yml -o -name podman-compose.yaml -o -name podman-compose.yml \) -print'
+docker logs <arcane-container> | grep -Ei 'filesystem watcher|sync projects|project sync|compose|inotify'
+```
+
+When opening an issue, include the Arcane version, install method, the `PROJECTS_DIRECTORY` mount/configuration, `PROJECT_SCAN_MAX_DEPTH`, whether `FOLLOW_PROJECT_SYMLINKS` is enabled, the relative path from `PROJECTS_DIRECTORY` to the missing compose file, the sanitized compose filename/content, and relevant logs from the filesystem watcher or project sync. This information is especially useful for nested compose detection reports such as #3080.


### PR DESCRIPTION
## Summary
- Add a nested compose file discovery troubleshooting guide for project detection failures
- Document expected project layout, supported compose filenames, scan depth behavior, symlink/mount checks, refresh/rescan steps, and diagnostics to include when reporting issues
- Reference #3080 for the nested compose detection scenario

Fixes #3080

## Test plan
- Docs-only change
- Ran `git diff --check`
- Verified the new guide has 48 lines and README links to it

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds troubleshooting documentation for nested Docker Compose discovery. The main changes are:

- Adds a README link to the new troubleshooting guide.
- Documents expected project layout and supported compose filenames.
- Explains scan depth, symlink, mount, refresh, and diagnostic checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge as a docs-only update with no code behavior changes identified.

The change is limited to README and troubleshooting documentation, with no runtime, API, database, or UI implementation changes.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Checked the nested-compose-docs baseline before running the documentation check, confirming README\_LINK\_PRESENT=0 and GUIDE\_EXISTS=0.
- After running the documentation check, verified the post-run results show README\_LINK\_PRESENT=1, GUIDE\_EXISTS=1, a line count of 48, and matching guide lines.

<a href="https://app.greptile.com/trex/runs/12718575/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add nested compose troubleshooting"](https://github.com/getarcaneapp/arcane/commit/62a3873bd8949f8e85941da1c2fd08ff25e819d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40691671)</sub>

<!-- /greptile_comment -->