### PR TITLE
fix: discard env_file when loading projects to match compose CLI config-hash

### DIFF
--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -270,6 +270,9 @@ func loadComposeProjectInternal(
 		if projectName != "" {
 			opts.SetProjectName(projectName, true)
 		}
+		// Discard env_file after folding into environment, as the compose CLI
+		// does, so config-hashes match and both tools stop recreating services.
+		loader.WithDiscardEnvFiles(opts)
 		if lenient {
 			opts.SkipValidation = true
 			opts.SkipConsistencyCheck = true


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

Makes Arcane compute the Compose `com.docker.compose.config-hash` the same way the upstream `docker compose` CLI does, by discarding `env_file` entries (folding their values into `environment`) before the hash is computed. This way a project deployed by Arcane and one brought up by a host-side `docker compose up -d` produce identical config hashes, so the two tools stop endlessly recreating `env_file`-using services when managing the same project.

<!-- All PRs should reference an existing issue. Use "Fixes #1234" or "Addresses #1234". -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: #2933

## Changes Made

- In `backend/pkg/projects/load.go`, pass `loader.WithDiscardEnvFiles(opts)` in the `loader.LoadWithContext` options callback within `loadComposeProjectInternal` — the single chokepoint all load paths funnel through, so every load computes the config hash the same way as the compose CLI.

## Testing Done

- `go build ./pkg/projects/` passes.
- Reproduced the original divergence: with a service using `env_file`, an Arcane deploy followed by a host `docker compose up -d` no longer recreates the service (and vice versa) — config hashes now match.

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

Claude Code.

## Additional Context

<!-- Any additional information reviewers should know -->

The retained `env_file` value was also an absolute, working-dir-dependent path, so the previous hash wasn't stable across environments either — discarding it fixes that as well.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns Arcane’s Compose project loading with the Docker Compose CLI. The main changes are:

- Discards `env_file` entries after compose-go folds their values into `environment`.
- Applies the option in the shared `loadComposeProjectInternal` path.
- Keeps config-hash calculation stable for projects managed by both Arcane and `docker compose`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrow and applies at the shared compose loading chokepoint. No correctness or security issues were identified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but the local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: discard env\_file when loading proj..."](https://github.com/getarcaneapp/arcane/commit/75c7bdfdbebd51e3f5a5f7764ae6ffcdf2db6926) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41134471)</sub>

<!-- /greptile_comment -->