### PR TITLE
fix: fix https links on containers list

### DIFF
--- a/frontend/src/lib/utils/navigation.ts
+++ b/frontend/src/lib/utils/navigation.ts
@@ -145,12 +145,19 @@ export function toPortHref(hostPort: string, baseServerUrl?: string): string {
 	try {
 		const base = baseServerUrl || (typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
 		const scheme = hostPort.endsWith('443') ? 'https' : 'http';
-		const url = new URL(base.startsWith('http') ? base.replace('http://', `${scheme}://`) : `${scheme}://${base}`);
+		const host = afterSubstring(base, "://");
+
+		const url = new URL(`${scheme}://${host}`);
 		url.port = hostPort;
 		return url.toString();
 	} catch {
 		return '#';
 	}
+}
+
+function afterSubstring(text: string, search: string): string {
+  const index = text.indexOf(search);
+  return index === -1 ? text : text.slice(index + search.length);
 }
 
 export function toSafeHref(raw: string, scheme: string = 'https'): string {

--- a/frontend/src/lib/utils/navigation.ts
+++ b/frontend/src/lib/utils/navigation.ts
@@ -144,7 +144,8 @@ function getExpectedCode(key: string): string | null {
 export function toPortHref(hostPort: string, baseServerUrl?: string): string {
 	try {
 		const base = baseServerUrl || (typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
-		const url = new URL(base.startsWith('http') ? base : `http://${base}`);
+		const scheme = hostPort.endsWith('443') ? 'https' : 'http';
+		const url = new URL(base.startsWith('http') ? base.replace('http://', `${scheme}://`) : `${scheme}://${base}`);
 		url.port = hostPort;
 		return url.toString();
 	} catch {


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes https (_Ports_) links on Containers page

Fixes: #3094, which displayed an error when clicking the link

## Changes Made

Use the https scheme, if the external port mapping ends with '443'

## Testing Done

UI testing

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates container port links on the Containers page. The main changes are:

- Uses `https` for published host ports ending in `443`.
- Uses `http` for other published host ports.
- Rebuilds the link from the configured base host before applying the selected scheme and port.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to `toPortHref`, and the previously reported HTTPS-base issue is addressed by rebuilding the URL with the selected scheme.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated a Playwright-driven UI test run and produced a full artifact bundle including the Playwright harness, dev server log, browser console/network log, UI assertion log, and a utility fallback log.
- Validated the containers-port-links-utility.log shows captured href values and an exit code of 0, confirming the utility ran successfully.
- Reviewed the UI run evidence across the UI assertions, UI devserver, and UI browser logs to confirm the UI flow executed and relevant events were recorded.
- Organized the produced artifacts under trex-artifacts for reviewer access and future inspection.

<a href="https://app.greptile.com/trex/runs/13642711/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix links with https base server url"](https://github.com/getarcaneapp/arcane/commit/18ab58237bb0d79e9a643aa843018173da48e1da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42235198)</sub>

<!-- /greptile_comment -->