### PR TITLE
fix: fix image polling schedule rescheduling api shape

### DIFF
--- a/backend/internal/services/job_service.go
+++ b/backend/internal/services/job_service.go
@@ -20,6 +20,7 @@ import (
 
 type JobRunner interface {
 	GetJob(jobID string) (schedulertypes.Job, bool)
+	GetJobRuntimeState(jobID string) (schedulertypes.JobRuntimeState, bool)
 	RescheduleJob(ctx context.Context, job schedulertypes.Job) error
 }
 
@@ -65,17 +66,19 @@ func (s *JobService) SetScheduler(ctx context.Context, scheduler JobRunner) { //
 }
 
 func (s *JobService) GetJobSchedules(ctx context.Context) jobschedule.Config {
+	defaults := DefaultSettingsConfig()
+
 	// Use SettingsService cache for fast reads.
 	return jobschedule.Config{
-		EnvironmentHealthInterval:      s.settings.GetStringSetting(ctx, "environmentHealthInterval", "0 */2 * * * *"),
-		EventCleanupInterval:           s.settings.GetStringSetting(ctx, "eventCleanupInterval", "0 0 */6 * * *"),
-		ExpiredSessionsCleanupInterval: s.settings.GetStringSetting(ctx, "expiredSessionsCleanupInterval", "0 0 0 * * *"),
-		AutoUpdateInterval:             s.settings.GetStringSetting(ctx, "autoUpdateInterval", "0 0 0 * * *"),
-		DockerClientRefreshInterval:    s.settings.GetStringSetting(ctx, "dockerClientRefreshInterval", "*/30 * * * * *"),
-		PollingInterval:                s.settings.GetStringSetting(ctx, "pollingInterval", "0 */15 * * * *"),
-		ScheduledPruneInterval:         s.settings.GetStringSetting(ctx, "scheduledPruneInterval", "0 0 0 * * *"),
-		VulnerabilityScanInterval:      s.settings.GetStringSetting(ctx, "vulnerabilityScanInterval", "0 0 0 * * *"),
-		AutoHealInterval:               s.settings.GetStringSetting(ctx, "autoHealInterval", "*/30 * * * * *"),
+		EnvironmentHealthInterval:      s.settings.GetStringSetting(ctx, "environmentHealthInterval", defaults.EnvironmentHealthInterval.Value),
+		EventCleanupInterval:           s.settings.GetStringSetting(ctx, "eventCleanupInterval", defaults.EventCleanupInterval.Value),
+		ExpiredSessionsCleanupInterval: s.settings.GetStringSetting(ctx, "expiredSessionsCleanupInterval", defaults.ExpiredSessionsCleanupInterval.Value),
+		AutoUpdateInterval:             s.settings.GetStringSetting(ctx, "autoUpdateInterval", defaults.AutoUpdateInterval.Value),
+		DockerClientRefreshInterval:    s.settings.GetStringSetting(ctx, "dockerClientRefreshInterval", defaults.DockerClientRefreshInterval.Value),
+		PollingInterval:                s.settings.GetStringSetting(ctx, "pollingInterval", defaults.PollingInterval.Value),
+		ScheduledPruneInterval:         s.settings.GetStringSetting(ctx, "scheduledPruneInterval", defaults.ScheduledPruneInterval.Value),
+		VulnerabilityScanInterval:      s.settings.GetStringSetting(ctx, "vulnerabilityScanInterval", defaults.VulnerabilityScanInterval.Value),
+		AutoHealInterval:               s.settings.GetStringSetting(ctx, "autoHealInterval", defaults.AutoHealInterval.Value),
 	}
 }
 
@@ -118,6 +121,7 @@ func (s *JobService) UpdateJobSchedules(ctx context.Context, updates jobschedule
 
 	changed := false
 	changedKeys := make([]string, 0, len(fields))
+	previousValues := make(map[string]string, len(fields))
 	upsert := func(tx *gorm.DB, key string, v *string, currentVal string) error {
 		if v == nil {
 			return nil
@@ -127,6 +131,7 @@ func (s *JobService) UpdateJobSchedules(ctx context.Context, updates jobschedule
 		}
 		changed = true
 		changedKeys = append(changedKeys, key)
+		previousValues[key] = currentVal
 		return tx.Save(&models.SettingVariable{Key: key, Value: *v}).Error
 	}
 
@@ -145,18 +150,31 @@ func (s *JobService) UpdateJobSchedules(ctx context.Context, updates jobschedule
 	// Refresh settings cache so jobs reading from SettingsService see new values.
 	if changed {
 		if err := s.settings.LoadDatabaseSettings(ctx); err != nil {
-			return jobschedule.Config{}, fmt.Errorf("failed to reload settings after job schedule update: %w", err)
+			restoreErr := s.restoreJobSchedulesInternal(ctx, previousValues, changedKeys)
+			return jobschedule.Config{}, errors.Join(
+				fmt.Errorf("failed to reload settings after job schedule update: %w", err),
+				restoreErr,
+			)
 		}
 
-		s.RescheduleJobsForSettingKeys(ctx, changedKeys)
+		if err := s.RescheduleJobsForSettingKeys(ctx, changedKeys); err != nil {
+			restoreErr := s.restoreJobSchedulesInternal(ctx, previousValues, changedKeys)
+			return jobschedule.Config{}, errors.Join(
+				fmt.Errorf("failed to apply job schedule update: %w", err),
+				restoreErr,
+			)
+		}
 	}
 
 	return s.GetJobSchedules(ctx), nil
 }
 
-func (s *JobService) RescheduleJobsForSettingKeys(ctx context.Context, changedKeys []string) {
-	if s == nil || s.scheduler == nil || len(changedKeys) == 0 {
-		return
+func (s *JobService) RescheduleJobsForSettingKeys(ctx context.Context, changedKeys []string) error {
+	if len(changedKeys) == 0 {
+		return nil
+	}
+	if s == nil || s.scheduler == nil {
+		return errors.New("job scheduler not initialized")
 	}
 
 	changed := make(map[string]struct{}, len(changedKeys))
@@ -164,6 +182,7 @@ func (s *JobService) RescheduleJobsForSettingKeys(ctx context.Context, changedKe
 		changed[key] = struct{}{}
 	}
 
+	var rescheduleErrors []error
 	for jobID, jobMeta := range meta.GetAllJobMetadata() {
 		if !jobMetadataAffectedBySettingInternal(jobMeta, changed) {
 			continue
@@ -182,13 +201,15 @@ func (s *JobService) RescheduleJobsForSettingKeys(ctx context.Context, changedKe
 					reschedCtx = s.lifecycleCtx
 				}
 				s.OnEnvironmentHealthReschedule(reschedCtx)
+			} else {
+				rescheduleErrors = append(rescheduleErrors, errors.New("environment-health rescheduler not initialized"))
 			}
 			continue
 		}
 
 		job, ok := s.scheduler.GetJob(jobID)
 		if !ok {
-			slog.DebugContext(ctx, "Skipping reschedule for unregistered job", "job", jobID)
+			rescheduleErrors = append(rescheduleErrors, fmt.Errorf("job %s not found in scheduler", jobID))
 			continue
 		}
 
@@ -198,9 +219,50 @@ func (s *JobService) RescheduleJobsForSettingKeys(ctx context.Context, changedKe
 			rescheduleCtx = s.lifecycleCtx
 		}
 		if err := s.scheduler.RescheduleJob(rescheduleCtx, job); err != nil {
-			slog.WarnContext(ctx, "Failed to reschedule job", "job", jobID, "error", err)
+			rescheduleErrors = append(rescheduleErrors, fmt.Errorf("reschedule job %s: %w", jobID, err))
+			continue
+		}
+
+		runtimeState, ok := s.scheduler.GetJobRuntimeState(jobID)
+		if !ok {
+			rescheduleErrors = append(rescheduleErrors, fmt.Errorf("job %s has no runtime scheduler state", jobID))
+			continue
+		}
+
+		expectedSchedule := job.Schedule(rescheduleCtx)
+		if runtimeState.Schedule != expectedSchedule {
+			rescheduleErrors = append(rescheduleErrors, fmt.Errorf("job %s runtime schedule %q does not match requested schedule %q", jobID, runtimeState.Schedule, expectedSchedule))
 		}
 	}
+
+	return errors.Join(rescheduleErrors...)
+}
+
+func (s *JobService) restoreJobSchedulesInternal(ctx context.Context, previousValues map[string]string, changedKeys []string) error {
+	if len(previousValues) == 0 {
+		return nil
+	}
+
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for key, value := range previousValues {
+			if err := tx.Save(&models.SettingVariable{Key: key, Value: value}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to restore previous job schedules: %w", err)
+	}
+
+	if err := s.settings.LoadDatabaseSettings(ctx); err != nil {
+		return fmt.Errorf("failed to reload restored job schedules: %w", err)
+	}
+
+	if err := s.RescheduleJobsForSettingKeys(ctx, changedKeys); err != nil {
+		return fmt.Errorf("failed to restore runtime job schedules: %w", err)
+	}
+
+	return nil
 }
 
 func jobMetadataAffectedBySettingInternal(jobMeta meta.JobMetadata, changed map[string]struct{}) bool {
@@ -225,13 +287,20 @@ func (s *JobService) ListJobs(ctx context.Context) (*jobschedule.JobListResponse
 	allMetadata := meta.GetAllJobMetadata()
 	jobs := make([]jobschedule.JobStatus, 0, len(allMetadata))
 
-	for _, meta := range allMetadata {
-		schedule := s.getJobScheduleInternal(ctx, meta)
+	for _, jobMeta := range allMetadata {
+		schedule := s.getJobScheduleInternal(ctx, jobMeta)
 		nextRun := s.calculateNextRunInternal(schedule)
-		enabled := s.isJobEnabledInternal(ctx, meta)
-		prerequisites := s.evaluatePrerequisitesInternal(ctx, meta)
+		enabled := s.isJobEnabledInternal(ctx, jobMeta)
+		prerequisites := s.evaluatePrerequisitesInternal(ctx, jobMeta)
 
-		jobStatus := meta.ToJobStatus(schedule, nextRun, enabled, prerequisites)
+		if s.scheduler != nil && jobMeta.SettingsKey != "" && jobMeta.ID != "environment-health" {
+			if runtimeState, ok := s.scheduler.GetJobRuntimeState(jobMeta.ID); ok && runtimeState.Schedule != "" {
+				schedule = runtimeState.Schedule
+				nextRun = runtimeState.NextRun
+			}
+		}
+
+		jobStatus := jobMeta.ToJobStatus(schedule, nextRun, enabled, prerequisites)
 		jobs = append(jobs, jobStatus)
 	}
 
@@ -305,20 +374,8 @@ func (s *JobService) getJobScheduleInternal(ctx context.Context, meta meta.JobMe
 		return ""
 	}
 
-	defaultSchedules := map[string]string{
-		"environmentHealthInterval":      "0 */2 * * * *",
-		"eventCleanupInterval":           "0 0 */6 * * *",
-		"expiredSessionsCleanupInterval": "0 0 0 * * *",
-		"autoUpdateInterval":             "0 0 0 * * *",
-		"dockerClientRefreshInterval":    "*/30 * * * * *",
-		"pollingInterval":                "0 */15 * * * *",
-		"scheduledPruneInterval":         "0 0 0 * * *",
-		"vulnerabilityScanInterval":      "0 0 0 * * *",
-		"autoHealInterval":               "*/30 * * * * *",
-	}
-
-	defaultSchedule := defaultSchedules[meta.SettingsKey]
-	if defaultSchedule == "" {
+	defaultSchedule, _, _, err := DefaultSettingsConfig().FieldByKey(meta.SettingsKey)
+	if err != nil || defaultSchedule == "" {
 		defaultSchedule = "0 0 0 * * *"
 	}
 

--- a/backend/internal/services/job_service_test.go
+++ b/backend/internal/services/job_service_test.go
@@ -2,9 +2,12 @@ package services
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/types/v2/jobschedule"
 	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
 	"github.com/stretchr/testify/require"
@@ -21,6 +24,7 @@ func TestJobService_GetJobSchedules_DefaultDockerClientRefreshInterval(t *testin
 	cfg := jobSvc.GetJobSchedules(ctx)
 
 	require.Equal(t, "*/30 * * * * *", cfg.DockerClientRefreshInterval)
+	require.Equal(t, "0 0 * * * *", cfg.PollingInterval)
 }
 
 func TestJobService_ListJobs_AnalyticsHeartbeatIsManagedInternally(t *testing.T) {
@@ -78,6 +82,31 @@ func TestJobService_ListJobs_IncludesDockerClientRefreshJob(t *testing.T) {
 	require.Equal(t, "*/30 * * * * *", refreshJob.Schedule)
 }
 
+func TestJobService_ListJobs_UsesRuntimeScheduleAndNextRun(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	nextRun := time.Date(2026, time.July, 10, 8, 0, 0, 0, time.UTC)
+	scheduler := newFakeJobSchedulerInternal("image-polling")
+	scheduler.runtimeStates["image-polling"] = schedulertypes.JobRuntimeState{
+		Schedule:  "0 0 8 * * *",
+		NextRun:   &nextRun,
+		Scheduled: true,
+	}
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	jobSvc.SetScheduler(ctx, scheduler)
+	jobs, err := jobSvc.ListJobs(ctx)
+	require.NoError(t, err)
+
+	imagePollingJob := findJobStatusByIDInternal(t, jobs.Jobs, "image-polling")
+	require.Equal(t, "0 0 8 * * *", imagePollingJob.Schedule)
+	require.Equal(t, nextRun, *imagePollingJob.NextRun)
+}
+
 func TestJobService_UpdateJobSchedules_ReschedulesChangedJob(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
@@ -124,6 +153,67 @@ func TestJobService_UpdateJobSchedules_UsesLifecycleContextForReschedule(t *test
 	require.Equal(t, true, scheduler.rescheduleContexts[0].Value(lifecycleContextKey{}))
 }
 
+func TestJobService_UpdateJobSchedules_RejectsInvalidCronWithoutChangingSetting(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsSvc.EnsureDefaultSettings(ctx))
+	require.NoError(t, settingsSvc.LoadDatabaseSettings(ctx))
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	scheduler := newFakeJobSchedulerInternal("image-polling")
+	jobSvc.SetScheduler(ctx, scheduler)
+
+	_, err = jobSvc.UpdateJobSchedules(ctx, jobschedule.Update{
+		PollingInterval: new("not a cron expression"),
+	})
+	require.ErrorContains(t, err, "invalid cron expression for pollingInterval")
+	require.Equal(t, "0 0 * * * *", settingsSvc.GetStringSetting(ctx, "pollingInterval", ""))
+	require.Empty(t, scheduler.rescheduled)
+}
+
+func TestJobService_UpdateJobSchedules_UnchangedScheduleDoesNotReschedule(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	updated, err := jobSvc.UpdateJobSchedules(ctx, jobschedule.Update{
+		PollingInterval: new("0 0 * * * *"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0 0 * * * *", updated.PollingInterval)
+}
+
+func TestJobService_UpdateJobSchedules_RestoresPreviousScheduleWhenRescheduleFails(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsSvc.EnsureDefaultSettings(ctx))
+	require.NoError(t, settingsSvc.LoadDatabaseSettings(ctx))
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	scheduler := newFakeJobSchedulerInternal("image-polling")
+	scheduler.rescheduleErr = errors.New("scheduler unavailable")
+	jobSvc.SetScheduler(ctx, scheduler)
+
+	_, err = jobSvc.UpdateJobSchedules(ctx, jobschedule.Update{
+		PollingInterval: new("0 0 8 * * *"),
+	})
+	require.ErrorContains(t, err, "scheduler unavailable")
+	require.Equal(t, "0 0 * * * *", settingsSvc.GetStringSetting(ctx, "pollingInterval", ""))
+
+	var persisted models.SettingVariable
+	require.NoError(t, db.WithContext(ctx).First(&persisted, "key = ?", "pollingInterval").Error)
+	require.Equal(t, "0 0 * * * *", persisted.Value)
+}
+
 func TestJobService_UpdateJobSchedules_SkipsManagerOnlyJobsInAgentMode(t *testing.T) {
 	ctx := context.Background()
 	db := setupSettingsTestDB(t)
@@ -143,6 +233,30 @@ func TestJobService_UpdateJobSchedules_SkipsManagerOnlyJobsInAgentMode(t *testin
 	require.Empty(t, scheduler.rescheduled)
 }
 
+func TestJobService_UpdateJobSchedules_DelegatesEnvironmentHealthReschedule(t *testing.T) {
+	ctx := context.Background()
+	db := setupSettingsTestDB(t)
+
+	settingsSvc, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	jobSvc := NewJobService(db, settingsSvc, &config.Config{})
+	scheduler := newFakeJobSchedulerInternal()
+	jobSvc.SetScheduler(ctx, scheduler)
+
+	rescheduled := 0
+	jobSvc.OnEnvironmentHealthReschedule = func(context.Context) {
+		rescheduled++
+	}
+
+	_, err = jobSvc.UpdateJobSchedules(ctx, jobschedule.Update{
+		EnvironmentHealthInterval: new("0 */5 * * * *"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, rescheduled)
+	require.Empty(t, scheduler.rescheduled)
+}
+
 func findJobStatusByIDInternal(t *testing.T, jobs []jobschedule.JobStatus, id string) jobschedule.JobStatus {
 	t.Helper()
 
@@ -158,8 +272,10 @@ func findJobStatusByIDInternal(t *testing.T, jobs []jobschedule.JobStatus, id st
 
 type fakeJobSchedulerInternal struct {
 	jobs               map[string]schedulertypes.Job
+	runtimeStates      map[string]schedulertypes.JobRuntimeState
 	rescheduled        []string
 	rescheduleContexts []context.Context
+	rescheduleErr      error
 }
 
 func newFakeJobSchedulerInternal(jobIDs ...string) *fakeJobSchedulerInternal {
@@ -169,7 +285,8 @@ func newFakeJobSchedulerInternal(jobIDs ...string) *fakeJobSchedulerInternal {
 	}
 
 	return &fakeJobSchedulerInternal{
-		jobs: jobs,
+		jobs:          jobs,
+		runtimeStates: make(map[string]schedulertypes.JobRuntimeState),
 	}
 }
 
@@ -178,9 +295,22 @@ func (s *fakeJobSchedulerInternal) GetJob(jobID string) (schedulertypes.Job, boo
 	return job, ok
 }
 
+func (s *fakeJobSchedulerInternal) GetJobRuntimeState(jobID string) (schedulertypes.JobRuntimeState, bool) {
+	state, ok := s.runtimeStates[jobID]
+	return state, ok
+}
+
 func (s *fakeJobSchedulerInternal) RescheduleJob(ctx context.Context, job schedulertypes.Job) error {
 	s.rescheduled = append(s.rescheduled, job.Name())
 	s.rescheduleContexts = append(s.rescheduleContexts, ctx)
+	if s.rescheduleErr != nil {
+		return s.rescheduleErr
+	}
+
+	s.runtimeStates[job.Name()] = schedulertypes.JobRuntimeState{
+		Schedule:  job.Schedule(ctx),
+		Scheduled: true,
+	}
 	return nil
 }
 

--- a/backend/pkg/scheduler/job_schedule_integration_test.go
+++ b/backend/pkg/scheduler/job_schedule_integration_test.go
@@ -1,0 +1,178 @@
+package scheduler
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
+	"github.com/getarcaneapp/arcane/types/v2/jobschedule"
+	sqlite "github.com/libtnb/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestImagePollingScheduleUpdatePersistsAndReplacesRuntimeEntry(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "arcane.db")
+	db, settingsService := openJobScheduleTestDatabaseInternal(t, ctx, databasePath)
+
+	appConfig := &config.Config{Timezone: "UTC"}
+	lifecycleCtx, cancelLifecycle := context.WithCancel(context.Background())
+	jobScheduler := NewJobScheduler(lifecycleCtx, appConfig.GetLocation())
+	jobScheduler.RegisterJob(NewImagePollingJob(nil, settingsService, nil))
+
+	jobService := services.NewJobService(db, settingsService, appConfig)
+	jobService.SetScheduler(lifecycleCtx, jobScheduler)
+	jobScheduler.StartScheduler()
+
+	initialState, ok := jobScheduler.GetJobRuntimeState("image-polling")
+	require.True(t, ok)
+	require.True(t, initialState.Scheduled)
+	require.Equal(t, "0 0 * * * *", initialState.Schedule)
+	require.Len(t, jobScheduler.cron.Entries(), 1)
+	initialEntryID := jobScheduler.entryIDs["image-polling"]
+
+	requestedSchedule := "0 0 8 * * *"
+	beforeUpdate := time.Now().UTC()
+	updatedSchedules, err := jobService.UpdateJobSchedules(ctx, jobschedule.Update{
+		PollingInterval: &requestedSchedule,
+	})
+	afterUpdate := time.Now().UTC()
+	require.NoError(t, err)
+	require.Equal(t, requestedSchedule, updatedSchedules.PollingInterval)
+
+	var persisted models.SettingVariable
+	require.NoError(t, db.WithContext(ctx).First(&persisted, "key = ?", "pollingInterval").Error)
+	require.Equal(t, requestedSchedule, persisted.Value)
+	require.Equal(t, requestedSchedule, settingsService.GetStringSetting(ctx, "pollingInterval", ""))
+
+	runtimeState, ok := jobScheduler.GetJobRuntimeState("image-polling")
+	require.True(t, ok)
+	require.True(t, runtimeState.Scheduled)
+	require.Equal(t, requestedSchedule, runtimeState.Schedule)
+	require.NotNil(t, runtimeState.NextRun)
+	require.Equal(t, "UTC", runtimeState.NextRun.Location().String())
+	requireNextDailyRunInternal(t, *runtimeState.NextRun, beforeUpdate, afterUpdate)
+	require.Len(t, jobScheduler.cron.Entries(), 1)
+	require.NotEqual(t, initialEntryID, jobScheduler.entryIDs["image-polling"])
+	for _, entry := range jobScheduler.cron.Entries() {
+		require.NotEqual(t, initialEntryID, entry.ID)
+	}
+
+	jobs, err := jobService.ListJobs(ctx)
+	require.NoError(t, err)
+	imagePollingStatus := findJobStatusInternal(t, jobs, "image-polling")
+	require.Equal(t, requestedSchedule, imagePollingStatus.Schedule)
+	require.Equal(t, runtimeState.NextRun, imagePollingStatus.NextRun)
+
+	cancelLifecycle()
+	waitForSchedulerStopInternal(jobScheduler)
+	closeJobScheduleTestDatabaseInternal(t, db)
+
+	restartDB, restartSettingsService := openJobScheduleTestDatabaseInternal(t, ctx, databasePath)
+	restartLifecycleCtx, cancelRestartLifecycle := context.WithCancel(context.Background())
+	restartScheduler := NewJobScheduler(restartLifecycleCtx, appConfig.GetLocation())
+	restartScheduler.RegisterJob(NewImagePollingJob(nil, restartSettingsService, nil))
+	restartJobService := services.NewJobService(restartDB, restartSettingsService, appConfig)
+	restartJobService.SetScheduler(restartLifecycleCtx, restartScheduler)
+	restartScheduler.StartScheduler()
+	t.Cleanup(func() {
+		cancelRestartLifecycle()
+		waitForSchedulerStopInternal(restartScheduler)
+		closeJobScheduleTestDatabaseInternal(t, restartDB)
+	})
+
+	restartedState, ok := restartScheduler.GetJobRuntimeState("image-polling")
+	require.True(t, ok)
+	require.True(t, restartedState.Scheduled)
+	require.Equal(t, requestedSchedule, restartedState.Schedule)
+	require.NotNil(t, restartedState.NextRun)
+	require.Len(t, restartScheduler.cron.Entries(), 1)
+	require.Equal(t, requestedSchedule, restartSettingsService.GetStringSetting(ctx, "pollingInterval", ""))
+
+	restartedJobs, err := restartJobService.ListJobs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, requestedSchedule, findJobStatusInternal(t, restartedJobs, "image-polling").Schedule)
+
+	require.NoError(t, restartSettingsService.SetBoolSetting(ctx, "pollingEnabled", false))
+	disabledSchedule := "0 0 9 * * *"
+	_, err = restartJobService.UpdateJobSchedules(ctx, jobschedule.Update{PollingInterval: &disabledSchedule})
+	require.NoError(t, err)
+
+	disabledState, ok := restartScheduler.GetJobRuntimeState("image-polling")
+	require.True(t, ok)
+	require.False(t, disabledState.Scheduled)
+	require.Nil(t, disabledState.NextRun)
+	require.Equal(t, disabledSchedule, disabledState.Schedule)
+	require.Empty(t, restartScheduler.cron.Entries())
+
+	disabledJobs, err := restartJobService.ListJobs(ctx)
+	require.NoError(t, err)
+	disabledStatus := findJobStatusInternal(t, disabledJobs, "image-polling")
+	require.False(t, disabledStatus.Enabled)
+	require.Nil(t, disabledStatus.NextRun)
+	require.Equal(t, disabledSchedule, disabledStatus.Schedule)
+}
+
+func openJobScheduleTestDatabaseInternal(t *testing.T, ctx context.Context, databasePath string) (*database.DB, *services.SettingsService) {
+	t.Helper()
+
+	gormDB, err := gorm.Open(sqlite.Open(databasePath), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, gormDB.AutoMigrate(&models.SettingVariable{}))
+
+	db := &database.DB{DB: gormDB}
+	settingsService, err := services.NewSettingsService(ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.EnsureDefaultSettings(ctx))
+	require.NoError(t, settingsService.LoadDatabaseSettings(ctx))
+
+	return db, settingsService
+}
+
+func closeJobScheduleTestDatabaseInternal(t *testing.T, db *database.DB) {
+	t.Helper()
+
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+}
+
+func waitForSchedulerStopInternal(jobScheduler *JobScheduler) {
+	<-jobScheduler.cron.Stop().Done()
+}
+
+func findJobStatusInternal(t *testing.T, jobs *jobschedule.JobListResponse, jobID string) jobschedule.JobStatus {
+	t.Helper()
+
+	for _, job := range jobs.Jobs {
+		if job.ID == jobID {
+			return job
+		}
+	}
+
+	t.Fatalf("job %q not found", jobID)
+	return jobschedule.JobStatus{}
+}
+
+func requireNextDailyRunInternal(t *testing.T, actual, beforeUpdate, afterUpdate time.Time) {
+	t.Helper()
+
+	nextAtEight := func(reference time.Time) time.Time {
+		next := time.Date(reference.Year(), reference.Month(), reference.Day(), 8, 0, 0, 0, time.UTC)
+		if !next.After(reference) {
+			next = next.AddDate(0, 0, 1)
+		}
+		return next
+	}
+
+	expectedBefore := nextAtEight(beforeUpdate)
+	expectedAfter := nextAtEight(afterUpdate)
+	require.Truef(t, actual.Equal(expectedBefore) || actual.Equal(expectedAfter), "next run %s is neither %s nor %s", actual, expectedBefore, expectedAfter)
+}

--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -11,17 +11,19 @@ import (
 )
 
 type JobScheduler struct {
-	// mu guards jobs, jobsByID and entryIDs. It is held across the cron
+	// mu guards jobs, jobsByID, entryIDs and schedules. It is held across the cron
 	// add/remove calls (which are themselves quick and never block on job
 	// execution) but never across job.Run — Run executes on cron's own
 	// goroutine, so a running job must not call back into a locking method here.
-	mu       sync.Mutex
-	cron     *cron.Cron
-	jobs     []schedulertypes.Job
-	jobsByID map[string]schedulertypes.Job
-	entryIDs map[string]cron.EntryID
-	context  context.Context
-	location *time.Location
+	mu        sync.Mutex
+	cron      *cron.Cron
+	jobs      []schedulertypes.Job
+	jobsByID  map[string]schedulertypes.Job
+	entryIDs  map[string]cron.EntryID
+	schedules map[string]string
+	parser    cron.Parser
+	context   context.Context
+	location  *time.Location
 }
 
 // NewJobScheduler creates a new job scheduler with the specified timezone location.
@@ -31,14 +33,17 @@ func NewJobScheduler(ctx context.Context, location *time.Location) *JobScheduler
 	if location == nil {
 		location = time.UTC
 	}
+	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 	slog.InfoContext(ctx, "Initializing job scheduler", "timezone", location.String())
 	return &JobScheduler{
-		cron:     cron.New(cron.WithSeconds(), cron.WithLocation(location)),
-		jobs:     []schedulertypes.Job{},
-		jobsByID: make(map[string]schedulertypes.Job),
-		entryIDs: make(map[string]cron.EntryID),
-		context:  ctx,
-		location: location,
+		cron:      cron.New(cron.WithParser(parser), cron.WithLocation(location)),
+		jobs:      []schedulertypes.Job{},
+		jobsByID:  make(map[string]schedulertypes.Job),
+		entryIDs:  make(map[string]cron.EntryID),
+		schedules: make(map[string]string),
+		parser:    parser,
+		context:   ctx,
+		location:  location,
 	}
 }
 
@@ -58,6 +63,38 @@ func (js *JobScheduler) GetJob(jobID string) (schedulertypes.Job, bool) {
 	return job, ok
 }
 
+// GetJobRuntimeState returns the schedule currently installed for a registered job.
+func (js *JobScheduler) GetJobRuntimeState(jobID string) (schedulertypes.JobRuntimeState, bool) {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	if _, ok := js.jobsByID[jobID]; !ok {
+		return schedulertypes.JobRuntimeState{}, false
+	}
+
+	state := schedulertypes.JobRuntimeState{Schedule: js.schedules[jobID]}
+	entryID, ok := js.entryIDs[jobID]
+	if !ok {
+		return state, true
+	}
+
+	entry := js.cron.Entry(entryID)
+	if entry.ID == 0 {
+		return state, true
+	}
+
+	state.Scheduled = true
+	nextRun := entry.Next
+	if nextRun.IsZero() && entry.Schedule != nil {
+		nextRun = entry.Schedule.Next(time.Now().In(js.location))
+	}
+	if !nextRun.IsZero() {
+		state.NextRun = new(nextRun)
+	}
+
+	return state, true
+}
+
 // HasJob reports whether a job with the given name is currently registered.
 func (js *JobScheduler) HasJob(jobID string) bool {
 	js.mu.Lock()
@@ -69,7 +106,7 @@ func (js *JobScheduler) HasJob(jobID string) bool {
 func (js *JobScheduler) StartScheduler() {
 	js.mu.Lock()
 	for _, job := range js.jobs {
-		if err := js.scheduleJobInternal(js.context, job); err != nil {
+		if err := js.upsertJobInternal(js.context, job); err != nil {
 			slog.ErrorContext(js.context, "Failed to schedule job", "name", job.Name(), "error", err)
 		}
 	}
@@ -77,10 +114,10 @@ func (js *JobScheduler) StartScheduler() {
 	js.cron.Start()
 }
 
-// AddJob registers and schedules a job at runtime. It is an idempotent upsert: if
-// a job with the same name is already scheduled, its existing cron entry is
-// removed first (preventing a leaked, forever-firing entry when the schedule
-// changes). Safe to call before or after StartScheduler.
+// AddJob registers and schedules a job at runtime. It is an idempotent upsert: a
+// replacement expression is validated before the existing entry is removed, then
+// the replacement is installed without leaking a second live entry.
+// Safe to call before or after StartScheduler.
 func (js *JobScheduler) AddJob(ctx context.Context, job schedulertypes.Job) error {
 	js.mu.Lock()
 	defer js.mu.Unlock()
@@ -98,6 +135,7 @@ func (js *JobScheduler) RemoveJob(ctx context.Context, jobName string) {
 		delete(js.entryIDs, jobName)
 	}
 	delete(js.jobsByID, jobName)
+	delete(js.schedules, jobName)
 	for i, j := range js.jobs {
 		if j.Name() == jobName {
 			js.jobs = append(js.jobs[:i], js.jobs[i+1:]...)
@@ -125,52 +163,74 @@ func (js *JobScheduler) Run(ctx context.Context) error {
 	return nil
 }
 
-// upsertJobInternal records the job and (re)schedules it. Callers must hold js.mu.
+// upsertJobInternal records the job and (re)schedules it. A replacement expression
+// is parsed before the previous entry is removed so invalid input leaves the last
+// valid entry untouched. Callers must hold js.mu.
 func (js *JobScheduler) upsertJobInternal(ctx context.Context, job schedulertypes.Job) error {
 	jobName := job.Name()
-	if entryID, ok := js.entryIDs[jobName]; ok {
-		js.cron.Remove(entryID)
+	previousSchedule := js.schedules[jobName]
+	previousEntryID, hadPreviousEntry := js.entryIDs[jobName]
+	schedule := job.Schedule(ctx)
+
+	shouldSchedule := true
+	if conditionalJob, ok := job.(schedulertypes.ConditionalJob); ok {
+		shouldSchedule = conditionalJob.ShouldSchedule(ctx)
+	}
+
+	var (
+		parsedSchedule cron.Schedule
+		entryID        cron.EntryID
+		nextRun        *time.Time
+	)
+	if shouldSchedule {
+		var err error
+		parsedSchedule, err = js.parser.Parse(schedule)
+		if err != nil {
+			return err
+		}
+	} else {
+		slog.DebugContext(ctx, "Job disabled; not scheduling", "name", jobName)
+	}
+
+	if hadPreviousEntry {
+		js.cron.Remove(previousEntryID)
 		delete(js.entryIDs, jobName)
 	}
-	delete(js.jobsByID, jobName)
-
-	if err := js.scheduleJobInternal(ctx, job); err != nil {
-		return err
+	if shouldSchedule {
+		entryID, nextRun = js.addCronEntryInternal(job, schedule, parsedSchedule)
+		js.entryIDs[jobName] = entryID
 	}
 
 	js.jobsByID[jobName] = job
+	js.schedules[jobName] = schedule
 
-	slog.DebugContext(ctx, "Job scheduled", "name", jobName, "scheduled", js.isJobScheduledInternal(jobName), "contextCanceled", ctx.Err() != nil)
+	if previousSchedule == "" && shouldSchedule {
+		slog.InfoContext(ctx, "Starting Job", "name", jobName, "schedule", schedule)
+	} else if previousSchedule != schedule || hadPreviousEntry != shouldSchedule {
+		slog.InfoContext(ctx, "Job rescheduled", "name", jobName, "previousSchedule", previousSchedule, "newSchedule", schedule, "nextRun", nextRun)
+	}
+
+	slog.DebugContext(ctx, "Job scheduled", "name", jobName, "scheduled", shouldSchedule, "contextCanceled", ctx.Err() != nil)
 	return nil
 }
 
-// scheduleJobInternal adds the job to cron. Callers must hold js.mu. The cron
-// closure runs the job with the scheduler's lifecycle context (js.context), never
-// the per-call ctx — the per-call ctx may be a request context that is canceled
-// once the originating handler returns, which would silently kill future fires.
-func (js *JobScheduler) scheduleJobInternal(ctx context.Context, job schedulertypes.Job) error {
-	if conditionalJob, ok := job.(schedulertypes.ConditionalJob); ok && !conditionalJob.ShouldSchedule(ctx) {
-		slog.DebugContext(ctx, "Job disabled; not scheduling", "name", job.Name())
-		return nil
-	}
-
-	schedule := job.Schedule(ctx)
-	slog.InfoContext(ctx, "Starting Job", "name", job.Name(), "schedule", schedule)
-
-	entryID, err := js.cron.AddFunc(schedule, func() {
+// addCronEntryInternal adds a job closure that always runs with the scheduler's
+// lifecycle context. Callers must hold js.mu.
+func (js *JobScheduler) addCronEntryInternal(job schedulertypes.Job, schedule string, parsedSchedule cron.Schedule) (cron.EntryID, *time.Time) {
+	entryID := js.cron.Schedule(parsedSchedule, cron.FuncJob(func() {
 		slog.InfoContext(js.context, "Job starting", "name", job.Name(), "schedule", schedule)
 		job.Run(js.context)
 		slog.InfoContext(js.context, "Job finished", "name", job.Name())
-	})
-	if err != nil {
-		return err
+	}))
+
+	entry := js.cron.Entry(entryID)
+	nextRun := entry.Next
+	if nextRun.IsZero() && entry.Schedule != nil {
+		nextRun = entry.Schedule.Next(time.Now().In(js.location))
+	}
+	if nextRun.IsZero() {
+		return entryID, nil
 	}
 
-	js.entryIDs[job.Name()] = entryID
-	return nil
-}
-
-func (js *JobScheduler) isJobScheduledInternal(jobName string) bool {
-	_, ok := js.entryIDs[jobName]
-	return ok
+	return entryID, new(nextRun)
 }

--- a/backend/pkg/scheduler/scheduler_test.go
+++ b/backend/pkg/scheduler/scheduler_test.go
@@ -201,21 +201,33 @@ func TestJobScheduler_AddJob_UpsertReplacesEntryWithoutLeaking(t *testing.T) {
 	require.NoError(t, js.AddJob(context.Background(), job))
 	require.Len(t, js.cron.Entries(), 1)
 	require.NotEqual(t, firstEntry, js.entryIDs[job.Name()])
+
+	state, ok := js.GetJobRuntimeState(job.Name())
+	require.True(t, ok)
+	require.True(t, state.Scheduled)
+	require.Equal(t, "*/10 * * * * *", state.Schedule)
+	require.NotNil(t, state.NextRun)
 }
 
-func TestJobScheduler_AddJob_InvalidRescheduleClearsRegisteredState(t *testing.T) {
+func TestJobScheduler_AddJob_InvalidRescheduleKeepsExistingEntry(t *testing.T) {
 	js := NewJobScheduler(context.Background(), nil)
 
 	job := &testSchedulerJob{name: "dyn-invalid-reschedule", schedule: "*/5 * * * * *"}
 	require.NoError(t, js.AddJob(context.Background(), job))
 	require.True(t, js.HasJob(job.Name()))
 	require.Len(t, js.cron.Entries(), 1)
+	firstEntry := js.entryIDs[job.Name()]
 
 	job.schedule = "not a cron schedule"
 	require.Error(t, js.AddJob(context.Background(), job))
-	require.False(t, js.HasJob(job.Name()))
-	require.NotContains(t, js.entryIDs, job.Name())
-	require.Empty(t, js.cron.Entries())
+	require.True(t, js.HasJob(job.Name()))
+	require.Equal(t, firstEntry, js.entryIDs[job.Name()])
+	require.Len(t, js.cron.Entries(), 1)
+
+	state, ok := js.GetJobRuntimeState(job.Name())
+	require.True(t, ok)
+	require.True(t, state.Scheduled)
+	require.Equal(t, "*/5 * * * * *", state.Schedule)
 }
 
 func TestJobScheduler_RemoveJob_RemovesEntryAndIsNoopWhenAbsent(t *testing.T) {

--- a/types/scheduler/job.go
+++ b/types/scheduler/job.go
@@ -1,6 +1,17 @@
 package scheduler
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// JobRuntimeState describes the schedule currently installed in a scheduler.
+// It intentionally exposes only read-only state needed by job-management APIs.
+type JobRuntimeState struct {
+	Schedule  string
+	NextRun   *time.Time
+	Scheduled bool
+}
 
 type Job interface {
 	Name() string


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3193

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes job schedule updates so the API reflects the active scheduler state. The main changes are:

- Uses canonical default cron values for job schedule reads.
- Rolls back persisted schedule settings when runtime rescheduling fails.
- Adds runtime scheduler state with active schedule, next run, and scheduled status.
- Updates scheduler tests and adds an image polling schedule integration test.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR needs a contained compile fix before merging.

The scheduler changes are localized, but the newly added Go tests use invalid `new("...")` expressions that fail the test package build.

`backend/internal/services/job_service_test.go`
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a narrow compile-only test build for the internal/services package using the requested build tags and ldflags; the build completed with exit code 0 after an earlier 120-second run timed out before diagnostics.
- I reviewed the scheduler regression artifacts and logs; they show exact commands, working directories, and start timestamps, and they confirm there was no Go test output due to external timeouts, and I did not file a finding for the known accepted invalid pointer construction in job\_service\_test.go, per instruction.

<a href="https://app.greptile.com/trex/runs/13884620/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2207-09-fix_fix_image_polling_schedule_rescheduling_api_shape%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2207-09-fix_fix_image_polling_schedule_rescheduling_api_shape%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fjob_service_test.go%3A170%0A**Fix%20invalid%20pointer%20construction**%0A%60new%28%22not%20a%20cron%20expression%22%29%60%20does%20not%20compile%20in%20Go%20because%20%60new%60%20expects%20a%20type%2C%20not%20a%20value.%20This%20pattern%20is%20repeated%20in%20the%20new%20schedule-update%20tests%2C%20including%20the%20%60PollingInterval%60%2C%20%60EnvironmentHealthInterval%60%2C%20and%20other%20cron%20update%20fields%2C%20so%20the%20package%20test%20build%20fails%20before%20exercising%20the%20scheduler%20changes.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fservices%2Fjob_service_test.go%3A170%0A**Fix%20invalid%20pointer%20construction**%0A%60new%28%22not%20a%20cron%20expression%22%29%60%20does%20not%20compile%20in%20Go%20because%20%60new%60%20expects%20a%20type%2C%20not%20a%20value.%20This%20pattern%20is%20repeated%20in%20the%20new%20schedule-update%20tests%2C%20including%20the%20%60PollingInterval%60%2C%20%60EnvironmentHealthInterval%60%2C%20and%20other%20cron%20update%20fields%2C%20so%20the%20package%20test%20build%20fails%20before%20exercising%20the%20scheduler%20changes.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/services/job_service_test.go:170
**Fix invalid pointer construction**
`new("not a cron expression")` does not compile in Go because `new` expects a type, not a value. This pattern is repeated in the new schedule-update tests, including the `PollingInterval`, `EnvironmentHealthInterval`, and other cron update fields, so the package test build fails before exercising the scheduler changes.

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: fix image polling schedule reschedu..."](https://github.com/getarcaneapp/arcane/commit/a664ba10d8ebb4b1a2a6cf1b5d38cd23eb548429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43101979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->