### PR TITLE
fix(cli): align image update checks with API contract

### DIFF
--- a/cli/internal/integrationtest/updates_commands_test.go
+++ b/cli/internal/integrationtest/updates_commands_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
 )
 
 func TestContainersListUpdatesJSONContract(t *testing.T) {
@@ -205,5 +207,223 @@ func TestProjectsUpdatesCommandUsesHasUpdateFilter(t *testing.T) {
 	}
 	if strings.TrimSpace(outBuf) == "" {
 		t.Fatal("expected output from projects updates command")
+	}
+}
+
+func TestImagesUpdatesCheckEncodesImageRefAndDecodesSingleResponse(t *testing.T) {
+	imageRef := "registry.example.com/team/image:latest&debug=true"
+	receivedImageRef := ""
+	receivedRawQuery := ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/environments/0/image-updates/check" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"success":false,"error":"not found"}`))
+			return
+		}
+
+		receivedImageRef = r.URL.Query().Get("imageRef")
+		receivedRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"hasUpdate": true,
+				"updateType": "minor",
+				"currentVersion": "1.0.0",
+				"latestVersion": "1.1.0",
+				"checkTime": "2026-07-09T12:00:00Z",
+				"responseTimeMs": 17
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	configPath := writeCLIIntegrationConfigInternal(t, srv.URL)
+	outBuf, errOut, err := executeCLIIntegrationCommandInternal(
+		t,
+		[]string{"--config", configPath, "images", "updates", "check", imageRef, "--json"},
+	)
+	if err != nil {
+		t.Fatalf("execute: %v (%s)", err, errOut)
+	}
+	if receivedImageRef != imageRef {
+		t.Fatalf("expected imageRef %q, got %q", imageRef, receivedImageRef)
+	}
+	if !strings.Contains(receivedRawQuery, "%26") || !strings.Contains(receivedRawQuery, "%3D") {
+		t.Fatalf("expected reserved query characters to be encoded, got %q", receivedRawQuery)
+	}
+	if strings.Contains(receivedRawQuery, "&debug=") {
+		t.Fatalf("imageRef escaped into a second query parameter: %q", receivedRawQuery)
+	}
+
+	var result imageupdate.Response
+	if err := json.Unmarshal([]byte(strings.TrimSpace(outBuf)), &result); err != nil {
+		t.Fatalf("single response JSON parse failed: %v\noutput=%s", err, outBuf)
+	}
+	if !result.HasUpdate || result.CurrentVersion != "1.0.0" || result.LatestVersion != "1.1.0" {
+		t.Fatalf("unexpected single image update response: %+v", result)
+	}
+}
+
+func TestImagesUpdatesCheckRequiresImageRef(t *testing.T) {
+	outBuf, _, err := executeCLIIntegrationCommandInternal(t, []string{"images", "updates", "check"})
+	if err == nil {
+		t.Fatalf("expected missing image reference to fail, got output %q", outBuf)
+	}
+	if !strings.Contains(err.Error(), "1 arg") || !strings.Contains(err.Error(), "received 0") {
+		t.Fatalf("unexpected argument error: %v", err)
+	}
+}
+
+func TestImageUpdateCommandsDecodeExpectedResponseTypes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/environments/0/image-updates/check-all":
+			_, _ = w.Write([]byte(`{
+				"success": true,
+				"data": {
+					"nginx:latest": {
+						"hasUpdate": true,
+						"updateType": "digest",
+						"currentVersion": "latest",
+						"latestVersion": "latest",
+						"checkTime": "2026-07-09T12:00:00Z",
+						"responseTimeMs": 21
+					}
+				}
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/environments/0/image-updates/check/image-123":
+			_, _ = w.Write([]byte(`{
+				"success": true,
+				"data": {
+					"hasUpdate": false,
+					"updateType": "none",
+					"currentVersion": "1.1.0",
+					"checkTime": "2026-07-09T12:00:00Z",
+					"responseTimeMs": 9
+				}
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/environments/0/image-updates/summary":
+			_, _ = w.Write([]byte(`{
+				"success": true,
+				"data": {
+					"totalImages": 4,
+					"imagesWithUpdates": 2,
+					"digestUpdates": 1,
+					"errorsCount": 0
+				}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"success":false,"error":"not found"}`))
+		}
+	}))
+	defer srv.Close()
+
+	configPath := writeCLIIntegrationConfigInternal(t, srv.URL)
+	outBuf, errOut, err := executeCLIIntegrationCommandInternal(
+		t,
+		[]string{"--config", configPath, "images", "updates", "check-all", "--json"},
+	)
+	if err != nil {
+		t.Fatalf("check-all: %v (%s)", err, errOut)
+	}
+	var batch imageupdate.BatchResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(outBuf)), &batch); err != nil {
+		t.Fatalf("batch response JSON parse failed: %v\noutput=%s", err, outBuf)
+	}
+	if batch["nginx:latest"] == nil || !batch["nginx:latest"].HasUpdate {
+		t.Fatalf("unexpected batch response: %+v", batch)
+	}
+
+	outBuf, errOut, err = executeCLIIntegrationCommandInternal(
+		t,
+		[]string{"--config", configPath, "images", "updates", "check-image", "image-123", "--json"},
+	)
+	if err != nil {
+		t.Fatalf("check-image: %v (%s)", err, errOut)
+	}
+	var single imageupdate.Response
+	if err := json.Unmarshal([]byte(strings.TrimSpace(outBuf)), &single); err != nil {
+		t.Fatalf("single response JSON parse failed: %v\noutput=%s", err, outBuf)
+	}
+	if single.HasUpdate || single.CurrentVersion != "1.1.0" {
+		t.Fatalf("unexpected image response: %+v", single)
+	}
+
+	outBuf, errOut, err = executeCLIIntegrationCommandInternal(
+		t,
+		[]string{"--config", configPath, "images", "updates", "summary", "--json"},
+	)
+	if err != nil {
+		t.Fatalf("summary: %v (%s)", err, errOut)
+	}
+	var summary imageupdate.Summary
+	if err := json.Unmarshal([]byte(strings.TrimSpace(outBuf)), &summary); err != nil {
+		t.Fatalf("summary response JSON parse failed: %v\noutput=%s", err, outBuf)
+	}
+	if summary.TotalImages != 4 || summary.ImagesWithUpdates != 2 || summary.DigestUpdates != 1 {
+		t.Fatalf("unexpected summary response: %+v", summary)
+	}
+}
+
+func TestImageUpdateCommandsRejectHTTPAndEnvelopeFailures(t *testing.T) {
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{name: "check", args: []string{"images", "updates", "check", "nginx:latest"}},
+		{name: "check-all", args: []string{"images", "updates", "check-all"}},
+		{name: "check-image", args: []string{"images", "updates", "check-image", "image-123"}},
+		{name: "summary", args: []string{"images", "updates", "summary"}},
+	}
+	failures := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantError  string
+	}{
+		{
+			name:       "non-2xx",
+			statusCode: http.StatusBadGateway,
+			body:       `{"success":true,"data":{}}`,
+			wantError:  "status 502",
+		},
+		{
+			name:       "success false",
+			statusCode: http.StatusOK,
+			body:       `{"success":false,"error":"permission denied"}`,
+			wantError:  "API error: permission denied",
+		},
+	}
+
+	for _, failure := range failures {
+		t.Run(failure.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(failure.statusCode)
+				_, _ = w.Write([]byte(failure.body))
+			}))
+			defer srv.Close()
+
+			configPath := writeCLIIntegrationConfigInternal(t, srv.URL)
+			for _, command := range commands {
+				t.Run(command.name, func(t *testing.T) {
+					args := append([]string{"--config", configPath}, command.args...)
+					outBuf, _, err := executeCLIIntegrationCommandInternal(t, args)
+					if err == nil {
+						t.Fatalf("expected %s error, got success with output %q", failure.name, outBuf)
+					}
+					if !strings.Contains(err.Error(), failure.wantError) {
+						t.Fatalf("expected error containing %q, got %v", failure.wantError, err)
+					}
+					if strings.TrimSpace(outBuf) != "" {
+						t.Fatalf("failed response produced success output: %q", outBuf)
+					}
+				})
+			}
+		})
 	}
 }

