### PR TITLE
fix: hide phantom projects from showing in the frontend when deleted

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -145,16 +145,6 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 		AgentMode:     cfg.AgentMode,
 	})
 	startup.InitializeDefaultSettings(appCtx, runtimeCfg, appServices.Settings)
-	if appServices.GitOpsSync != nil {
-		// Sweep leaked gitops scratch dirs before the filesystem watcher can import
-		// them as phantom projects and before the directory-sync reconcile runs.
-		if err := appServices.GitOpsSync.CleanupLeakedScratchDirsOnStartup(appCtx); err != nil {
-			slog.WarnContext(appCtx, "Failed to clean up leaked GitOps scratch directories on startup", "error", err)
-		}
-		if err := appServices.GitOpsSync.ReconcileDirectorySyncProjectsOnStartup(appCtx); err != nil {
-			slog.WarnContext(appCtx, "Failed to reconcile directory GitOps projects on startup", "error", err)
-		}
-	}
 
 	if err := appServices.Settings.NormalizeProjectsDirectory(appCtx, cfg.ProjectsDirectory); err != nil {
 		slog.WarnContext(appCtx, "Failed to normalize projects directory", "error", err)
@@ -167,6 +157,7 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 	if err := appServices.Environment.EnsureLocalEnvironment(appCtx, cfg.AppUrl); err != nil {
 		slog.WarnContext(appCtx, "Failed to ensure local environment", "error", err)
 	}
+	initializeGitOpsStartupStateInternal(appCtx, appServices.GitOpsSync)
 	if appServices.Project != nil {
 		if err := appServices.Project.RecoverProjectRenameJournals(appCtx); err != nil {
 			slog.WarnContext(appCtx, "Failed to recover interrupted project rename operations on startup", "error", err)
@@ -230,6 +221,23 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 		}
 	} else if cfg.AgentMode && !cfg.EdgeAgent {
 		slog.InfoContext(appCtx, "Direct mode active: agent operates as a passive HTTP server; no outbound connection to manager required")
+	}
+}
+
+func initializeGitOpsStartupStateInternal(appCtx context.Context, gitOpsSync *services.GitOpsSyncService) {
+	if gitOpsSync == nil {
+		return
+	}
+	if err := gitOpsSync.CleanupOrphanedSyncsOnStartup(appCtx); err != nil {
+		slog.WarnContext(appCtx, "Failed to clean up orphaned GitOps syncs on startup", "error", err)
+	}
+	// Sweep leaked gitops scratch dirs before the filesystem watcher can import
+	// them as phantom projects and before the directory-sync reconcile runs.
+	if err := gitOpsSync.CleanupLeakedScratchDirsOnStartup(appCtx); err != nil {
+		slog.WarnContext(appCtx, "Failed to clean up leaked GitOps scratch directories on startup", "error", err)
+	}
+	if err := gitOpsSync.ReconcileDirectorySyncProjectsOnStartup(appCtx); err != nil {
+		slog.WarnContext(appCtx, "Failed to reconcile directory GitOps projects on startup", "error", err)
 	}
 }
 

--- a/backend/internal/services/environment_service.go
+++ b/backend/internal/services/environment_service.go
@@ -1038,11 +1038,42 @@ func (s *EnvironmentService) DeleteEnvironment(ctx context.Context, id string, u
 	// Stop the per-environment health job before the row is removed.
 	s.removeHealthJobInternal(ctx, id)
 
-	if err := s.db.WithContext(ctx).Delete(&models.Environment{}, "id = ?", id).Error; err != nil {
+	var syncIDs []string
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.GitOpsSync{}).
+			Where("environment_id = ?", id).
+			Pluck("id", &syncIDs).Error; err != nil {
+			return fmt.Errorf("failed to list environment gitops syncs: %w", err)
+		}
+
+		if len(syncIDs) > 0 {
+			if err := tx.Model(&models.Project{}).
+				Where("gitops_managed_by IN ?", syncIDs).
+				Update("gitops_managed_by", nil).Error; err != nil {
+				return fmt.Errorf("failed to clear environment gitops project references: %w", err)
+			}
+			if err := tx.Where("environment_id = ?", id).Delete(&models.GitOpsSync{}).Error; err != nil {
+				return fmt.Errorf("failed to delete environment gitops syncs: %w", err)
+			}
+		}
+
+		if err := tx.Delete(&models.Environment{}, "id = ?", id).Error; err != nil {
+			return fmt.Errorf("failed to delete environment: %w", err)
+		}
+
+		return nil
+	}); err != nil {
 		if env.Enabled {
 			s.registerHealthJobInternal(ctx, env.ID)
 		}
-		return fmt.Errorf("failed to delete environment: %w", err)
+		return err
+	}
+
+	if s.scheduler != nil {
+		schedulerCtx := s.schedulerCtxInternal(ctx)
+		for _, syncID := range syncIDs {
+			s.scheduler.RemoveJob(schedulerCtx, gitOpsSyncJobNameInternal(syncID))
+		}
 	}
 
 	s.invalidateEnvironmentTokenInternal(id)

