### PR TITLE
fix: allow updater to update specific resource id's

### DIFF
--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -140,7 +140,11 @@ func (s *UpdaterService) registryDigestResolverInternal() updaterdigest.RemoteRe
 	return s.deps.RegistryDigestResolver
 }
 
-// ApplyPending executes pending image updates.
+// ApplyPending executes pending image updates. When the options carry
+// resource IDs the run is scoped: the engine's ApplyPending has no resource
+// filtering (it would apply every pending update), so scoped requests resolve
+// to concrete containers and go through the engine's single-container path
+// instead — same activity, events, and cleanup either way.
 func (s *UpdaterService) ApplyPending(ctx context.Context, options updater.Options) (out *updater.Result, err error) {
 	start := time.Now()
 	activityID := s.startAutoUpdateActivityInternal(ctx, options.DryRun)
@@ -163,19 +167,27 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, options updater.Optio
 		"phase":       "start",
 		"dryRun":      options.DryRun,
 		"forceUpdate": options.ForceUpdate,
+		"scopedType":  options.Type,
+		"scopedCount": len(options.ResourceIds),
 		"time":        time.Now().UTC().Format(time.RFC3339),
 	})
 	s.appendAutoUpdateActivityMessageInternal(ctx, activityID, "Planning pending updates", "Planning updates", 5)
 
