### PR TITLE
fix: preserve tag when saving update records for tag@digest-pinned images

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -647,6 +647,7 @@ func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Conte
 	}
 
 	repo, tag := extractRepoAndTagFromImage(inspectResponse.InspectResponse)
+	tag = tagWithFallbackInternal(tag, s.parseImageReference(imageRef))
 
 	return &localImageSnapshot{
 		ImageID:       inspectResponse.ID,
@@ -915,10 +916,15 @@ func (s *ImageUpdateService) saveUpdateResultByIDInternal(ctx context.Context, i
 	}
 
 	repo, tag := extractRepoAndTagFromImage(dockerImage.InspectResponse)
-	if tag == "<none>" && fallback != nil && strings.TrimSpace(fallback.Tag) != "" {
-		tag = fallback.Tag
-	}
+	tag = tagWithFallbackInternal(tag, fallback)
 	return s.savePreparedUpdateResultInternal(ctx, imageID, repo, tag, result)
+}
+
+func tagWithFallbackInternal(tag string, fallback *ImageParts) string {
+	if tag == "<none>" && fallback != nil && strings.TrimSpace(fallback.Tag) != "" {
+		return fallback.Tag
+	}
+	return tag
 }
 
 func (s *ImageUpdateService) savePreparedUpdateResultInternal(ctx context.Context, imageID, repo, tag string, result *imageupdate.Response) error {

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -682,7 +682,7 @@ func (s *ImageUpdateService) CheckImageUpdateByID(ctx context.Context, imageID s
 	if err != nil {
 		return nil, err
 	}
-	if saveErr := s.saveUpdateResultByIDInternal(ctx, imageID, result); saveErr != nil {
+	if saveErr := s.saveUpdateResultByIDInternal(ctx, imageID, result, s.parseImageReference(imageRef)); saveErr != nil {
 		slog.WarnContext(ctx, "Failed to save update result by ID", "imageID", imageID, "error", saveErr.Error())
 	}
 	return result, nil
@@ -712,7 +712,7 @@ func (s *ImageUpdateService) saveUpdateResultWithSnapshotInternal(ctx context.Co
 		return s.savePreparedUpdateResultInternal(ctx, syntheticID, repository, parts.Tag, result)
 	}
 
-	return s.saveUpdateResultByIDInternal(ctx, imageID, result)
+	return s.saveUpdateResultByIDInternal(ctx, imageID, result, parts)
 }
 
 func buildImageUpdateRepositoryInternal(parts *ImageParts) string {
@@ -900,7 +900,7 @@ func savePreparedUpdateResultWithTxInternal(tx *gorm.DB, imageID, repo, tag stri
 	return tx.Save(updateRecord).Error
 }
 
-func (s *ImageUpdateService) saveUpdateResultByIDInternal(ctx context.Context, imageID string, result *imageupdate.Response) error {
+func (s *ImageUpdateService) saveUpdateResultByIDInternal(ctx context.Context, imageID string, result *imageupdate.Response, fallback *ImageParts) error {
 	dockerClient, err := s.dockerClientInternal(ctx)
 	if err != nil {
 		return err
@@ -915,6 +915,9 @@ func (s *ImageUpdateService) saveUpdateResultByIDInternal(ctx context.Context, i
 	}
 
 	repo, tag := extractRepoAndTagFromImage(dockerImage.InspectResponse)
+	if tag == "<none>" && fallback != nil && strings.TrimSpace(fallback.Tag) != "" {
+		tag = fallback.Tag
+	}
 	return s.savePreparedUpdateResultInternal(ctx, imageID, repo, tag, result)
 }
 

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -574,6 +574,49 @@ func TestImageUpdateService_CheckMultipleImages_SkippedDigestPinnedReferenceClea
 	assert.Equal(t, pinnedDigest, stringPtrToString(saved.LatestDigest))
 }
 
+func TestImageUpdateService_CheckMultipleImages_DigestPinnedTagPreservedWhenLocalImageHasNoRepoTags(t *testing.T) {
+	db := setupImageUpdateTestDB(t)
+	pinnedDigest := digest.FromString("valkey-pinned").String()
+
+	server := newImageUpdateNoRepoTagsServer(t, "sha256:pinned-local-id", pinnedDigest)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	repository := serverURL.Host + "/valkey/valkey"
+	imageRef := repository + ":9@" + pinnedDigest
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, server)}
+	svc := NewImageUpdateService(db, nil, nil, dockerService, nil, nil, nil)
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{imageRef}, nil)
+	require.NoError(t, err)
+	require.Contains(t, results, imageRef)
+	assert.False(t, results[imageRef].HasUpdate)
+	assert.Empty(t, results[imageRef].Error)
+
+	var saved models.ImageUpdateRecord
+	require.NoError(t, db.WithContext(context.Background()).Where("id = ?", "sha256:pinned-local-id").First(&saved).Error)
+	assert.Equal(t, "9", saved.Tag, "tag should come from the original tag@digest reference, not fall back to the RepoDigests-only placeholder")
+}
+
+func newImageUpdateNoRepoTagsServer(t *testing.T, imageID, localDigest string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json") {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:          imageID,
+				RepoTags:    []string{},
+				RepoDigests: []string{r.Host + "/valkey/valkey@" + localDigest},
+			}))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
 func TestImageUpdateService_CheckImageUpdate_UsesRegistryFallback(t *testing.T) {
 	db := setupImageUpdateTestDB(t)
 	localDigest := digest.FromString("localdigest").String()


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes the Projects page "Updates" column getting permanently stuck on **Unknown** for Compose services that pin their image with both a tag and a digest (e.g. `image: docker.io/valkey/valkey:9@sha256:...`), such as Immich's official `redis` and `database` services.

Fixes: #3241

## Changes Made

- `backend/internal/services/image_update_service.go`: when a locally-pulled image was resolved via a combined `tag@digest` reference, `docker image inspect` can report an empty `RepoTags` list (only `RepoDigests`). The existing fallback in `extractRepoAndTagFromImage` hard-codes the tag as the literal string `"<none>"` in that case, discarding the real tag already known from the original reference. That bogus tag then got persisted to the `image_updates` table, so the project-level update summary (which requires an exact tag match to count an image as "checked") never counted that image, leaving the whole project's aggregate status stuck on `"unknown"` no matter how many times it was checked.
  - `saveUpdateResultByIDInternal` now accepts the already-parsed `ImageParts` of the original reference as a `fallback`, and uses its tag instead of `"<none>"` when the Docker-inspect-derived tag is the placeholder.
  - Both call sites (`CheckImageUpdateByID` and `saveUpdateResultWithSnapshotInternal`) now pass the parsed reference through.
- `backend/internal/services/image_update_service_test.go`: added `TestImageUpdateService_CheckMultipleImages_DigestPinnedTagPreservedWhenLocalImageHasNoRepoTags`, a regression test simulating a locally-pulled tag+digest image with empty `RepoTags`, asserting the saved record's tag comes from the original reference and not the `"<none>"` placeholder.

## Testing Done

- `go test ./internal/services/...`  - full suite passes.
- Added regression test fails against the pre-fix code (`expected: "9"`, `actual: "<none>"`) and passes with the fix.
- Reproduced against a live instance managing an Immich stack: inspected the `image_updates` SQLite table directly and confirmed the digest+tag-pinned images (`valkey/valkey`, `ghcr.io/immich-app/postgres`) were saved with `tag = "<none>"` before the fix.
- Built the image locally with the fix, deployed it against the same Immich project, triggered a fresh update check, and manually confirmed the Projects page now reports the correct aggregate status instead of "Unknown".

## AI Tool Used (if applicable)

Claude Code (Sonnet 5)

## Additional Context

See #3241 for the original bug report, including the `image_updates` table dump and the exact Immich compose snippet that reproduces this.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves image tags when saving update records for tag-and-digest pinned images. The main changes are:

- Pass the parsed original image reference into the update-result save path.
- Replace the Docker inspect `<none>` tag with the original tag when `RepoTags` is empty.
- Add a regression test for a RepoDigests-only local image inspect response.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused digest-pinned-tag-01-focused test ran with the exact command, working directory, verbose test run, pass line, and EXIT\_CODE: 0.
- The broader digest-pinned-tag-02-services-suite run executed and reported a failure with EXIT\_CODE: 1, including the failure details.
- Docker/live Immich validation was not attempted because Docker is unavailable in the sandbox.

<a href="https://app.greptile.com/trex/runs/14080902/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve tag when saving update rec..."](https://github.com/getarcaneapp/arcane/commit/b09a914c00b7b7816079648ace89eae629c60283) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43487951)</sub>

<!-- /greptile_comment -->