### PR TITLE
fix: pass registry auth to compose-initiated pulls during up

### DIFF
--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -115,8 +115,8 @@ func provideContainerRegistryServiceInternal(db *database.DB, docker *services.D
 	}, kv)
 }
 
-func provideProjectServiceInternal(db *database.DB, settings *services.SettingsService, event *services.EventService, image *services.ImageService, docker *services.DockerClientService, build *services.BuildService, lifecycle *services.LifecycleService, kv *services.KVService, environment *services.EnvironmentService, cfg *config.Config) *services.ProjectService {
-	return services.NewProjectService(db, settings, event, image, docker, build, lifecycle, cfg).
+func provideProjectServiceInternal(db *database.DB, settings *services.SettingsService, event *services.EventService, image *services.ImageService, docker *services.DockerClientService, build *services.BuildService, lifecycle *services.LifecycleService, kv *services.KVService, registry *services.ContainerRegistryService, environment *services.EnvironmentService, cfg *config.Config) *services.ProjectService {
+	return services.NewProjectService(db, settings, event, image, docker, build, lifecycle, registry, cfg).
 		WithKVService(kv).
 		WithRegistryCredentialsProvider(environment.GetEnabledRegistryCredentials)
 }

--- a/backend/internal/di/wire_gen.go
+++ b/backend/internal/di/wire_gen.go
@@ -44,7 +44,7 @@ func InitializeServices(ctx context.Context, db *database.DB, cfg *config.Config
 	gitRepositoryService := provideGitRepositoryServiceInternal(db, cfg, eventService, settingsService)
 	buildService := services.NewBuildService(db, settingsService, dockerClientService, containerRegistryService, gitRepositoryService, eventService)
 	lifecycleService := services.NewLifecycleService(db, settingsService, eventService, dockerClientService)
-	projectService := provideProjectServiceInternal(db, settingsService, eventService, imageService, dockerClientService, buildService, lifecycleService, kvService, environmentService, cfg)
+	projectService := provideProjectServiceInternal(db, settingsService, eventService, imageService, dockerClientService, buildService, lifecycleService, kvService, containerRegistryService, environmentService, cfg)
 	jobService := services.NewJobService(db, settingsService, cfg)
 	settingsSearchService := services.NewSettingsSearchService()
 	customizeSearchService := services.NewCustomizeSearchService()

--- a/backend/internal/services/dashboard_service_test.go
+++ b/backend/internal/services/dashboard_service_test.go
@@ -156,7 +156,7 @@ func TestDashboardService_GetSnapshot_ReturnsDashboardSnapshot(t *testing.T) {
 		Path:      projectPath,
 		Status:    models.ProjectStatusStopped,
 	}).Error)
-	projectSvc := NewProjectService(db, settingsSvc, nil, &ImageService{db: db}, nil, nil, nil, config.Load())
+	projectSvc := NewProjectService(db, settingsSvc, nil, &ImageService{db: db}, nil, nil, nil, nil, config.Load())
 	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, nil, settingsSvc, nil, nil, nil)
 
 	snapshot, err := svc.GetSnapshot(context.Background(), DashboardActionItemsOptions{})

