### PR TITLE
fix: stream direct environment request bodies

### DIFF
--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -1,14 +1,12 @@
 package middleware
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -449,34 +447,23 @@ func (m *EnvironmentMiddleware) createProxyRequest(c echo.Context, target string
 		return nil, &common.EnvironmentInvalidProxyTargetError{Err: err}
 	}
 
-	var bodyBytes []byte
-	if srcReq.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(srcReq.Body)
-		_ = srcReq.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-	}
+	slog.DebugContext(srcReq.Context(), "Creating proxy request",
+		"method", srcReq.Method,
+		"target", target,
+		"contentLength", srcReq.ContentLength,
+		"contentType", srcReq.Header.Get("Content-Type"),
+		"transferEncoding", srcReq.TransferEncoding)
 
-	slog.DebugContext(srcReq.Context(), "Creating proxy request", "method", srcReq.Method, "target", target, "contentLength", srcReq.ContentLength, "contentType", srcReq.Header.Get("Content-Type"), "bodyLength", len(bodyBytes), "body", string(bodyBytes))
-
-	var requestBody io.ReadCloser
-	var getBody func() (io.ReadCloser, error)
-	if len(bodyBytes) > 0 {
-		requestBody = io.NopCloser(bytes.NewReader(bodyBytes))
-		getBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
-		}
-	}
 	requestURL := *validatedTarget
 	req := (&http.Request{
-		Method:  srcReq.Method,
-		URL:     &requestURL,
-		Host:    requestURL.Host,
-		Header:  make(http.Header),
-		Body:    requestBody,
-		GetBody: getBody,
+		Method:           srcReq.Method,
+		URL:              &requestURL,
+		Host:             requestURL.Host,
+		Header:           make(http.Header),
+		Body:             srcReq.Body,
+		GetBody:          srcReq.GetBody,
+		ContentLength:    srcReq.ContentLength,
+		TransferEncoding: slices.Clone(srcReq.TransferEncoding),
 	}).WithContext(srcReq.Context())
 
 	skip := edge.GetSkipHeaders()
@@ -484,10 +471,6 @@ func (m *EnvironmentMiddleware) createProxyRequest(c echo.Context, target string
 	edge.SetAuthHeader(req, c)
 	edge.SetAgentToken(req, accessToken)
 	edge.SetForwardedHeaders(req, c.RealIP(), srcReq.Host)
-
-	if len(bodyBytes) > 0 {
-		req.ContentLength = int64(len(bodyBytes))
-	}
 
 	return req, nil
 }

