### PR TITLE
fix: preserve external .env symlinks on save

### DIFF
--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -5388,6 +5388,129 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 	assert.Equal(t, updatedEnv, string(envBytes))
 }
 
+func TestProjectService_UpdateProject_WritesThroughExternalEnvSymlink(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+	projectPath := createComposeProjectDir(t, projectsRoot, "demo")
+	targetPath := filepath.Join(t.TempDir(), "project.env")
+	targetPerm := os.FileMode(0o640)
+	require.NoError(t, os.WriteFile(targetPath, []byte("FOO=original\n"), targetPerm))
+	require.NoError(t, os.Chmod(targetPath, targetPerm))
+
+	envPath := filepath.Join(projectPath, projects.EffectiveEnvFileName)
+	if err := os.Symlink(targetPath, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	originalLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
+	dirName := "demo"
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-external-env-symlink-update"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	updatedEnv := "FOO=updated\n"
+	updated, err := svc.UpdateProject(ctx, project.ID, nil, nil, &updatedEnv, nil, nil, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	targetContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, updatedEnv, string(targetContent))
+	currentLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalLinkTarget, currentLinkTarget)
+	linkInfo, err := os.Lstat(envPath)
+	require.NoError(t, err)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+	if runtime.GOOS != "windows" {
+		targetInfo, statErr := os.Stat(targetPath)
+		require.NoError(t, statErr)
+		assert.Equal(t, targetPerm, targetInfo.Mode().Perm())
+	}
+}
+
+func TestProjectService_UpdateProject_RestoresExternalEnvSymlinkTargetWhenProjectSaveFails(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectsRoot := t.TempDir()
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+	projectPath := createComposeProjectDir(t, projectsRoot, "demo")
+	targetPath := filepath.Join(t.TempDir(), "project.env")
+	originalContent := "FOO=original\n"
+	targetPerm := os.FileMode(0o640)
+	require.NoError(t, os.WriteFile(targetPath, []byte(originalContent), targetPerm))
+	require.NoError(t, os.Chmod(targetPath, targetPerm))
+
+	envPath := filepath.Join(projectPath, projects.EffectiveEnvFileName)
+	if err := os.Symlink(targetPath, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	originalLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+
+	eventService := NewEventService(db, nil, nil)
+	svc := NewProjectService(db, settingsService, eventService, nil, nil, nil, nil, nil, config.Load())
+	dirName := "demo"
+	project := &models.Project{
+		BaseModel: models.BaseModel{ID: "proj-external-env-symlink-rollback"},
+		Name:      dirName,
+		DirName:   &dirName,
+		Path:      projectPath,
+		Status:    models.ProjectStatusStopped,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register("arcane_test_external_env_project_save_failure", func(tx *gorm.DB) {
+		if tx.Statement != nil && tx.Statement.Schema != nil && tx.Statement.Schema.Name == "Project" {
+			_ = tx.AddError(errors.New("forced project save failure"))
+		}
+	}))
+
+	updatedEnv := "FOO=updated\n"
+	_, err = svc.UpdateProject(ctx, project.ID, nil, nil, &updatedEnv, nil, nil, nil, models.User{
+		BaseModel: models.BaseModel{ID: "u1"},
+		Username:  "tester",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced project save failure")
+
+	targetContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(targetContent))
+	currentLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalLinkTarget, currentLinkTarget)
+	linkInfo, err := os.Lstat(envPath)
+	require.NoError(t, err)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+	if runtime.GOOS != "windows" {
+		targetInfo, statErr := os.Stat(targetPath)
+		require.NoError(t, statErr)
+		assert.Equal(t, targetPerm, targetInfo.Mode().Perm())
+	}
+}
+
 func createComposeProjectDir(t *testing.T, root, name string) string {
 	t.Helper()
 

--- a/backend/pkg/projects/env_test.go
+++ b/backend/pkg/projects/env_test.go
@@ -2,8 +2,10 @@ package projects
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	pkgutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
@@ -88,6 +90,48 @@ func TestLoadEnvironment_DoesNotCreateMissingGlobalEnvFile(t *testing.T) {
 
 	_, statErr := os.Stat(filepath.Join(projectsDir, GlobalEnvFileName))
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestWithTransientValidationEnvFile_PreservesExternalSymlink(t *testing.T) {
+	projectDir := t.TempDir()
+	targetPath := filepath.Join(t.TempDir(), "project.env")
+	originalContent := "VALUE=original\n"
+	targetPerm := os.FileMode(0o640)
+	require.NoError(t, os.WriteFile(targetPath, []byte(originalContent), targetPerm))
+	require.NoError(t, os.Chmod(targetPath, targetPerm))
+
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(targetPath, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	originalLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+
+	validationErr := errors.New("validation failed")
+	updatedContent := "VALUE=validation\n"
+	err = WithTransientValidationEnvFile(projectDir, &updatedContent, func() error {
+		content, readErr := os.ReadFile(targetPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, updatedContent, string(content))
+
+		linkInfo, statErr := os.Lstat(envPath)
+		require.NoError(t, statErr)
+		require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+		return validationErr
+	})
+	require.ErrorIs(t, err, validationErr)
+
+	restoredContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(restoredContent))
+	currentLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalLinkTarget, currentLinkTarget)
+	if runtime.GOOS != "windows" {
+		targetInfo, statErr := os.Stat(targetPath)
+		require.NoError(t, statErr)
+		assert.Equal(t, targetPerm, targetInfo.Mode().Perm())
+	}
 }
 
 func TestBuildEffectiveEnvContent(t *testing.T) {

--- a/backend/pkg/projects/fs_backup.go
+++ b/backend/pkg/projects/fs_backup.go
@@ -28,6 +28,12 @@ type ProjectUpdateBackupScope struct {
 	RenamedDirs [][2]string
 }
 
+type projectUpdateEnvSymlinkBackup struct {
+	relativePath string
+	linkTarget   string
+	resolvedPath string
+}
+
 func (s ProjectUpdateBackupScope) IsEmpty() bool {
 	return !s.TopLevelFiles && len(s.Paths) == 0 && len(s.RenamedDirs) == 0
 }
@@ -38,11 +44,12 @@ func (s ProjectUpdateBackupScope) IsEmpty() bool {
 type ProjectUpdateBackup struct {
 	BackupDir     string
 	TopLevelFiles bool
-	FileEntries   []string    // regular files copied into BackupDir
+	FileEntries   []string    // regular file contents copied into BackupDir
 	DirEntries    []string    // directories copied recursively
 	AbsentEntries []string    // did not exist at backup time -> removed on restore
 	RenamedDirs   [][2]string // undone via inverse rename on restore
 	Skipped       []string    // unreadable, skipped; preserved on restore
+	envSymlink    *projectUpdateEnvSymlinkBackup
 }
 
 // BackupProjectUpdateScope copies the parts of projectDir named by scope into
@@ -104,12 +111,16 @@ func backupTopLevelFilesInternal(projRoot, backupRoot *os.Root, backup *ProjectU
 		return fmt.Errorf("read project directory: %w", err)
 	}
 	for _, entry := range entries {
-		if !entry.Type().IsRegular() {
-			continue
-		}
 		name := entry.Name()
-		if err := copyBackupFileInternal(projRoot, backupRoot, name, backup); err != nil {
-			return err
+		switch {
+		case entry.Type().IsRegular():
+			if err := copyBackupFileInternal(projRoot, backupRoot, name, backup); err != nil {
+				return err
+			}
+		case name == EffectiveEnvFileName && entry.Type()&os.ModeSymlink != 0:
+			if err := copyBackupEnvSymlinkInternal(projRoot, backupRoot, name, backup); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -195,6 +206,50 @@ func copyBackupFileInternal(projRoot, backupRoot *os.Root, rel string, backup *P
 	return nil
 }
 
+func copyBackupEnvSymlinkInternal(projRoot, backupRoot *os.Root, rel string, backup *ProjectUpdateBackup) error {
+	envPath := filepath.Join(projRoot.Name(), filepath.FromSlash(rel))
+	linkTarget, err := os.Readlink(envPath)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			backup.Skipped = append(backup.Skipped, rel)
+			return nil
+		}
+		return fmt.Errorf("read project env symlink %s: %w", rel, err)
+	}
+
+	resolvedPath, perm, isSymlink, err := resolveEnvFileWriteTargetInternal(envPath)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			backup.Skipped = append(backup.Skipped, rel)
+			return nil
+		}
+		return fmt.Errorf("resolve project env symlink %s: %w", rel, err)
+	}
+	if !isSymlink {
+		return fmt.Errorf("project env file %s is no longer a symlink", rel)
+	}
+
+	content, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			backup.Skipped = append(backup.Skipped, rel)
+			return nil
+		}
+		return fmt.Errorf("read project env symlink target %s: %w", rel, err)
+	}
+	if err := atomic.WriteFile(filepath.Join(backupRoot.Name(), filepath.FromSlash(rel)), content, perm); err != nil {
+		return fmt.Errorf("write backup file %s: %w", rel, err)
+	}
+
+	backup.FileEntries = append(backup.FileEntries, rel)
+	backup.envSymlink = &projectUpdateEnvSymlinkBackup{
+		relativePath: rel,
+		linkTarget:   linkTarget,
+		resolvedPath: filepath.Clean(resolvedPath),
+	}
+	return nil
+}
+
 // dedupeCoveredBackupEntriesInternal drops entries that live under a directory
 // already covered by DirEntries or AbsentEntries (e.g. a file change inside a
 // folder that is also being deleted recursively).
@@ -250,7 +305,7 @@ func RestoreProjectUpdateBackup(projectDir string, backup *ProjectUpdateBackup) 
 
 	// 4. Restore individual files in place.
 	for _, rel := range backup.FileEntries {
-		if err := restoreBackupFileInternal(backupRoot, projRoot, rel); err != nil {
+		if err := restoreBackupFileInternal(backupRoot, projRoot, backup, rel); err != nil {
 			return err
 		}
 	}
@@ -260,7 +315,7 @@ func RestoreProjectUpdateBackup(projectDir string, backup *ProjectUpdateBackup) 
 	// then copy every top-level backup file back. Top-level directories and
 	// symlinks are never touched.
 	if backup.TopLevelFiles {
-		if err := restoreTopLevelFilesInternal(backupRoot, projRoot, backup.Skipped); err != nil {
+		if err := restoreTopLevelFilesInternal(backupRoot, projRoot, backup); err != nil {
 			return err
 		}
 	}
@@ -321,7 +376,7 @@ func skippedUnderInternal(skipped []string, rel string) []string {
 	return under
 }
 
-func restoreBackupFileInternal(backupRoot, projRoot *os.Root, rel string) error {
+func restoreBackupFileInternal(backupRoot, projRoot *os.Root, backup *ProjectUpdateBackup, rel string) error {
 	info, err := backupRoot.Lstat(rel)
 	if err != nil {
 		return fmt.Errorf("inspect backup file %s: %w", rel, err)
@@ -329,6 +384,9 @@ func restoreBackupFileInternal(backupRoot, projRoot *os.Root, rel string) error 
 	content, err := backupRoot.ReadFile(rel)
 	if err != nil {
 		return fmt.Errorf("read backup file %s: %w", rel, err)
+	}
+	if backup.envSymlink != nil && backup.envSymlink.relativePath == rel {
+		return restoreBackupEnvSymlinkInternal(projRoot, backup.envSymlink, content, info.Mode().Perm())
 	}
 	if live, err := projRoot.Lstat(rel); err == nil && live.IsDir() {
 		if err := projRoot.RemoveAll(rel); err != nil {
@@ -348,7 +406,39 @@ func restoreBackupFileInternal(backupRoot, projRoot *os.Root, rel string) error 
 	return nil
 }
 
-func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, skipped []string) error {
+func restoreBackupEnvSymlinkInternal(projRoot *os.Root, envBackup *projectUpdateEnvSymlinkBackup, content []byte, perm os.FileMode) error {
+	envPath := filepath.Join(projRoot.Name(), filepath.FromSlash(envBackup.relativePath))
+	info, err := os.Lstat(envPath)
+	if err != nil {
+		return fmt.Errorf("inspect project env symlink during restore: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("refusing to restore project env file %s: destination is no longer a symlink", envBackup.relativePath)
+	}
+
+	linkTarget, err := os.Readlink(envPath)
+	if err != nil {
+		return fmt.Errorf("read project env symlink during restore: %w", err)
+	}
+	if linkTarget != envBackup.linkTarget {
+		return fmt.Errorf("refusing to restore project env file %s: symlink target changed", envBackup.relativePath)
+	}
+
+	resolvedPath, _, isSymlink, err := resolveEnvFileWriteTargetInternal(envPath)
+	if err != nil {
+		return fmt.Errorf("resolve project env symlink during restore: %w", err)
+	}
+	if !isSymlink || filepath.Clean(resolvedPath) != envBackup.resolvedPath {
+		return fmt.Errorf("refusing to restore project env file %s: resolved symlink target changed", envBackup.relativePath)
+	}
+
+	if err := atomic.WriteFile(resolvedPath, content, perm); err != nil {
+		return fmt.Errorf("restore project env symlink target %s: %w", envBackup.relativePath, err)
+	}
+	return nil
+}
+
+func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, backup *ProjectUpdateBackup) error {
 	backupEntries, err := os.ReadDir(backupRoot.Name())
 	if err != nil {
 		return fmt.Errorf("read backup directory: %w", err)
@@ -360,7 +450,7 @@ func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, skipped []strin
 		}
 	}
 	skippedTopLevel := make(map[string]bool)
-	for _, s := range skipped {
+	for _, s := range backup.Skipped {
 		if !strings.Contains(s, "/") {
 			skippedTopLevel[s] = true
 		}
@@ -386,7 +476,7 @@ func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, skipped []strin
 		if !entry.Type().IsRegular() {
 			continue
 		}
-		if err := restoreBackupFileInternal(backupRoot, projRoot, entry.Name()); err != nil {
+		if err := restoreBackupFileInternal(backupRoot, projRoot, backup, entry.Name()); err != nil {
 			return err
 		}
 	}

--- a/backend/pkg/projects/fs_backup_test.go
+++ b/backend/pkg/projects/fs_backup_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,4 +31,76 @@ func TestRestoreProjectUpdateBackup_UndoesRenameWhenSourceWasRecreated(t *testin
 
 	require.NoDirExists(t, filepath.Join(projectDir, "b"))
 	require.FileExists(t, filepath.Join(projectDir, "a", "keep.txt"))
+}
+
+func TestRestoreProjectUpdateBackup_RestoresExternalEnvSymlinkTarget(t *testing.T) {
+	projectDir := t.TempDir()
+	targetPath := filepath.Join(t.TempDir(), "project.env")
+	originalContent := "VALUE=original\n"
+	targetPerm := os.FileMode(0o640)
+	require.NoError(t, os.WriteFile(targetPath, []byte(originalContent), targetPerm))
+	require.NoError(t, os.Chmod(targetPath, targetPerm))
+
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(targetPath, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	originalLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+
+	backup, err := BackupProjectUpdateScope(projectDir, t.TempDir(), ProjectUpdateBackupScope{TopLevelFiles: true})
+	require.NoError(t, err)
+	require.NotNil(t, backup.envSymlink)
+
+	require.NoError(t, WriteEnvFile(projectDir, projectDir, "VALUE=updated\n"))
+	require.NoError(t, RestoreProjectUpdateBackup(projectDir, backup))
+
+	restoredContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	require.Equal(t, originalContent, string(restoredContent))
+	currentLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+	require.Equal(t, originalLinkTarget, currentLinkTarget)
+	linkInfo, err := os.Lstat(envPath)
+	require.NoError(t, err)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+	if runtime.GOOS != "windows" {
+		targetInfo, statErr := os.Stat(targetPath)
+		require.NoError(t, statErr)
+		require.Equal(t, targetPerm, targetInfo.Mode().Perm())
+	}
+}
+
+func TestRestoreProjectUpdateBackup_RejectsRetargetedEnvSymlink(t *testing.T) {
+	projectDir := t.TempDir()
+	externalDir := t.TempDir()
+	originalTarget := filepath.Join(externalDir, "original.env")
+	newTarget := filepath.Join(externalDir, "new.env")
+	require.NoError(t, os.WriteFile(originalTarget, []byte("VALUE=original\n"), 0o600))
+	require.NoError(t, os.WriteFile(newTarget, []byte("VALUE=untouched\n"), 0o600))
+
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(originalTarget, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	backup, err := BackupProjectUpdateScope(projectDir, t.TempDir(), ProjectUpdateBackupScope{TopLevelFiles: true})
+	require.NoError(t, err)
+
+	require.NoError(t, WriteEnvFile(projectDir, projectDir, "VALUE=updated\n"))
+	require.NoError(t, os.Remove(envPath))
+	require.NoError(t, os.Symlink(newTarget, envPath))
+
+	err = RestoreProjectUpdateBackup(projectDir, backup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "symlink target changed")
+
+	originalContent, readErr := os.ReadFile(originalTarget)
+	require.NoError(t, readErr)
+	require.Equal(t, "VALUE=updated\n", string(originalContent))
+	newContent, readErr := os.ReadFile(newTarget)
+	require.NoError(t, readErr)
+	require.Equal(t, "VALUE=untouched\n", string(newContent))
+	currentLinkTarget, readlinkErr := os.Readlink(envPath)
+	require.NoError(t, readlinkErr)
+	require.Equal(t, newTarget, currentLinkTarget)
 }

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -116,7 +116,20 @@ func WriteProjectFile(projectsRoot, dirPath, fileName, content string) error {
 	}
 
 	targetPath := filepath.Join(dirPath, fileName)
-	existingContent, readErr := os.ReadFile(targetPath)
+	writePath := targetPath
+	writePerm := pkgutils.FilePerm
+	if fileName == EffectiveEnvFileName {
+		resolvedPath, resolvedPerm, isSymlink, resolveErr := resolveEnvFileWriteTargetInternal(targetPath)
+		if resolveErr != nil {
+			return fmt.Errorf("failed to resolve project file %s write target: %w", fileName, resolveErr)
+		}
+		if isSymlink {
+			writePath = resolvedPath
+			writePerm = resolvedPerm
+		}
+	}
+
+	existingContent, readErr := os.ReadFile(writePath)
 	if readErr == nil && string(existingContent) == content {
 		return nil
 	}
@@ -124,11 +137,38 @@ func WriteProjectFile(projectsRoot, dirPath, fileName, content string) error {
 		return fmt.Errorf("failed to read project file %s: %w", fileName, readErr)
 	}
 
-	if err := atomic.WriteFile(targetPath, []byte(content), pkgutils.FilePerm); err != nil {
+	if err := atomic.WriteFile(writePath, []byte(content), writePerm); err != nil {
 		return fmt.Errorf("failed to write project file %s: %w", fileName, err)
 	}
 
 	return nil
+}
+
+func resolveEnvFileWriteTargetInternal(envPath string) (writePath string, perm os.FileMode, isSymlink bool, err error) {
+	info, err := os.Lstat(envPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return envPath, pkgutils.FilePerm, false, nil
+		}
+		return "", 0, false, fmt.Errorf("inspect env file: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return envPath, pkgutils.FilePerm, false, nil
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(envPath)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("resolve env file symlink: %w", err)
+	}
+	targetInfo, err := os.Stat(resolvedPath)
+	if err != nil {
+		return "", 0, false, fmt.Errorf("inspect env file symlink target: %w", err)
+	}
+	if !targetInfo.Mode().IsRegular() {
+		return "", 0, false, fmt.Errorf("env file symlink target is not a regular file: %s", resolvedPath)
+	}
+
+	return resolvedPath, targetInfo.Mode().Perm(), true, nil
 }
 
 func RemoveProjectFile(projectsRoot, dirPath, fileName string) error {

--- a/backend/pkg/projects/fs_writer_test.go
+++ b/backend/pkg/projects/fs_writer_test.go
@@ -81,6 +81,111 @@ func TestWriteProjectFile_DoesNotReplaceIdenticalContent(t *testing.T) {
 	assert.True(t, info.ModTime().Equal(fixedTime), "identical content should not replace the file")
 }
 
+func TestWriteEnvFile_WritesThroughExternalSymlink(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	externalDir := t.TempDir()
+	targetPath := filepath.Join(externalDir, "project.env")
+	targetPerm := os.FileMode(0o640)
+	require.NoError(t, os.WriteFile(targetPath, []byte("VALUE=old\n"), targetPerm))
+	require.NoError(t, os.Chmod(targetPath, targetPerm))
+
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(targetPath, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+	originalLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+
+	require.NoError(t, WriteEnvFile(projectsRoot, projectDir, "VALUE=new\n"))
+
+	linkInfo, err := os.Lstat(envPath)
+	require.NoError(t, err)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+	currentLinkTarget, err := os.Readlink(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalLinkTarget, currentLinkTarget)
+
+	targetContent, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, "VALUE=new\n", string(targetContent))
+	if runtime.GOOS != "windows" {
+		targetInfo, statErr := os.Stat(targetPath)
+		require.NoError(t, statErr)
+		assert.Equal(t, targetPerm, targetInfo.Mode().Perm())
+	}
+}
+
+func TestWriteEnvFile_DanglingSymlinkRemainsUntouched(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	missingTarget := filepath.Join(t.TempDir(), "missing.env")
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(missingTarget, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	for range 2 {
+		err := WriteEnvFile(projectsRoot, projectDir, "VALUE=new\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve env file symlink")
+
+		linkInfo, statErr := os.Lstat(envPath)
+		require.NoError(t, statErr)
+		require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+		linkTarget, readlinkErr := os.Readlink(envPath)
+		require.NoError(t, readlinkErr)
+		assert.Equal(t, missingTarget, linkTarget)
+		require.NoFileExists(t, missingTarget)
+	}
+}
+
+func TestWriteEnvFile_RejectsNonRegularSymlinkTarget(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	targetDir := t.TempDir()
+	envPath := filepath.Join(projectDir, EffectiveEnvFileName)
+	if err := os.Symlink(targetDir, envPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	err := WriteEnvFile(projectsRoot, projectDir, "VALUE=new\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+	linkInfo, statErr := os.Lstat(envPath)
+	require.NoError(t, statErr)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+}
+
+func TestWriteProjectFile_StillRejectsNonEnvSymlink(t *testing.T) {
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "test-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	targetPath := filepath.Join(t.TempDir(), "project.env")
+	require.NoError(t, os.WriteFile(targetPath, []byte("VALUE=old\n"), 0o600))
+	linkPath := filepath.Join(projectDir, OverrideEnvFileName)
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	err := WriteProjectFile(projectsRoot, projectDir, OverrideEnvFileName, "VALUE=new\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destination is a symlink")
+	targetContent, readErr := os.ReadFile(targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "VALUE=old\n", string(targetContent))
+	linkInfo, statErr := os.Lstat(linkPath)
+	require.NoError(t, statErr)
+	require.NotZero(t, linkInfo.Mode()&os.ModeSymlink)
+}
+
 func TestWriteProjectFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	projectsRoot := tmpDir


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3235

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves external `.env` symlinks when project env content is saved. The main changes are:

- Writes to `.env` now resolve symlink targets and update the target file without replacing the link.
- Project update backup and restore now capture external `.env` symlink target content for rollback.
- Transient compose validation restores external `.env` symlink targets after validation.
- Tests cover symlink writes, rollback, dangling links, non-regular targets, and non-env symlink rejection.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is focused on `.env` symlink handling and includes targeted tests for direct writes, validation, backup restore, and update rollback.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the env-symlink test to validate the contract and saved a full run log documenting the command, working directory, verbose test output, PASS status, duration, and exit code 0.
- Saved the exact test invocation command to a separate artifact for precise reproducibility.

<a href="https://app.greptile.com/trex/runs/14022233/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve external .env symlinks on ..."](https://github.com/getarcaneapp/arcane/commit/52c76b11cd4f7b9510bf9a8c810454651d8bd614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43375292)</sub>

<!-- /greptile_comment -->