### PR TITLE
fix: stop phantom and duplicate projects from broken syncs

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -146,6 +146,11 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 	})
 	startup.InitializeDefaultSettings(appCtx, runtimeCfg, appServices.Settings)
 	if appServices.GitOpsSync != nil {
+		// Sweep leaked gitops scratch dirs before the filesystem watcher can import
+		// them as phantom projects and before the directory-sync reconcile runs.
+		if err := appServices.GitOpsSync.CleanupLeakedScratchDirsOnStartup(appCtx); err != nil {
+			slog.WarnContext(appCtx, "Failed to clean up leaked GitOps scratch directories on startup", "error", err)
+		}
 		if err := appServices.GitOpsSync.ReconcileDirectorySyncProjectsOnStartup(appCtx); err != nil {
 			slog.WarnContext(appCtx, "Failed to reconcile directory GitOps projects on startup", "error", err)
 		}

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -391,18 +391,31 @@ func (s *GitOpsSyncService) buildSyncJobInternal(syncID, environmentID string, i
 			return schedule
 		},
 		RunFn: func(ctx context.Context) {
-			sync, err := s.getSyncRecordByIDInternal(ctx, environmentID, syncID)
-			if err != nil {
-				slog.DebugContext(ctx, "gitops auto-sync skipped; sync not found", "syncId", syncID, "error", err)
-				return
-			}
-			if !sync.AutoSync {
-				return
-			}
-			if _, err := s.PerformSync(ctx, environmentID, syncID, systemUser); err != nil {
-				slog.ErrorContext(ctx, "gitops auto-sync run failed", "syncId", syncID, "error", err)
-			}
+			s.runScheduledSyncInternal(ctx, environmentID, syncID)
 		},
+	}
+}
+
+// runScheduledSyncInternal is the body of a scheduled sync fire. It re-reads the
+// sync each run so a row toggled to AutoSync=false self-cancels. If the row is gone
+// (e.g. deleted out-of-band via raw SQL), the job unregisters itself instead of
+// firing forever; transient load errors are skipped and retried next tick.
+func (s *GitOpsSyncService) runScheduledSyncInternal(ctx context.Context, environmentID, syncID string) {
+	sync, err := s.getSyncRecordByIDInternal(ctx, environmentID, syncID)
+	if err != nil {
+		if _, ok := errors.AsType[*models.NotFoundError](err); ok {
+			slog.InfoContext(ctx, "gitops auto-sync job unregistering; sync no longer exists", "syncId", syncID)
+			s.unregisterSyncJobInternal(ctx, syncID)
+			return
+		}
+		slog.DebugContext(ctx, "gitops auto-sync skipped; failed to load sync", "syncId", syncID, "error", err)
+		return
+	}
+	if !sync.AutoSync {
+		return
+	}
+	if _, err := s.PerformSync(ctx, environmentID, syncID, systemUser); err != nil {
+		slog.ErrorContext(ctx, "gitops auto-sync run failed", "syncId", syncID, "error", err)
 	}
 }
 
