### PR TITLE
fix: git clone failures with Azure DevOps repositories

### DIFF
--- a/backend/pkg/gitutil/git.go
+++ b/backend/pkg/gitutil/git.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -33,6 +34,15 @@ import (
 // distroless image. Unregister it so a repository URL can never reach it.
 func init() {
 	client.InstallProtocol("file", nil)
+
+	// go-git strips multi_ack/multi_ack_detailed from pack negotiation by
+	// default, which Azure DevOps rejects by sending an incomplete pack
+	// ("invalid reset option: object not found" on clone). Advertise them and
+	// keep only thin-pack disabled, matching Flux/ArgoCD; other hosts are
+	// unaffected.
+	transport.UnsupportedCapabilities = []capability.Capability{
+		capability.ThinPack,
+	}
 }
 
 // Client handles git operations

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -12,8 +12,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+// Azure DevOps requires multi_ack/multi_ack_detailed in pack negotiation;
+// go-git's default UnsupportedCapabilities strips them and clones fail with
+// "invalid reset option: object not found" (#3168).
+func TestInitAllowsMultiAckCapabilities(t *testing.T) {
+	if len(transport.UnsupportedCapabilities) != 1 || transport.UnsupportedCapabilities[0] != capability.ThinPack {
+		t.Errorf("expected UnsupportedCapabilities to contain only thin-pack, got %v", transport.UnsupportedCapabilities)
+	}
+}
 
 func TestGetKnownHostsPath(t *testing.T) {
 	t.Run("returns SSH_KNOWN_HOSTS env var when set", func(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3168

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts go-git capability negotiation for Azure DevOps clones. The main changes are:

- Keeps `multi_ack` and `multi_ack_detailed` available during pack negotiation.
- Leaves `thin-pack` disabled in go-git's unsupported capability list.
- Adds a regression test for the initialized unsupported capability state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and inspected the proof log for Go version, the exact command run, verbose test output, and exit code, and also reviewed the selection rationale documenting why this Azure DevOps clone regression test is the narrowest.

<a href="https://app.greptile.com/trex/runs/13636491/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: git clone failures with Azure DevOp..."](https://github.com/getarcaneapp/arcane/commit/1ee7be55776b1a692e92df9700f285dfd797c41f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42591424)</sub>

<!-- /greptile_comment -->