### PR TITLE
fix: overlay arcane env overrides on top of git env instead of copying

### DIFF
--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -400,6 +400,7 @@ func TestGitOpsSyncService_SyncProjectDirectory_CreatesProjectPreservingRepoLayo
 	}
 	require.NoError(t, db.Create(sync).Error)
 
+	gitEnvContent := "# keep git formatting\r\nZ_LAST=last\r\nCLOUDFLARE_CLIENT_SECRET=$$pbkdf2-sha512$$310000$$XXX\r\nQUOTED_SECRET='$pbkdf2-sha512$310000$XXX'\r\nA_FIRST=first"
 	syncFiles := []projects.SyncFile{
 		{
 			RelativePath: "docker-compose.yaml",
@@ -421,7 +422,7 @@ services:
 		},
 		{
 			RelativePath: ".env",
-			Content:      []byte("APP_MODE=production\n"),
+			Content:      []byte(gitEnvContent),
 		},
 	}
 
@@ -448,7 +449,16 @@ services:
 
 	envBytes, err := os.ReadFile(filepath.Join(project.Path, ".env"))
 	require.NoError(t, err)
-	assert.Equal(t, "APP_MODE=production\n", string(envBytes))
+	assert.Equal(t, gitEnvContent, string(envBytes))
+
+	gitEnvBytes, err := os.ReadFile(filepath.Join(project.Path, ".env.git"))
+	require.NoError(t, err)
+	assert.Equal(t, gitEnvContent, string(gitEnvBytes))
+
+	parsedEnv, err := projects.ParseProjectEnvFile(filepath.Join(project.Path, ".env"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "$pbkdf2-sha512$310000$XXX", parsedEnv["CLOUDFLARE_CLIENT_SECRET"])
+	assert.Equal(t, "$pbkdf2-sha512$310000$XXX", parsedEnv["QUOTED_SECRET"])
 
 	_, statErr := os.Stat(filepath.Join(project.Path, "compose.yaml"))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
@@ -589,6 +599,7 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGi
 	}
 	require.NoError(t, db.Create(sync).Error)
 
+	newGitEnvContent := "FOO=gitnew\nBAR=new\n"
 	syncFiles := []projects.SyncFile{
 		{
 			RelativePath: "docker-compose.yaml",
@@ -599,7 +610,7 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGi
 		},
 		{
 			RelativePath: ".env",
-			Content:      []byte("FOO=gitnew\nBAR=new\n"),
+			Content:      []byte(newGitEnvContent),
 		},
 	}
 
@@ -609,6 +620,18 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGi
 	require.False(t, created)
 	require.True(t, changed)
 	require.ElementsMatch(t, []string{"docker-compose.yaml"}, syncedFiles)
+
+	effectiveBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, ".env"))
+	require.NoError(t, err)
+	assert.Equal(t, newGitEnvContent+"FOO=useredit\n", string(effectiveBytes))
+
+	gitBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, ".env.git"))
+	require.NoError(t, err)
+	assert.Equal(t, newGitEnvContent, string(gitBytes))
+
+	overrideBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "project.env"))
+	require.NoError(t, err)
+	assert.Equal(t, "FOO=useredit\n", string(overrideBytes))
 
 	effectiveEnv, err := projects.ParseProjectEnvFile(filepath.Join(updatedProject.Path, ".env"), nil)
 	require.NoError(t, err)

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -3828,6 +3828,13 @@ func (s *ProjectService) persistEffectiveEnvContentInternal(projectPath, project
 		return fmt.Errorf("read project env state: %w", err)
 	}
 