@@ -836,35 +849,44 @@ func (s *GitOpsSyncService) UpdateSync(ctx context.Context, environmentID, id st
 }
 
 func (s *GitOpsSyncService) DeleteSync(ctx context.Context, environmentID, id string, actor models.User) error {
-	// Get sync info before deleting
-	sync, err := s.getSyncRecordByIDInternal(ctx, environmentID, id)
-	if err != nil {
-		return err
-	}
-
-	// Stop the recurring job before the row goes away. Any in-flight run re-reads
-	// the sync and self-cancels once the row is gone.
+	// Stop the recurring job first, unconditionally. Even a sync whose row can no
+	// longer be loaded (corrupt or environment-mismatched) must stop firing; any
+	// in-flight run re-reads the row and self-cancels once it is gone.
 	s.unregisterSyncJobInternal(ctx, id)
 
+	// Best-effort load for the audit-event metadata. A corrupt or env-mismatched row
+	// must still be deletable, so a load failure falls through to the direct delete
+	// below instead of aborting.
+	sync, loadErr := s.getSyncRecordByIDInternal(ctx, environmentID, id)
+
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Clear gitops_managed_by for the associated project, if any.
-		if sync.ProjectID != nil && *sync.ProjectID != "" {
-			if err := tx.Model(&models.Project{}).
-				Where("id = ? AND gitops_managed_by = ?", *sync.ProjectID, id).
-				Update("gitops_managed_by", nil).Error; err != nil {
-				return fmt.Errorf("failed to clear gitops_managed_by: %w", err)
-			}
+		// Clear gitops_managed_by for any project still pointing at this sync, keyed
+		// on the sync id so orphaned managed flags are cleared even when the sync row
+		// (and its ProjectID) could not be loaded.
+		if err := tx.Model(&models.Project{}).
+			Where("gitops_managed_by = ?", id).
+			Update("gitops_managed_by", nil).Error; err != nil {
+			return fmt.Errorf("failed to clear gitops_managed_by: %w", err)
 		}
 
+		// Delete by id only (no environment scoping). The handler already enforced the
+		// delete permission; env scoping is precisely what made env-mismatched corrupt
+		// rows undeletable. A zero-row delete is treated as success (idempotent).
 		if err := tx.Where("id = ?", id).Delete(&models.GitOpsSync{}).Error; err != nil {
 			return fmt.Errorf("failed to delete sync: %w", err)
 		}
 		return nil
 	}); err != nil {
-		if sync.AutoSync {
+		// Re-register the recurring job only when we actually loaded an auto-sync row.
+		if loadErr == nil && sync.AutoSync {
 			s.registerSyncJobInternal(ctx, sync.ID, sync.EnvironmentID, sync.SyncInterval)
 		}
 		return err
+	}
+
+	if loadErr != nil {
+		slog.WarnContext(ctx, "Deleted GitOps sync whose record could not be loaded", "syncId", id, "loadError", loadErr)
+		return nil
 	}
 
 	// Log event
@@ -1205,6 +1227,45 @@ func (s *GitOpsSyncService) GetSyncStatus(ctx context.Context, environmentID, id
 	return status, nil
 }
 
+// CleanupLeakedScratchDirsOnStartup removes orphaned GitOps scratch directories
+// (.gitops-sync-stage-*, .gitops-backup-*, and the legacy "<name>.gitops-backup-<digits>"
+// form) left in the projects directory by a crash or container restart that interrupted
+// a sync mid-flight. These are Arcane-internal working dirs; left in place the filesystem
+// discovery imports them as phantom projects. It is safe to run at startup because it
+// executes before any sync job is registered, so nothing is mid-stage.
+func (s *GitOpsSyncService) CleanupLeakedScratchDirsOnStartup(ctx context.Context) error {
+	projectsDir, err := s.projectService.getProjectsDirectoryInternal(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve projects directory for gitops scratch cleanup: %w", err)
+	}
+
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to list projects directory %s for gitops scratch cleanup: %w", projectsDir, err)
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() || !projects.IsGitOpsScratchDirName(entry.Name()) {
+			continue
+		}
+		scratchPath := filepath.Join(projectsDir, entry.Name())
+		if rmErr := os.RemoveAll(scratchPath); rmErr != nil {
+			slog.WarnContext(ctx, "Failed to remove leaked GitOps scratch directory on startup", "path", scratchPath, "error", rmErr)
+			continue
+		}
+		removed++
+		slog.InfoContext(ctx, "Removed leaked GitOps scratch directory on startup", "path", scratchPath)
+	}
+	if removed > 0 {
+		slog.InfoContext(ctx, "Cleaned up leaked GitOps scratch directories on startup", "count", removed)
+	}
+	return nil
+}
+
 func (s *GitOpsSyncService) ReconcileDirectorySyncProjectsOnStartup(ctx context.Context) error {
 	var syncs []models.GitOpsSync
 	if err := s.db.WithContext(ctx).
@@ -1390,8 +1451,17 @@ func (s *GitOpsSyncService) recordBrokenProjectBindingInternal(ctx context.Conte
 }
 
 func (s *GitOpsSyncService) createProjectForSyncInternal(ctx context.Context, sync *models.GitOpsSync, id string, composeContent string, envContent *string, result *gitops.SyncResult, actor models.User) (*models.Project, error) {
-	project, err := s.projectService.CreateProject(ctx, sync.ProjectName, composeContent, envContent, nil, actor)
+	// Use the non-suffixing create: a GitOps sync must never mint a "-N" duplicate.
+	// A name collision means a project directory already exists for this name, so the
+	// binding is broken — fail loudly and disable auto-sync instead of duplicating.
+	project, err := s.projectService.createProjectInternal(ctx, sync.ProjectName, composeContent, envContent, nil, actor, false)
 	if err != nil {
+		if errors.Is(err, projects.ErrProjectDirExists) {
+			bindingErr := &common.GitOpsSyncProjectBindingBrokenError{
+				Err: fmt.Errorf("sync %s cannot create project %q: a directory with that name already exists; refusing to create a duplicate", sync.ID, projects.SanitizeProjectName(sync.ProjectName)),
+			}
+			return nil, s.failSyncAndDisableAutoSyncInternal(ctx, id, result, sync, actor, "GitOps project binding broken", bindingErr)
+		}
 		return nil, s.failSync(ctx, id, result, sync, actor, "Failed to create project", err.Error())
 	}
 
@@ -1571,6 +1641,9 @@ func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sy
 	if stage.project == nil {
 		project, err := s.createDirectorySyncProjectInternal(ctx, sync, stage, actor)
 		if err != nil {
+			// A name-collision on create surfaces as a broken-binding error; disable
+			// auto-sync so it cannot keep retrying (no-op for other error kinds).
+			s.recordBrokenProjectBindingInternal(ctx, sync, actor, err)
 			return nil, nil, false, false, err
 		}
 		return project, stage.syncedFiles, true, true, nil
@@ -1887,6 +1960,10 @@ func (s *GitOpsSyncService) findUniqueProjectDirectoryCandidateInternal(ctx cont
 		if !projects.IsProjectDirectoryEntry(entry, candidatePath, false) {
 			continue
 		}
+		// Never adopt one of Arcane's own scratch dirs as a recovery candidate.
+		if projects.IsInternalScratchDirName(entry.Name()) {
+			continue
+		}
 		if prefix != "" && entry.Name() != prefix && !strings.HasPrefix(entry.Name(), prefix+"-") {
 			continue
 		}
@@ -2071,9 +2148,18 @@ func (s *GitOpsSyncService) createDirectorySyncProjectInternal(ctx context.Conte
 		return nil, fmt.Errorf("failed to get projects directory: %w", err)
 	}
 
+	// Non-suffixing create: a GitOps sync must never mint a "-N" duplicate. Any
+	// adoptable existing directory was already resolved by getDirectorySyncProjectInternal,
+	// so a collision here means the name is taken by an unrelated/unrecoverable dir;
+	// treat it as a broken binding rather than creating a duplicate.
 	basePath := filepath.Join(projectsDir, projects.SanitizeProjectName(sync.ProjectName))
-	projectPath, folderName, err := projects.CreateUniqueDir(projectsDir, basePath, sync.ProjectName, 0o755)
+	projectPath, folderName, err := projects.CreateExactDir(projectsDir, basePath, sync.ProjectName, 0o755)
 	if err != nil {
+		if errors.Is(err, projects.ErrProjectDirExists) {
+			return nil, &common.GitOpsSyncProjectBindingBrokenError{
+				Err: fmt.Errorf("sync %s cannot create project %q: a directory with that name already exists; refusing to create a duplicate", sync.ID, projects.SanitizeProjectName(sync.ProjectName)),
+			}
+		}
 		return nil, fmt.Errorf("failed to create project directory: %w", err)
 	}
 

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -115,6 +115,181 @@ func TestGitOpsSyncService_DeleteSync_DeletesStaleProjectReference(t *testing.T)
 	assert.Zero(t, count)
 }
 
+// TestGitOpsSyncService_DeleteSync_SucceedsWhenEnvironmentMismatched proves a
+// corrupt/env-mismatched sync is still deletable via the API: the request env ("0")
+// does not match the row's env ("5"), yet the delete must succeed and stop the job.
+func TestGitOpsSyncService_DeleteSync_SucceedsWhenEnvironmentMismatched(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+	scheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, scheduler)
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-env-mismatch"},
+		Name:          "corrupt-sync",
+		EnvironmentID: "5",
+		ProjectName:   "demo-project",
+		SyncInterval:  60,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	require.NoError(t, svc.DeleteSync(ctx, "0", sync.ID, models.User{}))
+
+	var count int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", sync.ID).Count(&count).Error)
+	assert.Zero(t, count)
+	assert.Contains(t, scheduler.removed, gitOpsSyncJobNameInternal(sync.ID))
+}
+
+// TestGitOpsSyncService_DeleteSync_ClearsOrphanedManagedFlag verifies the managed
+// flag is cleared keyed on the sync id even when the sync's ProjectID is nil.
+func TestGitOpsSyncService_DeleteSync_ClearsOrphanedManagedFlag(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+
+	syncID := "sync-orphan-flag"
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: syncID},
+		Name:          "demo-sync",
+		EnvironmentID: "0",
+		ProjectName:   "demo-project",
+		SyncInterval:  60,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	managed := &models.Project{
+		BaseModel:       models.BaseModel{ID: "proj-managed"},
+		Name:            "managed",
+		Path:            filepath.Join(t.TempDir(), "managed"),
+		GitOpsManagedBy: &syncID,
+	}
+	require.NoError(t, db.Create(managed).Error)
+
+	require.NoError(t, svc.DeleteSync(ctx, "0", syncID, models.User{}))
+
+	var got models.Project
+	require.NoError(t, db.Where("id = ?", managed.ID).First(&got).Error)
+	assert.Nil(t, got.GitOpsManagedBy)
+}
+
+// TestGitOpsSyncService_RunScheduledSync_UnregistersMissingSync verifies a scheduled
+// run whose row no longer exists (e.g. deleted out-of-band via raw SQL) unregisters
+// its own job instead of firing forever.
+func TestGitOpsSyncService_RunScheduledSync_UnregistersMissingSync(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupGitOpsSyncDirectoryTestService(t)
+	scheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, scheduler)
+
+	svc.runScheduledSyncInternal(ctx, "0", "ghost-sync")
+
+	assert.Contains(t, scheduler.removed, gitOpsSyncJobNameInternal("ghost-sync"))
+}
+
+// TestGitOpsSyncService_CleanupLeakedScratchDirsOnStartup_RemovesOrphans verifies the
+// startup sweep removes leaked gitops scratch dirs (hidden and legacy name-embedded
+// forms) while leaving real project directories untouched.
+func TestGitOpsSyncService_CleanupLeakedScratchDirsOnStartup_RemovesOrphans(t *testing.T) {
+	ctx := context.Background()
+	svc, _, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+
+	mkdir := func(name string) string {
+		p := filepath.Join(projectsDir, name)
+		require.NoError(t, os.MkdirAll(p, 0o755))
+		return p
+	}
+	scratch := []string{
+		mkdir(".gitops-sync-stage-1219810203"),
+		mkdir(".gitops-backup-456"),
+		mkdir("Makerra.gitops-backup-1780656786384743013"),
+	}
+	realProject := mkdir("app")
+	require.NoError(t, os.WriteFile(filepath.Join(realProject, "compose.yaml"), []byte("services: {}\n"), 0o644))
+
+	require.NoError(t, svc.CleanupLeakedScratchDirsOnStartup(ctx))
+
+	for _, p := range scratch {
+		_, err := os.Stat(p)
+		assert.ErrorIs(t, err, os.ErrNotExist, "scratch dir should be removed: %s", p)
+	}
+	_, err := os.Stat(realProject)
+	assert.NoError(t, err, "real project dir must be kept")
+}
+
+// TestGitOpsSyncService_SyncProjectDirectory_RefusesDuplicateOnNameCollision verifies a
+// directory sync refuses to create a "-N" sibling when its target name is already taken
+// by a non-adoptable directory; instead it errors as a broken binding and disables auto-sync.
+func TestGitOpsSyncService_SyncProjectDirectory_RefusesDuplicateOnNameCollision(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+
+	// Occupy the target name with a dir that is NOT an adoptable GitOps project
+	// (it has no matching compose file).
+	require.NoError(t, os.MkdirAll(filepath.Join(projectsDir, "Dozzle"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "Dozzle", "unrelated.txt"), []byte("x"), 0o644))
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-dup-refuse"},
+		Name:          "Dozzle",
+		EnvironmentID: "0",
+		ComposePath:   "Dozzle/docker-compose.yaml",
+		ProjectName:   "Dozzle",
+		SyncDirectory: true,
+		AutoSync:      true,
+		SyncInterval:  60,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	syncFiles := []projects.SyncFile{
+		{RelativePath: "docker-compose.yaml", Content: []byte("services:\n  app:\n    image: nginx:alpine\n")},
+	}
+
+	_, _, _, _, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, models.User{})
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	require.ErrorAs(t, err, &bindingErr)
+
+	_, statErr := os.Stat(filepath.Join(projectsDir, "Dozzle-1"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "must not mint a -N duplicate")
+
+	var got models.GitOpsSync
+	require.NoError(t, db.Where("id = ?", sync.ID).First(&got).Error)
+	assert.False(t, got.AutoSync, "auto-sync should be disabled on broken binding")
+}
+
+// TestGitOpsSyncService_GetOrCreateProject_RefusesDuplicateOnNameCollision is the
+// single-file-sync analogue of the directory refuse: a name collision on create is a
+// broken binding, not a "-N" duplicate.
+func TestGitOpsSyncService_GetOrCreateProject_RefusesDuplicateOnNameCollision(t *testing.T) {
+	ctx := context.Background()
+	svc, db, projectsDir := setupGitOpsSyncDirectoryTestService(t)
+	svc.SetScheduler(ctx, &gitOpsSyncTestSchedulerInternal{})
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectsDir, "Dozzle"), 0o755))
+
+	sync := &models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-single-dup"},
+		Name:          "Dozzle",
+		EnvironmentID: "0",
+		ComposePath:   "docker-compose.yaml",
+		ProjectName:   "Dozzle",
+		AutoSync:      true,
+		SyncInterval:  60,
+	}
+	require.NoError(t, db.Create(sync).Error)
+
+	result := &gitops.SyncResult{}
+	_, err := svc.getOrCreateProjectInternal(ctx, sync, sync.ID, "services:\n  app:\n    image: nginx:alpine\n", nil, result, models.User{})
+	var bindingErr *common.GitOpsSyncProjectBindingBrokenError
+	require.ErrorAs(t, err, &bindingErr)
+
+	_, statErr := os.Stat(filepath.Join(projectsDir, "Dozzle-1"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "must not mint a -N duplicate")
+
+	var got models.GitOpsSync
+	require.NoError(t, db.Where("id = ?", sync.ID).First(&got).Error)
+	assert.False(t, got.AutoSync, "auto-sync should be disabled on broken binding")
+}
+
 func TestGitOpsSyncService_SyncProjectDirectory_CreatesProjectPreservingRepoLayout(t *testing.T) {
 	ctx := context.Background()
 	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1724,8 +1724,8 @@ func (s *ProjectService) cleanupDBProjectsInternal(ctx context.Context, seen map
 		if skipProjectCleanupInternal(p, seen) {
 			continue
 		}
-		if isProjectUpdateTempProjectInternal(p) {
-			tempDeletions = append(tempDeletions, projectCleanupDecision{project: p, reason: "removed internal project update temp record"})
+		if isInternalScratchProjectInternal(p) {
+			tempDeletions = append(tempDeletions, projectCleanupDecision{project: p, reason: "removed internal Arcane scratch record (project-update/gitops temp dir)"})
 			continue
 		}
 		candidates++
@@ -1783,16 +1783,16 @@ func skipProjectCleanupInternal(p models.Project, seen map[string]struct{}) bool
 	return p.GitOpsManagedBy != nil && strings.TrimSpace(*p.GitOpsManagedBy) != ""
 }
 
-func isProjectUpdateTempProjectInternal(p models.Project) bool {
-	if isProjectUpdateTempNameInternal(p.Name) || isProjectUpdateTempNameInternal(filepath.Base(p.Path)) {
+// isInternalScratchProjectInternal reports whether a project row was imported from
+// one of Arcane's own scratch directories (project-update preview/backup, or GitOps
+// sync-stage/backup). Such rows are never real user projects — a crash or restart
+// mid-operation can leak the scratch dir, which the filesystem discovery then imports.
+// They are force-removed during cleanup regardless of whether the dir still exists.
+func isInternalScratchProjectInternal(p models.Project) bool {
+	if projects.IsInternalScratchDirName(p.Name) || projects.IsInternalScratchDirName(filepath.Base(p.Path)) {
 		return true
 	}
-	return p.DirName != nil && isProjectUpdateTempNameInternal(*p.DirName)
-}
-
-func isProjectUpdateTempNameInternal(name string) bool {
-	name = strings.TrimSpace(name)
-	return strings.HasPrefix(name, ".project-update-preview-") || strings.HasPrefix(name, ".project-update-backup-")
+	return p.DirName != nil && projects.IsInternalScratchDirName(*p.DirName)
 }
 
 // evaluateProjectCleanupInternal decides whether a project that was not seen in
@@ -2229,6 +2229,15 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 }
 
 func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent string, envContent *string, projectFiles []project.ProjectFileDraft, user models.User) (*models.Project, error) {
+	return s.createProjectInternal(ctx, name, composeContent, envContent, projectFiles, user, true)
+}
+
+// createProjectInternal creates a project's directory, files, and DB row. When
+// allowNameSuffix is true a directory-name collision is resolved by appending
+// "-N" (the interactive default). When false a collision returns
+// projects.ErrProjectDirExists (wrapped) so GitOps creates fail loudly instead of
+// minting runaway "-N" duplicate projects on a broken binding.
+func (s *ProjectService) createProjectInternal(ctx context.Context, name, composeContent string, envContent *string, projectFiles []project.ProjectFileDraft, user models.User, allowNameSuffix bool) (*models.Project, error) {
 	// A top-level `name:` in the compose file is authoritative over the
 	// submitted project name.
 	if yamlName := projects.ComposeContentProjectName(composeContent); yamlName != "" {
@@ -2242,7 +2251,12 @@ func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent
 	}
 
 	basePath := filepath.Join(projectsDirectory, sanitized)
-	projectPath, folderName, err := projects.CreateUniqueDir(projectsDirectory, basePath, name, common.DirPerm)
+	var projectPath, folderName string
+	if allowNameSuffix {
+		projectPath, folderName, err = projects.CreateUniqueDir(projectsDirectory, basePath, name, common.DirPerm)
+	} else {
+		projectPath, folderName, err = projects.CreateExactDir(projectsDirectory, basePath, name, common.DirPerm)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project directory: %w", err)
 	}

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -4572,6 +4572,40 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesDeletedNestedProject(t
 	assert.Empty(t, items)
 }
 
+// TestProjectService_SyncProjectsFromFileSystem_PrunesLeakedScratchRow verifies a
+// phantom project row imported from a leaked gitops scratch dir is pruned and not
+// re-imported, while a real project is kept. This closes the "deleted projects
+// resurrected on restart" loop for gitops scratch leftovers.
+func TestProjectService_SyncProjectsFromFileSystem_PrunesLeakedScratchRow(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	createComposeProjectDir(t, projectsRoot, "app")
+
+	scratchName := ".gitops-backup-9"
+	scratchPath := createComposeProjectDir(t, projectsRoot, scratchName)
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel: models.BaseModel{ID: "phantom-scratch"},
+		Name:      scratchName,
+		DirName:   &scratchName,
+		Path:      scratchPath,
+	}).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	items, err := svc.ListAllProjects(ctx)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "app", items[0].Name)
+}
+
 func TestProjectService_SyncProjectsFromFileSystem_PreservesProjectsWhenDirectoryEmptyOrUnmounted(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/pkg/projects/discovery.go
+++ b/backend/pkg/projects/discovery.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 )
@@ -86,7 +87,7 @@ func DiscoverProjectDirectories(root string, followSymlinks bool, maxDepth int) 
 }
 
 func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, maxDepth int, followSymlinks bool, ancestors map[string]struct{}, discovered *[]DiscoveredProjectDir) error {
-	if !isRoot && isProjectUpdateTempDirInternal(filepath.Base(path)) {
+	if !isRoot && IsInternalScratchDirName(filepath.Base(path)) {
 		return nil
 	}
 
@@ -142,7 +143,42 @@ func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, 
 	return nil
 }
 
-func isProjectUpdateTempDirInternal(name string) bool {
+// gitOpsScratchEmbeddedNameRe matches the legacy name-embedded gitops scratch
+// directory form, e.g. "Makerra.gitops-backup-1780656786384743013". That form always
+// used a time.Now().UnixNano() suffix (≥18 digits), so a long digit run is required:
+// it keeps a real user project ending in "<base>.gitops-backup-notes" (non-numeric) or
+// "<base>.gitops-backup-2024" (short, year-like) from being mistaken for Arcane scratch.
+// The hidden os.MkdirTemp forms (".gitops-backup-*", ".gitops-sync-stage-*") are matched
+// by prefix, not by this regex.
+var gitOpsScratchEmbeddedNameRe = regexp.MustCompile(`\.gitops-(?:backup|sync-stage)-\d{10,}$`)
+
+// IsGitOpsScratchDirName reports whether name is an Arcane GitOps scratch directory:
+// the hidden staging/backup temp dirs (".gitops-sync-stage-*", ".gitops-backup-*")
+// or the legacy name-embedded backup form ("<name>.gitops-backup-<digits>"). These are
+// Arcane-internal working directories and must never be imported as user projects.
+func IsGitOpsScratchDirName(name string) bool {
 	name = strings.TrimSpace(name)
-	return strings.HasPrefix(name, ".project-update-preview-") || strings.HasPrefix(name, ".project-update-backup-")
+	if name == "" {
+		return false
+	}
+	if strings.HasPrefix(name, ".gitops-sync-stage-") || strings.HasPrefix(name, ".gitops-backup-") {
+		return true
+	}
+	return gitOpsScratchEmbeddedNameRe.MatchString(name)
+}
+
+// IsInternalScratchDirName reports whether name is any Arcane-managed scratch
+// directory that must never be discovered or imported as a user project: the
+// project-update preview/backup temp dirs, or the GitOps sync-stage/backup dirs
+// (see IsGitOpsScratchDirName). This is the single source of truth for the
+// discovery walker and the DB cleanup pass.
+func IsInternalScratchDirName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	if strings.HasPrefix(name, ".project-update-preview-") || strings.HasPrefix(name, ".project-update-backup-") {
+		return true
+	}
+	return IsGitOpsScratchDirName(name)
 }

--- a/backend/pkg/projects/discovery_test.go
+++ b/backend/pkg/projects/discovery_test.go
@@ -149,3 +149,49 @@ func TestDiscoverProjectDirectories_UnlimitedDepthStillFindsNestedProject(t *tes
 	names := discoveredNamesInternal(discovered)
 	require.Equal(t, []string{"nested"}, names)
 }
+
+func TestIsInternalScratchDirName(t *testing.T) {
+	scratch := []string{
+		".project-update-preview-123",
+		".project-update-backup-123",
+		".gitops-sync-stage-1219810203",
+		".gitops-backup-456",
+		"Makerra.gitops-backup-1780656786384743013", // legacy name-embedded form
+	}
+	for _, name := range scratch {
+		require.True(t, IsInternalScratchDirName(name), "expected %q to be an internal scratch dir", name)
+	}
+
+	notScratch := []string{
+		"app",
+		"Dozzle",
+		"Dozzle-1",
+		"my.gitops-backup-notes", // non-numeric tail: a real user project, not scratch
+		"app.gitops-backup-2024", // short year-like tail: not a UnixNano scratch suffix
+		"gitops-backup-1",        // no leading dot before the marker
+	}
+	for _, name := range notScratch {
+		require.False(t, IsInternalScratchDirName(name), "expected %q NOT to be an internal scratch dir", name)
+	}
+
+	// IsGitOpsScratchDirName is the gitops-only subset used by the startup FS sweep.
+	require.True(t, IsGitOpsScratchDirName(".gitops-sync-stage-1"))
+	require.True(t, IsGitOpsScratchDirName("Makerra.gitops-backup-1780656786384743013"))
+	require.False(t, IsGitOpsScratchDirName(".project-update-backup-1"))
+}
+
+// TestDiscoverProjectDirectories_SkipsGitOpsScratchDirs verifies that leaked
+// gitops scratch directories (in both the hidden and legacy name-embedded forms)
+// are never discovered as projects, while a lookalike user project is kept.
+func TestDiscoverProjectDirectories_SkipsGitOpsScratchDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeComposeFileInternal(t, filepath.Join(root, "app"))
+	writeComposeFileInternal(t, filepath.Join(root, ".gitops-sync-stage-1219810203"))
+	writeComposeFileInternal(t, filepath.Join(root, ".gitops-backup-456"))
+	writeComposeFileInternal(t, filepath.Join(root, "Makerra.gitops-backup-1780656786384743013"))
+	writeComposeFileInternal(t, filepath.Join(root, "notes.gitops-backup-final")) // lookalike user project
+
+	names := discoveredNamesInternal(discoverProjectDirectoriesInternal(t, root))
+	require.ElementsMatch(t, []string{"app", "notes.gitops-backup-final"}, names)
+}

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -641,6 +641,57 @@ func CreateUniqueDir(projectsRoot, basePath, name string, perm os.FileMode) (pat
 	}
 }
 