--- a/backend/internal/services/environment_service_test.go
+++ b/backend/internal/services/environment_service_test.go
@@ -41,6 +41,8 @@ func setupEnvironmentServiceTestDB(t *testing.T) *database.DB {
 		&models.SettingVariable{},
 		&models.User{},
 		&models.ApiKey{},
+		&models.Project{},
+		&models.GitOpsSync{},
 	))
 
 	sqlDB, err := db.DB()
@@ -118,6 +120,46 @@ func createTestEnvironmentWithState(t *testing.T, db *database.DB, id, apiURL, s
 	}
 
 	require.NoError(t, db.WithContext(context.Background()).Create(env).Error)
+}
+
+func TestEnvironmentService_DeleteEnvironment_CascadesGitOpsSyncs(t *testing.T) {
+	ctx := context.Background()
+	db := setupEnvironmentServiceTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.GitOpsSync{}))
+
+	createTestEnvironment(t, db, "env-delete-gitops", "http://env.example", nil)
+	syncID := "sync-delete-env"
+	require.NoError(t, db.Create(&models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: syncID},
+		Name:          "delete-env-sync",
+		EnvironmentID: "env-delete-gitops",
+		RepositoryID:  "repo-1",
+		ComposePath:   "compose.yml",
+		ProjectName:   "demo",
+		SyncInterval:  15,
+	}).Error)
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel:       models.BaseModel{ID: "project-managed-by-deleted-env"},
+		Name:            "demo",
+		Path:            "/tmp/demo",
+		Status:          models.ProjectStatusStopped,
+		GitOpsManagedBy: &syncID,
+	}).Error)
+
+	scheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
+	svc.SetScheduler(ctx, scheduler)
+
+	require.NoError(t, svc.DeleteEnvironment(ctx, "env-delete-gitops", nil, nil))
+
+	var syncCount int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", syncID).Count(&syncCount).Error)
+	require.Zero(t, syncCount)
+
+	var project models.Project
+	require.NoError(t, db.First(&project, "id = ?", "project-managed-by-deleted-env").Error)
+	require.Nil(t, project.GitOpsManagedBy)
+	require.Contains(t, scheduler.removed, gitOpsSyncJobNameInternal(syncID))
 }
 
 func createTestRegistry(t *testing.T, db *database.DB, id string) {

--- a/backend/internal/services/gitops_sync_service.go
+++ b/backend/internal/services/gitops_sync_service.go
@@ -458,7 +458,7 @@ func (s *GitOpsSyncService) RegisterAutoSyncJobsOnStartup(ctx context.Context) {
 	}
 	var syncs []models.GitOpsSync
 	if err := s.db.WithContext(ctx).
-		Where("auto_sync = ?", true).
+		Where("auto_sync = ? AND environment_id IN (SELECT id FROM environments)", true).
 		Find(&syncs).Error; err != nil {
 		slog.ErrorContext(ctx, "Failed to load auto-sync jobs on startup", "error", err)
 		return
@@ -1263,6 +1263,35 @@ func (s *GitOpsSyncService) CleanupLeakedScratchDirsOnStartup(ctx context.Contex
 	if removed > 0 {
 		slog.InfoContext(ctx, "Cleaned up leaked GitOps scratch directories on startup", "count", removed)
 	}
+	return nil
+}
+
+func (s *GitOpsSyncService) CleanupOrphanedSyncsOnStartup(ctx context.Context) error {
+	var syncIDs []string
+	if err := s.db.WithContext(ctx).Model(&models.GitOpsSync{}).
+		Where("environment_id NOT IN (SELECT id FROM environments)").
+		Pluck("id", &syncIDs).Error; err != nil {
+		return fmt.Errorf("failed to list orphaned gitops syncs: %w", err)
+	}
+	if len(syncIDs) == 0 {
+		return nil
+	}
+
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.Project{}).
+			Where("gitops_managed_by IN ?", syncIDs).
+			Update("gitops_managed_by", nil).Error; err != nil {
+			return fmt.Errorf("failed to clear orphaned gitops project references: %w", err)
+		}
+		if err := tx.Where("id IN ?", syncIDs).Delete(&models.GitOpsSync{}).Error; err != nil {
+			return fmt.Errorf("failed to delete orphaned gitops syncs: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	slog.InfoContext(ctx, "Cleaned up orphaned GitOps syncs on startup", "syncIds", syncIDs)
 	return nil
 }
 

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
@@ -41,10 +42,12 @@ func setupGitOpsSyncDirectoryTestService(t *testing.T) (*GitOpsSyncService, *dat
 }
 
 type gitOpsSyncTestSchedulerInternal struct {
+	added   []string
 	removed []string
 }
 
-func (s *gitOpsSyncTestSchedulerInternal) AddJob(_ context.Context, _ schedulertypes.Job) error {
+func (s *gitOpsSyncTestSchedulerInternal) AddJob(_ context.Context, job schedulertypes.Job) error {
+	s.added = append(s.added, job.Name())
 	return nil
 }
 
@@ -89,6 +92,98 @@ func TestGitOpsSyncService_GetSyncByID_ReturnsNotFoundError(t *testing.T) {
 
 	var notFound *models.NotFoundError
 	require.ErrorAs(t, err, &notFound)
+}
+
+func TestGitOpsSyncService_CleanupOrphanedSyncsOnStartup_DeletesOnlyOrphans(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+	require.NoError(t, db.AutoMigrate(&models.Environment{}))
+
+	require.NoError(t, db.Create(&models.Environment{
+		BaseModel: models.BaseModel{ID: "env-live"},
+		Name:      "Live",
+	}).Error)
+	orphanSyncID := "sync-orphan"
+	liveSyncID := "sync-live"
+	require.NoError(t, db.Create(&models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: orphanSyncID},
+		Name:          "orphan",
+		EnvironmentID: "env-missing",
+		RepositoryID:  "repo-1",
+		ComposePath:   "compose.yml",
+		ProjectName:   "orphan",
+		SyncInterval:  15,
+	}).Error)
+	require.NoError(t, db.Create(&models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: liveSyncID},
+		Name:          "live",
+		EnvironmentID: "env-live",
+		RepositoryID:  "repo-1",
+		ComposePath:   "compose.yml",
+		ProjectName:   "live",
+		SyncInterval:  15,
+	}).Error)
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel:       models.BaseModel{ID: "project-orphan"},
+		Name:            "orphan",
+		Path:            "/tmp/orphan",
+		Status:          models.ProjectStatusStopped,
+		GitOpsManagedBy: &orphanSyncID,
+	}).Error)
+
+	require.NoError(t, svc.CleanupOrphanedSyncsOnStartup(ctx))
+
+	var orphanCount int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", orphanSyncID).Count(&orphanCount).Error)
+	require.Zero(t, orphanCount)
+
+	var liveCount int64
+	require.NoError(t, db.Model(&models.GitOpsSync{}).Where("id = ?", liveSyncID).Count(&liveCount).Error)
+	require.EqualValues(t, 1, liveCount)
+
+	var project models.Project
+	require.NoError(t, db.First(&project, "id = ?", "project-orphan").Error)
+	require.Nil(t, project.GitOpsManagedBy)
+}
+
+func TestGitOpsSyncService_RegisterAutoSyncJobsOnStartup_SkipsOrphans(t *testing.T) {
+	ctx := context.Background()
+	svc, db, _ := setupGitOpsSyncDirectoryTestService(t)
+	require.NoError(t, db.AutoMigrate(&models.Environment{}))
+
+	require.NoError(t, db.Create(&models.Environment{
+		BaseModel: models.BaseModel{ID: "env-live"},
+		Name:      "Live",
+	}).Error)
+	require.NoError(t, db.Create(&models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-orphan"},
+		Name:          "orphan",
+		EnvironmentID: "env-missing",
+		RepositoryID:  "repo-1",
+		ComposePath:   "compose.yml",
+		ProjectName:   "orphan",
+		AutoSync:      true,
+		SyncInterval:  15,
+	}).Error)
+	now := time.Now()
+	require.NoError(t, db.Create(&models.GitOpsSync{
+		BaseModel:     models.BaseModel{ID: "sync-live"},
+		Name:          "live",
+		EnvironmentID: "env-live",
+		RepositoryID:  "repo-1",
+		ComposePath:   "compose.yml",
+		ProjectName:   "live",
+		AutoSync:      true,
+		SyncInterval:  15,
+		LastSyncAt:    &now,
+	}).Error)
+
+	scheduler := &gitOpsSyncTestSchedulerInternal{}
+	svc.SetScheduler(ctx, scheduler)
+	svc.RegisterAutoSyncJobsOnStartup(ctx)
+
+	require.Equal(t, []string{gitOpsSyncJobNameInternal("sync-live")}, scheduler.added)
+	require.Empty(t, scheduler.removed)
 }
 
 func TestGitOpsSyncService_DeleteSync_DeletesStaleProjectReference(t *testing.T) {

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -2350,6 +2350,19 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 	if err := s.db.WithContext(ctx).Delete(proj).Error; err != nil {
 		return fmt.Errorf("failed to delete project from database: %w", err)
 	}
+
+	if !removeFiles {
+		if projectsDir, dirErr := s.getProjectsDirectoryInternal(ctx); dirErr != nil {
+			slog.WarnContext(ctx, "Failed to resolve projects directory for quarantine", "error", dirErr)
+		} else if projects.IsSafeSubdirectory(projectsDir, proj.Path) && filepath.Clean(projectsDir) != filepath.Clean(proj.Path) {
+			trashPath := filepath.Join(filepath.Dir(proj.Path), fmt.Sprintf(".arcane-trash-%s-%d", filepath.Base(proj.Path), time.Now().Unix()))
+			if err := os.Rename(proj.Path, trashPath); err != nil {
+				slog.WarnContext(ctx, "Failed to quarantine project files", "path", proj.Path, "trashPath", trashPath, "error", err)
+			} else {
+				slog.InfoContext(ctx, "Project files quarantined successfully", "path", proj.Path, "trashPath", trashPath)
+			}
+		}
+	}
 	s.invalidateComposeCacheInternal(projectID)
 	writeProjectProgressInternal(ctx, "Project destroyed", 100, "complete")
 

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -141,8 +141,15 @@ func TestProjectService_DestroyProject_PreservesFilesWhenRequested(t *testing.T)
 
 	require.NoError(t, svc.DestroyProject(ctx, project.ID, false, false, models.User{}))
 
-	assert.DirExists(t, projectPath)
-	assert.FileExists(t, projectDataPath)
+	assert.NoDirExists(t, projectPath)
+	assert.NoFileExists(t, projectDataPath)
+
+	entries, err := os.ReadDir(projectsDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	trashName := entries[0].Name()
+	require.True(t, strings.HasPrefix(trashName, ".arcane-trash-demo-preserve-"), "trash dir name: %s", trashName)
+	assert.FileExists(t, filepath.Join(projectsDir, trashName, "project-data.txt"))
 }
 
 func newProjectImagePullServerWithObserverInternal(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse, onPull func(fullRef string, authHeader string)) *httptest.Server {

--- a/backend/pkg/projects/discovery.go
+++ b/backend/pkg/projects/discovery.go
@@ -87,8 +87,11 @@ func DiscoverProjectDirectories(root string, followSymlinks bool, maxDepth int) 
 }
 
 func walkProjectDirectoriesInternal(path string, isRoot bool, currentDepth int, maxDepth int, followSymlinks bool, ancestors map[string]struct{}, discovered *[]DiscoveredProjectDir) error {
-	if !isRoot && IsInternalScratchDirName(filepath.Base(path)) {
-		return nil
+	if !isRoot {
+		base := filepath.Base(path)
+		if strings.HasPrefix(base, ".arcane-trash-") || IsInternalScratchDirName(base) {
+			return nil
+		}
 	}
 
 	identity, err := ResolveDirectoryIdentityInternal(path)

--- a/backend/pkg/projects/discovery_test.go
+++ b/backend/pkg/projects/discovery_test.go
@@ -195,3 +195,14 @@ func TestDiscoverProjectDirectories_SkipsGitOpsScratchDirs(t *testing.T) {
 	names := discoveredNamesInternal(discoverProjectDirectoriesInternal(t, root))
 	require.ElementsMatch(t, []string{"app", "notes.gitops-backup-final"}, names)
 }
+
+func TestDiscoverProjectDirectories_SkipsArcaneTrashDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeComposeFileInternal(t, filepath.Join(root, "app"))
+	writeComposeFileInternal(t, filepath.Join(root, ".arcane-trash-app-1234567890"))
+	writeComposeFileInternal(t, filepath.Join(root, ".hidden"))
+
+	names := discoveredNamesInternal(discoverProjectDirectoriesInternal(t, root))
+	require.ElementsMatch(t, []string{"app", ".hidden"}, names)
+}

--- a/types/project/project.go
+++ b/types/project/project.go
@@ -611,6 +611,8 @@ type Details struct {
 // Destroy is used to destroy a project.
 type Destroy struct {
 	// RemoveFiles indicates if project files should be removed. Defaults to true when omitted.
+	// When false and the project is stored under the projects directory, files are renamed
+	// to a hidden .arcane-trash-* directory so filesystem discovery does not re-import them.
 	//
 	// Required: false
 	RemoveFiles *bool `json:"removeFiles,omitempty"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes phantom project re-imports that occurred when a project was deleted without removing its files — the original directory remained on disk and was picked back up by the filesystem watcher. It does this by renaming deleted-but-preserved project directories to a `.arcane-trash-*` sibling and teaching the discovery walker to skip that prefix.

- **Quarantine on soft delete** (`project_service.go`): after the DB row is successfully deleted, the project directory is atomically renamed to `.arcane-trash-<name>-<unix>` so discovery never re-imports it. The rename is correctly placed *after* the DB delete, avoiding the stale-path inconsistency that would have occurred if the rename had been done first.
- **Discovery filter** (`discovery.go`): the walker now skips `.arcane-trash-*` directories with a targeted prefix check, leaving legitimate dot-named user directories (e.g. `.hidden`) visible — confirmed by the new test.
- **Orphaned GitOps sync cleanup**: a new `CleanupOrphanedSyncsOnStartup` sweeps sync records whose environment no longer exists; `DeleteEnvironment` now clears associated syncs and project references inside a single transaction; `RegisterAutoSyncJobsOnStartup` filters out orphan-backed syncs via a subquery.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The quarantine rename is correctly ordered after the DB delete, the discovery filter is surgical, and the GitOps sync cleanup is wrapped in a transaction.

All three functional changes (soft-delete quarantine, discovery filter, and orphaned-sync cleanup) are logically sound, well-tested, and consistent with the existing codebase patterns. No new unsafe orderings or data-loss paths are introduced.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/project_service.go`, line 2348-2365 ([link](https://github.com/getarcaneapp/arcane/blob/a0d80b9fa9a5727478fc5ae74d367de9111ce370/backend/internal/services/project_service.go#L2348-L2365)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **File quarantine races ahead of DB delete**

   The rename to `.arcane-trash-*` at line 2354 happens before the database row is deleted at line 2363. If `s.db.Delete(proj)` fails, the project record survives in the DB with `Path` pointing to the original directory (which no longer exists there), while the actual files sit in the trash path. The project will still appear in the frontend but every operation that touches `proj.Path` will break. Previously, with `removeFiles=false`, nothing was moved so a DB failure left both sides consistent. This PR introduces the inconsistency.

   Move the quarantine block to after `s.db.Delete` succeeds. If the quarantine fails after a successful DB delete it can be logged as a warning instead of returned as an error — the project is already gone from the DB and a failed rename is less harmful than leaving the DB record with a stale path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/project_service.go
   Line: 2348-2365

   Comment:
   **File quarantine races ahead of DB delete**

   The rename to `.arcane-trash-*` at line 2354 happens before the database row is deleted at line 2363. If `s.db.Delete(proj)` fails, the project record survives in the DB with `Path` pointing to the original directory (which no longer exists there), while the actual files sit in the trash path. The project will still appear in the frontend but every operation that touches `proj.Path` will break. Previously, with `removeFiles=false`, nothing was moved so a DB failure left both sides consistent. This PR introduces the inconsistency.

   Move the quarantine block to after `s.db.Delete` succeeds. If the quarantine fails after a successful DB delete it can be logged as a warning instead of returned as an error — the project is already gone from the DB and a failed rename is less harmful than leaving the DB record with a stale path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fsync-pahn2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsync-pahn2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%202348-2365%0A%0AComment%3A%0A**File%20quarantine%20races%20ahead%20of%20DB%20delete**%0A%0AThe%20rename%20to%20%60.arcane-trash-*%60%20at%20line%202354%20happens%20before%20the%20database%20row%20is%20deleted%20at%20line%202363.%20If%20%60s.db.Delete%28proj%29%60%20fails%2C%20the%20project%20record%20survives%20in%20the%20DB%20with%20%60Path%60%20pointing%20to%20the%20original%20directory%20%28which%20no%20longer%20exists%20there%29%2C%20while%20the%20actual%20files%20sit%20in%20the%20trash%20path.%20The%20project%20will%20still%20appear%20in%20the%20frontend%20but%20every%20operation%20that%20touches%20%60proj.Path%60%20will%20break.%20Previously%2C%20with%20%60removeFiles%3Dfalse%60%2C%20nothing%20was%20moved%20so%20a%20DB%20failure%20left%20both%20sides%20consistent.%20This%20PR%20introduces%20the%20inconsistency.%0A%0AMove%20the%20quarantine%20block%20to%20after%20%60s.db.Delete%60%20succeeds.%20If%20the%20quarantine%20fails%20after%20a%20successful%20DB%20delete%20it%20can%20be%20logged%20as%20a%20warning%20instead%20of%20returned%20as%20an%20error%20%E2%80%94%20the%20project%20is%20already%20gone%20from%20the%20DB%20and%20a%20failed%20rename%20is%20less%20harmful%20than%20leaving%20the%20DB%20record%20with%20a%20stale%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fproject_service.go%0ALine%3A%202348-2365%0A%0AComment%3A%0A**File%20quarantine%20races%20ahead%20of%20DB%20delete**%0A%0AThe%20rename%20to%20%60.arcane-trash-*%60%20at%20line%202354%20happens%20before%20the%20database%20row%20is%20deleted%20at%20line%202363.%20If%20%60s.db.Delete%28proj%29%60%20fails%2C%20the%20project%20record%20survives%20in%20the%20DB%20with%20%60Path%60%20pointing%20to%20the%20original%20directory%20%28which%20no%20longer%20exists%20there%29%2C%20while%20the%20actual%20files%20sit%20in%20the%20trash%20path.%20The%20project%20will%20still%20appear%20in%20the%20frontend%20but%20every%20operation%20that%20touches%20%60proj.Path%60%20will%20break.%20Previously%2C%20with%20%60removeFiles%3Dfalse%60%2C%20nothing%20was%20moved%20so%20a%20DB%20failure%20left%20both%20sides%20consistent.%20This%20PR%20introduces%20the%20inconsistency.%0A%0AMove%20the%20quarantine%20block%20to%20after%20%60s.db.Delete%60%20succeeds.%20If%20the%20quarantine%20fails%20after%20a%20successful%20DB%20delete%20it%20can%20be%20logged%20as%20a%20warning%20instead%20of%20returned%20as%20an%20error%20%E2%80%94%20the%20project%20is%20already%20gone%20from%20the%20DB%20and%20a%20failed%20rename%20is%20less%20harmful%20than%20leaving%20the%20DB%20record%20with%20a%20stale%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=getarcaneapp%2Farcane&pr=3136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: hide phantom projects from showing ..."](https://github.com/getarcaneapp/arcane/commit/69fbdf802c9478e11250237c8372a487e364f7eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41462910)</sub>

<!-- /greptile_comment -->