### PR TITLE
fix: use correct compose name so services match the project

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -1590,20 +1590,20 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 		Where("path = ?", dirPath).
 		First(&existing).Error
 
-	serviceCount, composeProjectName, serviceCountErr := s.loadComposeMetadataForSyncInternal(ctx, dirPath, dirName)
+	composeMetadata, serviceCountErr := s.loadComposeMetadataForSyncInternal(ctx, dirPath, dirName)
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create a minimal project entry
 		reason := "Project discovered from filesystem, status pending Docker service query"
 		proj := &models.Project{
-			Name:               dirName,
+			Name:               composeMetadata.resolvedProjectName,
 			DirName:            new(dirName),
 			Path:               dirPath,
 			Status:             models.ProjectStatusUnknown,
 			StatusReason:       new(reason),
-			ServiceCount:       serviceCount,
+			ServiceCount:       composeMetadata.serviceCount,
 			RunningCount:       0,
-			ComposeProjectName: composeProjectName,
+			ComposeProjectName: composeMetadata.composeProjectName,
 		}
 		slog.InfoContext(ctx, "Discovered new project with unknown status",
 			"project", dirName,
@@ -1615,6 +1615,7 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 		if cerr := s.db.WithContext(ctx).Create(proj).Error; cerr != nil {
 			return fmt.Errorf("create project for %q failed: %w", dirPath, cerr)
 		}
+		s.warnDuplicateComposeNameForPathInternal(ctx, composeMetadata.resolvedProjectName, dirPath, proj.ID)
 		return nil
 	}
 	if err != nil {
@@ -1628,13 +1629,22 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 	if existing.DirName == nil || *existing.DirName != dirName {
 		updates["dir_name"] = dirName
 	}
-	if serviceCountErr == nil && existing.ServiceCount != serviceCount {
-		updates["service_count"] = serviceCount
+	if serviceCountErr == nil && existing.ServiceCount != composeMetadata.serviceCount {
+		updates["service_count"] = composeMetadata.serviceCount
 	} else if serviceCountErr != nil {
 		slog.WarnContext(ctx, "failed to refresh compose service count during project sync", "projectID", existing.ID, "path", dirPath, "error", serviceCountErr)
 	}
-	if serviceCountErr == nil && !utils.StringPtrEqual(existing.ComposeProjectName, composeProjectName) {
-		updates["compose_project_name"] = composeProjectName
+	if serviceCountErr == nil && !utils.StringPtrEqual(existing.ComposeProjectName, composeMetadata.composeProjectName) {
+		updates["compose_project_name"] = composeMetadata.composeProjectName
+	}
+	if serviceCountErr == nil {
+		if composeMetadata.explicitProjectName {
+			if existing.Name != composeMetadata.resolvedProjectName {
+				updates["name"] = composeMetadata.resolvedProjectName
+			}
+		} else if normalizedExistingName := normalizeComposeProjectName(existing.Name); normalizedExistingName != existing.Name {
+			updates["name"] = normalizedExistingName
+		}
 	}
 	if len(updates) == 0 {
 		return nil
@@ -1647,7 +1657,28 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 		Updates(updates).Error; uerr != nil {
 		return fmt.Errorf("update project %s failed: %w", existing.ID, uerr)
 	}
+	if serviceCountErr == nil {
+		s.warnDuplicateComposeNameForPathInternal(ctx, composeMetadata.resolvedProjectName, dirPath, existing.ID)
+	}
 	return nil
+}
+
+func (s *ProjectService) warnDuplicateComposeNameForPathInternal(ctx context.Context, composeProjectName, dirPath, projectID string) {
+	if strings.TrimSpace(composeProjectName) == "" {
+		return
+	}
+
+	var count int64
+	if err := s.db.WithContext(ctx).
+		Model(&models.Project{}).
+		Where("name = ? AND path <> ? AND id <> ?", composeProjectName, dirPath, projectID).
+		Count(&count).Error; err != nil {
+		slog.WarnContext(ctx, "failed to check duplicate compose project names during project sync", "composeProjectName", composeProjectName, "path", dirPath, "error", err)
+		return
+	}
+	if count > 0 {
+		slog.WarnContext(ctx, "multiple project directories resolve to the same compose project name", "composeProjectName", composeProjectName, "path", dirPath, "duplicates", count)
+	}
 }
 
 // projectCleanupDecision records a project the reconcile pass intends to delete,
@@ -2297,10 +2328,11 @@ func (s *ProjectService) createProjectInternal(ctx context.Context, name, compos
 		_ = os.RemoveAll(projectPath)
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}
+	s.refreshComposeProjectNameInternal(ctx, proj)
 	s.refreshProjectImageRefsInternal(ctx, proj)
 
-	metadata := models.JSON{"action": "create", "projectID": proj.ID, "projectName": name, "path": projectPath}
-	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectCreate, proj.ID, name, user.ID, user.Username, "0", metadata); logErr != nil {
+	metadata := models.JSON{"action": "create", "projectID": proj.ID, "projectName": proj.Name, "path": projectPath}
+	if logErr := s.eventService.LogProjectEvent(ctx, models.EventTypeProjectCreate, proj.ID, proj.Name, user.ID, user.Username, "0", metadata); logErr != nil {
 		slog.ErrorContext(ctx, "could not log project creation", "error", logErr)
 	}
 
@@ -3251,6 +3283,7 @@ func (s *ProjectService) refreshProjectAfterContentUpdateInternal(ctx context.Co
 		return
 	}
 
+	s.refreshComposeProjectNameInternal(ctx, proj)
 	s.refreshProjectImageRefsInternal(ctx, proj)
 	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
 		slog.WarnContext(ctx, "failed to update service counts after compose edit", "projectID", proj.ID, "error", err)
@@ -3284,6 +3317,7 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 	if err := s.db.WithContext(ctx).Save(&proj).Error; err != nil {
 		return nil, fmt.Errorf("failed to update project: %w", err)
 	}
+	s.refreshComposeProjectNameInternal(ctx, &proj)
 	s.refreshProjectImageRefsInternal(ctx, &proj)
 
 	// Recalculate service counts and status after compose file sync
@@ -3629,7 +3663,7 @@ func (s *ProjectService) validateComposeContentForUpdate(ctx context.Context, pr
 		_, loadErr := loader.LoadWithContext(ctx, cfg, func(opts *loader.Options) {
 			opts.ResourceLoaders = append([]loader.ResourceLoader{missingIncludeLoader}, opts.ResourceLoaders...)
 			if validationProjectName != "" {
-				opts.SetProjectName(validationProjectName, true)
+				opts.SetProjectName(validationProjectName, false)
 			}
 			if lenient {
 				projects.ApplyLenientLoaderOptions(ctx, opts, cfg.ConfigFiles[0].Filename)
@@ -4970,21 +5004,29 @@ func (s *ProjectService) countServicesFromCompose(ctx context.Context, p models.
 	return len(proj.Services), nil
 }
 
+type composeSyncMetadataInternal struct {
+	serviceCount        int
+	resolvedProjectName string
+	composeProjectName  *string
+	explicitProjectName bool
+}
+
 // loadComposeMetadataForSyncInternal loads the compose file once and returns
-// both the service count and the effective compose project name. This avoids
-// parsing the compose file twice during project sync (once for service count
-// and once for the project name).
-// The effective name is nil when it matches the normalized directory name.
-func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context, dirPath, dirName string) (serviceCount int, composeProjectName *string, err error) {
+// the service count plus compose-go's effective project name.
+func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context, dirPath, dirName string) (composeSyncMetadataInternal, error) {
+	normName := normalizeComposeProjectName(dirName)
+	meta := composeSyncMetadataInternal{
+		resolvedProjectName: normName,
+	}
+
 	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
 	projectsDirectory, pErr := projects.GetProjectsDirectory(ctx, strings.TrimSpace(cfg.ProjectsDirectory.Value))
 	if pErr != nil {
-		return 0, nil, pErr
+		return meta, pErr
 	}
 
 	pathMapper := s.getPathMapperInternal(ctx)
 
-	normName := normalizeComposeProjectName(dirName)
 	autoInjectEnv := utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false)
 
 	// First, try loading without forcing a project name so compose-go can
@@ -4995,19 +5037,69 @@ func (s *ProjectService) loadComposeMetadataForSyncInternal(ctx context.Context,
 	if err != nil {
 		proj, _, err = projects.LoadComposeProjectFromDir(ctx, dirPath, normName, projectsDirectory, autoInjectEnv, pathMapper)
 		if err != nil {
-			return 0, nil, err
+			return meta, err
 		}
+	} else if proj.Name != "" && proj.Name != normName {
+		meta.explicitProjectName = true
 	}
 
-	serviceCount = len(proj.Services)
+	meta.serviceCount = len(proj.Services)
+	if proj.Name != "" {
+		meta.resolvedProjectName = proj.Name
+	}
 
 	// If compose-go resolved a different name (from COMPOSE_PROJECT_NAME),
 	// store it so we can match containers correctly.
 	if proj.Name != "" && proj.Name != normName {
-		composeProjectName = new(proj.Name)
+		meta.composeProjectName = new(proj.Name)
 	}
 
-	return serviceCount, composeProjectName, nil
+	return meta, nil
+}
+
+func (s *ProjectService) refreshComposeProjectNameInternal(ctx context.Context, proj *models.Project) {
+	if proj == nil {
+		return
+	}
+
+	dirName := proj.Name
+	if proj.DirName != nil && *proj.DirName != "" {
+		dirName = *proj.DirName
+	}
+
+	meta, err := s.loadComposeMetadataForSyncInternal(ctx, proj.Path, dirName)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to refresh compose project name", "projectID", proj.ID, "path", proj.Path, "error", err)
+		return
+	}
+
+	updates := map[string]any{}
+	shouldUpdateName := meta.explicitProjectName || normalizeComposeProjectName(proj.Name) != proj.Name
+	if shouldUpdateName && meta.resolvedProjectName != "" && proj.Name != meta.resolvedProjectName {
+		updates["name"] = meta.resolvedProjectName
+	}
+	if !utils.StringPtrEqual(proj.ComposeProjectName, meta.composeProjectName) {
+		updates["compose_project_name"] = meta.composeProjectName
+	}
+	if len(updates) == 0 {
+		return
+	}
+
+	updates["updated_at"] = time.Now()
+	if err := s.db.WithContext(ctx).
+		Model(&models.Project{}).
+		Where("id = ?", proj.ID).
+		Updates(updates).Error; err != nil {
+		slog.WarnContext(ctx, "failed to persist refreshed compose project name", "projectID", proj.ID, "error", err)
+		return
+	}
+
+	if name, ok := updates["name"].(string); ok {
+		proj.Name = name
+	}
+	if _, ok := updates["compose_project_name"]; ok {
+		proj.ComposeProjectName = meta.composeProjectName
+	}
 }
 
 func (s *ProjectService) calculateProjectStatus(services []ProjectServiceInfo) models.ProjectStatus {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -5002,6 +5002,67 @@ func TestProjectService_SyncProjectsFromFileSystem_RefreshesServiceCountOnCompos
 	assert.Equal(t, 2, project.ServiceCount)
 }
 
+func TestProjectService_SyncProjectsFromFileSystem_AlignsNameToEffectiveComposeName(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	projectPath := createComposeProjectDir(t, projectsRoot, "aitools")
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(`name: ai_tools
+services:
+  app:
+    image: nginx:alpine
+`), 0o644))
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	var project models.Project
+	require.NoError(t, db.WithContext(ctx).Where("path = ?", projectPath).First(&project).Error)
+	assert.Equal(t, "ai_tools", project.Name)
+	require.NotNil(t, project.DirName)
+	assert.Equal(t, "aitools", *project.DirName)
+	require.NotNil(t, project.ComposeProjectName)
+	assert.Equal(t, "ai_tools", *project.ComposeProjectName)
+}
+
+func TestProjectService_SyncProjectsFromFileSystem_PreservesValidCustomNameWithoutExplicitComposeName(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	projectPath := createComposeProjectDir(t, projectsRoot, "folder-name")
+	dirName := "folder-name"
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-custom-name"},
+		Name:      "custom-name",
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
+
+	var fromDB models.Project
+	require.NoError(t, db.WithContext(ctx).Where("id = ?", project.ID).First(&fromDB).Error)
+	assert.Equal(t, "custom-name", fromDB.Name)
+	require.NotNil(t, fromDB.DirName)
+	assert.Equal(t, "folder-name", *fromDB.DirName)
+	require.Nil(t, fromDB.ComposeProjectName)
+}
+
 func TestProjectService_SyncProjectsFromFileSystem_PreservesGitOpsProjectWithCustomComposeFilename(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -296,7 +296,7 @@ func loadComposeProjectInternal(
 
 	project, err = loader.LoadWithContext(ctx, cfg, func(opts *loader.Options) {
 		if projectName != "" {
-			opts.SetProjectName(projectName, true)
+			opts.SetProjectName(projectName, false)
 		}
 		// Discard env_file after folding into environment, as the compose CLI
 		// does, so config-hashes match and both tools stop recreating services.

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -247,6 +247,52 @@ services:
 	require.Equal(t, expectedConfigFiles, includedService.CustomLabels[api.ConfigFilesLabel])
 }
 
+func TestLoadComposeProject_YamlNameOverridesDefaultName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		composeBody string
+		wantName    string
+	}{
+		{
+			name: "yaml name",
+			composeBody: `name: ai_tools
+services:
+  app:
+    image: nginx:alpine
+`,
+			wantName: "ai_tools",
+		},
+		{
+			name: "default name",
+			composeBody: `services:
+  app:
+    image: nginx:alpine
+`,
+			wantName: "aitools",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projectDir := t.TempDir()
+			composePath := filepath.Join(projectDir, "compose.yaml")
+			require.NoError(t, os.WriteFile(composePath, []byte(tt.composeBody), 0o600))
+
+			project, err := LoadComposeProject(context.Background(), composePath, "aitools", projectDir, false, nil)
+			require.NoError(t, err)
+			require.NotNil(t, project)
+			require.Equal(t, tt.wantName, project.Name)
+
+			service := project.Services["app"]
+			require.Equal(t, tt.wantName, service.CustomLabels[api.ProjectLabel])
+		})
+	}
+}
+
 func TestResolveRelativeProjectPaths(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3098

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates Compose project-name handling so Arcane follows compose-go's resolved project identity. The main changes are:

- Compose loading now treats Arcane's project name as a default instead of an override.
- Project sync now stores the effective Compose project name and service count from one metadata load.
- Project create and compose update flows refresh persisted project names after file changes.
- Tests cover YAML `name:` overrides and preserving custom names without an explicit Compose name.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The changes are focused on Compose name resolution and include targeted tests for the key behavior. No correctness or security issues were identified in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran pkg/projects targeted tests and confirmed they passed with exit code 0.
- Ran internal/services targeted sync tests and confirmed they passed with exit code 0.
- Reviewed the proof\_note.log to verify the exact test/assertion lines proving resolved compose names and labels match the expected values.

<a href="https://app.greptile.com/trex/runs/13247634/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use correct compose name so service..."](https://github.com/getarcaneapp/arcane/commit/f89db858fd51fadfee639b48a370acdf30da9bc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41765669)</sub>

<!-- /greptile_comment -->