### PR TITLE
fix: stale pending-update counts after container updates

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -1488,12 +1488,29 @@ func (s *ImageUpdateService) GetUpdateSummary(ctx context.Context) (*imageupdate
 	}
 	dockerImages := dockerImagesResult.Items
 
+	// Only tagged images count: a replaced image lingers untagged
+	// ("<none>:<none>") until pruned, and its stale update record would
+	// otherwise keep inflating the summary with updates nothing can act on.
 	liveImageIDs := make([]string, 0, len(dockerImages))
 	for _, img := range dockerImages {
+		if !hasUsableTagInternal(img.RepoTags) {
+			continue
+		}
 		liveImageIDs = append(liveImageIDs, img.ID)
 	}
 
 	return s.getUpdateSummaryForImageIDsInternal(ctx, liveImageIDs)
+}
+
+// hasUsableTagInternal reports whether an image still carries a pullable
+// repo:tag.
+func hasUsableTagInternal(repoTags []string) bool {
+	for _, tag := range repoTags {
+		if tag != "" && tag != "<none>:<none>" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *ImageUpdateService) getUpdateSummaryForImageIDsInternal(ctx context.Context, imageIDs []string) (*imageupdate.Summary, error) {

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -247,6 +247,7 @@ func (s *UpdaterService) applyScopedUpdatesInternal(ctx context.Context, options
 		}
 	}
 	s.logResultItemsInternal(ctx, out)
+	s.clearAppliedUpdateRecordsInternal(ctx, out)
 	out.Success = out.Failed == 0
 	// Engine errors propagate like the unscoped path's engine error does —
 	// the remaining containers were still attempted and recorded above.
@@ -382,6 +383,7 @@ func (s *UpdaterService) UpdateSingleContainer(ctx context.Context, containerID 
 		out = resultFromModuleInternal(moduleResult)
 		out.ActivityID = utils.StringPtrFromTrimmed(activityID)
 		s.logResultItemsInternal(ctx, out)
+		s.clearAppliedUpdateRecordsInternal(ctx, out)
 	}
 	if engineErr != nil {
 		err = engineErr
@@ -954,6 +956,37 @@ func (s *UpdaterService) clearImageUpdateRecordForModuleInternal(ctx context.Con
 		return query.Where("id = ?", record.ID).Update("has_update", false).Error
 	}
 	return query.Where("repository = ? AND tag = ?", record.Repository, record.Tag).Update("has_update", false).Error
+}
+
+// clearAppliedUpdateRecordsInternal flips has_update off for records the
+// engine just applied through the single-container path. The engine's
+// ApplyPending clears its own records, but UpdateContainer does not — without
+// this, an applied update keeps counting toward the pending-updates summary
+// for as long as the replaced (now dangling) image remains on disk.
+func (s *UpdaterService) clearAppliedUpdateRecordsInternal(ctx context.Context, result *updater.Result) {
+	if result == nil || s.deps.DB == nil {
+		return
+	}
+	for _, item := range result.Items {
+		if !item.UpdateApplied && item.Status != updater.StatusUpdated {
+			continue
+		}
+		// The record row is keyed by the replaced image's ID; the repo:tag
+		// pair is the stable fallback key when the old ref isn't ID-like.
+		if oldID := strings.TrimSpace(item.OldImages["main"]); refs.IsImageIDLikeReference(oldID) {
+			if err := s.clearImageUpdateRecordForModuleInternal(ctx, moduletypes.ImageUpdateRecord{ID: oldID}); err != nil {
+				s.loggerInternal().WarnContext(ctx, "clear applied update record by id failed", "id", oldID, "error", err)
+			}
+		}
+		if newRef := strings.TrimSpace(item.NewImages["main"]); newRef != "" {
+			if parsed, err := refs.NormalizeReference(newRef); err == nil {
+				record := moduletypes.ImageUpdateRecord{Repository: parsed.Repository, Tag: parsed.Tag}
+				if err := s.clearImageUpdateRecordForModuleInternal(ctx, record); err != nil {
+					s.loggerInternal().WarnContext(ctx, "clear applied update record by ref failed", "ref", newRef, "error", err)
+				}
+			}
+		}
+	}
 }
 
 func mapToJSONInternal(values map[string]string) models.JSON {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates pending image update cleanup so stale counts are reduced after container updates. The main changes are:

- Filters untagged dangling Docker images out of update summary counts.
- Clears applied update records after scoped update runs.
- Clears applied update records after single-container update runs.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the stale-record cleanup bug.

One contained correctness issue remains in the new cleanup fallback. The fallback targets the replacement image reference, so old repo/tag records can stay marked as pending.

`backend/internal/services/updater_service.go`
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the target code path to confirm how item.NewImages\['main'\] is normalized and cleared by the new repository/tag.
- Identified existing same-package test patterns using setupProjectTestDB with in-memory sqlite and models.ImageUpdateRecord, but did not complete or run the generated repro test.
- Evaluated the stale-pending-update test source and examined the verbose Go test output, which shows the targeted test passed with exit code 0.
- Verified cleanup ran and removed the temporary test file, leaving only artifact/internal directories untracked.

<a href="https://app.greptile.com/trex/runs/13776052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2207-08-fix_scope_updater_runs_and_stop_stale_update_counts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2207-08-fix_scope_updater_runs_and_stop_stale_update_counts%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fupdater_service.go%3A981-984%0A**Clears%20wrong%20reference**%0AWhen%20%60OldImages%5B%22main%22%5D%60%20is%20a%20tag%20instead%20of%20an%20image%20ID%2C%20this%20fallback%20clears%20the%20new%20image's%20repo%2Ftag%2C%20not%20the%20pending%20record%20for%20the%20replaced%20image.%20For%20an%20update%20from%20%60nginx%3A1.2.3%60%20to%20%60nginx%3A1.2.4%60%2C%20the%20stale%20%60nginx%3A1.2.3%60%20row%20remains%20%60has_update%3Dtrue%60%2C%20so%20the%20pending%20count%20stays%20stale%20for%20the%20exact%20non-ID%20case%20this%20branch%20is%20meant%20to%20fix.%0A%0A&repo=getarcaneapp%2Farcane&pr=3218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fupdater_service.go%3A981-984%0A**Clears%20wrong%20reference**%0AWhen%20%60OldImages%5B%22main%22%5D%60%20is%20a%20tag%20instead%20of%20an%20image%20ID%2C%20this%20fallback%20clears%20the%20new%20image's%20repo%2Ftag%2C%20not%20the%20pending%20record%20for%20the%20replaced%20image.%20For%20an%20update%20from%20%60nginx%3A1.2.3%60%20to%20%60nginx%3A1.2.4%60%2C%20the%20stale%20%60nginx%3A1.2.3%60%20row%20remains%20%60has_update%3Dtrue%60%2C%20so%20the%20pending%20count%20stays%20stale%20for%20the%20exact%20non-ID%20case%20this%20branch%20is%20meant%20to%20fix.%0A%0A&repo=getarcaneapp%2Farcane&pr=3218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/updater_service.go:981-984
**Clears wrong reference**
When `OldImages["main"]` is a tag instead of an image ID, this fallback clears the new image's repo/tag, not the pending record for the replaced image. For an update from `nginx:1.2.3` to `nginx:1.2.4`, the stale `nginx:1.2.3` row remains `has_update=true`, so the pending count stays stale for the exact non-ID case this branch is meant to fix.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stale pending-update counts after c..."](https://github.com/getarcaneapp/arcane/commit/62acca39a5ea76924153377a37ffba5a0b9325ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42886501)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->