+	if state.HasGitSource && state.HasEffective && envContent == state.EffectiveContent {
+		storedEffectiveContent, buildErr := projects.BuildEffectiveEnvContent(state.GitContent, state.OverrideContent)
+		if buildErr == nil && envContent == storedEffectiveContent {
+			return nil
+		}
+	}
+
 	if !state.HasGitSource {
 		if state.HasOverride {
 			if err := projects.RemoveProjectFile(projectsDirectory, projectPath, projects.OverrideEnvFileName); err != nil {

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -2899,6 +2899,105 @@ func TestProjectService_UpdateProject_DerivesProjectOverrideEnvWhenGitSourceExis
 	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=example\n")
 }
 
+func TestProjectService_UpdateProject_UnchangedGitEnvLeavesFilesUntouched(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
+
+	dirName := "unchanged-git-env"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+
+	gitContent := "# git formatting\nBASE=git\n"
+	overrideContent := "# local formatting\nTOKEN='$pbkdf2-sha512$310000$XXX'\n"
+	effectiveContent := gitContent + overrideContent
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte(effectiveContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte(gitContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte(overrideContent), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-unchanged-git-env"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, nil, &effectiveContent, nil, nil, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, effectiveContent, string(effectiveBytes))
+
+	gitBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env.git"))
+	require.NoError(t, readErr)
+	assert.Equal(t, gitContent, string(gitBytes))
+
+	overrideBytes, readErr := os.ReadFile(filepath.Join(projectPath, "project.env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, overrideContent, string(overrideBytes))
+}
+
+func TestProjectService_PersistEffectiveEnvContent_RemovesStaleOverrideWithoutGitSource(t *testing.T) {
+	projectsDir := t.TempDir()
+	projectPath := filepath.Join(projectsDir, "direct-env")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	effectiveContent := "TOKEN=current\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte(effectiveContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=stale\n"), 0o600))
+
+	svc := &ProjectService{}
+	require.NoError(t, svc.persistEffectiveEnvContentInternal(projectPath, projectsDir, effectiveContent))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, effectiveContent, string(effectiveBytes))
+
+	_, statErr := os.Stat(filepath.Join(projectPath, "project.env"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestProjectService_PersistEffectiveEnvContent_RemovesStaleGitOverride(t *testing.T) {
+	projectsDir := t.TempDir()
+	projectPath := filepath.Join(projectsDir, "git-env")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+
+	effectiveContent := "BASE=git\nTOKEN=git\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env"), []byte(effectiveContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, ".env.git"), []byte(effectiveContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "project.env"), []byte("TOKEN=stale\n"), 0o600))
+
+	svc := &ProjectService{}
+	require.NoError(t, svc.persistEffectiveEnvContentInternal(projectPath, projectsDir, effectiveContent))
+
+	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+	require.NoError(t, readErr)
+	assert.Equal(t, effectiveContent, string(effectiveBytes))
+
+	gitBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env.git"))
+	require.NoError(t, readErr)
+	assert.Equal(t, effectiveContent, string(gitBytes))
+
+	_, statErr := os.Stat(filepath.Join(projectPath, "project.env"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
 func TestProjectService_UpdateProject_DeletingGitBackedKeyFallsBackToGit(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
@@ -2998,6 +3097,67 @@ func TestProjectService_ApplyGitSyncProjectFiles_MigratesDirectEnvIntoProjectOve
 	assert.Contains(t, string(effectiveBytes), "TOKEN=git\n")
 	assert.Contains(t, string(effectiveBytes), "LOCAL_ONLY=1\n")
 	assert.Contains(t, string(effectiveBytes), "REMOTE_ONLY=1\n")
+}
+
+func TestProjectService_ApplyGitSyncProjectFiles_PreservesGitEnvSyntax(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsDir := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsDir)
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
+
+	dirName := "git-sync-env-syntax"
+	projectPath := filepath.Join(projectsDir, dirName)
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o600))
+
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-git-sync-env-syntax"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	compose := `services:
+  app:
+    image: nginx:alpine
+    environment:
+      CLOUDFLARE_CLIENT_SECRET: ${CLOUDFLARE_CLIENT_SECRET:?set in env}
+`
+	gitEnv := "# keep git formatting\nZ_LAST=last\nCLOUDFLARE_CLIENT_SECRET=$$pbkdf2-sha512$$310000$$XXX\nQUOTED_SECRET='$pbkdf2-sha512$310000$XXX'\nA_FIRST=first"
+
+	for range 2 {
+		updated, err := svc.ApplyGitSyncProjectFiles(ctx, project.ID, compose, &gitEnv, nil, "", models.User{
+			BaseModel: models.BaseModel{ID: "u1"},
+			Username:  "tester",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+
+		effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
+		require.NoError(t, readErr)
+		assert.Equal(t, gitEnv, string(effectiveBytes))
+
+		gitBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env.git"))
+		require.NoError(t, readErr)
+		assert.Equal(t, gitEnv, string(gitBytes))
+
+		_, statErr := os.Stat(filepath.Join(projectPath, "project.env"))
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+	}
+
+	effectiveEnv, err := projects.ParseProjectEnvFile(filepath.Join(projectPath, ".env"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "$pbkdf2-sha512$310000$XXX", effectiveEnv["CLOUDFLARE_CLIENT_SECRET"])
+	assert.Equal(t, "$pbkdf2-sha512$310000$XXX", effectiveEnv["QUOTED_SECRET"])
 }
 
 func TestProjectService_ApplyGitSyncProjectFiles_NormalizesStaleCopiedGitOverrides(t *testing.T) {
@@ -3326,7 +3486,7 @@ func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
 
 	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
 	require.NoError(t, readErr)
-	assert.Equal(t, "BASE=git-updated\nREMOTE=1\nTOKEN=local\n", string(effectiveBytes))
+	assert.Equal(t, "BASE=git-updated\nTOKEN=git\nREMOTE=1\nTOKEN=local\n", string(effectiveBytes))
 }
 
 func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.T) {

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -274,7 +274,8 @@ func WithTransientValidationEnvFile(projectPath string, effectiveEnvContent *str
 		return run()
 	}
 
-	shouldWrite := effectiveEnvContent != nil || !originalExists
+	contentMatches := effectiveEnvContent != nil && originalExists && string(originalContent) == *effectiveEnvContent
+	shouldWrite := !contentMatches && (effectiveEnvContent != nil || !originalExists)
 	if shouldWrite {
 		content := ""
 		if effectiveEnvContent != nil {
@@ -311,8 +312,9 @@ func WithTransientValidationEnvFile(projectPath string, effectiveEnvContent *str
 }
 
 // BuildEffectiveEnvContent merges git and override env sources into the effective
-// .env content written to disk. The output is normalized: comments are dropped,
-// keys are sorted, and values are rewritten with Arcane's formatter.
+// .env content written to disk. Each source is preserved verbatim, with the
+// override appended after the Git content so duplicate keys resolve to the
+// override value when Compose parses the effective file.
 func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error) {
 	contextEnv := make(EnvMap)
 
@@ -322,21 +324,26 @@ func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error
 	}
 	maps.Copy(contextEnv, gitEnv)
 
-	overrideEnv, err := ParseProjectEnvContent(overrideContent, contextEnv)
+	_, err = ParseProjectEnvContent(overrideContent, contextEnv)
 	if err != nil {
 		return "", fmt.Errorf("parse override env content: %w", err)
 	}
 
-	merged := make(EnvMap, len(gitEnv)+len(overrideEnv))
-	maps.Copy(merged, gitEnv)
-	maps.Copy(merged, overrideEnv)
-
-	return formatEnvMapInternal(merged), nil
+	switch {
+	case gitContent == "":
+		return overrideContent, nil
+	case overrideContent == "":
+		return gitContent, nil
+	case strings.HasSuffix(gitContent, "\n"), strings.HasPrefix(overrideContent, "\n"):
+		return gitContent + overrideContent, nil
+	default:
+		return gitContent + "\n" + overrideContent, nil
+	}
 }
 
 // BuildOverrideEnvContent derives the editable override file from git-backed and
-// effective env content. The generated output is normalized and does not retain
-// comments or original key ordering.
+// effective env content. Content that already contains only real overrides is
+// returned verbatim; derived or cleaned output uses Arcane's canonical format.
 func BuildOverrideEnvContent(gitContent, effectiveContent string) (string, error) {
 	return buildOverrideEnvContentInternal(gitContent, effectiveContent)
 }
@@ -395,6 +402,10 @@ func buildOverrideEnvContentInternal(gitContent, effectiveContent string) (strin
 		case gitValue != value:
 			override[key] = value
 		}
+	}
+
+	if maps.Equal(effectiveEnv, override) {
+		return effectiveContent, nil
 	}
 
 	return formatEnvMapInternal(override), nil
@@ -559,6 +570,7 @@ func formatEnvValueInternal(value string) string {
 		return value
 	}
 
+	value = strings.ReplaceAll(value, "$", "$$")
 	needsQuotes := strings.ContainsAny(value, " \t\r\n#\"'") || strings.TrimSpace(value) != value
 	if !needsQuotes {
 		return value

--- a/backend/pkg/projects/env_test.go
+++ b/backend/pkg/projects/env_test.go
@@ -91,15 +91,55 @@ func TestLoadEnvironment_DoesNotCreateMissingGlobalEnvFile(t *testing.T) {
 }
 
 func TestBuildEffectiveEnvContent(t *testing.T) {
-	gitContent := "BASE_URL=https://example.com\nSHARED=git\n"
-	overrideContent := "API_TOKEN=secret\nSHARED=override\n"
+	tests := []struct {
+		name            string
+		gitContent      string
+		overrideContent string
+		want            string
+		wantEnv         EnvMap
+	}{
+		{
+			name:       "preserves escaped dollar secret exactly",
+			gitContent: "CLOUDFLARE_CLIENT_SECRET=$$pbkdf2-sha512$$310000$$XXX\n",
+			want:       "CLOUDFLARE_CLIENT_SECRET=$$pbkdf2-sha512$$310000$$XXX\n",
+			wantEnv:    EnvMap{"CLOUDFLARE_CLIENT_SECRET": "$pbkdf2-sha512$310000$XXX"},
+		},
+		{
+			name:       "preserves single quoted dollar secret exactly",
+			gitContent: "CLOUDFLARE_CLIENT_SECRET='$pbkdf2-sha512$310000$XXX'",
+			want:       "CLOUDFLARE_CLIENT_SECRET='$pbkdf2-sha512$310000$XXX'",
+			wantEnv:    EnvMap{"CLOUDFLARE_CLIENT_SECRET": "$pbkdf2-sha512$310000$XXX"},
+		},
+		{
+			name:       "preserves comments ordering blank lines bom and crlf",
+			gitContent: "\ufeff# keep this comment\r\nZ_LAST=last\r\n\r\nA_FIRST=first",
+			want:       "\ufeff# keep this comment\r\nZ_LAST=last\r\n\r\nA_FIRST=first",
+			wantEnv:    EnvMap{"Z_LAST": "last", "A_FIRST": "first"},
+		},
+		{
+			name:            "adds a separator without changing either layer",
+			gitContent:      "BASE_URL=https://example.com\nSHARED=git",
+			overrideContent: "# local values\nAPI_TOKEN=secret\nSHARED=override\n",
+			want:            "BASE_URL=https://example.com\nSHARED=git\n# local values\nAPI_TOKEN=secret\nSHARED=override\n",
+			wantEnv: EnvMap{
+				"BASE_URL":  "https://example.com",
+				"API_TOKEN": "secret",
+				"SHARED":    "override",
+			},
+		},
+	}
 
-	effective, err := BuildEffectiveEnvContent(gitContent, overrideContent)
-	require.NoError(t, err)
-	assert.Contains(t, effective, "BASE_URL=https://example.com\n")
-	assert.Contains(t, effective, "API_TOKEN=secret\n")
-	assert.Contains(t, effective, "SHARED=override\n")
-	assert.NotContains(t, effective, "SHARED=git\n")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			effective, err := BuildEffectiveEnvContent(tt.gitContent, tt.overrideContent)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, effective)
+
+			parsed, err := ParseProjectEnvContent(effective, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnv, parsed)
+		})
+	}
 }
 
 func TestBuildOverrideEnvContent(t *testing.T) {
@@ -156,6 +196,48 @@ func TestBuildOverrideEnvContent(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "LOCAL_ONLY=1\n", override)
 	})
+
+	t.Run("preserves an existing valid override verbatim", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\n"
+		overrideContent := "# keep local formatting\nTOKEN='$pbkdf2-sha512$310000$XXX'\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, overrideContent)
+		require.NoError(t, err)
+		assert.Equal(t, overrideContent, override)
+	})
+
+	t.Run("generated overrides escape literal dollars", func(t *testing.T) {
+		gitContent := "BASE_URL=https://example.com\n"
+		effectiveContent := "BASE_URL=https://example.com\nTOKEN='$pbkdf2-sha512$310000$XXX'\n"
+
+		override, err := BuildOverrideEnvContent(gitContent, effectiveContent)
+		require.NoError(t, err)
+		assert.Equal(t, "TOKEN=$$pbkdf2-sha512$$310000$$XXX\n", override)
+
+		parsed, err := ParseProjectEnvContent(override, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "$pbkdf2-sha512$310000$XXX", parsed["TOKEN"])
+	})
+}
+
+func TestFormatEnvMapInternal_RoundTripsValues(t *testing.T) {
+	values := []string{
+		"$pbkdf2-sha512$310000$XXX",
+		"prefix $VALUE with spaces",
+		`quote " and apostrophe '`,
+		`backslash\$VALUE`,
+		"line one\nline two",
+		"$$literal-dollars",
+	}
+
+	for _, value := range values {
+		t.Run(value, func(t *testing.T) {
+			content := formatEnvMapInternal(EnvMap{"VALUE": value})
+			parsed, err := ParseProjectEnvContent(content, nil)
+			require.NoError(t, err)
+			assert.Equal(t, value, parsed["VALUE"])
+		})
+	}
 }
 
 func TestReadProjectEnvState(t *testing.T) {

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -116,6 +116,14 @@ func WriteProjectFile(projectsRoot, dirPath, fileName, content string) error {
 	}
 
 	targetPath := filepath.Join(dirPath, fileName)
+	existingContent, readErr := os.ReadFile(targetPath)
+	if readErr == nil && string(existingContent) == content {
+		return nil
+	}
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return fmt.Errorf("failed to read project file %s: %w", fileName, readErr)
+	}
+
 	if err := atomic.WriteFile(targetPath, []byte(content), pkgutils.FilePerm); err != nil {
 		return fmt.Errorf("failed to write project file %s: %w", fileName, err)
 	}

--- a/backend/pkg/projects/fs_writer_test.go
+++ b/backend/pkg/projects/fs_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	pkgutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,25 @@ func TestWriteFilesPermissions(t *testing.T) {
 			assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 		}
 	})
