### PR TITLE
fix(websocket): aggregate hub overload warnings

### DIFF
--- a/backend/pkg/libarcane/ws/hub.go
+++ b/backend/pkg/libarcane/ws/hub.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
+	"time"
 )
+
+const broadcastDropWarningInterval = 5 * time.Second
 
 type Hub struct {
 	mu         sync.RWMutex
@@ -15,6 +19,8 @@ type Hub struct {
 	onFirst    func()
 	onActive   func()
 	onEmpty    func()
+	dropped    atomic.Uint64
+	lastWarned atomic.Int64
 }
 
 func NewHub(buffer int) *Hub {
@@ -99,7 +105,13 @@ func (h *Hub) Broadcast(msg []byte) {
 	default:
 		// prevent global stall if hub buffer fills
 		// This indicates the hub is not processing messages fast enough
-		slog.Warn("websocket hub broadcast buffer full; dropping message")
+		h.dropped.Add(1)
+
+		now := time.Now().UnixNano()
+		lastWarned := h.lastWarned.Load()
+		if now-lastWarned >= broadcastDropWarningInterval.Nanoseconds() && h.lastWarned.CompareAndSwap(lastWarned, now) {
+			slog.Warn("websocket hub broadcast buffer full; dropping messages", "dropped_count", h.dropped.Swap(0))
+		}
 	}
 }
 

--- a/backend/pkg/libarcane/ws/hub_test.go
+++ b/backend/pkg/libarcane/ws/hub_test.go
@@ -1,7 +1,9 @@
 package ws
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -320,6 +322,44 @@ func TestHub_BroadcastBufferFull(t *testing.T) {
 
 	// Verify no panic or deadlock occurred
 	go h.Run(ctx)
+}
+
+func TestHub_BroadcastOverloadAggregatesDropWarning(t *testing.T) {
+	var logBuffer bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	h := NewHub(1)
+	h.broadcast <- []byte("fill")
+	h.lastWarned.Store(time.Now().UnixNano())
+
+	const dropCount = 1000
+	var wg sync.WaitGroup
+	for range dropCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.Broadcast([]byte("overload"))
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, uint64(dropCount), h.dropped.Load())
+	assert.Empty(t, logBuffer.String())
+
+	h.lastWarned.Store(time.Now().Add(-broadcastDropWarningInterval).UnixNano())
+	h.Broadcast([]byte("trigger aggregate warning"))
+
+	logLines := strings.Split(strings.TrimSpace(logBuffer.String()), "\n")
+	require.Len(t, logLines, 1)
+	assert.Contains(t, logLines[0], "websocket hub broadcast buffer full; dropping messages")
+	assert.Contains(t, logLines[0], "dropped_count=1001")
+	assert.Zero(t, h.dropped.Load())
+
+	h.Broadcast([]byte("still overloaded"))
+	assert.Len(t, strings.Split(strings.TrimSpace(logBuffer.String()), "\n"), 1)
+	assert.Equal(t, uint64(1), h.dropped.Load())
 }
 
 func TestHub_ConcurrentOperations(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aggregates websocket hub overload warnings. The main changes are:

- Adds atomic counters for dropped broadcast messages.
- Rate-limits overload warnings to one log entry per interval.
- Reports the aggregated dropped message count in the warning.
- Adds a test for concurrent dropped broadcasts and counter reset behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues were found in the changed code; the overload path stays non-blocking, and the new atomic fields have valid zero-value behavior for new hubs.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the targeted proof showing TestHub\_BroadcastOverloadAggregatesDropWarning ran and passed with exit code 0 in ws-overload-aggregation.
- Validated the race proof showing TestHub\_BroadcastOverloadAggregatesDropWarning passed under go test -race for the websocket package suite, with exit code 0.

<a href="https://app.greptile.com/trex/runs/14065956/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(websocket): aggregate hub overload w..."](https://github.com/getarcaneapp/arcane/commit/abb69c7c6abf41dba68d6687a57c79bab01e2303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43459048)</sub>

<!-- /greptile_comment -->