### PR TITLE
fix: don't overwrite good image update records on registry rate-limit errors

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -1328,7 +1328,11 @@ func isRateLimitErrorInternal(err error) bool {
 	if err == nil {
 		return false
 	}
-	errLower := strings.ToLower(err.Error())
+	return isRateLimitErrorStringInternal(err.Error())
+}
+
+func isRateLimitErrorStringInternal(msg string) bool {
+	msgLower := strings.ToLower(msg)
 	indicators := []string{
 		"toomanyrequests",
 		"rate limit",
@@ -1338,7 +1342,7 @@ func isRateLimitErrorInternal(err error) bool {
 		"retry-after",
 	}
 	for _, indicator := range indicators {
-		if strings.Contains(errLower, indicator) {
+		if strings.Contains(msgLower, indicator) {
 			return true
 		}
 	}

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -866,7 +866,20 @@ func savePreparedUpdateResultWithTxInternal(tx *gorm.DB, imageID, repo, tag stri
 
 	// Check if there's an existing record to compare state changes
 	var existingRecord models.ImageUpdateRecord
-	if err := tx.Where("id = ?", imageID).First(&existingRecord).Error; err == nil {
+	hasExisting := tx.Where("id = ?", imageID).First(&existingRecord).Error == nil
+
+	// A registry rate limit (429) is transient: keep the previous good result
+	// instead of clobbering it with an error record
+	if hasExisting &&
+		strings.TrimSpace(result.Error) != "" &&
+		isRateLimitErrorStringInternal(result.Error) &&
+		strings.TrimSpace(stringPtrToString(existingRecord.LastError)) == "" {
+		slog.Debug("Preserving previous image update result; check hit a registry rate limit",
+			"imageID", imageID, "repository", repo, "tag", tag, "error", result.Error)
+		return nil
+	}
+
+	if hasExisting {
 		// Existing record found - check if we need to reset notification_sent
 		stateChanged := existingRecord.HasUpdate != updateRecord.HasUpdate
 		digestChanged := stringPtrToString(existingRecord.LatestDigest) != stringPtrToString(updateRecord.LatestDigest)

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -1188,6 +1188,68 @@ func TestImageUpdateService_NotificationSentReset(t *testing.T) {
 	}
 }
 
+func TestImageUpdateService_RateLimitErrorPreservesPreviousResult(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+
+	imageID := "sha256:ratelimit1"
+	repo := "docker.io/library/nginx"
+	tag := "latest"
+	checkTime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+
+	tests := []struct {
+		name            string
+		resultError     string
+		expectPreserved bool
+	}{
+		{
+			name:            "rate limit error preserves previous good record",
+			resultError:     "registry manifest inspect failed for docker.io/library/nginx:latest: manifest request failed with status: 429",
+			expectPreserved: true,
+		},
+		{
+			name:            "non-rate-limit error overwrites previous good record",
+			resultError:     "registry manifest inspect failed for docker.io/library/nginx:latest: manifest unknown",
+			expectPreserved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db.Exec("DELETE FROM image_updates WHERE id = ?", imageID)
+
+			existing := &models.ImageUpdateRecord{
+				ID:             imageID,
+				Repository:     repo,
+				Tag:            tag,
+				HasUpdate:      false,
+				CurrentVersion: tag,
+				CurrentDigest:  stringToPtr("sha256:current"),
+				LatestDigest:   stringToPtr("sha256:current"),
+				CheckTime:      checkTime,
+			}
+			require.NoError(t, db.Create(existing).Error)
+
+			result := &imageupdate.Response{
+				Error:     tt.resultError,
+				CheckTime: time.Now(),
+			}
+			require.NoError(t, savePreparedUpdateResultWithTxInternal(db.DB, imageID, repo, tag, result))
+
+			var saved models.ImageUpdateRecord
+			require.NoError(t, db.First(&saved, "id = ?", imageID).Error)
+
+			if tt.expectPreserved {
+				assert.Nil(t, saved.LastError, "previous good record should be preserved")
+				assert.Equal(t, "sha256:current", stringPtrToString(saved.LatestDigest))
+				assert.Equal(t, checkTime, saved.CheckTime.UTC())
+			} else {
+				assert.Equal(t, tt.resultError, stringPtrToString(saved.LastError))
+				assert.Nil(t, saved.LatestDigest)
+			}
+		})
+	}
+}
+
 // TestGetUnnotifiedUpdates tests retrieving updates that haven't been notified
 func TestImageUpdateService_GetUnnotifiedUpdates(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3186

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes image update persistence so registry rate limits do not erase good update records. The main changes are:

- Reused rate-limit string detection for persisted image update results.
- Preserved an existing successful image update record when a new check returns a transient 429-style error.
- Added tests for preserving good records on rate-limit errors and overwriting them on non-rate-limit errors.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrow, reuses existing rate-limit detection, and includes tests for the preserved and overwritten cases.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We reviewed the focused rate-limit image update tests log and confirmed that TestImageUpdateService\_RateLimitErrorPreservesPreviousRecord and rate\_limit\_error\_preserves\_previous\_good\_record passed, along with snapshot persistence, and the run ended with EXIT\_CODE 0.
- We reviewed the broader affected-image-update-registry tests log and confirmed the affected TestContainerRegistryService... and TestImageUpdateService... subsets passed, with the package ok and EXIT\_CODE 0.

<a href="https://app.greptile.com/trex/runs/13479494/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t overwrite good image update r..."](https://github.com/getarcaneapp/arcane/commit/cbb431ad6f8935cddf57639731d47b7635023536) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42235169)</sub>

<!-- /greptile_comment -->