+// ErrProjectDirExists is returned by CreateExactDir when the target directory
+// already exists. Callers that must not auto-rename (e.g. GitOps creates, which
+// must never mint "-N" duplicate projects on a broken binding) use this to fail
+// loudly instead of suffixing.
+var ErrProjectDirExists = errors.New("project directory already exists")
+
+// CreateExactDir creates basePath (the sanitized project directory) under
+// projectsRoot WITHOUT any "-N" collision suffixing. It returns ErrProjectDirExists
+// when the directory already exists, leaving the caller to decide how to proceed.
+// Validation mirrors CreateUniqueDir so the created directory is always within
+// projectsRoot.
+func CreateExactDir(projectsRoot, basePath, name string, perm os.FileMode) (path, folderName string, err error) {
+	sanitized := SanitizeProjectName(name)
+	if sanitized == "" || strings.Trim(sanitized, "_") == "" {
+		return "", "", errors.New("invalid project name: results in empty directory name")
+	}
+
+	projectsRootAbs, err := filepath.Abs(projectsRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve projects root directory: %w", err)
+	}
+	projectsRootAbs = filepath.Clean(projectsRootAbs)
+
+	candidateAbs, err := filepath.Abs(basePath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve candidate path: %w", err)
+	}
+	candidateAbs = filepath.Clean(candidateAbs)
+
+	if !IsSafeSubdirectory(projectsRootAbs, candidateAbs) {
+		return "", "", errors.New("project directory would be outside allowed projects root")
+	}
+
+	if mkErr := os.Mkdir(basePath, perm); mkErr != nil {
+		if os.IsExist(mkErr) {
+			return "", "", ErrProjectDirExists
+		}
+		return "", "", mkErr
+	}
+
+	// Paranoid post-create validation, matching CreateUniqueDir.
+	if !IsSafeSubdirectory(projectsRootAbs, candidateAbs) {
+		if strings.HasPrefix(candidateAbs, projectsRootAbs+string(filepath.Separator)) {
+			_ = os.Remove(candidateAbs)
+		}
+		return "", "", errors.New("created directory is outside allowed projects root")
+	}
+
+	return basePath, sanitized, nil
+}
+
 func SanitizeProjectName(name string) string {
 	name = strings.TrimSpace(name)
 	return strings.Map(func(r rune) rune {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2824

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs: (1) GitOps scratch directories left behind by a crash or container restart were being imported by filesystem discovery as "phantom" projects, and (2) broken GitOps syncs were minting `-N` duplicate project directories instead of failing loudly.

- Adds `CleanupLeakedScratchDirsOnStartup` to sweep orphaned GitOps staging/backup dirs at boot, called before the FS watcher or directory-sync reconcile can see them; also extends `isInternalScratchProjectInternal` (and the discovery walker) to recognise GitOps scratch dir names alongside the existing project-update temp names.
- Replaces `CreateUniqueDir` with a new `CreateExactDir` in GitOps create paths, returning `ErrProjectDirExists` on collision so broken bindings fail loudly and disable auto-sync rather than appending `-1`, `-2`, etc.
- Hardens `DeleteSync` to unregister the scheduler job unconditionally and delete by sync ID without environment scoping, fixing "env-mismatched" rows that were previously undeletable; `gitops_managed_by` is now cleared keyed on sync ID so orphaned flags are cleaned up even when the sync row could not be fully loaded.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are well-scoped bug fixes with comprehensive test coverage, and no existing behaviour is regressed.

All three fix paths (startup cleanup, exact-create guard, env-agnostic delete) are correctly implemented: error chains use `%w` so `errors.Is` unwraps properly, the scheduler re-registration on failed delete only fires when a row was actually loaded, `CleanupLeakedScratchDirsOnStartup` is called before anything can re-import the dirs it removes, and the regex threshold of ≥10 digits correctly excludes realistic user-project name patterns. Tests cover each new code path, including the env-mismatched delete, the orphaned managed-flag clear, the self-unregistering ghost sync, and both the directory-sync and single-file-sync duplicate-refusal flows.

No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stop phantom and duplicate projects..."](https://github.com/getarcaneapp/arcane/commit/4a84d8ccdc0d10c01d457b3ec2a94482319d4f03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40703108)</sub>

<!-- /greptile_comment -->