### PR TITLE
fix: ntfy tls regression, image update notifcation flag not be recognized

### DIFF
--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -158,6 +158,7 @@ type NtfyConfig struct {
 	Icon                   string                         `json:"icon,omitempty"`
 	Cache                  bool                           `json:"cache"`
 	Firebase               bool                           `json:"firebase"`
+	DisableTLS             bool                           `json:"disableTls"`
 	DisableTLSVerification bool                           `json:"disableTlsVerification"`
 	Events                 map[NotificationEventType]bool `json:"events,omitempty"`
 }

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -37,6 +37,7 @@ type ImageUpdateService struct {
 	notificationService *NotificationService
 	registryLimiter     *ratelimit.RegistryRateLimiter
 	activityService     *ActivityService
+	notifyMu            sync.Mutex
 }
 
 type ImageParts struct {
@@ -1324,6 +1325,12 @@ func (s *ImageUpdateService) sendBatchImageUpdateNotificationsInternal(ctx conte
 	if s.notificationService == nil {
 		return
 	}
+
+	// Serialize the query→send→mark sequence so the poll-end flush and the
+	// updater consumption-path flush can't both read the same unnotified set
+	// and double-send.
+	s.notifyMu.Lock()
+	defer s.notifyMu.Unlock()
 
 	// completeImageUpdateActivityInternal cancels the activity-tracked ctx before
 	// we reach here, so detach from that cancellation (mirrors the helper it uses)

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -389,6 +389,13 @@ func (s *UpdaterService) PendingImageUpdates(ctx context.Context) ([]moduletypes
 	if err := s.deps.DB.WithContext(ctx).Where("has_update = ?", true).Find(&records).Error; err != nil {
 		return nil, fmt.Errorf("query pending image updates: %w", err)
 	}
+
+	// Flush pending "Updates Available" notifications before the engine
+	// consumes and clears these records, otherwise the notification for an
+	// update applied here is silently lost (#3132).
+	if s.deps.ImageUpdates != nil {
+		s.deps.ImageUpdates.sendBatchImageUpdateNotificationsInternal(ctx)
+	}
 	s.appendAutoUpdateActivityMessageInternal(
 		ctx,
 		activityIDFromContextInternal(ctx),

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -466,6 +467,82 @@ func TestUpdaterService_PendingImageUpdatesAdapterInternal(t *testing.T) {
 	assert.Equal(t, &currentDigest, records[0].CurrentDigest)
 	assert.Equal(t, &latestDigest, records[0].LatestDigest)
 	assert.Equal(t, &lastError, records[0].LastError)
+}
+
+// TestUpdaterService_PendingImageUpdatesFlushesPendingNotificationsInternal guards
+// issue #3132: the updater consumes and clears has_update records without checking
+// notification_sent, so an "Updates Available" notification pending at consumption
+// time was silently lost. PendingImageUpdates must flush it before the engine runs.
+func TestUpdaterService_PendingImageUpdatesFlushesPendingNotificationsInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.NotificationSettings{}, &models.NotificationLog{}))
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	require.NoError(t, db.Create(&models.NotificationSettings{
+		Provider: models.NotificationProviderGeneric,
+		Enabled:  true,
+		Config: models.JSON{
+			"webhookUrl":  server.URL,
+			"method":      "POST",
+			"contentType": "application/json",
+		},
+	}).Error)
+
+	notif := NewNotificationService(db, nil, nil)
+	imageUpdates := NewImageUpdateService(db, nil, nil, nil, nil, notif, nil)
+	svc := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil)
+
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:               "sha256:pending-unnotified",
+		Repository:       "test/repo",
+		Tag:              "latest",
+		HasUpdate:        true,
+		NotificationSent: false,
+	}).Error)
+
+	records, err := svc.PendingImageUpdates(ctx)
+
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.EqualValues(t, 1, calls.Load())
+	var reloaded models.ImageUpdateRecord
+	require.NoError(t, db.First(&reloaded, "id = ?", "sha256:pending-unnotified").Error)
+	assert.True(t, reloaded.NotificationSent)
+}
+
+// With no providers configured, PendingImageUpdates still returns the records and
+// leaves notification_sent false (preserves the #3079 "don't mark when nothing
+// delivered" semantics).
+func TestUpdaterService_PendingImageUpdatesNoProvidersLeavesUnnotifiedInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.NotificationSettings{}, &models.NotificationLog{}))
+
+	notif := NewNotificationService(db, nil, nil)
+	imageUpdates := NewImageUpdateService(db, nil, nil, nil, nil, notif, nil)
+	svc := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil)
+
+	require.NoError(t, db.Create(&models.ImageUpdateRecord{
+		ID:               "sha256:pending-no-provider",
+		Repository:       "test/repo",
+		Tag:              "latest",
+		HasUpdate:        true,
+		NotificationSent: false,
+	}).Error)
+
+	records, err := svc.PendingImageUpdates(ctx)
+
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	var reloaded models.ImageUpdateRecord
+	require.NoError(t, db.First(&reloaded, "id = ?", "sha256:pending-no-provider").Error)
+	assert.False(t, reloaded.NotificationSent)
 }
 
 func TestUpdaterService_RecordUpdateRunAdapterInternal(t *testing.T) {

--- a/backend/pkg/utils/notifications/ntfy_sender.go
+++ b/backend/pkg/utils/notifications/ntfy_sender.go
@@ -77,6 +77,10 @@ func BuildNtfyURL(config models.NtfyConfig) (string, error) {
 		q.Set("firebase", "no")
 	}
 
+	if config.DisableTLS {
+		q.Set("disabletls", "yes")
+	}
+
 	if config.DisableTLSVerification {
 		q.Set("disabletlsverification", "yes")
 	}

--- a/backend/pkg/utils/notifications/ntfy_sender_test.go
+++ b/backend/pkg/utils/notifications/ntfy_sender_test.go
@@ -147,3 +147,21 @@ func TestBuildNtfyURLDisableTLSVerificationUsesCertificateVerificationFlag(t *te
 	assert.Equal(t, "yes", query.Get("disabletlsverification"))
 	assert.Empty(t, query.Get("disabletls"))
 }
+
+func TestBuildNtfyURLDisableTLSUsesPlainHTTPFlag(t *testing.T) {
+	gotURL, err := BuildNtfyURL(models.NtfyConfig{
+		Host:       "ntfy.example.com",
+		Topic:      "alerts",
+		Cache:      true,
+		Firebase:   true,
+		DisableTLS: true,
+	})
+	require.NoError(t, err)
+
+	parsedURL, err := url.Parse(gotURL)
+	require.NoError(t, err)
+
+	query := parsedURL.Query()
+	assert.Equal(t, "yes", query.Get("disabletls"))
+	assert.Empty(t, query.Get("disabletlsverification"))
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2647,6 +2647,8 @@
 	"notifications_ntfy_firebase_help": "Send notifications via Firebase (enabled by default)",
 	"notifications_ntfy_disable_tls_label": "Disable TLS Verification",
 	"notifications_ntfy_disable_tls_help": "Disable TLS certificate verification (not recommended)",
+	"notifications_ntfy_use_http_label": "Use HTTP (Disable TLS)",
+	"notifications_ntfy_use_http_help": "Connect over plain HTTP instead of HTTPS, for self-hosted ntfy servers without TLS",
 	"notifications_pushover_description": "Send notifications via Pushover when container updates are detected",
 	"notifications_pushover_enabled_label": "Enable Pushover Notifications",
 	"notifications_pushover_token_label": "API Token",

--- a/frontend/src/lib/types/notifications.ts
+++ b/frontend/src/lib/types/notifications.ts
@@ -103,6 +103,7 @@ export interface NtfyFormValues extends BaseProviderFormValues {
 	icon: string;
 	cache: boolean;
 	firebase: boolean;
+	disableTls: boolean;
 	disableTlsVerification: boolean;
 }
 
@@ -427,6 +428,7 @@ export function ntfySettingsToFormValues(settings?: NotificationSettings): NtfyF
 		icon: getString(cfg, 'icon'),
 		cache: getBoolean(cfg, 'cache', true),
 		firebase: getBoolean(cfg, 'firebase', true),
+		disableTls: getBoolean(cfg, 'disableTls', false),
 		disableTlsVerification: getBoolean(cfg, 'disableTlsVerification', false),
 		...eventFlagsToFormValues(events)
 	};
@@ -517,6 +519,7 @@ export function ntfyFormValuesToSettings(values: NtfyFormValues): NotificationSe
 			icon: values.icon,
 			cache: values.cache,
 			firebase: values.firebase,
+			disableTls: values.disableTls,
 			disableTlsVerification: values.disableTlsVerification,
 			events: {
 				image_update: values.eventImageUpdate,

--- a/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
@@ -279,6 +279,7 @@
 				icon: z.string(),
 				cache: z.boolean(),
 				firebase: z.boolean(),
+				disableTls: z.boolean(),
 				disableTlsVerification: z.boolean(),
 				...eventSubscriptionSchemaFields
 			})
