### PR TITLE
fix: restore tooltips and focus behavior for dashboard actions

### DIFF
--- a/frontend/src/lib/components/arcane-tooltip/arcane-tooltip-trigger.svelte
+++ b/frontend/src/lib/components/arcane-tooltip/arcane-tooltip-trigger.svelte
@@ -6,8 +6,14 @@
 	import { cn } from '$lib/utils.js';
 
 	type ChildProps = { props: Record<string, unknown> };
+	type TriggerEventProps = { onclick?: (event: MouseEvent) => void };
 
-	let { children, child, class: className }: TooltipPrimitive.TriggerProps = $props();
+	let {
+		children,
+		child,
+		class: className,
+		disabledChild = false
+	}: TooltipPrimitive.TriggerProps & { disabledChild?: boolean } = $props();
 
 	const ctx = getArcaneTooltipContext();
 
@@ -70,11 +76,23 @@
 		}
 	}
 
-	function handleWrapperClick(event: MouseEvent, props: any) {
+	function getClickHandler(props: Record<string, unknown>) {
+		return (props as TriggerEventProps).onclick;
+	}
+
+	function handleDirectClick(event: MouseEvent) {
+		if (ctx.interactive) {
+			handleClick(event);
+		}
+	}
+
+	function handleWrapperClick(event: MouseEvent, props: Record<string, unknown>) {
+		const onclick = getClickHandler(props);
+
 		if (ctx.interactive) {
 			handleClick(event);
 			if (!event.defaultPrevented) {
-				props.onclick?.(event);
+				onclick?.(event);
 			}
 		} else {
 			// Check if the click originated from an interactive element
@@ -106,44 +124,80 @@
 			}
 
 			if (!isInteractive) {
-				props.onclick?.(event);
+				onclick?.(event);
 			}
 		}
+	}
+
+	function getDirectTouchProps(props: Record<string, unknown>) {
+		const { onclick: _onclick, class: triggerClass, ...restProps } = props;
+
+		return {
+			...restProps,
+			class: cn('pointer-events-auto inline-flex max-w-full min-w-0', triggerClass as string | undefined, className),
+			ontouchstart: ctx.interactive ? handleTouchStart : undefined,
+			ontouchend: ctx.interactive ? handleTouchEnd : undefined,
+			ontouchcancel: ctx.interactive ? handleTouchCancel : undefined,
+			ontouchmove: ctx.interactive ? handleTouchMove : undefined,
+			onclick: handleDirectClick
+		};
+	}
+
+	function getDirectTooltipProps(props: Record<string, unknown>) {
+		return {
+			...props,
+			class: cn('inline-flex max-w-full min-w-0', props['class'] as string | undefined, className)
+		};
 	}
 </script>
 
 {#if ctx.isTouch}
 	<Popover.Trigger>
 		{#snippet child({ props }: ChildProps)}
-			<div
-				{...props}
-				class={cn('pointer-events-auto inline-flex max-w-full min-w-0 cursor-pointer', className)}
-				ontouchstart={ctx.interactive ? handleTouchStart : undefined}
-				ontouchend={ctx.interactive ? handleTouchEnd : undefined}
-				ontouchcancel={ctx.interactive ? handleTouchCancel : undefined}
-				ontouchmove={ctx.interactive ? handleTouchMove : undefined}
-				onclick={(e) => handleWrapperClick(e, props)}
-				role="button"
-				tabindex="0"
-			>
-				{#if child}
-					{@render child({ props })}
-				{:else}
-					{@render children?.()}
-				{/if}
-			</div>
+			{#if child && !disabledChild}
+				{@render child({ props: getDirectTouchProps(props) })}
+			{:else}
+				<div
+					{...props}
+					class={cn('pointer-events-auto inline-flex max-w-full min-w-0 cursor-pointer', className)}
+					ontouchstart={ctx.interactive ? handleTouchStart : undefined}
+					ontouchend={ctx.interactive ? handleTouchEnd : undefined}
+					ontouchcancel={ctx.interactive ? handleTouchCancel : undefined}
+					ontouchmove={ctx.interactive ? handleTouchMove : undefined}
+					onclick={(event) => handleWrapperClick(event, props)}
+					role="button"
+					data-disabled-child={disabledChild ? '' : undefined}
+					tabindex="0"
+				>
+					{#if child}
+						{@render child({ props: {} })}
+					{:else}
+						{@render children?.()}
+					{/if}
+				</div>
+			{/if}
 		{/snippet}
 	</Popover.Trigger>
 {:else}
 	<Tooltip.Trigger>
 		{#snippet child({ props }: ChildProps)}
-			<div {...props} role="button" tabindex="0" class={cn('inline-flex max-w-full min-w-0', className)}>
-				{#if child}
-					{@render child({ props })}
-				{:else}
-					{@render children?.()}
-				{/if}
-			</div>
+			{#if child && !disabledChild}
+				{@render child({ props: getDirectTooltipProps(props) })}
+			{:else}
+				<div
+					{...props}
+					role="button"
+					data-disabled-child={disabledChild ? '' : undefined}
+					tabindex="0"
+					class={cn('inline-flex max-w-full min-w-0 cursor-pointer', className)}
+				>
+					{#if child}
+						{@render child({ props: {} })}
+					{:else}
+						{@render children?.()}
+					{/if}
+				</div>
+			{/if}
 		{/snippet}
 	</Tooltip.Trigger>
 {/if}

--- a/frontend/src/lib/components/badges/port-badge.svelte
+++ b/frontend/src/lib/components/badges/port-badge.svelte
@@ -4,6 +4,7 @@
 	import * as ArcaneTooltip from '$lib/components/arcane-tooltip';
 	import settingsStore from '$lib/stores/config-store';
 	import { toPortHref } from '$lib/utils/navigation';
+	import { mergeProps } from 'bits-ui';
 
 	let {
 		ports = [] as ContainerPorts[],
@@ -93,17 +94,21 @@
 		{#each published as p, i (i)}
 			<ArcaneTooltip.Root interactive>
 				<ArcaneTooltip.Trigger>
-					<a
-						class="ring-offset-background focus-visible:ring-ring bg-background/70 inline-flex items-center gap-1 rounded-md border border-sky-700/20 px-2 py-1 text-[11px] transition-colors hover:border-sky-700/40 hover:bg-sky-500/10 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:border-sky-400/40 dark:bg-sky-500/20 dark:text-sky-100 dark:hover:border-sky-300/60 dark:hover:bg-sky-500/30"
-						href={toPortHref(p.hostPort!, baseServerUrl)}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<span class="font-medium tabular-nums">{p.hostPort}:{p.containerPort}</span>
-						{#if p.proto}
-							<span class="text-muted-foreground uppercase">{p.proto}</span>
-						{/if}
-					</a>
+					{#snippet child({ props })}
+						{@const triggerProps = mergeProps(props, {
+							class:
+								'ring-offset-background focus-visible:ring-ring bg-background/70 inline-flex items-center gap-1 rounded-md border border-sky-700/20 px-2 py-1 text-[11px] transition-colors hover:border-sky-700/40 hover:bg-sky-500/10 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:border-sky-400/40 dark:bg-slate-500/20 dark:text-sky-100 dark:hover:border-sky-300/60 dark:hover:bg-sky-500/30',
+							href: toPortHref(p.hostPort!, baseServerUrl),
+							target: '_blank',
+							rel: 'noopener noreferrer'
+						})}
+						<a {...triggerProps}>
+							<span class="font-medium tabular-nums">{p.hostPort}:{p.containerPort}</span>
+							{#if p.proto}
+								<span class="text-muted-foreground uppercase">{p.proto}</span>
+							{/if}
+						</a>
+					{/snippet}
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content>
 					<p class="text-xs">
@@ -134,12 +139,14 @@
 		{#if collapsible && allPorts.length > maxVisible}
 			<ArcaneTooltip.Root>
 				<ArcaneTooltip.Trigger>
-					<button
-						onclick={() => (expanded = !expanded)}
-						class="bg-muted hover:bg-muted/80 text-muted-foreground inline-flex cursor-pointer items-center rounded-md border px-2 py-1 text-[11px] font-medium transition-colors"
-					>
-						{expanded ? '−' : `+${hiddenCount}`}
-					</button>
+					{#snippet child({ props })}
+						{@const triggerProps = mergeProps(props, {
+							onclick: () => (expanded = !expanded),
+							class:
+								'bg-muted hover:bg-muted/80 text-muted-foreground inline-flex cursor-pointer items-center rounded-md border px-2 py-1 text-[11px] font-medium transition-colors'
+						})}
+						<button {...triggerProps}>{expanded ? '−' : `+${hiddenCount}`}</button>
+					{/snippet}
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content>
 					<p class="text-xs">

--- a/frontend/src/lib/components/compose-create-menu.svelte
+++ b/frontend/src/lib/components/compose-create-menu.svelte
@@ -16,6 +16,7 @@
 	import IfPermitted from '$lib/components/if-permitted.svelte';
 	import { TerminalIcon, TemplateIcon, AddIcon, ArrowDownIcon as ChevronDown, GitBranchIcon } from '$lib/icons';
 	import { dropdownContentClass, dropdownItemClass, templateBtnClass } from '$lib/utils/compose-flow';
+	import { mergeProps } from 'bits-ui';
 
 	interface Props {
 		// Tooltip shows when the tooltipOpen prop is truthy-undefined (bits-ui
@@ -94,33 +95,34 @@
 {/snippet}
 
 <ButtonGroup.Root>
-	<ArcaneTooltip.Root open={tooltipOpen}>
-		<ArcaneTooltip.Trigger>
-			<span>
-				{#if showCreateButton}
+	{#if showCreateButton}
+		<ArcaneTooltip.Root open={tooltipOpen}>
+			<ArcaneTooltip.Trigger disabledChild={createDisabled || createLoading}>
+				{#snippet child({ props })}
+					{@const triggerProps = mergeProps(props, { onclick: onCreate })}
 					<ArcaneButton
+						{...triggerProps}
 						action="create"
 						tone="ghost"
 						disabled={createDisabled}
-						onclick={onCreate}
 						class={`${templateBtnClass} gap-2 rounded-r-none`}
 						loading={createLoading}
 						customLabel={createLabel}
 						loadingLabel={createLoadingLabel}
 					/>
+				{/snippet}
+			</ArcaneTooltip.Trigger>
+			<ArcaneTooltip.Content class="arcane-tooltip-content max-w-[280px]">
+				{#if tooltipVisible}
+					<p class="mb-1 text-sm font-medium">{tooltipTitle}</p>
+					<p class="text-muted-foreground text-xs">{tooltipDescription}</p>
+					<p class="bg-muted mt-1.5 inline-block rounded px-1.5 py-0.5 font-mono text-xs">
+						{tooltipExample}
+					</p>
 				{/if}
-			</span>
-		</ArcaneTooltip.Trigger>
-		<ArcaneTooltip.Content class="arcane-tooltip-content max-w-[280px]">
-			{#if tooltipVisible}
-				<p class="mb-1 text-sm font-medium">{tooltipTitle}</p>
-				<p class="text-muted-foreground text-xs">{tooltipDescription}</p>
-				<p class="bg-muted mt-1.5 inline-block rounded px-1.5 py-0.5 font-mono text-xs">
-					{tooltipExample}
-				</p>
-			{/if}
-		</ArcaneTooltip.Content>
-	</ArcaneTooltip.Root>
+			</ArcaneTooltip.Content>
+		</ArcaneTooltip.Root>
+	{/if}
 
 	<DropdownMenu.Root>
 		<DropdownMenu.Trigger>

--- a/frontend/src/lib/components/form/labeled-switch.svelte
+++ b/frontend/src/lib/components/form/labeled-switch.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Label } from '$lib/components/ui/label';
 	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { mergeProps } from 'bits-ui';
 
 	let {
 		id,
@@ -9,7 +10,8 @@
 		description,
 		error,
 		disabled = false,
-		onCheckedChange
+		onCheckedChange,
+		triggerProps
 	}: {
 		id: string;
 		checked: boolean;
@@ -18,12 +20,21 @@
 		error?: string | null;
 		disabled?: boolean;
 		onCheckedChange?: (checked: boolean) => void;
+		triggerProps?: Record<string, unknown>;
 	} = $props();
 	void checked;
+
+	const switchProps = $derived(
+		mergeProps(triggerProps ?? {}, {
+			id,
+			disabled,
+			onCheckedChange: (value: boolean) => onCheckedChange?.(value === true)
+		})
+	);
 </script>
 
 <div class="flex items-center space-x-2">
-	<Switch {id} {disabled} onCheckedChange={(v) => onCheckedChange && onCheckedChange(v == true)} bind:checked />
+	<Switch {...switchProps} bind:checked />
 	<div class="grid gap-1.5 leading-none">
 		<Label for={id} class="mb-0 text-sm leading-none font-medium">
 			{label}

--- a/frontend/src/lib/components/image-update-item.svelte
+++ b/frontend/src/lib/components/image-update-item.svelte
@@ -13,6 +13,7 @@
 	import UpdateStatusBanner from '$lib/components/update-status-banner.svelte';
 	import { activityToastOptions, extractActivityId } from '$lib/utils/activity-toast';
 	import UncheckedRingIcon from '$lib/components/unchecked-ring-icon.svelte';
+	import { mergeProps } from 'bits-ui';
 
 	interface Props {
 		updateInfo?: ImageUpdateData;
@@ -450,8 +451,12 @@
 
 {#if isLocalImage}
 	<UpdateStatusPopover bind:open={isOpen} contentClass="max-w-[280px] p-0">
-		{#snippet trigger()}
-			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle" data-testid="image-update-trigger">
+		{#snippet trigger({ props })}
+			<span
+				{...props}
+				class="mr-2 inline-flex size-4 items-center justify-center align-middle"
+				data-testid="image-update-trigger"
+			>
 				<BoxIcon class="size-4 text-slate-500" />
 			</span>
 		{/snippet}
@@ -464,8 +469,12 @@
 	</UpdateStatusPopover>
 {:else if effectiveUpdateInfo}
 	<UpdateStatusPopover bind:open={isOpen} contentClass="max-w-[280px] p-0">
-		{#snippet trigger()}
-			<span class="mr-2 inline-flex size-4 items-center justify-center align-middle" data-testid="image-update-trigger">
+		{#snippet trigger({ props })}
+			<span
+				{...props}
+				class="mr-2 inline-flex size-4 items-center justify-center align-middle"
+				data-testid="image-update-trigger"
+			>
 				{#if hasError}
 					<AlertIcon class="size-4 text-red-500" />
 				{:else if !effectiveUpdateInfo?.hasUpdate}
@@ -494,8 +503,8 @@
 	</UpdateStatusPopover>
 {:else if isLoadingInBackground || isChecking}
 	<UpdateStatusPopover contentClass="max-w-[220px] p-0">
-		{#snippet trigger()}
-			<span class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
+		{#snippet trigger({ props })}
+			<span {...props} class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
 				<Spinner class="size-4 text-blue-400" />
 			</span>
 		{/snippet}
@@ -507,27 +516,28 @@
 		{/snippet}
 	</UpdateStatusPopover>
 {:else}
-	<UpdateStatusPopover interactive contentClass="max-w-[240px] p-0">
-		{#snippet trigger()}
-			<span class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
-				{#if canCheckUpdate}
-					<button
-						onclick={checkImageUpdate}
-						disabled={isChecking}
-						class="flex size-4 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-blue-400 disabled:cursor-not-allowed"
-					>
-						{#if isChecking}
-							<Spinner class="size-3 text-blue-400" />
-						{:else}
-							<UncheckedRingIcon />
-						{/if}
-					</button>
-				{:else}
+	<UpdateStatusPopover interactive directTrigger={canCheckUpdate} contentClass="max-w-[240px] p-0">
+		{#snippet trigger({ props })}
+			{#if canCheckUpdate}
+				{@const triggerProps = mergeProps(props, {
+					onclick: checkImageUpdate,
+					class:
+						'mr-2 inline-flex size-4 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-blue-400 disabled:cursor-not-allowed'
+				})}
+				<button {...triggerProps} disabled={isChecking} data-testid="image-update-trigger">
+					{#if isChecking}
+						<Spinner class="size-3 text-blue-400" />
+					{:else}
+						<UncheckedRingIcon />
+					{/if}
+				</button>
+			{:else}
+				<span {...props} class="mr-2 inline-flex size-4 items-center justify-center" data-testid="image-update-trigger">
 					<div class="flex size-4 items-center justify-center text-gray-400 opacity-30">
 						<UncheckedRingIcon />
 					</div>
-				{/if}
-			</span>
+				</span>
+			{/if}
 		{/snippet}
 
 		{#snippet content()}

--- a/frontend/src/lib/components/logs/log-controls.svelte
+++ b/frontend/src/lib/components/logs/log-controls.svelte
@@ -198,14 +198,17 @@
 		<div class="flex flex-wrap items-center gap-4">
 			<ArcaneTooltip.Root>
 				<ArcaneTooltip.Trigger>
-					<SwitchWithLabel
-						id="auto-scroll-toggle"
-						checked={autoScroll}
-						label={m.common_autoscroll()}
-						onCheckedChange={(checked) => {
-							autoScroll = checked;
-						}}
-					/>
+					{#snippet child({ props })}
+						<SwitchWithLabel
+							triggerProps={props}
+							id="auto-scroll-toggle"
+							checked={autoScroll}
+							label={m.common_autoscroll()}
+							onCheckedChange={(checked) => {
+								autoScroll = checked;
+							}}
+						/>
+					{/snippet}
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content side="bottom" class="max-w-xs">
 					{m.log_auto_scroll_tooltip()}
@@ -214,14 +217,17 @@
 
 			<ArcaneTooltip.Root>
 				<ArcaneTooltip.Trigger>
-					<SwitchWithLabel
-						id="auto-start-logs-toggle"
-						checked={autoStartLogs}
-						label={m.auto_start()}
-						onCheckedChange={(checked) => {
-							autoStartLogs = checked;
-						}}
-					/>
+					{#snippet child({ props })}
+						<SwitchWithLabel
+							triggerProps={props}
+							id="auto-start-logs-toggle"
+							checked={autoStartLogs}
+							label={m.auto_start()}
+							onCheckedChange={(checked) => {
+								autoStartLogs = checked;
+							}}
+						/>
+					{/snippet}
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content side="bottom" class="max-w-xs">
 					{m.log_auto_start_tooltip()}
@@ -230,14 +236,17 @@
 
 			<ArcaneTooltip.Root>
 				<ArcaneTooltip.Trigger>
-					<SwitchWithLabel
-						id="parsed-log-mode-toggle"
-						checked={showParsedJson}
-						label={showParsedJson ? m.common_parsed() : m.common_raw()}
-						onCheckedChange={(checked) => {
-							showParsedJson = checked;
-						}}
-					/>
+					{#snippet child({ props })}
+						<SwitchWithLabel
+							triggerProps={props}
+							id="parsed-log-mode-toggle"
+							checked={showParsedJson}
+							label={showParsedJson ? m.common_parsed() : m.common_raw()}
+							onCheckedChange={(checked) => {
+								showParsedJson = checked;
+							}}
+						/>
+					{/snippet}
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content side="bottom" class="max-w-xs">
 					{m.log_parsed_mode_tooltip()}

--- a/frontend/src/lib/components/project-update-item.svelte
+++ b/frontend/src/lib/components/project-update-item.svelte
@@ -9,6 +9,7 @@
 	import type { Component } from 'svelte';
 	import { format } from 'date-fns';
 	import UncheckedRingIcon from '$lib/components/unchecked-ring-icon.svelte';
+	import { mergeProps } from 'bits-ui';
 
 	interface Props {
 		updateInfo?: ProjectUpdateInfo;
@@ -149,10 +150,16 @@
 	{/if}
 {/snippet}
 
-<UpdateStatusPopover bind:open={isOpen} interactive={canCheck} contentClass="max-w-[320px] p-0">
-	{#snippet trigger()}
+<UpdateStatusPopover
+	bind:open={isOpen}
+	interactive={canCheck}
+	directTrigger={directCheckFromTrigger}
+	contentClass="max-w-[320px] p-0"
+>
+	{#snippet trigger({ props })}
 		{#if checking}
 			<span
+				{...props}
 				class="inline-flex size-4 items-center justify-center align-middle {className}"
 				aria-label={indicatorLabel}
 				data-testid="project-update-trigger"
@@ -160,29 +167,28 @@
 				<Spinner class="size-4 text-blue-400" />
 			</span>
 		{:else if directCheckFromTrigger}
-			<span
-				class="inline-flex size-4 items-center justify-center align-middle {className}"
-				aria-label={indicatorLabel}
+			{@const triggerProps = mergeProps(props, {
+				onclick: handleCheckClick,
+				class: `group inline-flex size-4 items-center justify-center align-middle transition-colors disabled:cursor-not-allowed dark:hover:bg-blue-950 ${className}`
+			})}
+			<button
+				{...triggerProps}
+				disabled={checking}
+				aria-label={m.image_update_recheck_button()}
+				title={m.image_update_recheck_button()}
 				data-testid="project-update-trigger"
 			>
-				<button
-					onclick={handleCheckClick}
-					disabled={checking}
-					aria-label={m.image_update_recheck_button()}
-					title={m.image_update_recheck_button()}
-					class="group flex h-4 w-4 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed dark:hover:bg-blue-950"
-				>
-					{#if status === 'error'}
-						<AlertIcon class="size-4 text-red-500 transition-colors group-hover:text-blue-400" />
-					{:else}
-						<span class="flex size-4 items-center justify-center text-gray-400 transition-colors group-hover:text-blue-400">
-							<UncheckedRingIcon />
-						</span>
-					{/if}
-				</button>
-			</span>
+				{#if status === 'error'}
+					<AlertIcon class="size-4 text-red-500 transition-colors group-hover:text-blue-400" />
+				{:else}
+					<span class="flex size-4 items-center justify-center text-gray-400 transition-colors group-hover:text-blue-400">
+						<UncheckedRingIcon />
+					</span>
+				{/if}
+			</button>
 		{:else}
 			<span
+				{...props}
 				class="inline-flex size-4 items-center justify-center align-middle {className}"
 				aria-label={indicatorLabel}
 				data-testid="project-update-trigger"

--- a/frontend/src/lib/components/update-status-popover.svelte
+++ b/frontend/src/lib/components/update-status-popover.svelte
@@ -7,15 +7,17 @@
 	interface Props {
 		open?: boolean;
 		interactive?: boolean;
+		directTrigger?: boolean;
 		side?: TooltipSide;
 		contentClass?: string;
-		trigger: Snippet;
+		trigger: Snippet<[{ props: Record<string, unknown> }]>;
 		content: Snippet;
 	}
 
 	let {
 		open = $bindable(false),
 		interactive = false,
+		directTrigger = false,
 		side = 'right',
 		contentClass = 'max-w-[280px] p-0',
 		trigger,
@@ -24,9 +26,17 @@
 </script>
 
 <ArcaneTooltip.Root bind:open {interactive}>
-	<ArcaneTooltip.Trigger>
-		{@render trigger()}
-	</ArcaneTooltip.Trigger>
+	{#if directTrigger}
+		<ArcaneTooltip.Trigger>
+			{#snippet child({ props })}
+				{@render trigger({ props })}
+			{/snippet}
+		</ArcaneTooltip.Trigger>
+	{:else}
+		<ArcaneTooltip.Trigger>
+			{@render trigger({ props: {} })}
+		</ArcaneTooltip.Trigger>
+	{/if}
 	<ArcaneTooltip.Content {side} class={contentClass} data-open={open ? 'true' : 'false'}>
 		{@render content()}
 	</ArcaneTooltip.Content>

--- a/frontend/src/lib/components/vulnerability/vulnerability-scan-item.svelte
+++ b/frontend/src/lib/components/vulnerability/vulnerability-scan-item.svelte
@@ -17,6 +17,7 @@
 	import { toastVulnerabilityScanStatus } from '$lib/utils/vulnerability';
 	import { ShieldCheckIcon, ShieldAlertIcon, ScanIcon, ShieldXIcon } from '$lib/icons';
 	import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+	import { mergeProps } from 'bits-ui';
 
 	interface Props {
 		scanSummary?: VulnerabilityScanSummary;
@@ -357,40 +358,43 @@
 
 <ArcaneTooltip.Root bind:open={isOpen} interactive>
 	<ArcaneTooltip.Trigger>
-		<div class="flex w-16 flex-col items-center gap-1">
-			{#if isScanInProgress}
-				<div class="flex items-center justify-center gap-1.5 text-xs text-blue-500">
-					<Spinner class="size-3 shrink-0" />
-					<span class="truncate">{activePhaseLabel}</span>
-				</div>
-			{:else if hasError}
-				<div class="flex items-center justify-center gap-1.5 text-xs text-red-500">
-					<ShieldXIcon class="size-3 shrink-0" />
-					<span class="truncate">{m.vuln_scan_failed()}</span>
-				</div>
-			{:else if isCompleted}
-				<div
-					class="border-border/50 bg-muted/20 flex w-full min-w-0 items-center justify-center gap-1.5 rounded-md border px-2 py-1"
-				>
-					<span class="{triggerDotClass} size-2 shrink-0 rounded-full" aria-hidden="true"></span>
-					<span class="text-foreground text-xs font-medium tabular-nums">{totalCount}</span>
-				</div>
+		{#snippet child({ props })}
+			{#if !isScanInProgress && !hasError && !isCompleted}
+				{@const triggerProps = mergeProps(props, { onclick: startScan })}
+				<ArcaneButton
+					{...triggerProps}
+					action="base"
+					tone="ghost"
+					size="icon"
+					icon={ScanIcon}
+					showLabel={false}
+					customLabel={m.vuln_scan()}
+					disabled={isScanning}
+					class="size-7"
+				/>
 			{:else}
-				<div class="flex justify-center">
-					<ArcaneButton
-						action="base"
-						tone="ghost"
-						size="icon"
-						icon={ScanIcon}
-						showLabel={false}
-						customLabel={m.vuln_scan()}
-						onclick={startScan}
-						disabled={isScanning}
-						class="size-7"
-					/>
+				<div {...props} class="flex w-16 flex-col items-center gap-1">
+					{#if isScanInProgress}
+						<div class="flex items-center justify-center gap-1.5 text-xs text-blue-500">
+							<Spinner class="size-3 shrink-0" />
+							<span class="truncate">{activePhaseLabel}</span>
+						</div>
+					{:else if hasError}
+						<div class="flex items-center justify-center gap-1.5 text-xs text-red-500">
+							<ShieldXIcon class="size-3 shrink-0" />
+							<span class="truncate">{m.vuln_scan_failed()}</span>
+						</div>
+					{:else if isCompleted}
+						<div
+							class="border-border/50 bg-muted/20 flex w-full min-w-0 items-center justify-center gap-1.5 rounded-md border px-2 py-1"
+						>
+							<span class="{triggerDotClass} size-2 shrink-0 rounded-full" aria-hidden="true"></span>
+							<span class="text-foreground text-xs font-medium tabular-nums">{totalCount}</span>
+						</div>
+					{/if}
 				</div>
 			{/if}
-		</div>
+		{/snippet}
 	</ArcaneTooltip.Trigger>
 	<ArcaneTooltip.Content side="right">
 		{@render tooltipContent()}

--- a/frontend/src/lib/hooks/is-touch-device.svelte.ts
+++ b/frontend/src/lib/hooks/is-touch-device.svelte.ts
@@ -1,32 +1,10 @@
+import { MediaQuery } from 'svelte/reactivity';
+
 /**
- * Detects if the device has touch capability.
- *
- * Note: Some hybrid devices (laptops with touchscreens) will be detected as touch devices,
- * which is correct as they support both touch and pointer interactions.
+ * Detects when the primary input cannot hover and should use touch-first UI.
  */
-export class IsTouchDevice {
-	current = $state(false);
-
+export class IsTouchDevice extends MediaQuery {
 	constructor() {
-		// Check on initialization
-		this.current = this.detectTouch();
-
-		// Re-check if media query changes (for devices that can switch modes)
-		$effect(() => {
-			this.current = this.detectTouch();
-		});
-	}
-
-	private detectTouch(): boolean {
-		// Check if running in browser
-		if (typeof window === 'undefined') return false;
-
-		// Multiple checks for better accuracy across browsers
-		const hasTouchPoints = 'maxTouchPoints' in navigator && navigator.maxTouchPoints > 0;
-		const hasTouchStart = 'ontouchstart' in window;
-		const hasTouchEvent = 'DocumentTouch' in window && 'ontouchstart' in document.documentElement;
-		const hasPointerCoarse = window.matchMedia?.('(pointer: coarse)').matches;
-
-		return hasTouchPoints || hasTouchStart || hasTouchEvent || hasPointerCoarse;
+		super('(hover: none)', false);
 	}
 }

--- a/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
+++ b/frontend/src/routes/(app)/dashboard/dashboard-all-environments-view.svelte
@@ -55,6 +55,7 @@
 	import DashboardMetricTile from './dash-metric-tile.svelte';
 	import DashboardEnvironmentUpgradeAction from './dashboard-environment-upgrade-action.svelte';
 	import * as ArcaneTooltip from '$lib/components/arcane-tooltip';
+	import { mergeProps } from 'bits-ui';
 
 	let {
 		heroGreeting,
@@ -959,10 +960,11 @@
 										{#each getEnvironmentActionButtons(boardState.overviewById.get(environment.id) ?? baseItem, isCurrent) as btn (btn.id)}
 											{@const isActiveEnv = isCurrent && btn.id === `${environment.id}-use`}
 											<ArcaneTooltip.Root>
-												<ArcaneTooltip.Trigger>
+												<ArcaneTooltip.Trigger disabledChild={!!(btn.disabled || btn.loading)}>
 													{#snippet child({ props })}
+														{@const triggerProps = mergeProps(props, { onclick: btn.onclick })}
 														<ArcaneButton
-															{...props}
+															{...triggerProps}
 															action={btn.action}
 															size="icon"
 															tone="ghost"
@@ -970,7 +972,6 @@
 															customLabel={btn.label}
 															loading={btn.loading}
 															disabled={btn.disabled}
-															onclick={btn.onclick}
 															class={cn(
 																'size-8',
 																btn.action === 'prune' && 'text-destructive hover:bg-destructive/10 hover:text-destructive',

--- a/frontend/src/routes/(app)/settings/authentication/+page.svelte
+++ b/frontend/src/routes/(app)/settings/authentication/+page.svelte
@@ -29,6 +29,7 @@
 	import { tryCatch } from '$lib/utils/api';
 	import { untrack } from 'svelte';
 	import IfPermitted from '$lib/components/if-permitted.svelte';
+	import { mergeProps } from 'bits-ui';
 
 	let { data }: PageProps = $props();
 	type AuthenticationTab = 'settings' | 'federated';
@@ -580,13 +581,18 @@
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3" role="group" aria-labelledby="passwordPolicyLabel">
 								<ArcaneTooltip.Root>
 									<ArcaneTooltip.Trigger>
-										<ArcaneButton
-											action="base"
-											tone={$formInputs.authPasswordPolicy.value === 'basic' ? 'outline-primary' : 'outline'}
-											class="h-12 w-full text-xs sm:text-sm"
-											onclick={() => ($formInputs.authPasswordPolicy.value = 'basic')}
-											customLabel={m.common_basic()}
-										/>
+										{#snippet child({ props })}
+											{@const triggerProps = mergeProps(props, {
+												onclick: () => ($formInputs.authPasswordPolicy.value = 'basic'),
+												class: 'h-12 w-full text-xs sm:text-sm'
+											})}
+											<ArcaneButton
+												{...triggerProps}
+												action="base"
+												tone={$formInputs.authPasswordPolicy.value === 'basic' ? 'outline-primary' : 'outline'}
+												customLabel={m.common_basic()}
+											/>
+										{/snippet}
 									</ArcaneTooltip.Trigger>
 									<ArcaneTooltip.Content side="top">
 										{m.security_password_policy_basic_tooltip()}
@@ -595,13 +601,18 @@
 
 								<ArcaneTooltip.Root>
 									<ArcaneTooltip.Trigger>
-										<ArcaneButton
-											action="base"
-											tone={$formInputs.authPasswordPolicy.value === 'standard' ? 'outline-primary' : 'outline'}
-											class="h-12 w-full text-xs sm:text-sm"
-											onclick={() => ($formInputs.authPasswordPolicy.value = 'standard')}
-											customLabel={m.security_password_policy_standard()}
-										/>
+										{#snippet child({ props })}
+											{@const triggerProps = mergeProps(props, {
+												onclick: () => ($formInputs.authPasswordPolicy.value = 'standard'),
+												class: 'h-12 w-full text-xs sm:text-sm'
+											})}
+											<ArcaneButton
+												{...triggerProps}
+												action="base"
+												tone={$formInputs.authPasswordPolicy.value === 'standard' ? 'outline-primary' : 'outline'}
+												customLabel={m.security_password_policy_standard()}
+											/>
+										{/snippet}
 									</ArcaneTooltip.Trigger>
 									<ArcaneTooltip.Content side="top">
 										{m.security_password_policy_standard_tooltip()}
@@ -610,13 +621,18 @@
 
 								<ArcaneTooltip.Root>
 									<ArcaneTooltip.Trigger>
-										<ArcaneButton
-											action="base"
-											tone={$formInputs.authPasswordPolicy.value === 'strong' ? 'outline-primary' : 'outline'}
-											class="h-12 w-full text-xs sm:text-sm"
-											onclick={() => ($formInputs.authPasswordPolicy.value = 'strong')}
-											customLabel={m.security_password_policy_strong()}
-										/>
+										{#snippet child({ props })}
+											{@const triggerProps = mergeProps(props, {
+												onclick: () => ($formInputs.authPasswordPolicy.value = 'strong'),
+												class: 'h-12 w-full text-xs sm:text-sm'
+											})}
+											<ArcaneButton
+												{...triggerProps}
+												action="base"
+												tone={$formInputs.authPasswordPolicy.value === 'strong' ? 'outline-primary' : 'outline'}
+												customLabel={m.security_password_policy_strong()}
+											/>
+										{/snippet}
 									</ArcaneTooltip.Trigger>
 									<ArcaneTooltip.Content side="top">
 										{m.security_password_policy_strong_tooltip()}

--- a/tests/spec/dashboard-system-stats.spec.ts
+++ b/tests/spec/dashboard-system-stats.spec.ts
@@ -101,6 +101,36 @@ async function mockDashboardStatsWebSocket(page: Page) {
 	}, mockedStats);
 }
 
+async function mockInputCapabilities(page: Page, hoverNone: boolean, maxTouchPoints: number) {
+	await page.addInitScript(
+		({ hoverNone, maxTouchPoints }) => {
+			Object.defineProperty(navigator, 'maxTouchPoints', {
+				configurable: true,
+				get: () => maxTouchPoints
+			});
+
+			const nativeMatchMedia = window.matchMedia.bind(window);
+			window.matchMedia = (query: string) => {
+				if (query !== '(hover: none)') {
+					return nativeMatchMedia(query);
+				}
+
+				return {
+					matches: hoverNone,
+					media: query,
+					onchange: null,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+					addListener: () => undefined,
+					removeListener: () => undefined,
+					dispatchEvent: () => true
+				} as MediaQueryList;
+			};
+		},
+		{ hoverNone, maxTouchPoints }
+	);
+}
+
 function collectDashboardRequestPaths(page: Page): string[] {
 	const requestPaths: string[] = [];
 
@@ -183,5 +213,64 @@ test.describe('Dashboard system stats websocket', () => {
 		expect(
 			countMatchingRequests(requestPaths, /\/api\/environments\/[^/]+\/system\/docker\/info$/)
 		).toBe(1);
+	});
+});
+
+test.describe('Dashboard environment action tooltips', () => {
+	test('uses hover tooltips on hover-capable devices that expose touch APIs', async ({ page }) => {
+		await mockInputCapabilities(page, false, 5);
+		await mockDashboardStatsWebSocket(page);
+
+		await page.goto(defaultDashboardPath);
+		await expect(page.getByRole('heading', { name: 'Environment Board' })).toBeVisible();
+
+		const detailsButton = page.getByRole('button', { name: 'View Details', exact: true });
+		await expect(detailsButton).toHaveCount(1);
+		await expect(detailsButton).toHaveAttribute('data-tooltip-trigger', '');
+
+		await detailsButton.hover();
+		await expect(page.locator('[data-slot="tooltip-content"]')).toContainText('View Details');
+	});
+
+	test('keeps one keyboard focus target and the Arcane button focus ring', async ({ page }) => {
+		await mockInputCapabilities(page, false, 0);
+		await mockDashboardStatsWebSocket(page);
+
+		await page.goto(defaultDashboardPath);
+		await expect(page.getByRole('heading', { name: 'Environment Board' })).toBeVisible();
+
+		const detailsButton = page.getByRole('button', { name: 'View Details', exact: true });
+		const inspectButton = page.getByRole('button', { name: 'Inspect', exact: true });
+		await expect(detailsButton).toHaveCount(1);
+		await expect(inspectButton).toHaveCount(1);
+
+		await detailsButton.focus();
+		await page.keyboard.press('Tab');
+		await expect(inspectButton).toBeFocused();
+
+		const focusShadow = await inspectButton.evaluate(
+			(element) => getComputedStyle(element).boxShadow
+		);
+		expect(focusShadow).not.toBe('none');
+	});
+
+	test('uses a popover for disabled actions when the primary input cannot hover', async ({
+		page
+	}) => {
+		await mockInputCapabilities(page, true, 5);
+		await mockDashboardStatsWebSocket(page);
+
+		await page.goto(defaultDashboardPath);
+		await expect(page.getByRole('heading', { name: 'Environment Board' })).toBeVisible();
+
+		const useEnvironmentButton = page.getByRole('button', { name: 'Use Environment', exact: true });
+		const disabledTrigger = page
+			.locator('div[data-popover-trigger][data-disabled-child]')
+			.filter({ has: useEnvironmentButton })
+			.first();
+
+		await expect(disabledTrigger).toBeVisible();
+		await disabledTrigger.click();
+		await expect(page.locator('[data-slot="popover-content"]')).toContainText('Current');
 	});
 });

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -199,9 +199,9 @@ async function createProjectViaUI(page: Page, projectName: string) {
 		})
 		.toBe(TEST_COMPOSE_YAML.trimEnd());
 
-	const createButton = page
-		.getByRole('button', { name: 'Create Project' })
-		.locator('[data-slot="arcane-button"]');
+	const createButton = page.locator('button[data-slot="arcane-button"]', {
+		hasText: 'Create Project'
+	});
 	await expect(createButton).toBeEnabled();
 	const createResponsePromise = page.waitForResponse(
 		(response) =>
@@ -510,9 +510,9 @@ test.describe('New Compose Project Page', () => {
 	});
 
 	test('should validate required fields', async ({ page }) => {
-		const createButton = page
-			.getByRole('button', { name: 'Create Project' })
-			.locator('[data-slot="arcane-button"]');
+		const createButton = page.locator('button[data-slot="arcane-button"]', {
+			hasText: 'Create Project'
+		});
 		await expect(createButton).toBeDisabled();
 
 		await page.getByRole('button', { name: 'My New Project' }).click();
@@ -531,9 +531,9 @@ test.describe('New Compose Project Page', () => {
 			if (msg.type() === 'error') observedErrors.push(msg.text());
 		});
 
-		const createButton = page
-			.getByRole('button', { name: 'Create Project' })
-			.locator('[data-slot="arcane-button"]');
+		const createButton = page.locator('button[data-slot="arcane-button"]', {
+			hasText: 'Create Project'
+		});
 
 		await expect(createButton).toBeVisible();
 
@@ -652,9 +652,9 @@ test.describe('New Compose Project Page', () => {
 			}
 		});
 
-		const createButton = page
-			.getByRole('button', { name: 'Create Project' })
-			.locator('[data-slot="arcane-button"]');
+		const createButton = page.locator('button[data-slot="arcane-button"]', {
+			hasText: 'Create Project'
+		});
 		const createResponsePromise = page.waitForResponse(
 			(response) =>
 				response.request().method() === 'POST' &&


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3140

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores tooltip and focus behavior for dashboard and action controls. The main changes are:

- Pass Bits UI tooltip trigger props directly into interactive child controls when possible.
- Use wrapper triggers for disabled or loading child controls so tooltips and popovers remain accessible.
- Replace broad touch detection with hover-capability detection for touch-first tooltip behavior.
- Update related status popover, switch, button, and Playwright test paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are localized to Svelte tooltip trigger composition and related tests. The updated code uses derived values for computed props and avoids the previously repeated tooltip wrapper focus issue. No verified functional or security issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to validate the PR by running the focused Playwright test for dashboard environment action tooltips from the tests folder, but the sandbox failed because docker is not available.
- T-Rex started the frontend Svelte/Vite app and created the real-app Playwright probe trex-artifacts/dashboard-tooltip-realapp-probe.mjs to navigate to /dashboard and patch API requests for environment and auth.
- The probe attempted to hover the View Details action and tab to Inspect using the repository's UI, instead of a hand-authored mock page.
- The probe was blocked before UI assertions could complete, with browser logs showing a dynamic module fetch failure and the dev-server process killed with exit code 137.
- A blocker screenshot and generated videos/logs were captured and stored as artifacts for review.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: restore tooltips and focus behavior..."](https://github.com/getarcaneapp/arcane/commit/94298527a1a28f3e03757e5b8dfbbe5f43b10721) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43401599)</sub>

<!-- /greptile_comment -->