### PR TITLE
fix: keep modals and menus opaque in dark mode when Glass & Blur is off

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -599,23 +599,35 @@ html.no-blur *::after {
 	backdrop-filter: none !important;
 }
 
-html.no-blur :is([class^='bg-card/'], [class*=' bg-card/']) {
-	background-color: var(--card) !important;
-}
-html.no-blur :is([class^='bg-background/'], [class*=' bg-background/']) {
-	background-color: var(--background) !important;
-}
-html.no-blur :is([class^='bg-popover/'], [class*=' bg-popover/']) {
-	background-color: var(--popover) !important;
-}
-html.no-blur :is([class^='bg-input/'], [class*=' bg-input/']) {
-	background-color: var(--input) !important;
-}
-
 /* Modal/sheet/drawer scrims relied on blur for separation — keep them dimmed
-   (not solid) so dialogs stay legible in light and dark mode. */
+   (not solid) so dialogs stay legible in light and dark mode. Declared before
+   the opaque-surface rules below so that content surfaces which also carry a
+   scrim utility (e.g. the drawer's `bg-white/10 dark:bg-surface/10`) end up
+   opaque, while the true overlays — which carry no surface token — stay dimmed. */
 html.no-blur :is(.bg-white\/10, .bg-black\/40, .bg-black\/60) {
 	background-color: color-mix(in oklab, black 55%, transparent) !important;
+}
+
+/* Glass surfaces (cards, popovers, dialogs, sheets, drawers, menus) drop to a
+   translucent bg + backdrop-blur. With blur stripped they must fall back to an
+   opaque themed color or they show through to the page. The substring match
+   (no leading-space anchor) is deliberate: it catches the `dark:`-prefixed
+   variants (e.g. `dark:bg-surface/10`, `dark:bg-popover/20`) that are the
+   active background in dark mode — the reason the previous rules missed them. */
+html.no-blur [class*='bg-card/'] {
+	background-color: var(--card) !important;
+}
+html.no-blur [class*='bg-background/'] {
+	background-color: var(--background) !important;
+}
+html.no-blur [class*='bg-popover/'] {
+	background-color: var(--popover) !important;
+}
+html.no-blur [class*='bg-input/'] {
+	background-color: var(--input) !important;
+}
+html.no-blur [class*='bg-surface/'] {
+	background-color: var(--surface) !important;
 }
 
 /* Neutralize every animation and transition — catches CSS keyframes as well as


### PR DESCRIPTION
## Checklist

- [x] This PR is not opened from my fork's main branch
- [x] No new user-facing strings (nothing to translate via Paraglide)

## What This PR Fixes

Fixes #3133.

In dark mode, with **Settings → Appearance → Glass & Blur Effects** turned **OFF**, modals and menus became see-through — you could read the page content straight through dialogs, sheets, the Activity Center, the About/Upload-Image modals, dropdowns, selects, popovers and tooltips. Light mode was unaffected. This was a regression from the `no-blur` mode added in #3091.

### Root cause

`no-blur` mode strips `backdrop-filter` and is supposed to make the (now unblurred) glass surfaces opaque again. But the overrides in `app.css` only matched **unprefixed** light-mode classes:

```css
html.no-blur :is([class^='bg-card/'], [class*=' bg-card/']) { ... }
```

Those anchors (`^= starts-with`, `*=' ' space-then-token`) never match a `dark:`-prefixed class such as `dark:bg-surface/10`, because in the class attribute it reads `dark:bg-surface/…` (preceded by :, not a space). In dark mode the `dark:`-prefixed class is the active background, so nothing was made opaque. The surface token was also missing from the list entirely.

- Modal surfaces use `dark:bg-surface/10` (dialog, sheet, drawer, card) — `bg-surface/` wasn't overridden at all.
- Menu surfaces use `dark:bg-popover/20` (popover, dropdown-menu, select, tooltip) — matched by the light `bg-popover/` anchor but not the dark: one.

## Changes Made

CSS-only change in `frontend/src/app.css` (the `html.no-blur` block):

- Broaden the opacity overrides to a plain substring match (`[class*='bg-<token>/']`) so they catch the `dark:-prefixed` variants that are the active background in dark mode.
- Add the missing `bg-surface/` → `var(--surface)` rule.
- Order the opaque-surface rules after the scrim rule, so drawer-content (which carries both a scrim class `bg-white/10` and a surface class `dark:bg-surface/10`) ends up opaque, while the true modal overlays — which carry no surface token — stay a dimmed scrim.

No component or backend changes; existing behaviour with Glass & Blur ON is untouched.

## Testing Done

- `pnpm check`: 0 errors & 0 warnings
- `prettier --check`: clean
- Manual smoke testing (Docker dev env, dark mode + OLED, Glass & Blur OFF): dialogs, sheets, Activity Center, About/Upload-Image modals, dropdowns/selects/popovers/tooltips and dashboard cards all render as solid, opaque panels. Before/after screenshots posted to #3133.
- Regressions checked: toggling Glass & Blur back ON restores the frosted-glass look unchanged; modal overlays/scrims still dim (don't turn solid); light mode with blur off remains solid as before.
- dev.sh start boots the container cleanly; HMR working.

### Dark Mode:

<img alt="Screenshot 2026-07-03 at 09 48 11" src="https://github.com/user-attachments/assets/0ef83be4-eb86-4685-8ca7-f5388272cb95" />
<img alt="Screenshot 2026-07-03 at 09 47 49" src="https://github.com/user-attachments/assets/b83732d2-c5b6-4049-bedc-8fef07413305" />
<img alt="Screenshot 2026-07-03 at 09 47 46" src="https://github.com/user-attachments/assets/8ca01c1b-ff3b-4b25-96d6-cf942da51763" />

### Light Mode:

<img alt="Screenshot 2026-07-03 at 09 48 53" src="https://github.com/user-attachments/assets/57cbb213-8c44-42b3-a8fc-8dcd7fbcbb8b" />
<img alt="Screenshot 2026-07-03 at 09 48 44" src="https://github.com/user-attachments/assets/4d5bf450-7cd6-414a-af39-6d2491a4cb40" />
<img alt="Screenshot 2026-07-03 at 09 48 42" src="https://github.com/user-attachments/assets/79831cfe-00a5-44d8-a24c-b53ab4434530" />

## AI Assistance

Written with Claude Code (Opus 4.8) assistance; root-caused, implemented, and manually verified in the dev environment by me before submission (per AI_POLICY.md).

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression where modals, menus, drawers, and other glass surfaces became transparent in dark mode when the Glass & Blur setting was disabled. The root cause was that the `html.no-blur` attribute-selector overrides used anchored CSS substring patterns (`^=` start-of-string, `*=' '` space-preceded) that never matched `dark:`-prefixed Tailwind classes like `dark:bg-surface/10` or `dark:bg-popover/20`, since those tokens are preceded by a colon, not a space.

- Broadens the opacity-override selectors from `[class^='bg-token/'], [class*=' bg-token/']` to plain `[class*='bg-token/']` so that dark-mode-prefixed variants are caught; a well-commented explanation of the deliberate tradeoff is included.
- Adds the previously missing `bg-surface/` → `var(--surface)` rule for dialog/sheet/drawer surfaces.
- Reorders the scrim rule to appear before the opaque-surface rules so that drawer content (which carries both a scrim class and a surface class) resolves correctly to the opaque surface color via CSS cascade.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

CSS-only change to a single no-blur mode block; all variables referenced are defined across every theme, and the selector-ordering logic correctly resolves the drawer dual-class case.

The fix is surgical: the old anchored selectors provably could not match dark:-prefixed class tokens, the new substring selectors do, --surface is defined in every theme variant, and the moved scrim rule uses equal specificity so the last matching declaration wins. Manual smoke-test evidence and pnpm check pass are documented.

No files require special attention. The changed block is self-contained and only affects html.no-blur mode.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep modals and menus opaque in dar..."](https://github.com/getarcaneapp/arcane/commit/0c1011ba2e064149a4bfb41ad11242e88d1570e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41598064)</sub>

<!-- /greptile_comment -->