+}
+
+func TestWriteProjectFile_DoesNotReplaceIdenticalContent(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	filePath := filepath.Join(projectDir, EffectiveEnvFileName)
+	content := "VALUE=unchanged\n"
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0o600))
+
+	fixedTime := time.Unix(1_700_000_000, 0)
+	require.NoError(t, os.Chtimes(filePath, fixedTime, fixedTime))
+
+	require.NoError(t, WriteProjectFile(projectsRoot, projectDir, EffectiveEnvFileName, content))
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	assert.True(t, info.ModTime().Equal(fixedTime), "identical content should not replace the file")
 }
 
 func TestWriteProjectFiles(t *testing.T) {

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -745,6 +745,7 @@
 		const { composeContent, envContent, overrideContent } = validated;
 		const namePayload = isGitOpsManaged ? undefined : effectiveName;
 		const composePayload = isGitOpsManaged ? undefined : composeContent;
+		const envPayload = envContent !== serverEnvContent ? envContent : undefined;
 		// Blank override => delete, which the backend treats as a no-op when none
 		// exists, so we can always send it (except for read-only GitOps projects).
 		const overridePayload = isGitOpsManaged ? undefined : overrideContent;
@@ -759,7 +760,7 @@
 						projectId,
 						namePayload,
 						composePayload,
-						envContent,
+						envPayload,
 						overridePayload,
 						fileTreeRevision,
 						fileChangesPayload


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how project env files preserve git content and local overrides.

- Git env content is kept verbatim in `.env.git` and the effective `.env`.
- Local override content is appended instead of rewriting the whole env map.
- Stale override cleanup is kept reachable when saved env content is unchanged.
- The project page now compares validated env content before deciding whether to send it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran focused package tests and captured a test log showing command headers, working directories, verbose test names, harness content evidence, and exit codes.
- I saved the harness source to an uploaded artifact to enable reproducibility of the overlay test.
- A broader internal services go test run timed out before producing results beyond the command header, so validation stopped after the focused package tests and the direct runtime harness proof of the central overlay claim.

<a href="https://app.greptile.com/trex/runs/13920484/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: overlay arcane env overrides on top..."](https://github.com/getarcaneapp/arcane/commit/3693fcb9015ac1e406331fc2b100dcbaebd7dcdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43164308)</sub>

<!-- /greptile_comment -->