### PR TITLE
fix: only display memory usage thats non-reclaimable

### DIFF
--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -1163,7 +1163,14 @@ func (h *WebSocketHandler) getMemoryInfo() (uint64, uint64) {
 	if memInfo == nil {
 		return 0, 0
 	}
-	return memInfo.Used, memInfo.Total
+	// gopsutil counts ZFS ARC as used memory (the kernel excludes it from
+	// MemAvailable). Treat the reclaimable portion as cache, matching
+	// btop/htop, so the dashboard does not over-report usage on ZFS hosts.
+	used := memInfo.Used
+	if arc := docker.ZFSARCReclaimable(); arc > 0 {
+		used -= min(used, arc)
+	}
+	return used, memInfo.Total
 }
 
 // applyCgroupLimits applies cgroup limits when running in an LXC (or similar)

--- a/backend/pkg/dockerutil/cgroup_utils.go
+++ b/backend/pkg/dockerutil/cgroup_utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -99,6 +100,11 @@ func detectCgroupV2Limits(limits *CgroupLimits) (*CgroupLimits, error) {
 	}
 
 	if memUsage, err := readCgroupV2Int64("/sys/fs/cgroup/memory.current"); err == nil {
+		// memory.current includes reclaimable page cache; subtract inactive_file
+		// to match what `docker stats` reports as usage.
+		if inactiveFile, err := readMemoryStatValue("/sys/fs/cgroup/memory.stat", "inactive_file"); err == nil {
+			memUsage = max(memUsage-inactiveFile, 0)
+		}
 		limits.MemoryUsage = memUsage
 	}
 
