### PR TITLE
fix: dont create trivy cache in server/client mode

### DIFF
--- a/backend/internal/services/vulnerability_service.go
+++ b/backend/internal/services/vulnerability_service.go
@@ -1403,9 +1403,13 @@ func (s *VulnerabilityService) setupTrivyBatchContainer(ctx context.Context) (st
 		return "", nil, fmt.Errorf("trivy scanner not available: %w", err)
 	}
 
-	cacheVolume, err := s.ensureTrivyCacheVolumeInternal(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to ensure trivy cache volume: %w", err)
+	serverURL, _ := s.getTrivyServerConfig()
+	var cacheVolume string
+	if serverURL == "" {
+		cacheVolume, err = s.ensureTrivyCacheVolumeInternal(ctx)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to ensure trivy cache volume: %w", err)
+		}
 	}
 
 	containerID, err := s.createBatchTrivyContainer(ctx, trivyImage, cacheVolume)
@@ -2232,11 +2236,13 @@ func buildTrivyBatchHostConfigInternal(
 	privileged bool,
 ) *containertypes.HostConfig {
 	mounts := append([]mounttypes.Mount{}, runtimeOptions.Mounts...)
-	mounts = append(mounts, mounttypes.Mount{
-		Type:   mounttypes.TypeVolume,
-		Source: cacheVolume,
-		Target: trivyCacheMountTarget,
-	})
+	if strings.TrimSpace(cacheVolume) != "" {
+		mounts = append(mounts, mounttypes.Mount{
+			Type:   mounttypes.TypeVolume,
+			Source: cacheVolume,
+			Target: trivyCacheMountTarget,
+		})
+	}
 
 	hostConfig := &containertypes.HostConfig{
 		NetworkMode: containertypes.NetworkMode(selectDefaultTrivyNetworkModeInternal(runtimeOptions.NetworkMode)),
@@ -2258,11 +2264,13 @@ func buildTrivyHostConfig(
 	privileged bool,
 ) *containertypes.HostConfig {
 	mounts := append([]mounttypes.Mount{}, runtimeOptions.Mounts...)
-	mounts = append(mounts, mounttypes.Mount{
-		Type:   mounttypes.TypeVolume,
-		Source: cacheVolume,
-		Target: trivyCacheMountTarget,
-	})
+	if strings.TrimSpace(cacheVolume) != "" {
+		mounts = append(mounts, mounttypes.Mount{
+			Type:   mounttypes.TypeVolume,
+			Source: cacheVolume,
+			Target: trivyCacheMountTarget,
+		})
+	}
 
 	hostConfig := &containertypes.HostConfig{
 		NetworkMode: containertypes.NetworkMode(selectDefaultTrivyNetworkModeInternal(runtimeOptions.NetworkMode)),
@@ -3286,15 +3294,22 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
-	cacheVolume, err := s.ensureTrivyCacheVolumeInternal(ctx)
-	if err != nil {
-		return nil, err
+	serverURL, serverToken := s.getTrivyServerConfig()
+	var cacheVolume string
+	if serverURL == "" {
+		cacheVolume, err = s.ensureTrivyCacheVolumeInternal(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get Trivy config files if they exist
 	configContent, ignoreContent := s.getTrivyConfigFiles()
 
-	cacheDir := s.getTrivySingleScanCacheDirForSlotInternal(slotID)
+	var cacheDir string
+	if serverURL == "" {
+		cacheDir = s.getTrivySingleScanCacheDirForSlotInternal(slotID)
+	}
 	if cacheDir != "" {
 		slog.DebugContext(ctx,
 			"using slot-based trivy cache dir for scan",
@@ -3319,7 +3334,7 @@ func (s *VulnerabilityService) runTrivyScan(ctx context.Context, trivyImage stri
 	if len(registryConfigJSON) > 0 {
 		env = append(env, "DOCKER_CONFIG="+trivyRegistryConfigDir)
 	}
-	if _, serverToken := s.getTrivyServerConfig(); serverToken != "" {
+	if serverToken != "" {
 		env = append(env, vuln.ServerTokenEnv(serverToken)...)
 	}
 

--- a/backend/internal/services/vulnerability_service_test.go
+++ b/backend/internal/services/vulnerability_service_test.go
@@ -391,6 +391,43 @@ func TestBuildTrivyHostConfig_AppliesRuntimeSecurity(t *testing.T) {
 	require.True(t, hostConfig.Privileged)
 }
 
+func TestBuildTrivyHostConfig_SkipsCacheMountWhenVolumeEmpty(t *testing.T) {
+	hostConfig := buildTrivyHostConfig(
+		"",
+		nil,
+		containertypes.Resources{},
+		"",
+		false,
+		trivyRuntimeOptions{NetworkMode: "bridge"},
+		nil,
+		false,
+	)
+
+	require.Empty(t, hostConfig.Mounts)
+
+	socketMount := mounttypes.Mount{
+		Type:   mounttypes.TypeBind,
+		Source: "/run/user/1000/podman/podman.sock",
+		Target: "/run/user/1000/podman/podman.sock",
+	}
+	hostConfig = buildTrivyHostConfig(
+		"",
+		nil,
+		containertypes.Resources{},
+		"",
+		false,
+		trivyRuntimeOptions{
+			NetworkMode: "bridge",
+			Mounts:      []mounttypes.Mount{socketMount},
+		},
+		nil,
+		false,
+	)
+
+	require.Len(t, hostConfig.Mounts, 1)
+	require.Equal(t, socketMount.Source, hostConfig.Mounts[0].Source)
+}
+
 func TestBuildTrivyBatchHostConfig_AppliesRuntimeSecurity(t *testing.T) {
 	hostConfig := buildTrivyBatchHostConfigInternal(
 		"cache-volume",
@@ -404,6 +441,17 @@ func TestBuildTrivyBatchHostConfig_AppliesRuntimeSecurity(t *testing.T) {
 	require.True(t, hostConfig.Privileged)
 	require.Len(t, hostConfig.Mounts, 1)
 	require.Equal(t, "cache-volume", hostConfig.Mounts[0].Source)
+}
+
+func TestBuildTrivyBatchHostConfig_SkipsCacheMountWhenVolumeEmpty(t *testing.T) {
+	hostConfig := buildTrivyBatchHostConfigInternal(
+		"",
+		trivyRuntimeOptions{NetworkMode: "arcane-external"},
+		nil,
+		false,
+	)
+
+	require.Empty(t, hostConfig.Mounts)
 }
 
 func TestBuildTrivyHostConfig_IncludesInheritedSocketMount(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3082

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes Trivy scans to avoid creating or mounting a local cache in client/server mode. The main changes are:

- Skips Trivy cache volume creation when a server URL is configured.
- Omits the Trivy cache mount when no cache volume is provided.
- Avoids passing a slot-based cache directory for single scans in server mode.
- Adds tests for empty cache volume host config behavior in single and batch scan paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are narrowly scoped to Trivy cache handling in server/client mode and are covered by targeted tests.

No correctness issues were identified in the changed cache-volume and scan-argument behavior, and the added tests exercise the main single and batch scan paths affected by the change.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the cache mount state: before the artifact, base mounted Target:/root/.cache for both single and batch host configs with an empty cacheVolume; after the artifact, the head shows zero Trivy cache mounts for empty cacheVolume and one named arcane\_trivy\_cache mount for local-cache mode in both the single and batch paths.

<a href="https://app.greptile.com/trex/runs/12719304/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dont create trivy cache in server/c..."](https://github.com/getarcaneapp/arcane/commit/870b0a14f38cd535388c3f8920b025a8d765dec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40692868)</sub>

<!-- /greptile_comment -->