### PR TITLE
fix: gitops sync failing with 'invalid hostPort: /placeholder-undefined' for compose files using variable defaults

### DIFF
--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -2,6 +2,7 @@ package projects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -208,12 +209,20 @@ func lenientCastSizeInternal(value string) (any, error) {
 	return int(n), nil
 }
 
+const lenientUndefinedPlaceholder = "/placeholder-undefined"
+
 // ApplyLenientLoaderOptions configures a compose loader.Options for tolerant
 // loading: structural validation and consistency checks are skipped, and
-// undefined ${VAR} references are substituted with a placeholder instead of
+// unresolvable ${VAR} references are substituted with a placeholder instead of
 // an empty string (which would otherwise produce invalid volume/bind specs
 // like ":/path"). Callers use this when a .env file may not yet exist or may
 // not define every variable the compose file references.
+//
+// The placeholder is applied at the substitution level, not the lookup level:
+// the lookup must keep reporting undefined variables as missing so compose-go
+// resolves default operators (${VAR:-default}, ${VAR-default}) normally.
+// Reporting the placeholder as the variable's value would suppress those
+// defaults and feed the placeholder into fields like ports host entries.
 func ApplyLenientLoaderOptions(ctx context.Context, opts *loader.Options, composeFile string) {
 	opts.SkipValidation = true
 	opts.SkipConsistencyCheck = true
@@ -222,16 +231,28 @@ func ApplyLenientLoaderOptions(ctx context.Context, opts *loader.Options, compos
 		return
 	}
 
-	realLookup := opts.Interpolate.LookupValue
 	opts.Interpolate = &interp.Options{
-		Substitute:      template.Substitute,
+		LookupValue:     opts.Interpolate.LookupValue,
 		TypeCastMapping: wrapTypeCastMappingLenientInternal(opts.Interpolate.TypeCastMapping),
-		LookupValue: func(key string) (string, bool) {
-			if val, ok := realLookup(key); ok {
-				return val, true
-			}
-			slog.DebugContext(ctx, "compose variable undefined during lenient load, using placeholder", "variable", key, "compose_file", composeFile)
-			return "/placeholder-undefined", true
+		Substitute: func(tmpl string, mapping template.Mapping) (string, error) {
+			return template.SubstituteWithOptions(tmpl, mapping,
+				template.WithoutLogging,
+				template.WithReplacementFunction(func(substring string, mapping template.Mapping, cfg *template.Config) (string, error) {
+					value, applied, err := template.DefaultReplacementAppliedFunc(substring, mapping, cfg)
+					var missingErr *template.MissingRequiredError
+					switch {
+					case err == nil && applied:
+						return value, nil
+					case err != nil && !errors.As(err, &missingErr):
+						return "", err
+					default:
+						// Variable is unset with no default (or a ${VAR:?msg}
+						// required variable, which lenient loading tolerates).
+						slog.DebugContext(ctx, "compose variable undefined during lenient load, using placeholder", "expression", substring, "compose_file", composeFile)
+						return lenientUndefinedPlaceholder, nil
+					}
+				}),
+			)
 		},
 	}
 }

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -308,6 +308,36 @@ func TestLoadComposeProjectLenient_ToleratesUndefinedTypedFieldVariables(t *test
 	assert.Len(t, project.Services, 1)
 }
 
+func TestLoadComposeProjectLenient_AppliesVariableDefaults(t *testing.T) {
+	t.Parallel()
+
+	// The lenient loader used to report the placeholder as every undefined
+	// variable's value, which suppressed
+	// ${VAR:-default} resolution and fed "/placeholder-undefined" into the
+	// ports host entry ("invalid hostPort"). Defaults must resolve normally;
+	// only variables with no default fall back to the placeholder.
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte(`services:
+  app:
+    image: nginx:alpine
+    ports:
+      - "${ARCANE_TEST_UNSET_PORT:-3169}:3000"
+    environment:
+      - MAX_FILE_SIZE=${ARCANE_TEST_UNSET_SIZE:-104857600}
+`), 0o600))
+
+	project, err := LoadComposeProjectLenient(context.Background(), composePath, "demo", dir, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	require.Len(t, project.Services, 1)
+	svc := project.Services["app"]
+	require.Len(t, svc.Ports, 1)
+	assert.Equal(t, "3169", svc.Ports[0].Published)
+	require.NotNil(t, svc.Environment["MAX_FILE_SIZE"])
+	assert.Equal(t, "104857600", *svc.Environment["MAX_FILE_SIZE"])
+}
+
 func TestLoadComposeProject_UsesProjectLevelComposeLabelsForIncludedServices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3195

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes lenient Compose loading for variable defaults. The main changes are:

- Keeps undefined variables missing during lookup so Compose default operators still apply.
- Falls back to the lenient placeholder only for unresolved substitutions without usable defaults.
- Adds a regression test for defaulted port and environment substitutions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to lenient Compose interpolation and preserves existing lookup and type-cast wrapping behavior. The new test covers the reported default-variable failure path.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The temporary pre-fix placeholder lookup run failed, demonstrating the path change is exercised by the focused regression test.
- The compose-loader environment tests were executed, and the run exited with code 0 with the TestLoadComposeProjectLenient\_AppliesVariableDefaults test passing.
- The regression snippet was reviewed, confirming a port binding of 3169 and the default environment value of 104857600.
- Three test logs were opened and referenced to verify the test outcomes.

<a href="https://app.greptile.com/trex/runs/13637696/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gitops sync failing with &#39;invalid h..."](https://github.com/getarcaneapp/arcane/commit/de5f70ab93cc214f3af9c5c7c0766f3f47ed4d72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42593699)</sub>

<!-- /greptile_comment -->