### PR TITLE
fix: nested compose files discovery permission issues

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -2355,7 +2355,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 		if projectsDir, dirErr := s.getProjectsDirectoryInternal(ctx); dirErr != nil {
 			slog.WarnContext(ctx, "Failed to resolve projects directory for quarantine", "error", dirErr)
 		} else if projects.IsSafeSubdirectory(projectsDir, proj.Path) && filepath.Clean(projectsDir) != filepath.Clean(proj.Path) {
-			trashPath := filepath.Join(filepath.Dir(proj.Path), fmt.Sprintf(".arcane-trash-%s-%d", filepath.Base(proj.Path), time.Now().Unix()))
+			trashPath := filepath.Join(filepath.Dir(proj.Path), fmt.Sprintf("%s%s-%d", projects.ArcaneTrashPrefix, filepath.Base(proj.Path), time.Now().Unix()))
 			if err := os.Rename(proj.Path, trashPath); err != nil {
 				slog.WarnContext(ctx, "Failed to quarantine project files", "path", proj.Path, "trashPath", trashPath, "error", err)
 			} else {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -4764,6 +4764,72 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesDBRecordsWhenDirecto
 	assert.Equal(t, before[0].Path, after[0].Path)
 }
 
+// TestProjectService_SyncProjectsFromFileSystem_DiscoversReadableProjectsDespiteUnreadableNestedSibling
+// covers the regression from GitHub issue #3080: a permission-denied error on a
+// non-root nested subdirectory used to abort discovery of ALL projects. Unlike
+// TestProjectService_SyncProjectsFromFileSystem_PreservesDBRecordsWhenDirectoryUnreadable
+// above (which makes the projects ROOT itself unreadable and expects sync to still
+// error), this test makes only a NESTED subdirectory unreadable and expects sync to
+// succeed, discover the readable sibling project, and leave alone any existing DB
+// record whose path happens to live under the now-skipped unreadable subtree.
+func TestProjectService_SyncProjectsFromFileSystem_DiscoversReadableProjectsDespiteUnreadableNestedSibling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission-denied behavior is not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root UID to trigger permission-denied on ReadDir")
+	}
+
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	project1Path := createComposeProjectDir(t, projectsRoot, "project1")
+
+	unreadableDir := filepath.Join(projectsRoot, "adguard-cheetah", "workingdir")
+	require.NoError(t, os.MkdirAll(unreadableDir, 0o755))
+	t.Cleanup(func() { _ = os.Chmod(unreadableDir, 0o700) })
+	require.NoError(t, os.Chmod(unreadableDir, 0))
+
+	// Seed a DB row (bypassing the filesystem) whose Path sits under the
+	// now-unreadable subtree, simulating a project Arcane previously knew about.
+	strandedDirName := "stranded-project"
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel: models.BaseModel{ID: "stranded-under-unreadable"},
+		Name:      "stranded-project",
+		DirName:   &strandedDirName,
+		Path:      filepath.Join(unreadableDir, "stranded-project"),
+		Status:    models.ProjectStatusStopped,
+	}).Error)
+
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx), "sync must succeed despite the unreadable nested directory")
+
+	after, err := svc.ListAllProjects(ctx)
+	require.NoError(t, err)
+
+	var foundReadableSibling bool
+	var foundStrandedRecord bool
+	for _, p := range after {
+		if p.Path == project1Path {
+			foundReadableSibling = true
+		}
+		if p.ID == "stranded-under-unreadable" {
+			foundStrandedRecord = true
+		}
+	}
+
+	assert.True(t, foundReadableSibling, "readable sibling project must still be discovered")
+	// evaluateProjectPathErrorInternal only prunes on os.IsNotExist; a permission-denied
+	// stat falls into the "keep the record" branch, so the stranded record must survive.
+	assert.True(t, foundStrandedRecord, "DB record under the unreadable subtree must not be pruned by a permission-denied stat")
+}
+
 func TestProjectService_SyncProjectsFromFileSystem_AllowsDuplicateLeafDirectoriesInDifferentParents(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/pkg/fswatch/watcher.go
+++ b/backend/pkg/fswatch/watcher.go
@@ -275,6 +275,10 @@ func (fw *Watcher) addExistingDirectories(root string) error {
 func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, logicalPath string, ancestors map[string]struct{}) error {
 	identity, err := projects.ResolveDirectoryIdentityInternal(path)
 	if err != nil {
+		if path != fw.watchedPath && errors.Is(err, os.ErrPermission) {
+			slog.Warn("Skipping unreadable directory for watcher", "path", path, "error", err)
+			return nil
+		}
 		return err
 	}
 	if _, seen := ancestors[identity]; seen {
@@ -302,6 +306,10 @@ func (fw *Watcher) addExistingDirectoriesRecursiveInternal(path string, logicalP
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
+		if path != fw.watchedPath && errors.Is(err, os.ErrPermission) {
+			slog.Warn("Skipping unreadable directory for watcher", "path", path, "error", err)
+			return nil
+		}
 		return err
 	}
 

--- a/backend/pkg/projects/discovery.go
+++ b/backend/pkg/projects/discovery.go
@@ -1,7 +1,9 @@
 package projects
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -87,15 +89,16 @@ func DiscoverProjectDirectories(root string, followSymlinks bool, maxDepth int) 
 }
 
 func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, maxDepth int, followSymlinks bool, ancestors map[string]struct{}, discovered *[]DiscoveredProjectDir) error {
-	if !isRoot {
-		base := filepath.Base(path)
-		if strings.HasPrefix(base, ".arcane-trash-") || IsInternalScratchDirName(base) {
-			return nil
-		}
+	if !isRoot && IsInternalScratchDirName(filepath.Base(path)) {
+		return nil
 	}
 
 	identity, err := ResolveDirectoryIdentityInternal(path)
 	if err != nil {
+		if !isRoot && errors.Is(err, os.ErrPermission) {
+			slog.Warn("Skipping unreadable project directory during discovery", "path", path, "error", err)
+			return nil
+		}
 		return err
 	}
 	if _, seen := ancestors[identity]; seen {
@@ -129,6 +132,10 @@ func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, 
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
+		if !isRoot && errors.Is(err, os.ErrPermission) {
+			slog.Warn("Skipping unreadable project directory during discovery", "path", path, "error", err)
+			return nil
+		}
 		return err
 	}
 
@@ -170,17 +177,26 @@ func IsGitOpsScratchDirName(name string) bool {
 	return gitOpsScratchEmbeddedNameRe.MatchString(name)
 }
 
+// ArcaneTrashPrefix is the prefix Arcane uses when quarantining (soft-deleting) a
+// project's files, e.g. ".arcane-trash-<name>-<unix>". Trash directories are
+// Arcane-managed and must never be discovered or imported as user projects.
+const ArcaneTrashPrefix = ".arcane-trash-"
+
 // IsInternalScratchDirName reports whether name is any Arcane-managed scratch
 // directory that must never be discovered or imported as a user project: the
-// project-update preview/backup temp dirs, or the GitOps sync-stage/backup dirs
-// (see IsGitOpsScratchDirName). This is the single source of truth for the
-// discovery walker and the DB cleanup pass.
+// project-update preview/backup temp dirs, the quarantine/trash dirs (see
+// ArcaneTrashPrefix), or the GitOps sync-stage/backup dirs (see
+// IsGitOpsScratchDirName). This is the single source of truth for the discovery
+// walker and the DB cleanup pass.
 func IsInternalScratchDirName(name string) bool {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return false
 	}
 	if strings.HasPrefix(name, ".project-update-preview-") || strings.HasPrefix(name, ".project-update-backup-") {
+		return true
+	}
+	if strings.HasPrefix(name, ArcaneTrashPrefix) {
 		return true
 	}
 	return IsGitOpsScratchDirName(name)

--- a/backend/pkg/projects/discovery_test.go
+++ b/backend/pkg/projects/discovery_test.go
@@ -3,8 +3,10 @@ package projects
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,6 +159,7 @@ func TestIsInternalScratchDirName(t *testing.T) {
 		".gitops-sync-stage-1219810203",
 		".gitops-backup-456",
 		"Makerra.gitops-backup-1780656786384743013", // legacy name-embedded form
+		".arcane-trash-app-1234567890",              // quarantined (soft-deleted) project files
 	}
 	for _, name := range scratch {
 		require.True(t, IsInternalScratchDirName(name), "expected %q to be an internal scratch dir", name)
@@ -205,4 +208,36 @@ func TestDiscoverProjectDirectories_SkipsArcaneTrashDirs(t *testing.T) {
 
 	names := discoveredNamesInternal(discoverProjectDirectoriesInternal(t, root))
 	require.ElementsMatch(t, []string{"app", ".hidden"}, names)
+}
+
+// TestDiscoverProjectDirectories_SkipsUnreadableNestedSibling is a regression
+// test for #3080: a permission-denied error on a non-root nested directory
+// must be logged and skipped, not abort the entire discovery walk. Without the
+// fix, one unreadable sibling directory would cause every other project under
+// the root to go undiscovered.
+func TestDiscoverProjectDirectories_SkipsUnreadableNestedSibling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission-denied behavior is not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("test requires a non-root UID to trigger permission-denied on ReadDir")
+	}
+
+	root := t.TempDir()
+
+	writeComposeFileInternal(t, filepath.Join(root, "project1"))
+
+	unreadableDir := filepath.Join(root, "adguard-cheetah", "workingdir")
+	require.NoError(t, os.MkdirAll(unreadableDir, 0o755))
+	t.Cleanup(func() { _ = os.Chmod(unreadableDir, 0o700) })
+	require.NoError(t, os.Chmod(unreadableDir, 0))
+
+	discovered, err := DiscoverProjectDirectories(root, false, 0)
+	require.NoError(t, err, "discovery must not fail when only a nested, non-root directory is unreadable")
+
+	// os.ReadDir returns entries sorted, so "adguard-cheetah" is walked before
+	// "project1" alphabetically. Finding project1 in the results proves the
+	// walk continued past the permission-denied failure rather than merely
+	// tolerating a failure at the very end of the scan.
+	assert.Equal(t, []string{"project1"}, discoveredNamesInternal(discovered))
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3080

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression from issue #3080 where a permission-denied error on any nested (non-root) subdirectory would abort the entire project discovery walk and the filesystem watcher setup, preventing other valid compose projects from being found.

- In `discovery.go`, `walkProjectDirectoriesInternal` now catches `os.ErrPermission` at both the `ResolveDirectoryIdentityInternal` and `os.ReadDir` call sites for non-root directories, logging a warning and continuing the walk instead of propagating the error.
- In `watcher.go`, `addExistingDirectoriesRecursiveInternal` applies the same treatment, using `path != fw.watchedPath` as the equivalent root-guard, so unreadable nested directories are skipped rather than aborting the watcher setup.
- Two regression tests are added: a unit test in `discovery_test.go` and an integration-level test in `project_service_test.go`, both verifying that the readable sibling project is still discovered and that a pre-existing DB record for a path under the unreadable subtree is preserved (since the pruning logic only removes records on `os.IsNotExist`, not on `os.ErrPermission`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The fix is narrow and targeted — it only changes behavior when a non-root directory is inaccessible due to permissions, converting a fatal error into a logged warning and a graceful skip. All other error types are still propagated normally.

The change is minimal and surgical — two identical guard blocks added in `discovery.go` and a mirrored pair in `watcher.go`. The root-directory path is always excluded from the new skip logic (guarded by `!isRoot` and `path != fw.watchedPath` respectively), so the previously correct behavior for truly unreadable project roots is unchanged. Both new code paths are covered by well-structured regression tests that verify the alphabetically-earlier unreadable directory is traversed first, confirming the walk genuinely continues rather than only tolerating a failure at the scan's tail end.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: nested compose files discovery perm..."](https://github.com/getarcaneapp/arcane/commit/498a0c6c7c57b7b1facafa6639fe76742fdad4ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41000066)</sub>

<!-- /greptile_comment -->