@@ -788,6 +789,13 @@
 						id: 'ntfy-firebase',
 						label: m.notifications_ntfy_firebase_label(),
 						description: m.notifications_ntfy_firebase_help()
+					},
+					{
+						kind: 'switch',
+						key: 'disableTls',
+						id: 'ntfy-use-http',
+						label: m.notifications_ntfy_use_http_label(),
+						description: m.notifications_ntfy_use_http_help()
 					},
 					{
 						kind: 'switch',


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3132

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details>
<summary></summary>
This PR fixes ntfy TLS settings and preserves image update notifications during updater runs. The main changes are:

- Added a separate `disableTls` flag for ntfy plain HTTP mode.
- Wired the new ntfy option through backend config, frontend types, form validation, and settings UI.
- Kept TLS certificate verification as its own `disableTlsVerification` setting.
- Flushed pending image update notifications before updater consumption clears update records.
- Added tests for ntfy URL flags and pending notification flush behavior.

</details>

<details>
<summary></summary>
Safe to merge with minimal risk.
The changes are narrow and covered by targeted tests for both ntfy URL generation and updater notification flushing.
No files require special attention.
</details>

<details>
<summary></summary>

**What T-Rex did**

- The ntfy test suite ran and passed, including TestBuildNtfyURLDisableTLSVerificationUsesCertificateVerificationFlag and TestBuildNtfyURLDisableTLSUsesPlainHTTPFlag.
- Updater image notification tests ran and passed, including flushing pending notifications and preserving notification_sent=false when no providers exist.
- An initial 60-second updater package run timed out before test output, so only the two explicit PR-relevant updater tests were re-run with a 180-second timeout; that targeted run passed.

<picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture>

<sub><a href="https://www.greptile.com/trex"><img src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" alt="T-Rex"></a> Ran code and verified through T-Rex</sub>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ntfy tls regression, image update n..."](https://github.com/getarcaneapp/arcane/commit/3fb508e2857aed1de02997ce0d1f7721a741ca28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41655704)</sub>

<!-- /greptile_comment -->