### PR TITLE
fix: set explicit gorm LRU cache TTL to avoid constantly rising heap memory

### DIFF
--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -39,6 +39,19 @@ const (
 	legacyVersionTable = "schema_migrations"
 )
 
+// Prepared-statement cache bounds. GORM's PrepareStmt cache is a global LRU keyed
+// by SQL text. When PrepareStmtMaxSize/PrepareStmtTTL are left at zero, GORM falls
+// back to math.MaxInt entries with a 24h TTL, i.e. effectively unbounded. Because
+// this codebase emits highly variable SQL (dynamic filter/sort/pagination and
+// GORM's IN (?,?,...) slice expansion, whose placeholder count changes the query
+// text), the cache — and the modernc.org/sqlite compiled statements it retains on
+// the Go heap — grows steadily under normal use. Bounding size and TTL keeps hot
+// queries prepared while evicting the long tail (evicted statements are closed).
+const (
+	preparedStmtMaxSize = 256
+	preparedStmtTTL     = 15 * time.Minute
+)
+
 var customGormLogger logger.Interface
 
 func SetGormLogger(l logger.Interface) {
@@ -122,6 +135,8 @@ func connectDatabaseInternal(ctx context.Context, databaseURL string) (*DB, erro
 				return time.Now().UTC()
 			},
 			PrepareStmt:                      true,
+			PrepareStmtMaxSize:               preparedStmtMaxSize,
+			PrepareStmtTTL:                   preparedStmtTTL,
 			IgnoreRelationshipsWhenMigrating: true,
 		})
 		if err == nil {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds GORM's prepared statement cache during database startup. The main changes are:

- Adds shared constants for prepared statement cache size and TTL.
- Sets `PrepareStmtMaxSize` to `256` when opening the GORM database.
- Sets `PrepareStmtTTL` to `15 * time.Minute` to evict older cached statements.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to supported GORM configuration fields and does not alter connection selection, migrations, or query behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the baseline prepared-stmt-cache-bounds test on base, executing go test ./internal/database -run TestTrexPreparedStmtCacheBounds -v -count=1 and capturing verbose output with exit code 0.
- Ran the updated prepared-stmt-cache-bounds test on head, executing go test ./internal/database -run TestTrexPreparedStmtCacheBounds -v -count=1 with max size 256 and TTL 15 minutes, and captured verbose output with exit code 0.

<a href="https://app.greptile.com/trex/runs/12944706/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: set explicit gorm LRU cache TTL to ..."](https://github.com/getarcaneapp/arcane/commit/758051d40ed55d6980bc85c20c3f09cbd589558f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41153354)</sub>

<!-- /greptile_comment -->