@@ -138,6 +144,12 @@ func detectCgroupV1Limits(limits *CgroupLimits) (*CgroupLimits, error) {
 
 	memoryUsagePath := filepath.Join("/sys/fs/cgroup/memory", cgroupPath, "memory.usage_in_bytes")
 	if memUsage, err := readCgroupV1Int64(memoryUsagePath); err == nil {
+		// memory.usage_in_bytes includes reclaimable page cache; subtract
+		// total_inactive_file (from memory.stat) to match `docker stats`.
+		memoryStatPath := filepath.Join("/sys/fs/cgroup/memory", cgroupPath, "memory.stat")
+		if inactiveFile, err := readMemoryStatValue(memoryStatPath, "total_inactive_file"); err == nil {
+			memUsage = max(memUsage-inactiveFile, 0)
+		}
 		limits.MemoryUsage = memUsage
 	}
 
@@ -193,6 +205,30 @@ func readCgroupV1Int64(path string) (int64, error) {
 	}
 
 	return value, nil
+}
+
+// readMemoryStatValue reads a single "key value" line from a cgroup memory.stat
+// file and returns the value for the given key.
+func readMemoryStatValue(path, key string) (int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[0] != key {
+			continue
+		}
+		return strconv.ParseInt(fields[1], 10, 64)
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	return 0, fmt.Errorf("key %q not found in %s", key, path)
 }
 
 func readCgroupV2Int64(path string) (int64, error) {
@@ -392,4 +428,61 @@ func getContainerIDFromHostname() (string, error) {
 	}
 
 	return "", errors.New("hostname doesn't match expected container ID length")
+}
+
+// ZFSARCReclaimable returns the number of bytes of ZFS ARC (Adaptive
+// Replacement Cache) that the kernel counts as used memory but that can be
+// reclaimed under memory pressure.
+//
+// The kernel accounts ZFS ARC as used and excludes it from /proc/meminfo's
+// MemAvailable, so gopsutil's Used (= Total - MemAvailable) counts the whole
+// ARC as used. Tools like btop/htop instead treat ARC as reclaimable cache. We
+// subtract the reclaimable portion so the dashboard does not over-report usage
+// on ZFS hosts.
+//
+// The arcstats file only exists when the ZFS kernel module is loaded, so the
+// open fails cheaply on non-ZFS systems (including macOS dev machines) and this
+// returns 0 there.
+func ZFSARCReclaimable() uint64 {
+	f, err := os.Open("/proc/spl/kstat/zfs/arcstats")
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	return parseARCStats(f)
+}
+
+// parseARCStats parses the kstat-format arcstats content and returns the
+// reclaimable ARC size in bytes: max(size-c_min, 0). The ARC cannot shrink
+// below c_min, so only the portion above c_min is genuinely reclaimable — a
+// slightly more conservative choice than btop's full-size treatment, which is
+// the right call for a "used" metric.
+//
+// Each kstat row is "name type data"; the value is the third column.
+func parseARCStats(r io.Reader) uint64 {
+	var size, cMin uint64
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		switch fields[0] {
+		case "size":
+			if v, err := strconv.ParseUint(fields[2], 10, 64); err == nil {
+				size = v
+			}
+		case "c_min":
+			if v, err := strconv.ParseUint(fields[2], 10, 64); err == nil {
+				cMin = v
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Error("failed to parse ARC stats", "error", err)
+	}
+	if size <= cMin {
+		return 0
+	}
+	return size - cMin
 }

--- a/backend/pkg/dockerutil/cgroup_utils_test.go
+++ b/backend/pkg/dockerutil/cgroup_utils_test.go
@@ -1,0 +1,64 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMemoryStatValue(t *testing.T) {
+	// Trimmed cgroup memory.stat: flat "key value" lines.
+	const memoryStat = `anon 1048576
+file 2097152
+inactive_file 524288
+active_file 1572864
+total_inactive_file 786432
+`
+	path := filepath.Join(t.TempDir(), "memory.stat")
+	require.NoError(t, os.WriteFile(path, []byte(memoryStat), 0o600))
+
+	// Exact key match: inactive_file must not be shadowed by total_inactive_file.
+	value, err := readMemoryStatValue(path, "inactive_file")
+	require.NoError(t, err)
+	require.Equal(t, int64(524288), value)
+
+	value, err = readMemoryStatValue(path, "total_inactive_file")
+	require.NoError(t, err)
+	require.Equal(t, int64(786432), value)
+}
+
+func TestReadMemoryStatValue_MissingKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "memory.stat")
+	require.NoError(t, os.WriteFile(path, []byte("anon 1048576\n"), 0o600))
+
+	_, err := readMemoryStatValue(path, "inactive_file")
+	require.Error(t, err)
+}
+
+func TestParseARCStats(t *testing.T) {
+	// Abbreviated kstat dump: rows are "name type data".
+	const arcstats = `13 1 0x01 98 26656 5560875779 158279494432
+name                            type data
+hits                            4    1234567
+misses                          4    89012
+c_min                           4    1073741824
+c_max                           4    8589934592
+size                            4    7516192768
+`
+	// size (7 GiB) - c_min (1 GiB) = 6 GiB reclaimable.
+	require.Equal(t, uint64(6442450944), parseARCStats(strings.NewReader(arcstats)))
+}
+
+func TestParseARCStats_ClampsAndHandlesMissing(t *testing.T) {
+	// No arcstats content (non-ZFS host): nothing reclaimable.
+	require.Equal(t, uint64(0), parseARCStats(strings.NewReader("")))
+
+	// ARC already at its floor (size <= c_min): clamped to 0, never underflows.
+	const atFloor = `size  4  1073741824
+c_min 4  1073741824
+`
+	require.Equal(t, uint64(0), parseARCStats(strings.NewReader(atFloor)))
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/2875

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how memory usage is reported so reclaimable cache is not counted as used memory. The main changes are:

- Subtracts reclaimable ZFS ARC from host memory usage.
- Subtracts inactive file cache from cgroup v1 and v2 memory usage.
- Adds tests for parsing cgroup `memory.stat` and ZFS `arcstats` data.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The change is narrowly scoped to memory accounting, clamps subtraction to avoid underflow, and keeps existing fallbacks when stat files are unavailable.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only display memory usage thats non..."](https://github.com/getarcaneapp/arcane/commit/cad44ad800419abe6f16c151a890f03304aa261b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41210629)</sub>

<!-- /greptile_comment -->