### PR TITLE
fix: wait for schedulers during shutdown

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -60,18 +61,28 @@ func Bootstrap(ctx context.Context) error {
 
 	appCtx, cancelApp := context.WithCancel(ctx)
 	appCtx = utils.WithAppLifecycleContext(appCtx)
-	defer cancelApp()
 
 	db, err := initializeDBAndMigrate(appCtx, cfg)
 	if err != nil {
+		cancelApp()
 		return fmt.Errorf("failed to initialize database: %w", err)
 	}
+	var appServices *di.Services
 	defer func(ctx context.Context) {
+		cancelApp()
 		// appCtx is already canceled here, so derive the shutdown deadline from a
 		// non-canceled copy of it.
 		baseCtx := context.WithoutCancel(ctx)
 		shutdownCtx, shutdownCancel := context.WithTimeout(baseCtx, 10*time.Second)
 		defer shutdownCancel()
+		if appServices != nil {
+			if appServices.Volume != nil {
+				appServices.Volume.CleanupHelperContainers(shutdownCtx)
+			}
+			if appServices.Docker != nil {
+				appServices.Docker.Close()
+			}
+		}
 		if err := db.Close(); err != nil {
 			slog.ErrorContext(shutdownCtx, "Error closing database", "error", err)
 		}
@@ -79,20 +90,11 @@ func Bootstrap(ctx context.Context) error {
 
 	httpClient := newConfiguredHTTPClient(cfg)
 
-	appServices, err := di.InitializeServices(appCtx, db, cfg, httpClient)
+	appServices, err = di.InitializeServices(appCtx, db, cfg, httpClient)
 	if err != nil {
 		return fmt.Errorf("failed to initialize services: %w", err)
 	}
 	dockerClientService := appServices.Docker
-	defer dockerClientService.Close()
-	defer func(ctx context.Context) {
-		baseCtx := context.WithoutCancel(ctx)
-		shutdownCtx, shutdownCancel := context.WithTimeout(baseCtx, 10*time.Second)
-		defer shutdownCancel()
-		if appServices.Volume != nil {
-			appServices.Volume.CleanupHelperContainers(shutdownCtx)
-		}
-	}(appCtx)
 
 	initializeStartupState(appCtx, cfg, appServices, dockerClientService, httpClient)
 
@@ -105,7 +107,7 @@ func Bootstrap(ctx context.Context) error {
 
 	startEdgeTunnelClientIfConfigured(appCtx, cfg, router)
 
-	err = runServicesInternal(appCtx, cfg, router, tunnelServer, scheduler)
+	err = runServicesInternal(appCtx, cancelApp, cfg, router, tunnelServer, scheduler)
 	if err != nil {
 		return fmt.Errorf("failed to run services: %w", err)
 	}
@@ -388,21 +390,14 @@ func handleAgentBootstrapPairing(ctx context.Context, cfg *config.Config, httpCl
 	}
 }
 
-func runServicesInternal(appCtx context.Context, cfg *config.Config, router http.Handler, tunnelServer *edge.TunnelServer, schedulers ...interface {
+func runServicesInternal(appCtx context.Context, cancelApp context.CancelFunc, cfg *config.Config, router http.Handler, tunnelServer *edge.TunnelServer, schedulers ...interface {
 	Run(ctx context.Context) error
 }) error {
-	for _, s := range schedulers {
-		scheduler := s
-		go func() {
-			slog.InfoContext(appCtx, "Starting scheduler")
-			if err := scheduler.Run(appCtx); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					slog.ErrorContext(appCtx, "Job scheduler exited with error", "error", err)
-				}
-			}
-			slog.InfoContext(appCtx, "Scheduler stopped")
-		}()
-	}
+	var schedulerWaitGroup sync.WaitGroup
+	defer func() {
+		cancelApp()
+		schedulerWaitGroup.Wait()
+	}()
 
 	listenAddr := cfg.ListenAddr()
 	useTLS, tlsCertFile, tlsKeyFile, edgeCfg, err := prepareServerTLSInternal(appCtx, cfg)
@@ -427,6 +422,18 @@ func runServicesInternal(appCtx context.Context, cfg *config.Config, router http
 	if err != nil {
 		return err
 	}
+	for _, serviceScheduler := range schedulers {
+		scheduler := serviceScheduler
+		schedulerWaitGroup.Go(func() {
+			slog.InfoContext(appCtx, "Starting scheduler")
+			if err := scheduler.Run(appCtx); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					slog.ErrorContext(appCtx, "Job scheduler exited with error", "error", err)
+				}
+			}
+			slog.InfoContext(appCtx, "Scheduler stopped")
+		})
+	}
 
 	go func() {
 		slog.InfoContext(appCtx, "Starting HTTP server", "addr", listenAddr, "listen", cfg.Listen, "port", cfg.Port, "tls_enabled", useTLS)
@@ -445,10 +452,12 @@ func runServicesInternal(appCtx context.Context, cfg *config.Config, router http
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(quit)
 
 	select {
 	case <-quit:
 		slog.InfoContext(appCtx, "Received shutdown signal")
+		cancelApp()
 	case <-appCtx.Done():
 		slog.InfoContext(appCtx, "Context canceled")
 	}

--- a/backend/internal/bootstrap/bootstrap_test.go
+++ b/backend/internal/bootstrap/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,28 @@ import (
 	libcrypto "go.getarcane.app/sys/crypto"
 	"golang.org/x/net/http2"
 )
+
+type blockingServiceSchedulerInternal struct {
+	runCalls             atomic.Int32
+	started              chan struct{}
+	cancellationObserved chan struct{}
+	release              <-chan struct{}
+}
+
+func (s *blockingServiceSchedulerInternal) Run(ctx context.Context) error {
+	s.runCalls.Add(1)
+	if s.started != nil {
+		s.started <- struct{}{}
+	}
+	<-ctx.Done()
+	if s.cancellationObserved != nil {
+		s.cancellationObserved <- struct{}{}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	return nil
+}
 
 func TestNormalizeTunnelGRPCRequestPathInternal(t *testing.T) {
 	fullMethodPath := tunnelpb.TunnelService_Connect_FullMethodName
@@ -251,6 +274,84 @@ func TestShutdownCancelsStreamingRequestContextsInternal(t *testing.T) {
 	require.NoError(t, srv.Shutdown(shutdownCtx))
 	require.Less(t, time.Since(start), time.Second)
 	require.ErrorIs(t, <-errCh, http.ErrServerClosed)
+}
+
+func TestRunServicesInternalDoesNotStartSchedulersBeforeServerInitialization(t *testing.T) {
+	appCtx, cancelApp := context.WithCancel(context.Background())
+	scheduler := &blockingServiceSchedulerInternal{}
+	cfg := &config.Config{
+		AgentMode:  true,
+		TLSEnabled: true,
+	}
+
+	err := runServicesInternal(appCtx, cancelApp, cfg, http.NewServeMux(), nil, scheduler)
+	require.ErrorContains(t, err, "TLS_ENABLED requires both TLS_CERT_FILE and TLS_KEY_FILE")
+	require.Zero(t, scheduler.runCalls.Load())
+	require.ErrorIs(t, appCtx.Err(), context.Canceled)
+}
+
+func TestRunServicesInternalWaitsForSchedulersBeforeReleasingDependencies(t *testing.T) {
+	appCtx, cancelApp := context.WithCancel(context.Background())
+	started := make(chan struct{}, 1)
+	cancellationObserved := make(chan struct{}, 1)
+	releaseScheduler := make(chan struct{}, 1)
+	scheduler := &blockingServiceSchedulerInternal{
+		started:              started,
+		cancellationObserved: cancellationObserved,
+		release:              releaseScheduler,
+	}
+	cfg := &config.Config{
+		AgentMode:   true,
+		Environment: config.AppEnvironmentTest,
+		Listen:      "127.0.0.1",
+		Port:        "0",
+	}
+
+	runDone := make(chan error, 1)
+	dependenciesReleased := make(chan struct{})
+	go func() {
+		err := runServicesInternal(appCtx, cancelApp, cfg, http.NewServeMux(), nil, scheduler)
+		close(dependenciesReleased)
+		runDone <- err
+	}()
+	t.Cleanup(func() {
+		cancelApp()
+		select {
+		case releaseScheduler <- struct{}{}:
+		default:
+		}
+	})
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not start")
+	}
+	cancelApp()
+	select {
+	case <-cancellationObserved:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not observe lifecycle cancellation")
+	}
+
+	select {
+	case <-dependenciesReleased:
+		t.Fatal("service runner released dependencies before the scheduler stopped")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseScheduler <- struct{}{}
+	select {
+	case <-dependenciesReleased:
+	case <-time.After(time.Second):
+		t.Fatal("service runner did not release dependencies after the scheduler stopped")
+	}
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("service runner did not return")
+	}
 }
 
 func TestPrepareServerTLSInternal_AgentModeSkipsManagerMTLSValidation(t *testing.T) {

--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -159,7 +159,10 @@ func (js *JobScheduler) GetLocation() *time.Location {
 func (js *JobScheduler) Run(ctx context.Context) error {
 	js.StartScheduler()
 	<-ctx.Done()
-	js.cron.Stop()
+	// Running jobs may still own Docker or database resources. Wait for them here
+	// so Bootstrap cannot close shared services underneath them; the process-level
+	// signal handler owns the hard shutdown deadline for non-cooperative jobs.
+	<-js.cron.Stop().Done()
 	return nil
 }
 

--- a/backend/pkg/scheduler/scheduler_test.go
+++ b/backend/pkg/scheduler/scheduler_test.go
@@ -260,3 +260,69 @@ func TestJobScheduler_AddJob_GenericJobWithoutShouldRunIsScheduled(t *testing.T)
 	require.True(t, js.HasJob(job.Name()))
 	require.Len(t, js.cron.Entries(), 1)
 }
+
+func TestJobScheduler_RunWaitsForCanceledJobToFinish(t *testing.T) {
+	lifecycleCtx, cancelLifecycle := context.WithCancel(context.Background())
+	jobStarted := make(chan struct{}, 1)
+	cancellationObserved := make(chan struct{}, 1)
+	releaseJob := make(chan struct{}, 1)
+	jobFinished := make(chan struct{}, 1)
+	var runOnce sync.Once
+
+	js := NewJobScheduler(lifecycleCtx, nil)
+	js.RegisterJob(&testSchedulerJob{
+		name:     "test-shutdown-waits",
+		schedule: "*/1 * * * * *",
+		run: func(ctx context.Context) {
+			runOnce.Do(func() {
+				jobStarted <- struct{}{}
+				<-ctx.Done()
+				cancellationObserved <- struct{}{}
+				<-releaseJob
+				jobFinished <- struct{}{}
+			})
+		},
+	})
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- js.Run(lifecycleCtx) }()
+	t.Cleanup(func() {
+		cancelLifecycle()
+		select {
+		case releaseJob <- struct{}{}:
+		default:
+		}
+	})
+
+	select {
+	case <-jobStarted:
+	case <-time.After(2500 * time.Millisecond):
+		t.Fatal("timed out waiting for scheduled job to start")
+	}
+
+	cancelLifecycle()
+	select {
+	case <-cancellationObserved:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled job did not observe lifecycle cancellation")
+	}
+
+	select {
+	case err := <-runDone:
+		t.Fatalf("scheduler returned before the running job finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseJob <- struct{}{}
+	select {
+	case <-jobFinished:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled job did not finish after release")
+	}
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not return after the running job finished")
+	}
+}

--- a/backend/pkg/utils/signals/signals.go
+++ b/backend/pkg/utils/signals/signals.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 /*
@@ -19,8 +20,10 @@ Also referenced from pocket-id/pocket-id
 
 var onlyOneSignalHandler = make(chan struct{})
 
+const forcedShutdownTimeout = 30 * time.Second
+
 // SignalContext returns a context that is canceled when the application receives an interrupt signal.
-// A second signal forces an immediate shutdown.
+// A second signal or an expired graceful-shutdown deadline forces the process to exit.
 func SignalContext(parentCtx context.Context) context.Context {
 	close(onlyOneSignalHandler) // Panics when called twice
 
@@ -33,8 +36,17 @@ func SignalContext(parentCtx context.Context) context.Context {
 		slog.Info("Received interrupt signal. Shutting down…")
 		cancel()
 
-		<-sigCh
-		slog.Warn("Received a second interrupt signal. Forcing an immediate shutdown.")
+		shutdownTimer := time.NewTimer(forcedShutdownTimeout)
+		defer shutdownTimer.Stop()
+
+		select {
+		case <-sigCh:
+			slog.Warn("Received a second interrupt signal. Forcing an immediate shutdown.")
+		case <-shutdownTimer.C:
+			slog.Error("Graceful shutdown timed out. Forcing process exit.", "timeout", forcedShutdownTimeout)
+		}
+		// Go cannot safely terminate a hung goroutine. Exit the process instead of
+		// allowing Bootstrap to close dependencies that goroutine may still use.
 		os.Exit(1)
 	}()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates shutdown ordering so schedulers can finish before shared services are released. The main changes are:

- Scheduler startup now happens after server initialization.
- Service shutdown now cancels the app context and waits for scheduler goroutines.
- Cron shutdown now waits for running jobs to finish.
- Signal handling now adds a forced exit deadline after the first interrupt.
- Tests cover scheduler startup ordering and dependency release timing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The run sequence documented in the scheduler wait probe shows a TREX\_EVENT run\_still\_blocked\_after\_cancel, followed by job\_released and then run\_returned, with a successful exit code.
- Bootstrap tests finished with all tests passing, including TestRunServicesInternalWaitsForSchedulersBeforeReleasingDependencies, confirming dependencies were released after waiting.
- The signals package compiled with no tests and reported exit code 0, indicating no tests were present to run.
- Scheduler startup smoke coverage passed, indicating the scheduler started correctly under smoke testing.

<a href="https://app.greptile.com/trex/runs/13939619/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: wait for schedulers during shutdown"](https://github.com/getarcaneapp/arcane/commit/58a8fc1493c3cb847383b576b505c2876769fe22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43207988)</sub>

<!-- /greptile_comment -->