--- a/backend/internal/middleware/environment_middleware_test.go
+++ b/backend/internal/middleware/environment_middleware_test.go
@@ -1,16 +1,37 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type trackingReadCloser struct {
+	reader io.Reader
+	reads  int
+	closed bool
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	r.reads++
+	return r.reader.Read(p)
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
 
 func newTestEnvironmentMiddleware() *EnvironmentMiddleware {
 	return &EnvironmentMiddleware{
@@ -366,4 +387,103 @@ func TestEnvironmentMiddleware_CreateProxyRequest_RejectsInvalidProxyTarget(t *t
 	_, err := middleware.createProxyRequest(c, "ftp://example.com/containers", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Invalid proxy target URL")
+}
+
+func TestEnvironmentMiddleware_CreateProxyRequest_DoesNotReadBody(t *testing.T) {
+	middleware := newTestEnvironmentMiddleware()
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	body := &trackingReadCloser{reader: strings.NewReader("streamed request body")}
+	req := httptest.NewRequest(http.MethodPost, "/api/environments/env-direct/projects", body)
+	req.ContentLength = 21
+	req.TransferEncoding = []string{"chunked"}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("streamed request body")), nil
+	}
+	c := e.NewContext(req, recorder)
+
+	proxyReq, err := middleware.createProxyRequest(c, "http://remote.example/projects", nil)
+	require.NoError(t, err)
+
+	assert.Same(t, body, proxyReq.Body)
+	assert.Zero(t, body.reads)
+	assert.False(t, body.closed)
+	assert.Equal(t, req.ContentLength, proxyReq.ContentLength)
+	assert.Equal(t, req.TransferEncoding, proxyReq.TransferEncoding)
+	require.NotNil(t, proxyReq.GetBody)
+	replay, err := proxyReq.GetBody()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = replay.Close() })
+	replayedBody, err := io.ReadAll(replay)
+	require.NoError(t, err)
+	assert.Equal(t, "streamed request body", string(replayedBody))
+	assert.Zero(t, body.reads)
+}
+
+func TestEnvironmentMiddleware_ProxyHTTP_StreamsLargeChunkedBody(t *testing.T) {
+	const chunkCount = 256
+	chunk := bytes.Repeat([]byte("arcane-stream-"), 2560)
+	expectedHash := sha256.New()
+	for range chunkCount {
+		_, err := expectedHash.Write(chunk)
+		require.NoError(t, err)
+	}
+
+	type uploadResult struct {
+		bytesRead        int64
+		hash             [sha256.Size]byte
+		contentLength    int64
+		transferEncoding []string
+		contentType      string
+		err              error
+	}
+	resultCh := make(chan uploadResult, 1)
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hash := sha256.New()
+		bytesRead, err := io.Copy(hash, r.Body)
+		resultCh <- uploadResult{
+			bytesRead:        bytesRead,
+			hash:             [sha256.Size]byte(hash.Sum(nil)),
+			contentLength:    r.ContentLength,
+			transferEncoding: r.TransferEncoding,
+			contentType:      r.Header.Get("Content-Type"),
+			err:              err,
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(remote.Close)
+
+	pipeReader, pipeWriter := io.Pipe()
+	writeErrCh := make(chan error, 1)
+	go func() {
+		var writeErr error
+		for range chunkCount {
+			if _, writeErr = pipeWriter.Write(chunk); writeErr != nil {
+				break
+			}
+		}
+		closeErr := pipeWriter.CloseWithError(writeErr)
+		writeErrCh <- closeErr
+	}()
+
+	middleware := newTestEnvironmentMiddleware()
+	middleware.httpClient = remote.Client()
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/environments/env-direct/upload", pipeReader)
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	c := e.NewContext(req, recorder)
+
+	require.NoError(t, middleware.proxyHTTP(c, remote.URL+"/upload", nil))
+	require.NoError(t, <-writeErrCh)
+	result := <-resultCh
+	require.NoError(t, result.err)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, int64(len(chunk)*chunkCount), result.bytesRead)
+	assert.Equal(t, [sha256.Size]byte(expectedHash.Sum(nil)), result.hash)
+	assert.Equal(t, int64(-1), result.contentLength)
+	assert.Equal(t, []string{"chunked"}, result.transferEncoding)
+	assert.Equal(t, "application/octet-stream", result.contentType)
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes direct environment proxy requests to stream request bodies. The main changes are:

- Reuses the inbound request body instead of buffering it.
- Preserves content length and transfer encoding on the proxied request.
- Adds tests for non-consuming body setup and large chunked uploads.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Redirected proxied requests with bodies can behave incorrectly.

Streaming itself is covered by focused tests, but the changed body setup no longer creates a replayable body for normal inbound requests.

backend/internal/middleware/environment_middleware.go
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted T-Rex verification for Redirect Body Replay Lost, but the run was blocked by the step limit and no runtime repro or runtime artifacts were captured; only source inspection occurred.
- Reran the exact Go command under bash and captured a successful streaming environment middleware test run, with both tests passing (EXIT\_CODE 0).
- Validated the broader environment middleware regression run, which also completed with EXIT\_CODE 0 and confirmed the streaming tests' stability.

<a href="https://app.greptile.com/trex/runs/14058583/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_stream_direct_environment_request_bodies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_stream_direct_environment_request_bodies%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%3A464%0A**Redirect%20Body%20Replay%20Lost**%0A%0AWhen%20a%20proxied%20POST%20or%20PUT%20receives%20a%20307%20or%20308%20from%20the%20target%2C%20the%20outbound%20client%20can%20only%20replay%20the%20body%20when%20%60GetBody%60%20is%20set.%20Normal%20inbound%20server%20requests%20usually%20leave%20%60srcReq.GetBody%60%20nil%2C%20so%20this%20change%20removes%20the%20replayable%20buffered%20body%20that%20the%20proxy%20used%20to%20create%20and%20can%20return%20the%20redirect%20instead%20of%20the%20final%20upstream%20response.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abackend%2Finternal%2Fmiddleware%2Fenvironment_middleware.go%3A464%0A**Redirect%20Body%20Replay%20Lost**%0A%0AWhen%20a%20proxied%20POST%20or%20PUT%20receives%20a%20307%20or%20308%20from%20the%20target%2C%20the%20outbound%20client%20can%20only%20replay%20the%20body%20when%20%60GetBody%60%20is%20set.%20Normal%20inbound%20server%20requests%20usually%20leave%20%60srcReq.GetBody%60%20nil%2C%20so%20this%20change%20removes%20the%20replayable%20buffered%20body%20that%20the%20proxy%20used%20to%20create%20and%20can%20return%20the%20redirect%20instead%20of%20the%20final%20upstream%20response.%0A%0A**What%3A**%20Code%20should%20p...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3Dc1082b6a-5fdc-4db8-8419-8a71ccd57636%29%29%0A%0A&repo=getarcaneapp%2Farcane&pr=3239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/internal/middleware/environment_middleware.go:464
**Redirect Body Replay Lost**

When a proxied POST or PUT receives a 307 or 308 from the target, the outbound client can only replay the body when `GetBody` is set. Normal inbound server requests usually leave `srcReq.GetBody` nil, so this change removes the replayable buffered body that the proxy used to create and can return the redirect instead of the final upstream response.

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stream direct environment request b..."](https://github.com/getarcaneapp/arcane/commit/cbe80bcfe80dd600f822d1a028278660f07cc5e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43445032)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Go Development Patterns

**What:** Code should p... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=c1082b6a-5fdc-4db8-8419-8a71ccd57636))

<!-- /greptile_comment -->