--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -36,7 +36,7 @@ func setupGitOpsSyncDirectoryTestService(t *testing.T) (*GitOpsSyncService, *dat
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, config.Load(), nil)
-	projectService := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	projectService := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	return NewGitOpsSyncService(db, nil, projectService, nil, eventService, settingsService), db, projectsDir
 }

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -20,6 +20,7 @@ import (
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	"gorm.io/gorm"
 
@@ -54,6 +55,7 @@ type ProjectService struct {
 	buildService                *BuildService
 	lifecycleService            *LifecycleService
 	kvService                   *KVService
+	containerRegistryService    *ContainerRegistryService
 	config                      *config.Config
 	registryCredentialsProvider registryCredentialsProviderInternal
 
@@ -71,17 +73,18 @@ type composeCacheEntry struct {
 	project       *composetypes.Project
 }
 
-func NewProjectService(db *database.DB, settingsService *SettingsService, eventService *EventService, imageService *ImageService, dockerService *DockerClientService, buildService *BuildService, lifecycleService *LifecycleService, cfg *config.Config) *ProjectService {
+func NewProjectService(db *database.DB, settingsService *SettingsService, eventService *EventService, imageService *ImageService, dockerService *DockerClientService, buildService *BuildService, lifecycleService *LifecycleService, containerRegistryService *ContainerRegistryService, cfg *config.Config) *ProjectService {
 	return &ProjectService{
-		db:               db,
-		settingsService:  settingsService,
-		eventService:     eventService,
-		imageService:     imageService,
-		dockerService:    dockerService,
-		buildService:     buildService,
-		lifecycleService: lifecycleService,
-		config:           cfg,
-		composeCache:     cache.NewKeyed[string, composeCacheEntry](),
+		db:                       db,
+		settingsService:          settingsService,
+		eventService:             eventService,
+		imageService:             imageService,
+		dockerService:            dockerService,
+		buildService:             buildService,
+		lifecycleService:         lifecycleService,
+		containerRegistryService: containerRegistryService,
+		config:                   cfg,
+		composeCache:             cache.NewKeyed[string, composeCacheEntry](),
 	}
 }
 
@@ -112,6 +115,20 @@ func (s *ProjectService) resolveRegistryCredentialsInternal(ctx context.Context)
 	}
 
 	return credentials, nil
+}
+
+func (s *ProjectService) composeRegistryAuthConfigsInternal(ctx context.Context) map[string]dockerregistry.AuthConfig {
+	if s == nil || s.containerRegistryService == nil {
+		return nil
+	}
+
+	authConfigs, err := s.containerRegistryService.GetAllRegistryAuthConfigs(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to load registry auth for compose pulls", "error", err)
+		return nil
+	}
+
+	return authConfigs
 }
 
 func (s *ProjectService) getPathMapperInternal(ctx context.Context) *projects.PathMapper {
@@ -798,7 +815,7 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 
 	// 5. Up specific services
 	writeProjectProgressInternal(ctx, "Starting selected services", 70, "up")
-	if err := composeUpProjectServicesInternal(ctx, compProj, servicesToUpdate, false, true); err != nil {
+	if err := composeUpProjectServicesInternal(ctx, compProj, servicesToUpdate, false, true, s.composeRegistryAuthConfigsInternal(ctx)); err != nil {
 		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return fmt.Errorf("failed to up services: %w", err)
 	}
@@ -2094,8 +2111,14 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		return fmt.Errorf("failed to load compose project in %s: %w", projectFromDb.Path, derr)
 	}
 
+	credentials, cerr := s.resolveRegistryCredentialsInternal(ctx)
+	if cerr != nil {
+		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
+		return fmt.Errorf("resolve registry credentials: %w", cerr)
+	}
+
 	progressWriter, _ := ctx.Value(projects.ProgressWriterKey{}).(io.Writer)
-	if perr := s.prepareProjectImagesForDeploy(ctx, projectID, project, progressWriter, nil, &user, resolvedPullPolicy); perr != nil {
+	if perr := s.prepareProjectImagesForDeploy(ctx, projectID, project, progressWriter, credentials, &user, resolvedPullPolicy); perr != nil {
 		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return fmt.Errorf("failed to prepare project images for deploy: %w", perr)
 	}
@@ -2105,7 +2128,7 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 
 	slog.Info("starting compose up with health check support", "projectID", projectID, "projectName", project.Name, "services", len(project.Services), "removeOrphans", removeOrphans)
 	// Health/progress streaming (if any) is handled inside projects.ComposeUp via ctx.
-	if err := projects.ComposeUp(ctx, project, nil, removeOrphans, forceRecreate); err != nil {
+	if err := projects.ComposeUp(ctx, project, nil, removeOrphans, forceRecreate, s.composeRegistryAuthConfigsInternal(ctx)); err != nil {
 		slog.Error("compose up failed", "projectName", project.Name, "projectID", projectID, "error", err)
 		if containers, psErr := s.GetProjectServices(ctx, projectID); psErr == nil {
 			slog.Info("containers after failed deploy", "projectID", projectID, "containers", containers)
@@ -2333,7 +2356,11 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 		slog.DebugContext(ctx, "failed to write redeploy pull progress", "error", writeErr)
 	}
 
-	if err := s.PullProjectImages(ctx, projectID, progressWriter, user, nil); err != nil {
+	credentials, cerr := s.resolveRegistryCredentialsInternal(ctx)
+	if cerr != nil {
+		slog.WarnContext(ctx, "failed to resolve registry credentials for redeploy pull", "error", cerr)
+	}
+	if err := s.PullProjectImages(ctx, projectID, progressWriter, user, credentials); err != nil {
 		slog.WarnContext(ctx, "failed to pull project images", "error", err)
 	}
 

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -33,6 +33,7 @@ import (
 	glsqlite "github.com/glebarez/sqlite"
 	"github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,7 @@ func setupProjectDestroyTestServiceInternal(t *testing.T) (*ProjectService, *dat
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, config.Load(), nil)
-	return NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load()), db, projectsDir
+	return NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load()), db, projectsDir
 }
 
 func newProjectImagePullServer(t *testing.T, inspectByRef map[string]dockertypesimage.InspectResponse) *httptest.Server {
@@ -207,7 +208,7 @@ func TestProjectService_GetProjectFromDatabaseByID(t *testing.T) {
 
 	// Setup dependencies
 	settingsService, _ := NewSettingsService(ctx, db)
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	// Create test project
 	proj := &models.Project{
@@ -324,7 +325,7 @@ func TestProjectService_CalculateProjectStatus(t *testing.T) {
 func TestProjectService_UpdateProjectStatusInternal(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 	proj := &models.Project{
 		BaseModel: models.BaseModel{
@@ -405,7 +406,7 @@ func TestProjectService_GetProjectByComposeName(t *testing.T) {
 
 	t.Run("exact match", func(t *testing.T) {
 		db := setupProjectTestDB(t)
-		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 		proj := &models.Project{
 			BaseModel: models.BaseModel{ID: "p1"},
@@ -421,7 +422,7 @@ func TestProjectService_GetProjectByComposeName(t *testing.T) {
 
 	t.Run("normalized fallback", func(t *testing.T) {
 		db := setupProjectTestDB(t)
-		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 		proj := &models.Project{
 			BaseModel: models.BaseModel{ID: "p1"},
@@ -437,7 +438,7 @@ func TestProjectService_GetProjectByComposeName(t *testing.T) {
 
 	t.Run("display name in db, normalized compose label input", func(t *testing.T) {
 		db := setupProjectTestDB(t)
-		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 		display := &models.Project{
 			BaseModel: models.BaseModel{ID: "p2"},
@@ -453,7 +454,7 @@ func TestProjectService_GetProjectByComposeName(t *testing.T) {
 
 	t.Run("invalidates stale normalized cache entries after deletion", func(t *testing.T) {
 		db := setupProjectTestDB(t)
-		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 		original := &models.Project{
 			BaseModel: models.BaseModel{ID: "p3"},
@@ -490,7 +491,7 @@ func TestProjectService_GetProjectByComposeName(t *testing.T) {
 
 	t.Run("invalidates stale normalized cache entries after rename", func(t *testing.T) {
 		db := setupProjectTestDB(t)
-		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load())
+		svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
 
 		original := &models.Project{
 			BaseModel: models.BaseModel{ID: "p5"},
@@ -550,7 +551,7 @@ func TestProjectService_PullProjectImages_UpdatesCurrentImageRecordAfterPull(t *
 	eventService := NewEventService(db, nil, nil)
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, eventService)
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 
 	projectPath := createComposeProjectDir(t, projectsDir, "compose-pull")
 	composeContent := fmt.Sprintf("services:\n  app:\n    image: %s\n  builder:\n    build: .\n", imageRef)
@@ -646,7 +647,7 @@ func TestProjectService_EnsureImagesPresent_UpdatesCurrentImageRecordAfterPull(t
 	eventService := NewEventService(db, nil, nil)
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, eventService)
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
 		ID:             "sha256:old-api",
@@ -698,7 +699,7 @@ func TestProjectService_PullImageForService_UpdatesCurrentImageRecordAfterPull(t
 	eventService := NewEventService(db, nil, nil)
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, eventService)
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
 		ID:             "sha256:old-worker",
@@ -761,7 +762,7 @@ func TestProjectService_ComposePullSelectedServicesInternal_ReconcilesOnlyOnSucc
 	eventService := NewEventService(db, nil, nil)
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, eventService)
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 
 	projectDef := &composetypes.Project{
 		Name: "compose-selected",
@@ -865,7 +866,7 @@ func TestProjectService_ComposePullSelectedServicesInternal_LeavesRecordsWhenPul
 	dockerService := &DockerClientService{client: newTestDockerClient(t, failingServer)}
 	imageUpdateService := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
 	imageService := NewImageService(db, dockerService, nil, imageUpdateService, nil, NewEventService(db, nil, nil))
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 
 	projectDef := &composetypes.Project{
 		Name: "compose-selected",
@@ -950,12 +951,12 @@ func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *t
 		composeUpProjectServicesInternal = originalComposeUp
 	})
 	upCalled := false
-	composeUpProjectServicesInternal = func(context.Context, *composetypes.Project, []string, bool, bool) error {
+	composeUpProjectServicesInternal = func(context.Context, *composetypes.Project, []string, bool, bool, map[string]dockerregistry.AuthConfig) error {
 		upCalled = true
 		return errors.New("compose up should not run")
 	}
 
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "pull updated service images")
@@ -1020,7 +1021,7 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 	}
 	upCalled := false
 	forceRecreate := false
-	composeUpProjectServicesInternal = func(_ context.Context, _ *composetypes.Project, services []string, removeOrphans bool, force bool) error {
+	composeUpProjectServicesInternal = func(_ context.Context, _ *composetypes.Project, services []string, removeOrphans bool, force bool, _ map[string]dockerregistry.AuthConfig) error {
 		upCalled = true
 		forceRecreate = force
 		assert.Equal(t, []string{"app"}, services)
@@ -1028,7 +1029,7 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 		return errors.New("compose up failed after assertion")
 	}
 
-	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, dockerService, nil, nil, nil, config.Load())
 	err = svc.UpdateProjectServices(ctx, projectRecord.ID, []string{"app"}, systemUser)
 	require.Error(t, err)
 	assert.True(t, upCalled)
@@ -1098,7 +1099,7 @@ func TestProjectService_UpdateProject_RenameFailsWhenVolumeMigrationPreparationF
 	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, dockerServer.URL))
 
 	dockerService := &DockerClientService{client: newTestDockerClient(t, dockerServer)}
-	svc := NewProjectService(db, settingsService, eventService, nil, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, dockerService, nil, nil, nil, config.Load())
 
 	originalDirName := "Foo"
 	originalPath := createComposeProjectDir(t, projectsDir, originalDirName)
@@ -1139,7 +1140,7 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_AppliesVolumeMigrati
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	migration := &fakeProjectVolumeRenameMigrationInternal{}
 
@@ -1210,7 +1211,7 @@ func TestProjectService_PrepareProjectRenameVolumeMigrationForUpdate_UsesCompose
 	t.Cleanup(dockerServer.Close)
 
 	dockerService := &DockerClientService{client: newTestDockerClient(t, dockerServer)}
-	svc := NewProjectService(db, settingsService, nil, nil, dockerService, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, dockerService, nil, nil, nil, config.Load())
 
 	projectPath := filepath.Join(projectsDir, "nginx")
 	require.NoError(t, os.MkdirAll(projectPath, 0o755))
@@ -1301,7 +1302,7 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_RollsBackVolumeMigra
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	migration := &fakeProjectVolumeRenameMigrationInternal{}
 
@@ -1350,7 +1351,7 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_SucceedsCommittedRen
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	migration := &fakeProjectVolumeRenameMigrationInternal{
 		commitErr: errors.New("source cleanup failed"),
@@ -1402,7 +1403,7 @@ func TestProjectService_UpdateProject_ClearsJournalForNonRenameWhenRecoveryDocke
 
 	eventService := NewEventService(db, nil, nil)
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 
 	oldDir := "nginx"
 	projectPath := createComposeProjectDir(t, projectsDir, oldDir)
@@ -1467,7 +1468,7 @@ func TestProjectService_UpdateProject_AllowsRenameAfterJournalRecoveryDockerUnav
 
 	eventService := NewEventService(db, nil, nil)
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 
 	oldDir := "nginx"
 	projectPath := createComposeProjectDir(t, projectsDir, oldDir)
@@ -1527,7 +1528,7 @@ func TestProjectService_UpdateProject_RenamesDirectoryWhenNameChanges(t *testing
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	configureProjectRuntimeDockerInternal(t, nil)
 
 	originalDirName := "Foo"
@@ -1575,7 +1576,7 @@ func TestProjectService_UpdateProject_RenameFailsWhenTargetDirectoryExists(t *te
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	configureProjectRuntimeDockerInternal(t, nil)
 
 	originalDirName := "Foo"
@@ -1621,7 +1622,7 @@ func TestProjectService_UpdateProject_RenameFailsWhenProjectRunning(t *testing.T
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	originalDirName := "Foo"
 	originalPath := filepath.Join(projectsDir, originalDirName)
@@ -1665,7 +1666,7 @@ func TestProjectService_UpdateProject_RenameRejectsStaleStoppedWhenRuntimeIsRunn
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	configureProjectRuntimeDockerInternal(t, []container.Summary{
 		{
 			ID:     "app-container",
@@ -1722,7 +1723,7 @@ func TestProjectService_UpdateProject_RenameResolvesUnknownStoppedStatusBeforeVo
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	server := newProjectRuntimeDockerServerInternal(t, nil)
 	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, server.URL))
@@ -1779,7 +1780,7 @@ func TestProjectService_UpdateProject_RenameRejectsUnknownWhenRuntimeIsRunning(t
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	server := newProjectRuntimeDockerServerInternal(t, []container.Summary{
 		{
@@ -1841,7 +1842,7 @@ func TestProjectService_UpdateProject_ValidatesComposeUsingExistingProjectName(t
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "demo"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -1883,7 +1884,7 @@ func TestProjectService_UpdateProject_AllowsMissingEnvFileDuringComposeValidatio
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "env-required"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -1927,7 +1928,7 @@ func TestProjectService_UpdateProject_AllowsMissingLocalIncludeDuringComposeVali
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "include-new"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -1991,7 +1992,7 @@ func TestProjectService_UpdateProject_RejectsMissingExternalIncludeDuringCompose
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "include-external"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2035,7 +2036,7 @@ func TestProjectService_CreateProject_RejectsExternalInclude(t *testing.T) {
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "metadata.yaml"), []byte("services: {}\n"), 0o644))
 
 	compose := `include:
@@ -2071,7 +2072,7 @@ func TestProjectService_CreateProject_RejectsArrayPathInclude(t *testing.T) {
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "metadata.yaml"), []byte("services: {}\n"), 0o644))
 
 	compose := `include:
@@ -2109,7 +2110,7 @@ func TestProjectService_CreateProject_WritesStagedProjectFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	includeContent := "services: {}\n"
 	compose := `include:
@@ -2164,7 +2165,7 @@ func TestProjectService_GetProjectDetails_UsesFileTreeMaxDepthForProjectFiles(t 
 
 	eventService := NewEventService(db, nil, nil)
 	cfg := config.Load()
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, cfg)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, cfg)
 
 	deepFolder := filepath.ToSlash(filepath.Join("level1", "level2", "level3", "level4", "level5"))
 	project, err := svc.CreateProject(ctx, "deep-files", "services:\n  app:\n    image: nginx:alpine\n", nil, []projecttypes.ProjectFileDraft{
@@ -2206,7 +2207,7 @@ func TestProjectService_UpdateProject_AppliesStagedProjectFileChanges(t *testing
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	project, err := svc.CreateProject(ctx, "editable-files", "services:\n  app:\n    image: nginx:alpine\n", nil, nil, models.User{
 		BaseModel: models.BaseModel{ID: "u1"},
@@ -2248,7 +2249,7 @@ func TestProjectService_UpdateProject_RejectsStaleProjectFileRevision(t *testing
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	project, err := svc.CreateProject(ctx, "stale-files", "services:\n  app:\n    image: nginx:alpine\n", nil, nil, models.User{
 		BaseModel: models.BaseModel{ID: "u1"},
@@ -2286,7 +2287,7 @@ func TestProjectService_UpdateProject_RejectsStaleDeepProjectFileRevision(t *tes
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	project, err := svc.CreateProject(ctx, "stale-deep-files", "services:\n  app:\n    image: nginx:alpine\n", nil, nil, models.User{
 		BaseModel: models.BaseModel{ID: "u1"},
@@ -2326,7 +2327,7 @@ func TestProjectService_GetProjectFileContent_RejectsExternalInclude(t *testing.
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "include-read"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2369,7 +2370,7 @@ func TestProjectService_GetProjectFileContent_RejectsSymlinkInclude(t *testing.T
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "include-symlink"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2415,7 +2416,7 @@ func TestProjectService_GetProjectFileContent_RejectsIntermediateSymlinkInclude(
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "include-intermediate-symlink"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2461,7 +2462,7 @@ func TestProjectService_GetProjectFileContent_RejectsIntermediateSymlinkProjectF
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "project-file-intermediate-symlink"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2500,7 +2501,7 @@ func TestProjectService_UpdateProject_UsesExistingEnvFileDuringComposeValidation
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "env-existing"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2546,7 +2547,7 @@ func TestProjectService_UpdateProject_UsesProvidedEnvContentDuringComposeValidat
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "env-updated"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2592,7 +2593,7 @@ func TestProjectService_UpdateProject_ReturnsEnvParseErrorDuringComposeValidatio
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "env-invalid"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2636,7 +2637,7 @@ func TestProjectService_UpdateProject_UsesGlobalEnvDuringComposeValidation(t *te
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "global-env-update"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2684,7 +2685,7 @@ func TestProjectService_UpdateProject_DoesNotResolveHostEnvThroughGlobalEnvDurin
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "host-env-guard"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2727,7 +2728,7 @@ func TestProjectService_UpdateProject_DerivesProjectOverrideEnvWhenGitSourceExis
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "override-edit"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2773,7 +2774,7 @@ func TestProjectService_UpdateProject_DeletingGitBackedKeyFallsBackToGit(t *test
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "override-delete"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2822,7 +2823,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_MigratesDirectEnvIntoProjectOve
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-migrate"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2873,7 +2874,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_NormalizesStaleCopiedGitOverrid
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-normalize"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2921,7 +2922,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_RemovesLegacyDeletedGitMasks(t 
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-delete-mask"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -2970,7 +2971,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_RemovesGitEnvSource(t *testing.
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-remove"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -3014,7 +3015,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_UsesGlobalEnvDuringComposeValid
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-global-env"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -3065,7 +3066,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_TolerantOfUndefinedComposeVar(t
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-undefined-var"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -3113,7 +3114,7 @@ func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-prepared-state"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -3151,7 +3152,7 @@ func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "details-override"
 	projectPath := filepath.Join(projectsDir, dirName)
@@ -3278,7 +3279,7 @@ func TestProjectService_GetProjectDetails_IncludesUpdateInfo(t *testing.T) {
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	imageService := &ImageService{db: db}
-	svc := NewProjectService(db, settingsService, nil, imageService, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, nil, nil, nil, nil, config.Load())
 
 	projectPath := createComposeProjectDir(t, projectsDir, "updates-demo")
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:latest\n"), 0o644))
@@ -3377,7 +3378,7 @@ func TestProjectService_GetProjectDetails_RefreshesRuntimeStatusWithoutRuntimeSe
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	details, err := svc.GetProjectDetails(ctx, projectRecord.ID, projecttypes.DetailsOptions{})
 	require.NoError(t, err)
@@ -3429,7 +3430,7 @@ func TestProjectService_GetProjectDetails_PopulatesRuntimeServicesFromComposePs(
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	details, err := svc.GetProjectDetails(ctx, projectRecord.ID, projecttypes.DetailsOptions{IncludeRuntimeServices: true})
 	require.NoError(t, err)
@@ -3453,7 +3454,7 @@ func TestProjectService_ListProjects_FiltersByUpdateStatus(t *testing.T) {
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	imageService := &ImageService{db: db}
-	svc := NewProjectService(db, settingsService, nil, imageService, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, imageService, nil, nil, nil, nil, config.Load())
 
 	updatedPath := createComposeProjectDir(t, projectsDir, "updated-demo")
 	require.NoError(t, os.WriteFile(filepath.Join(updatedPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:latest\n"), 0o644))
@@ -3684,7 +3685,7 @@ func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 		ArchivedAt: new(time.Now().UTC()),
 	}).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
 		Params:     pagination.Params{Limit: -1},
@@ -3736,7 +3737,7 @@ func TestProjectService_ArchiveProject_RequiresStoppedProject(t *testing.T) {
 		RunningCount: 1,
 	}).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	err = svc.ArchiveProject(ctx, "project-running", models.User{BaseModel: models.BaseModel{ID: "user-1"}, Username: "tester"})
 	require.Error(t, err)
 	var stoppedErr *common.ProjectMustBeStoppedError
@@ -3766,7 +3767,7 @@ func TestProjectService_ArchiveProject_TogglesArchiveFlag(t *testing.T) {
 		Status:    models.ProjectStatusStopped,
 	}).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	user := models.User{BaseModel: models.BaseModel{ID: "user-1"}, Username: "tester"}
 
 	require.NoError(t, svc.ArchiveProject(ctx, "project-stopped", user))
@@ -3907,7 +3908,7 @@ func TestProjectService_ListProjects_WithDerivedStatusFilter_AllowsAllPageSizeSe
 		}).Error)
 	}
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
 		Filters: map[string]string{
@@ -4145,7 +4146,7 @@ func TestProjectService_DeployProject_StopsOnBuildPreparationError(t *testing.T)
 	require.NoError(t, db.Create(proj).Error)
 
 	buildSvc := &BuildService{builder: testBuildBuilder{err: errors.New("boom build")}}
-	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc, nil, nil, config.Load())
 
 	err = svc.DeployProject(ctx, "p1", models.User{BaseModel: models.BaseModel{ID: "u1"}, Username: "tester"}, nil)
 	require.Error(t, err)
@@ -4187,7 +4188,7 @@ func TestProjectService_DeployProject_BuildsGeneratedImageWithoutPull(t *testing
 	require.NoError(t, db.Create(proj).Error)
 
 	buildSvc := &BuildService{builder: testBuildBuilder{err: errors.New("boom build")}}
-	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, buildSvc, nil, nil, config.Load())
 
 	err = svc.DeployProject(ctx, proj.ID, models.User{BaseModel: models.BaseModel{ID: "u1"}, Username: "tester"}, nil)
 	require.Error(t, err)
@@ -4213,7 +4214,7 @@ func TestProjectService_SyncProjectsFromFileSystem_IgnoresSymlinkedProjectDirsWh
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "false"))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4239,7 +4240,7 @@ func TestProjectService_SyncProjectsFromFileSystem_DetectsSymlinkedProjectDirsWh
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "true"))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4264,7 +4265,7 @@ func TestProjectService_CountProjectFolders_RespectsFollowProjectSymlinks(t *tes
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "false"))
 	count, err := svc.countProjectFolders(ctx)
@@ -4290,7 +4291,7 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversNestedProjectsAndRel
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
@@ -4324,7 +4325,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RespectsConfiguredScanMaxDept
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	t.Setenv("PROJECT_SCAN_MAX_DEPTH", "1")
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4371,7 +4372,7 @@ services:
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
@@ -4399,7 +4400,7 @@ func TestProjectService_CountProjectFolders_RecursivelyCountsNestedProjects(t *t
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	count, err := svc.countProjectFolders(ctx)
 	require.NoError(t, err)
@@ -4420,7 +4421,7 @@ func TestProjectService_CountProjectFolders_RespectsConfiguredScanMaxDepth(t *te
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	t.Setenv("PROJECT_SCAN_MAX_DEPTH", "1")
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	count, err := svc.countProjectFolders(ctx)
 	require.NoError(t, err)
@@ -4439,7 +4440,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesDeletedNestedProject(t
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4479,7 +4480,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PrunesLeakedScratchRow(t *tes
 		Path:      scratchPath,
 	}).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4515,7 +4516,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesProjectsWhenDirector
 		}).Error)
 	}
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4535,7 +4536,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesProjectWithAmbiguous
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4574,7 +4575,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesProjectsBeyondReducedS
 
 	// Initial sync at the default scan depth discovers both the top-level and
 	// the nested project, persisting them to the database.
-	defaultSvc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	defaultSvc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, defaultSvc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := defaultSvc.ListAllProjects(ctx)
@@ -4584,7 +4585,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesProjectsBeyondReducedS
 	// Lowering the scan depth must prune the nested project from the database on
 	// the next sync, even though its compose file still exists on disk.
 	t.Setenv("PROJECT_SCAN_MAX_DEPTH", "1")
-	depthLimitedSvc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	depthLimitedSvc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, depthLimitedSvc.SyncProjectsFromFileSystem(ctx))
 
 	items, err = depthLimitedSvc.ListAllProjects(ctx)
@@ -4617,7 +4618,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesDBRecordsWhenDirecto
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	before, err := svc.ListAllProjects(ctx)
@@ -4682,7 +4683,7 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversReadableProjectsDesp
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx), "sync must succeed despite the unreadable nested directory")
 
 	after, err := svc.ListAllProjects(ctx)
@@ -4718,7 +4719,7 @@ func TestProjectService_SyncProjectsFromFileSystem_AllowsDuplicateLeafDirectorie
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	var items []models.Project
@@ -4749,7 +4750,7 @@ func TestProjectService_SyncProjectsFromFileSystem_DetectsNestedSymlinkedProject
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "true"))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, page, err := svc.ListProjects(ctx, pagination.QueryParams{
@@ -4780,7 +4781,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RemovesSymlinkedProjectsWhenD
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "true"))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4810,7 +4811,7 @@ func TestProjectService_SyncProjectsFromFileSystem_RefreshesServiceCountOnCompos
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	var project models.Project
@@ -4842,7 +4843,7 @@ services:
     image: nginx:alpine
 `), 0o644))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	var project models.Project
@@ -4875,7 +4876,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesValidCustomNameWitho
 	}
 	require.NoError(t, db.Create(project).Error)
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	var fromDB models.Project
@@ -4925,7 +4926,7 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesGitOpsProjectWithCus
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 	require.NoError(t, svc.SyncProjectsFromFileSystem(ctx))
 
 	items, err := svc.ListAllProjects(ctx)
@@ -4975,7 +4976,7 @@ func TestProjectService_GetProjectDetails_UsesGitOpsCustomComposeFilename(t *tes
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
-	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
 
 	composeFromContent, envFromContent, err := svc.GetProjectContent(ctx, syncProjectID)
 	require.NoError(t, err)
@@ -5007,7 +5008,7 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	require.NoError(t, settingsService.SetStringSetting(ctx, "followProjectSymlinks", "true"))
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	project := &models.Project{
 		BaseModel: models.BaseModel{ID: "proj-symlink-update"},
@@ -5151,7 +5152,7 @@ func TestProjectService_UpdateProject_RenameRollsBackWhenFileRevisionIsStale(t *
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsDir))
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 	configureProjectRuntimeDockerInternal(t, nil)
 
 	originalDirName := "Foo"
@@ -5214,7 +5215,7 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackUncommittedDirecto
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5268,7 +5269,7 @@ func TestProjectService_RecoverProjectRenameJournals_StartedPhaseSkipsVolumeRoll
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5331,7 +5332,7 @@ func TestProjectService_RecoverProjectRenameJournals_RelocatesTargetWhenBothPath
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5394,7 +5395,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsStartedJournalWhenDir
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5457,7 +5458,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsPreservedTargetJourna
 	t.Cleanup(server.Close)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, &DockerClientService{client: newTestDockerClient(t, server)}, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, &DockerClientService{client: newTestDockerClient(t, server)}, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5519,7 +5520,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournal(t *t
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5559,7 +5560,7 @@ func TestProjectService_FinalizeProjectRenameAfterCommit_ClearsJournalAfterSourc
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := &projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5600,7 +5601,7 @@ func TestProjectService_FinalizeProjectRenameAfterCommit_KeepsJournalWhenSourceC
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := &projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5679,7 +5680,7 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsJournalWhenDirectoryRo
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5771,7 +5772,7 @@ func TestProjectService_RecoverProjectRenameJournals_CompletesCommittedVolumeJou
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5842,7 +5843,7 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackCommittedJournalWh
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -5944,7 +5945,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalAfterDBRestore
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6021,7 +6022,7 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsRollbackCleanupWhenDoc
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	cleanup := projectRenameRollbackCleanupInternal{
 		ProjectID: project.ID,
 		OldName:   "nginx",
@@ -6084,7 +6085,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournalWhenS
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6166,7 +6167,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournalAndCl
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6247,7 +6248,7 @@ func TestProjectService_RecoverProjectRenameJournals_MarksSourceCleanupPendingWh
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6330,7 +6331,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsSourceCleanupPendingJ
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6421,7 +6422,7 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackSourceCleanupPendi
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6509,7 +6510,7 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsSourceCleanupPendingJo
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6575,7 +6576,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsStartedJournalWhenDir
 	require.NoError(t, db.Create(project).Error)
 
 	kvService := NewKVService(db)
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6641,7 +6642,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsMissingPathJournalWhe
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6715,7 +6716,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenRollbackSo
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6792,7 +6793,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenRollbackTa
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",
@@ -6873,7 +6874,7 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenTargetPres
 
 	kvService := NewKVService(db)
 	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
-	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, config.Load()).WithKVService(kvService)
+	svc := NewProjectService(db, nil, nil, nil, dockerService, nil, nil, nil, config.Load()).WithKVService(kvService)
 	journal := projectRenameJournalInternal{
 		ProjectID:  project.ID,
 		OldName:    "nginx",

--- a/backend/internal/services/project_service_unix_test.go
+++ b/backend/internal/services/project_service_unix_test.go
@@ -33,7 +33,7 @@ func TestProjectService_ApplyGitSyncProjectFiles_TolerantOfPermissionLockedEnv(t
 	require.NoError(t, err)
 
 	eventService := NewEventService(db, nil, nil)
-	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, config.Load())
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
 
 	dirName := "git-sync-locked-env"
 	projectPath := filepath.Join(projectsDir, dirName)

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -406,7 +406,7 @@ func TestUpdaterService_PullImageAdapterInternal(t *testing.T) {
 		registrySvc := NewContainerRegistryService(db, nil, NewKVService(db))
 		imageSvc := NewImageService(db, dockerSvc, registrySvc, nil, nil, NewEventService(db, nil, nil))
 		envSvc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
-		projectSvc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil).
+		projectSvc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, nil).
 			WithRegistryCredentialsProvider(envSvc.GetEnabledRegistryCredentials)
 		svc := NewUpdaterService(db, nil, dockerSvc, projectSvc, nil, nil, nil, imageSvc, nil, nil, nil)
 		var progress bytes.Buffer

--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
@@ -58,7 +59,7 @@ func ComposeRestart(ctx context.Context, proj *types.Project, services []string)
 	restartCtx, cancel := detachFromHTTPContextInternal(ctx)
 	defer cancel()
 
-	c, err := NewClient(restartCtx)
+	c, err := NewClient(restartCtx, nil)
 	if err != nil {
 		return err
 	}
@@ -77,7 +78,7 @@ func ComposeStop(ctx context.Context, proj *types.Project, services []string) er
 	stopCtx, cancel := detachFromHTTPContextInternal(ctx)
 	defer cancel()
 
-	c, err := NewClient(stopCtx)
+	c, err := NewClient(stopCtx, nil)
 	if err != nil {
 		return err
 	}
@@ -89,13 +90,13 @@ func ComposeStop(ctx context.Context, proj *types.Project, services []string) er
 	})
 }
 
-func ComposeUp(ctx context.Context, proj *types.Project, services []string, removeOrphans bool, forceRecreate bool) error {
+func ComposeUp(ctx context.Context, proj *types.Project, services []string, removeOrphans bool, forceRecreate bool, authConfigs map[string]registry.AuthConfig) error {
 	// Detach from the HTTP request context so that proxy timeouts and client
 	// disconnects do not cancel a long-running compose up. See #1209.
 	composeCtx, cancel := detachFromHTTPContextInternal(ctx)
 	defer cancel()
 
-	c, err := NewClient(composeCtx)
+	c, err := NewClient(composeCtx, authConfigs)
 	if err != nil {
 		return err
 	}
@@ -294,7 +295,7 @@ func pollContainerStatus(ctx context.Context, svc api.Compose, projectName strin
 }
 
 func ComposePs(ctx context.Context, proj *types.Project, services []string, all bool) ([]api.ContainerSummary, error) {
-	c, err := NewClient(ctx)
+	c, err := NewClient(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +308,7 @@ func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) e
 	downCtx, cancel := detachFromHTTPContextInternal(ctx)
 	defer cancel()
 
-	c, err := NewClient(downCtx)
+	c, err := NewClient(downCtx, nil)
 	if err != nil {
 		return err
 	}
@@ -320,7 +321,7 @@ func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) e
 }
 
 func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow bool, tail string) error {
-	c, err := NewClient(ctx)
+	c, err := NewClient(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -330,7 +331,7 @@ func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow 
 }
 
 func ListGlobalComposeContainers(ctx context.Context) ([]container.Summary, error) {
-	c, err := NewClient(ctx)
+	c, err := NewClient(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/projects/compose.go
+++ b/backend/pkg/projects/compose.go
@@ -3,13 +3,16 @@ package projects
 import (
 	"context"
 	"io"
+	"maps"
 	"strings"
 
 	"github.com/docker/cli/cli/command"
+	clitypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
+	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 )
 
@@ -18,7 +21,7 @@ type Client struct {
 	dockerCli command.Cli
 }
 
-func NewClient(ctx context.Context) (*Client, error) {
+func NewClient(ctx context.Context, authConfigs map[string]registry.AuthConfig) (*Client, error) {
 	cli, err := command.NewDockerCli()
 	if err != nil {
 		return nil, err
@@ -26,6 +29,13 @@ func NewClient(ctx context.Context) (*Client, error) {
 	opts := flags.NewClientOptions()
 	if err := cli.Initialize(opts); err != nil {
 		return nil, err
+	}
+	if composeAuthConfigs := buildComposeAuthConfigsInternal(authConfigs); len(composeAuthConfigs) > 0 {
+		configFile := cli.ConfigFile()
+		if configFile.AuthConfigs == nil {
+			configFile.AuthConfigs = map[string]clitypes.AuthConfig{}
+		}
+		maps.Copy(configFile.AuthConfigs, composeAuthConfigs)
 	}
 
 	composeCLI := wrapDockerCLIWithInspectCompatibilityInternal(cli)
@@ -37,6 +47,37 @@ func NewClient(ctx context.Context) (*Client, error) {
 	}
 
 	return &Client{svc: svc, dockerCli: composeCLI}, nil
+}
+
+func buildComposeAuthConfigsInternal(authConfigs map[string]registry.AuthConfig) map[string]clitypes.AuthConfig {
+	if len(authConfigs) == 0 {
+		return nil
+	}
+
+	composeAuthConfigs := make(map[string]clitypes.AuthConfig, len(authConfigs))
+	for host, authConfig := range authConfigs {
+		key := strings.TrimSpace(host)
+		if key == "" {
+			continue
+		}
+		// Docker CLI auth lookup still uses the legacy index URL for Docker Hub.
+		if key == "docker.io" {
+			key = "https://index.docker.io/v1/"
+		}
+		composeAuthConfigs[key] = clitypes.AuthConfig{
+			Username:      authConfig.Username,
+			Password:      authConfig.Password,
+			Auth:          authConfig.Auth,
+			ServerAddress: authConfig.ServerAddress,
+			IdentityToken: authConfig.IdentityToken,
+			RegistryToken: authConfig.RegistryToken,
+		}
+	}
+	if len(composeAuthConfigs) == 0 {
+		return nil
+	}
+
+	return composeAuthConfigs
 }
 
 type inspectCompatibleDockerCli struct {

--- a/backend/pkg/projects/compose_test.go
+++ b/backend/pkg/projects/compose_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/command"
+	clitypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/flags"
+	dockerregistry "github.com/moby/moby/api/types/registry"
 	mobyclient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +29,32 @@ func TestWrapDockerCLIWithInspectCompatibility(t *testing.T) {
 	require.NotNil(t, wrapped)
 	require.NotSame(t, baseCLI, wrapped)
 	require.NotEqual(t, reflect.TypeFor[*mobyclient.Client](), reflect.TypeOf(wrapped.Client()))
+}
+
+func TestBuildComposeAuthConfigs(t *testing.T) {
+	authConfigs := buildComposeAuthConfigsInternal(map[string]dockerregistry.AuthConfig{
+		"docker.io": {
+			Username:      "docker-user",
+			Password:      "docker-token",
+			ServerAddress: "https://index.docker.io/v1/",
+		},
+		"registry.gitlab.com": {
+			Username:      "gitlab-user",
+			Password:      "gitlab-token",
+			ServerAddress: "registry.gitlab.com",
+		},
+	})
+
+	require.Equal(t, map[string]clitypes.AuthConfig{
+		"https://index.docker.io/v1/": {
+			Username:      "docker-user",
+			Password:      "docker-token",
+			ServerAddress: "https://index.docker.io/v1/",
+		},
+		"registry.gitlab.com": {
+			Username:      "gitlab-user",
+			Password:      "gitlab-token",
+			ServerAddress: "registry.gitlab.com",
+		},
+	}, authConfigs)
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3090

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR passes registry credentials into compose-driven image pulls. The main changes are:

- Wires `ContainerRegistryService` into `ProjectService` creation.
- Loads stored registry auth configs before compose `up` operations.
- Injects registry auth into the Docker CLI config used by Compose.
- Reuses resolved registry credentials for deploy and redeploy image preparation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are narrow and preserve nil-auth behavior for compose operations that do not need credentials. The updated auth conversion path has focused test coverage.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the targeted compose-auth-focused Go test to validate the auth config construction and Docker CLI inspect compatibility, which reported PASS.
- Ran the broader backend package tests, which confirmed the compose-auth subset passed again but surfaced unrelated internal/services failures.
- Reviewed the backend-compose-auth-validation-notes document to capture the commands used, results, and Docker limitations encountered during validation.

<a href="https://app.greptile.com/trex/runs/13288205/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pass registry auth to compose-initi..."](https://github.com/getarcaneapp/arcane/commit/ca8eb0c03c80403689ed9517c3dae1a5a3b774bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41847693)</sub>

<!-- /greptile_comment -->