### PR TITLE
fix: workspace editor showing stale file content after save

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -533,16 +533,21 @@
 
 		const normalizedProject = withLoadedProjectFileContent(details);
 		if (!normalizedProject) return;
+		// A slim save response (no file changes) carries no projectFiles; the tree is
+		// unchanged server-side, so keep the current contents instead of deriving
+		// them from an empty tree.
 		const savedManagedProjectFileContents =
 			options.preserveManagedProjectFileContents === true
-				? Object.fromEntries(
-						(normalizedProject.projectFiles ?? []).flatMap((file) => {
-							if (file.isDirectory) return [];
-							const content =
-								loadedManagedProjectFileContents[file.relativePath] ?? managedProjectFileContents[file.relativePath];
-							return content === undefined ? [] : [[file.relativePath, content] as const];
-						})
-					)
+				? details.projectFiles === undefined
+					? { ...managedProjectFileContents }
+					: Object.fromEntries(
+							(normalizedProject.projectFiles ?? []).flatMap((file) => {
+								if (file.isDirectory) return [];
+								const content =
+									loadedManagedProjectFileContents[file.relativePath] ?? managedProjectFileContents[file.relativePath];
+								return content === undefined ? [] : [[file.relativePath, content] as const];
+							})
+						)
 				: {};
 
 		$inputs.name.value = normalizedProject.name || '';
@@ -551,8 +556,16 @@
 		$inputs.envContent.value = shouldPreserveEnvDraft ? envDraft : normalizedProject.envContent || '';
 		managedProjectFileChanges = [];
 		managedProjectFileContents = savedManagedProjectFileContents;
-		managedProjectFileHasErrors = {};
-		managedProjectFileValidationReady = {};
+		// Seed the per-file UI-state records for every retained path. A mounted
+		// CodePanel binds these entries; handing a bound $bindable-with-fallback
+		// prop an undefined entry throws props_invalid_value and kills the page's
+		// effect tree (stale editor shown until a full refresh).
+		managedProjectFileHasErrors = Object.fromEntries(
+			Object.keys(savedManagedProjectFileContents).map((relativePath) => [relativePath, false])
+		);
+		managedProjectFileValidationReady = Object.fromEntries(
+			Object.keys(savedManagedProjectFileContents).map((relativePath) => [relativePath, true])
+		);
 		managedProjectFileLoadErrors = {};
 		managedProjectFileLoading = {};
 
@@ -956,6 +969,11 @@
 	}
 
 	function openFileTab(key: string) {
+		// The file panel's bound UI-state entries must exist before mount; binding
+		// an undefined entry to a $bindable-with-fallback prop throws props_invalid_value.
+		if (key.startsWith('file:') && !isManagedDirectoryKey(key)) {
+			ensureManagedProjectFileUiState(key.slice(5));
+		}
 		if (!isManagedDirectoryKey(key) && !openTabsPreference.includes(key)) {
 			openTabsPreference = [...openTabsPreference, key];
 		}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3187

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the workspace editor displayed stale (blank) file content after saving a project whose API response did not include a `projectFiles` payload (a "slim" save). It also prevents a secondary crash (`props_invalid_value`) that killed the effect tree when bound per-file UI-state records were `undefined` on re-mount.

- **Root cause fix**: `rebaseEditorDraft` now checks `details.projectFiles === undefined` before calling `withLoadedProjectFileContent`, which converts `undefined` to `[]`; the old code then derived an empty content map from that empty array, wiping the editor.
- **UI-state seeding**: Instead of resetting `managedProjectFileHasErrors` / `managedProjectFileValidationReady` to `{}` (leaving entries `undefined`), the function now seeds them with valid `false`/`true` values for every retained file path, preventing the `props_invalid_value` crash in CodePanel bindings.
- **Proactive guard in `openFileTab`**: Calls `ensureManagedProjectFileUiState` before a tab is pushed, so the bound props always exist before the CodePanel mounts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the save/rebase path and correctly preserves file content on slim save responses.

The three-part fix is logically consistent: the `details.projectFiles === undefined` guard is applied to the raw response before `withLoadedProjectFileContent` converts `undefined` to `[]`, which is precisely where the blank-editor regression occurred. The UI-state seeding replaces an unconditional clear with valid initial values, preventing the bindable-prop crash without introducing new side effects. The `openFileTab` guard mirrors the same invariant. No unhandled branches or race conditions are introduced.

No files require special attention — only `+page.svelte` changed and all three hunks are self-contained.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: workspace editor showing stale file..."](https://github.com/getarcaneapp/arcane/commit/5eadf07b8bc30bcae0f077ceeb1ddab46ea970f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42230021)</sub>

<!-- /greptile_comment -->