### PR TITLE
fix: remove rbac from notification dispatch endpoint for agents

### DIFF
--- a/backend/api/handlers/notifications.go
+++ b/backend/api/handlers/notifications.go
@@ -150,6 +150,8 @@ func RegisterNotifications(api huma.API, notificationSvc *services.NotificationS
 		Security:    []map[string][]string{{"BearerAuth": {}}, {"ApiKeyAuth": {}}},
 	}, authz.PermNotificationsManage, h.TestNotification)
 
+	// Environment tokens are authenticated by ApiKeyAuth and revalidated by the
+	// handler. RBAC middleware cannot scope this route because it has no environment ID.
 	huma.Register(api, huma.Operation{
 		OperationID: "dispatch-notification",
 		Method:      http.MethodPost,
@@ -157,7 +159,6 @@ func RegisterNotifications(api huma.API, notificationSvc *services.NotificationS
 		Summary:     "Dispatch notification from remote agent to manager",
 		Tags:        []string{"Notifications"},
 		Security:    []map[string][]string{{"ApiKeyAuth": {}}},
-		Middlewares: humamw.RequirePermission(api, authz.PermNotificationsManage),
 	}, h.DispatchNotification)
 }
 

--- a/backend/api/handlers/notifications_test.go
+++ b/backend/api/handlers/notifications_test.go
@@ -1,17 +1,27 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humaecho"
+	humamw "github.com/getarcaneapp/arcane/backend/v2/api/middleware"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
+	"github.com/getarcaneapp/arcane/types/v2/base"
+	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
 	notificationdto "github.com/getarcaneapp/arcane/types/v2/notification"
+	"github.com/labstack/echo/v4"
 	sqlite "github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -133,4 +143,93 @@ func TestDispatchNotification_ReturnsBadRequestForUnsupportedDispatchKind(t *tes
 	require.ErrorAs(t, err, &statusErr)
 	require.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
 	require.Contains(t, statusErr.Error(), "unsupported dispatch kind")
+}
+
+func TestDispatchNotificationRoute_AuthenticatesEnvironmentAccessToken(t *testing.T) {
+	ctx := context.Background()
+	db, svc := setupNotificationHandlerTestService(t)
+	cfg := &config.Config{}
+	envSvc := services.NewEnvironmentService(db, nil, nil, nil, nil, nil)
+
+	token := "remote-token"
+	now := time.Now()
+	require.NoError(t, db.WithContext(ctx).Create(&models.Environment{
+		BaseModel:   models.BaseModel{ID: "env-remote", CreatedAt: now, UpdatedAt: &now},
+		Name:        "Remote Edge",
+		ApiUrl:      "http://remote.example",
+		Enabled:     true,
+		Status:      string(models.EnvironmentStatusOnline),
+		AccessToken: &token,
+	}).Error)
+
+	router := echo.New()
+	humaConfig := huma.DefaultConfig("test", "1.0.0")
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"BearerAuth": {Type: "http", Scheme: "bearer"},
+		"ApiKeyAuth": {Type: "apiKey", In: "header", Name: "X-API-Key"},
+	}
+	humaConfig.Components.Schemas = huma.NewMapRegistry("#/components/schemas/", func(t reflect.Type, hint string) string {
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		name := huma.DefaultSchemaNamer(t, hint)
+		if t.PkgPath() == "" {
+			return name
+		}
+		return strings.NewReplacer("/", "_", ".", "_").Replace(t.PkgPath()) + "_" + name
+	})
+	api := humaecho.NewWithGroup(router, router.Group("/api"), humaConfig)
+	api.UseMiddleware(humamw.NewAuthBridge(api, &services.AuthService{}, nil, nil, envSvc, cfg))
+	RegisterNotifications(api, svc, cfg)
+
+	payload, err := json.Marshal(notificationdto.DispatchRequest{
+		Kind: notificationdto.DispatchKindImageUpdate,
+		ImageUpdate: &notificationdto.DispatchImageUpdate{
+			ImageRef: "nginx:latest",
+			UpdateInfo: imageupdate.Response{
+				HasUpdate:     true,
+				UpdateType:    "digest",
+				CurrentDigest: "sha256:current",
+				LatestDigest:  "sha256:latest",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("accepts stored environment token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/notifications/dispatch", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", token)
+		rec := httptest.NewRecorder()
+
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		var response base.ApiResponse[notificationdto.DispatchResponse]
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+		require.True(t, response.Success)
+		require.Equal(t, "Notification dispatched successfully", response.Data.Message)
+		require.Zero(t, response.Data.Delivered)
+	})
+
+	for _, testCase := range []struct {
+		name  string
+		token string
+	}{
+		{name: "rejects missing token"},
+		{name: "rejects unknown token", token: "unknown-token"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/notifications/dispatch", bytes.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			if testCase.token != "" {
+				req.Header.Set("X-API-Key", testCase.token)
+			}
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+		})
+	}
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3205

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the notification dispatch route so remote agents can authenticate with environment tokens. The main changes are:

- Removes RBAC middleware from `POST /notifications/dispatch` while keeping `ApiKeyAuth` on the route.
- Documents that environment tokens are authenticated by middleware and revalidated by the handler.
- Adds route-level tests for accepted, missing, and unknown environment access tokens.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to one dispatch endpoint, and the route still requires `ApiKeyAuth` with handler/service token validation before dispatch.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the notification dispatch authentication tests against the updated backend handler package to confirm the initial failure with an HTTP 403 and permission denied for accepts\_stored\_environment\_token.
- Re-ran the tests after applying changes, confirming that all three subtests pass, with the valid environment token path logging a dispatch message and the missing/unknown token rejections returning HTTP 401.
- Compared the before and after artifacts to verify the transition from failure to success in the authentication checks.
- Executed tests directly against the updated backend handler package without Docker or unrelated frontend/UI suites.

<a href="https://app.greptile.com/trex/runs/13874210/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove rbac from notification dispa..."](https://github.com/getarcaneapp/arcane/commit/e8b25ac176f1c68104cb394e8e297c0113ba9efc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43082227)</sub>

<!-- /greptile_comment -->