--- a/cli/internal/types/endpoints.go
+++ b/cli/internal/types/endpoints.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
 // ArcaneApiEndpoints holds the API endpoint path templates for the Arcane API.
 // Endpoint paths may contain format specifiers (e.g., %s) for environment IDs or resource IDs.
@@ -461,8 +464,10 @@ func (e ArcaneApiEndpoints) ImagesUpload(envID string) string {
 
 // Image Update endpoints
 
-func (e ArcaneApiEndpoints) ImageUpdatesCheck(envID string) string {
-	return fmt.Sprintf(e.ImageUpdatesCheckEndpoint, envID)
+func (e ArcaneApiEndpoints) ImageUpdatesCheck(envID, imageRef string) string {
+	query := url.Values{}
+	query.Set("imageRef", imageRef)
+	return fmt.Sprintf(e.ImageUpdatesCheckEndpoint, envID) + "?" + query.Encode()
 }
 
 func (e ArcaneApiEndpoints) ImageUpdatesCheckAll(envID string) string {

--- a/cli/pkg/images/updates/cmd.go
+++ b/cli/pkg/images/updates/cmd.go
@@ -8,7 +8,6 @@ import (
 	"github.com/getarcaneapp/arcane/cli/v2/internal/client"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/output"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/types"
-	"github.com/getarcaneapp/arcane/types/v2/base"
 	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +21,9 @@ var UpdatesCmd = &cobra.Command{
 }
 
 var checkCmd = &cobra.Command{
-	Use:          "check",
-	Short:        "Check for image updates",
+	Use:          "check <image-ref>",
+	Short:        "Check an image reference for updates",
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client.NewFromConfig()
@@ -31,15 +31,14 @@ var checkCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Get(cmd.Context(), types.Endpoints.ImageUpdatesCheck(c.EnvID()))
+		resp, err := c.Get(cmd.Context(), types.Endpoints.ImageUpdatesCheck(c.EnvID(), args[0]))
 		if err != nil {
 			return fmt.Errorf("failed to check updates: %w", err)
 		}
-		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[imageupdate.BatchResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+		result, err := client.DecodeResponseStrict[imageupdate.Response](resp)
+		if err != nil {
+			return fmt.Errorf("failed to check updates: %w", err)
 		}
 
 		if jsonOutput {
@@ -51,16 +50,16 @@ var checkCmd = &cobra.Command{
 			return nil
 		}
 
-		output.Header("Image Update Check Results")
-		updatesAvailable := 0
-		for imageRef, update := range result.Data {
-			if update != nil && update.HasUpdate {
-				output.KeyValue(imageRef, fmt.Sprintf("%s → %s (%s)", update.CurrentVersion, update.LatestVersion, update.UpdateType))
-				updatesAvailable++
-			}
+		output.Header("Image Update Status")
+		output.KeyValue("Image", args[0])
+		output.KeyValue("Has Update", strconv.FormatBool(result.Data.HasUpdate))
+		if result.Data.HasUpdate {
+			output.KeyValue("Update Type", result.Data.UpdateType)
+			output.KeyValue("Current Version", result.Data.CurrentVersion)
+			output.KeyValue("Latest Version", result.Data.LatestVersion)
 		}
-
-		fmt.Printf("\nTotal: %d images checked, %d updates available\n", len(result.Data), updatesAvailable)
+		output.KeyValue("Check Time", result.Data.CheckTime.String())
+		output.KeyValue("Response Time", fmt.Sprintf("%dms", result.Data.ResponseTimeMs))
 		return nil
 	},
 }
@@ -79,11 +78,10 @@ var checkAllCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to check all updates: %w", err)
 		}
-		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[imageupdate.BatchResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+		result, err := client.DecodeResponseStrict[imageupdate.BatchResponse](resp)
+		if err != nil {
+			return fmt.Errorf("failed to check all updates: %w", err)
 		}
 
 		if jsonOutput {
@@ -124,11 +122,10 @@ var checkImageCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to check image update: %w", err)
 		}
-		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[imageupdate.Response]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+		result, err := client.DecodeResponseStrict[imageupdate.Response](resp)
+		if err != nil {
+			return fmt.Errorf("failed to check image update: %w", err)
 		}
 
 		if jsonOutput {
@@ -167,11 +164,10 @@ var summaryCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to get summary: %w", err)
 		}
-		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[imageupdate.Summary]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+		result, err := client.DecodeResponseStrict[imageupdate.Summary](resp)
+		if err != nil {
+			return fmt.Errorf("failed to get summary: %w", err)
 		}
 
 		if jsonOutput {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN pnpm -C frontend build
 
 # Stage 2: Build Backend
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS backend-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS backend-builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG BUILD_TAGS

--- a/docker/Dockerfile-agent
+++ b/docker/Dockerfile-agent
@@ -3,7 +3,7 @@ ARG VERSION="dev"
 ARG REVISION="unknown"
 ARG ARCANE_RUNTIME_BASE_IMAGE=ghcr.io/getarcaneapp/base:distroless
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS agent-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS agent-builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG BUILD_TAGS="exclude_frontend"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -31,7 +31,7 @@ EXPOSE 3000
 CMD ["pnpm", "-C", "frontend", "dev", "--host", "0.0.0.0"]
 
 # Stage 2: Backend Development with optimized caching
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS backend-dev
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS backend-dev
 
 # Install development tools in a single layer
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns the image update CLI commands with the API response contract. The main changes are:

- `images updates check` now requires an image reference.
- The image reference is URL-encoded as an `imageRef` query parameter.
- Image update commands now use strict API envelope decoding.
- Integration tests cover response shapes, argument validation, and API failures.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changed CLI flow looks safe to merge after removing the generated coverage file.

The endpoint helper now matches the backend query contract, and the strict decoder matches the API envelope while closing response bodies.

types/coverage.txt can publish stale diagnostics when the real file is not regenerated.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the CLI updates-contract-01 integration tests with a 120-second timeout; all targeted update contract tests passed as shown in the log.
- Ran the CLI updates-contract-02 packages tests spanning internal/types, pkg/images/updates, and internal/integrationtest; all tests passed.

<a href="https://app.greptile.com/trex/runs/13943104/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2207-10-fix_cli_align_image_update_checks_with_api_contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2207-10-fix_cli_align_image_update_checks_with_api_contract%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atypes%2Fcoverage.txt%3A1%0A**Stale%20Coverage%20Artifact%20Upload**%0A%0AThis%20committed%20all-zero%20coverage%20profile%20can%20be%20uploaded%20by%20the%20CI%20coverage%20artifact%20step%20when%20the%20%60types%60%20test%20job%20fails%20before%20regenerating%20%60coverage.txt%60.%20That%20makes%20the%20%60types-coverage%60%20artifact%20report%20stale%20zero%20coverage%20instead%20of%20reflecting%20the%20current%20run%20or%20failing%20without%20a%20coverage%20file.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atypes%2Fcoverage.txt%3A1%0A**Stale%20Coverage%20Artifact%20Upload**%0A%0AThis%20committed%20all-zero%20coverage%20profile%20can%20be%20uploaded%20by%20the%20CI%20coverage%20artifact%20step%20when%20the%20%60types%60%20test%20job%20fails%20before%20regenerating%20%60coverage.txt%60.%20That%20makes%20the%20%60types-coverage%60%20artifact%20report%20stale%20zero%20coverage%20instead%20of%20reflecting%20the%20current%20run%20or%20failing%20without%20a%20coverage%20file.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
types/coverage.txt:1
**Stale Coverage Artifact Upload**

This committed all-zero coverage profile can be uploaded by the CI coverage artifact step when the `types` test job fails before regenerating `coverage.txt`. That makes the `types-coverage` artifact report stale zero coverage instead of reflecting the current run or failing without a coverage file.

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): align image update checks with..."](https://github.com/getarcaneapp/arcane/commit/3235f9259b3faa88d65b8a5d3f77f019db692fed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43219278)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->