-	moduleResult, engineErr := s.engineInternal().ApplyPending(ctx, moduleOptionsFromUpdaterOptionsInternal(options))
-	if moduleResult != nil {
-		out = resultFromModuleInternal(moduleResult)
-		out.ActivityID = utils.StringPtrFromTrimmed(activityID)
-		s.logResultItemsInternal(ctx, out)
-	}
-	if engineErr != nil {
-		err = engineErr
-		return out, err
+	if len(options.ResourceIds) > 0 {
+		if err = s.applyScopedUpdatesInternal(ctx, options, out); err != nil {
+			return out, err
+		}
+	} else {
+		moduleResult, engineErr := s.engineInternal().ApplyPending(ctx, moduleOptionsFromUpdaterOptionsInternal(options))
+		if moduleResult != nil {
+			out = resultFromModuleInternal(moduleResult)
+			out.ActivityID = utils.StringPtrFromTrimmed(activityID)
+			s.logResultItemsInternal(ctx, out)
+		}
+		if engineErr != nil {
+			err = engineErr
+			return out, err
+		}
 	}
 
 	if !options.DryRun && s.deps.ImageUpdates != nil {
@@ -196,6 +208,154 @@ func (s *UpdaterService) ApplyPending(ctx context.Context, options updater.Optio
 		"time":      time.Now().UTC().Format(time.RFC3339),
 	})
 	return out, nil
+}
+
+// applyScopedUpdatesInternal runs a scoped update into the caller's result:
+// resolves the requested resources to container IDs and updates each through
+// the engine's single-container path.
+func (s *UpdaterService) applyScopedUpdatesInternal(ctx context.Context, options updater.Options, out *updater.Result) error {
+	containerIDs, err := s.resolveScopedContainerIDsInternal(ctx, options)
+	if err != nil {
+		return err
+	}
+	if len(containerIDs) == 0 {
+		return fmt.Errorf("no containers matched the requested %s resources", strings.TrimSpace(options.Type))
+	}
+
+	engineOpts := moduletypes.Options{Force: options.ForceUpdate, DryRun: options.DryRun}
+	var engineErrs []error
+	for _, containerID := range containerIDs {
+		moduleResult, engineErr := s.engineInternal().UpdateContainer(ctx, containerID, engineOpts)
+		if moduleResult != nil {
+			partial := resultFromModuleInternal(moduleResult)
+			out.Checked += partial.Checked
+			out.Updated += partial.Updated
+			out.Restarted += partial.Restarted
+			out.Skipped += partial.Skipped
+			out.Failed += partial.Failed
+			out.Items = append(out.Items, partial.Items...)
+		}
+		if engineErr != nil {
+			out.Failed++
+			out.Items = append(out.Items, updater.ResourceResult{
+				ResourceID:   containerID,
+				ResourceType: "container",
+				Status:       updater.StatusFailed,
+				Error:        engineErr.Error(),
+			})
+			engineErrs = append(engineErrs, fmt.Errorf("%s: %w", containerID, engineErr))
+		}
+	}
+	s.logResultItemsInternal(ctx, out)
+	out.Success = out.Failed == 0
+	// Engine errors propagate like the unscoped path's engine error does —
+	// the remaining containers were still attempted and recorded above.
+	return errors.Join(engineErrs...)
+}
+
+// resolveScopedContainerIDsInternal maps a scoped options payload to the
+// container IDs it covers.
+func (s *UpdaterService) resolveScopedContainerIDsInternal(ctx context.Context, options updater.Options) ([]string, error) {
+	requested := make([]string, 0, len(options.ResourceIds))
+	for _, id := range options.ResourceIds {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			requested = append(requested, trimmed)
+		}
+	}
+	if len(requested) == 0 {
+		return nil, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(options.Type)) {
+	case "", "container":
+		return requested, nil
+	case "project":
+		return s.containerIDsForProjectsInternal(ctx, requested)
+	case "image":
+		return s.containerIDsForImagesInternal(ctx, requested)
+	default:
+		return nil, fmt.Errorf("unsupported scoped update type %q", options.Type)
+	}
+}
+
+// containerIDsForProjectsInternal resolves project IDs or compose names to
+// the IDs of the containers that belong to those projects.
+func (s *UpdaterService) containerIDsForProjectsInternal(ctx context.Context, projectRefs []string) ([]string, error) {
+	if s.deps.Docker == nil {
+		return nil, errors.New("docker service unavailable")
+	}
+
+	names := make(map[string]struct{}, len(projectRefs))
+	for _, ref := range projectRefs {
+		name := ref
+		if s.deps.Projects != nil {
+			if project, lookupErr := s.deps.Projects.GetProjectFromDatabaseByID(ctx, ref); lookupErr == nil && project != nil {
+				switch {
+				case project.ComposeProjectName != nil && strings.TrimSpace(*project.ComposeProjectName) != "":
+					name = *project.ComposeProjectName
+				case strings.TrimSpace(project.Name) != "":
+					name = project.Name
+				}
+			}
+		}
+		names[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+	}
+
+	containers, _, _, _, err := s.deps.Docker.GetAllContainers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+
+	var ids []string
+	for _, summary := range containers {
+		project := strings.ToLower(strings.TrimSpace(dockerutil.ComposeProjectLabel(summary.Labels)))
+		if project == "" {
+			continue
+		}
+		if _, ok := names[project]; ok {
+			ids = append(ids, summary.ID)
+		}
+	}
+	return ids, nil
+}
+
+// containerIDsForImagesInternal resolves image IDs or references to the IDs
+// of the containers currently running those images.
+func (s *UpdaterService) containerIDsForImagesInternal(ctx context.Context, imageRefs []string) ([]string, error) {
+	if s.deps.Docker == nil {
+		return nil, errors.New("docker service unavailable")
+	}
+
+	wanted := make(map[string]struct{}, len(imageRefs)*2)
+	for _, ref := range imageRefs {
+		trimmed := strings.TrimSpace(ref)
+		if trimmed == "" {
+			continue
+		}
+		wanted[trimmed] = struct{}{}
+		if normalized := refs.NormalizeImageUpdateRef(trimmed); normalized != "" {
+			wanted[normalized] = struct{}{}
+		}
+	}
+
+	containers, _, _, _, err := s.deps.Docker.GetAllContainers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+
+	var ids []string
+	for _, summary := range containers {
+		if _, ok := wanted[summary.ImageID]; ok {
+			ids = append(ids, summary.ID)
+			continue
+		}
+		if normalized := refs.NormalizeImageUpdateRef(summary.Image); normalized != "" {
+			if _, ok := wanted[normalized]; ok {
+				ids = append(ids, summary.ID)
+			}
+		}
+	}
+	return ids, nil
 }
 
 // UpdateSingleContainer updates a single container by ID to the latest available image.


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds scoped update support to the updater service, allowing callers to pass specific resource IDs (containers, projects, or images) so only those resources are updated instead of running the full pending-update sweep.

- `applyScopedUpdatesInternal` resolves resources to container IDs and drives each through the engine's per-container path, accumulating results and propagating hard engine errors via `errors.Join`.
- Two new helpers (`containerIDsForProjectsInternal`, `containerIDsForImagesInternal`) map project and image refs to container IDs, with proper normalization and deduplication via the Docker container list.
- The direct `container` type path returns caller-supplied IDs verbatim; duplicate IDs in `ResourceIds` would cause the same container to be attempted twice.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; the new scoped path is well-isolated from the existing unscoped path and mirrors its error-propagation contract.

The core resolution and update logic is sound. The engine's UpdateContainer always returns either a result with nil error or a nil result with an error, so the failure-accumulation loop is free of double-counting. Project and image resolution naturally deduplicate through the Docker container list. The only identified issue is the direct-container path not deduplicating caller-supplied IDs, which requires the caller to pass duplicates to trigger and is a defensive-coding concern rather than a present defect in normal usage.

backend/internal/services/updater_service.go — specifically the resolveScopedContainerIDsInternal return for the container type (no deduplication of the incoming ID slice).
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: allow updater to update specific re..."](https://github.com/getarcaneapp/arcane/commit/078becf60f44458fdc2c16eec9de40192cffc938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42843006)</sub>

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->