### PR TITLE
fix: tab routing for all pages can cuase in correct tabs to tr yand be shown

### DIFF
--- a/frontend/src/lib/hooks/use-url-tab.svelte.ts
+++ b/frontend/src/lib/hooks/use-url-tab.svelte.ts
@@ -1,0 +1,65 @@
+import { replaceState } from '$app/navigation';
+import { page } from '$app/state';
+import { onMount, untrack } from 'svelte';
+
+type UseUrlTabOptions<T extends string> = {
+	validTabs: () => readonly T[];
+	defaultTab: () => T;
+	ready?: () => boolean;
+};
+
+export function useUrlTab<T extends string>({ validTabs, defaultTab, ready = () => true }: UseUrlTabOptions<T>) {
+	function currentUrl() {
+		const reactiveUrl = page.url;
+		return typeof window === 'undefined' ? new URL(reactiveUrl) : new URL(window.location.href);
+	}
+
+	function resolveTab(url = currentUrl()) {
+		const tabs = validTabs();
+		const defaultValue = defaultTab();
+		const fallback = tabs.includes(defaultValue) ? defaultValue : (tabs[0] ?? defaultValue);
+		const requested = url.searchParams.get('tab');
+
+		return requested && tabs.includes(requested as T) ? (requested as T) : fallback;
+	}
+
+	let value = $state<T>(resolveTab());
+	let mounted = $state(false);
+
+	onMount(() => {
+		const timeout = window.setTimeout(() => {
+			mounted = true;
+		});
+
+		return () => window.clearTimeout(timeout);
+	});
+
+	function select(tab: string) {
+		if (!validTabs().includes(tab as T)) return;
+
+		const url = currentUrl();
+		if (url.searchParams.get('tab') !== tab) {
+			url.searchParams.set('tab', tab);
+			replaceState(url, page.state);
+		}
+
+		value = tab as T;
+	}
+
+	$effect(() => {
+		const url = currentUrl();
+		const selected = resolveTab(url);
+		if (mounted && ready() && url.searchParams.get('tab') !== selected) {
+			url.searchParams.set('tab', selected);
+			replaceState(url, page.state);
+		}
+		if (untrack(() => value) !== selected) value = selected;
+	});
+
+	return {
+		get value() {
+			return value;
+		},
+		select
+	};
+}

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -49,11 +49,11 @@
 	import { ImagesIcon, PauseIcon, PlayIcon, ZapIcon } from '$lib/icons';
 	import { runContainerLifecycleAction } from '$lib/utils/container-actions';
 	import KillContainerDialog from '../components/kill-container-dialog.svelte';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 	let { data } = $props();
 	let container = $derived(data?.container as ContainerDetailsDto);
 	let stats = $state(null as ContainerStatsType | null);
 
-	let selectedTab = $state<string>('overview');
 	let autoScrollLogs = $state(true);
 	let hasInitialStatsLoaded = $state(false);
 
@@ -263,22 +263,20 @@
 		{ value: 'inspect', label: m.tabs_inspect(), icon: InspectIcon }
 	]);
 
-	const activeTab = $derived.by(() => {
-		if (tabItems.some((t) => t.value === selectedTab)) {
-			return selectedTab;
-		}
-
-		return tabItems[0]?.value ?? 'overview';
+	const urlTab = useUrlTab({
+		validTabs: () => tabItems.map((tab) => tab.value),
+		defaultTab: () => 'overview'
 	});
+	const activeTab = $derived(urlTab.value);
 
 	function onTabChange(value: string) {
-		selectedTab = value;
+		urlTab.select(value);
 	}
 
 	async function navigateToNetworkPortMappings() {
 		if (!showNetworkTab) return;
 
-		selectedTab = 'network';
+		urlTab.select('network');
 		await tick();
 
 		requestAnimationFrame(() => {

--- a/frontend/src/routes/(app)/customize/templates/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/+page.svelte
@@ -14,14 +14,13 @@
 	import type { SearchPaginationSortRequest } from '$lib/types/shared';
 	import { RegistryIcon, TemplateIcon, FolderOpenIcon } from '$lib/icons';
 	import { hasPermission } from '$lib/utils/auth';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 
 	let templates = $state(untrack(() => data.templates));
 	let registries = $state<TemplateRegistry[]>(untrack(() => data.registries));
 	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.templateRequestOptions));
-	let activeView = $state<'browse' | 'registries'>('browse');
-
 	const tabItems: TabItem[] = [
 		{
 			value: 'browse',
@@ -34,6 +33,11 @@
 			icon: RegistryIcon
 		}
 	];
+	const urlTab = useUrlTab({
+		validTabs: () => tabItems.map((tab) => tab.value),
+		defaultTab: () => 'browse'
+	});
+	const activeView = $derived(urlTab.value);
 
 	let isLoading = $state({
 		addingRegistry: false,
@@ -188,14 +192,10 @@
 <ResourcePageLayout title={m.templates_title()} subtitle={m.templates_subtitle()} {actionButtons} {statCards}>
 	{#snippet mainContent()}
 		<div class="space-y-6">
-			<Tabs.Root bind:value={activeView}>
+			<Tabs.Root value={activeView}>
 				<div class="pb-6">
 					<div class="w-fit">
-						<TabBar
-							items={tabItems}
-							value={activeView}
-							onValueChange={(value) => (activeView = value as 'browse' | 'registries')}
-						/>
+						<TabBar items={tabItems} value={activeView} onValueChange={urlTab.select} />
 					</div>
 				</div>
 

--- a/frontend/src/routes/(app)/environments/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/+page.svelte
@@ -10,7 +10,6 @@
 	import { CopyButton } from '$lib/components/ui/copy-button';
 	import { cn } from '$lib/utils';
 	import { goto, invalidateAll } from '$app/navigation';
-	import { page } from '$app/state';
 	import { toast } from 'svelte-sonner';
 	import { m } from '$lib/paraglide/messages';
 	import { environmentManagementService } from '$lib/services/env-mgmt-service.js';
@@ -22,6 +21,7 @@
 	import { isEnvironmentOnline, resolveEnvironmentStatus } from '$lib/utils/docker';
 	import MobileFloatingFormActions from '$lib/components/form/mobile-floating-form-actions.svelte';
 	import { createSettingsForm } from '$lib/utils/settings-form';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 	import EnvironmentStatusSummary from './components/EnvironmentStatusSummary.svelte';
 	import GeneralTab from './components/GeneralTab.svelte';
 	import DockerTab from './components/DockerTab.svelte';
@@ -52,7 +52,6 @@
 
 	let currentEnvironment = $derived(environmentStore.selected);
 
-	let activeTab = $state('general');
 	let activeSecurityTab = $state('trivy');
 
 	let isRefreshing = $state(false);
@@ -174,7 +173,11 @@
 		return items;
 	});
 
-	const tabValues = $derived(new Set(tabItems.map((tab) => tab.value)));
+	const urlTab = useUrlTab({
+		validTabs: () => tabItems.map((tab) => tab.value),
+		defaultTab: () => 'general'
+	});
+	const activeTab = $derived(urlTab.value);
 	const securityTabItems = $derived.by((): TabItem[] => [
 		{
 			value: 'trivy',
@@ -189,21 +192,7 @@
 	]);
 
 	$effect(() => {
-		if (!tabValues.has(activeTab)) {
-			activeTab = 'general';
-		}
-	});
-
-	$effect(() => {
-		const tabFromUrl = page.url.searchParams.get('tab');
-		if (!tabFromUrl || !tabValues.has(tabFromUrl) || tabFromUrl === activeTab) {
-			return;
-		}
-		if (tabFromUrl === 'gitops') {
-			goto(`/environments/${environment.id}/gitops`);
-			return;
-		}
-		activeTab = tabFromUrl;
+		if (activeTab === 'gitops') void goto(`/environments/${environment.id}/gitops`);
 	});
 
 	function handleTabChange(value: string) {
@@ -211,7 +200,7 @@
 			goto(`/environments/${environment.id}/gitops`);
 			return;
 		}
-		activeTab = value;
+		urlTab.select(value);
 	}
 
 	const formSchema = environmentFormSchema;
@@ -650,7 +639,7 @@
 		</div>
 	{/if}
 
-	<Tabs.Root bind:value={activeTab} class="w-full">
+	<Tabs.Root value={activeTab} class="w-full">
 		<div class="my-4">
 			<TabBar items={tabItems} value={activeTab} onValueChange={handleTabChange} />
 		</div>

--- a/frontend/src/routes/(app)/images/builds/+page.svelte
+++ b/frontend/src/routes/(app)/images/builds/+page.svelte
@@ -54,6 +54,7 @@
 	import { queryKeys } from '$lib/query/query-keys';
 	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { formatDateTimeShort } from '$lib/utils/formatting';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let {}: PageProps = $props();
 
@@ -152,7 +153,12 @@
 	let hasReachedComplete = $state(false);
 	let logLines = $state<string[]>([]);
 	let autoScroll = $state(true);
-	let mainTab = $state<'build' | 'history'>('build');
+	type MainTab = 'build' | 'history';
+	const mainUrlTab = useUrlTab<MainTab>({
+		validTabs: () => ['build', 'history'],
+		defaultTab: () => 'build'
+	});
+	const mainTab = $derived(mainUrlTab.value);
 	let buildTab = $state('workspace');
 	let rightPanelTab = $state<'config' | 'output'>('config');
 	let showAdvanced = $state(false);
@@ -754,7 +760,7 @@
 			remoteContextSource = '';
 			selectedContextPath = getContextPathFromBuild(build);
 		}
-		mainTab = 'build';
+		mainUrlTab.select('build');
 		rightPanelTab = 'config';
 		buildTab = 'configuration';
 		buildHistoryDetailsOpen = false;
@@ -854,7 +860,7 @@
 	}
 
 	function onMainTabChange(value: string) {
-		mainTab = value as 'build' | 'history';
+		mainUrlTab.select(value);
 	}
 </script>
 
@@ -1328,7 +1334,7 @@
 
 {#if isDesktop}
 	<ResourceDetailLayout title={m.manual_build_workspace()} subtitle={m.manual_build_workspace_subtitle()}>
-		<Tabs.Root bind:value={mainTab} class="flex h-[calc(100vh-12rem)] flex-col">
+		<Tabs.Root value={mainTab} onValueChange={mainUrlTab.select} class="flex h-[calc(100vh-12rem)] flex-col">
 			<Tabs.List class="border-border/60 bg-muted/60 mb-3 flex w-fit gap-2 rounded-lg border p-1">
 				<Tabs.Trigger
 					value="build"

--- a/frontend/src/routes/(app)/images/vulnerabilities/+page.svelte
+++ b/frontend/src/routes/(app)/images/vulnerabilities/+page.svelte
@@ -7,7 +7,7 @@
 	import { useEnvironmentRefresh } from '$lib/hooks/use-environment-refresh.svelte';
 	import type { EnvironmentVulnerabilitySummary, VulnerabilityWithImage, IgnoredVulnerability } from '$lib/types/environment';
 	import type { Paginated, SearchPaginationSortRequest } from '$lib/types/shared';
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import SecurityVulnerabilityTable from './security-vulnerability-table.svelte';
 	import IgnoredVulnerabilitiesTable from './ignored-vulnerabilities-table.svelte';
 	import { toast } from 'svelte-sonner';
@@ -16,6 +16,7 @@
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { hasPermission } from '$lib/utils/auth';
 	import { mapVulnerabilityPage, mapVulnerabilityRequest } from '$lib/utils/vulnerability';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 
@@ -26,7 +27,11 @@
 	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.vulnerabilityRequestOptions));
 	let isLoading = $state({ refreshing: false, scanningAll: false });
 	let scanProgress = $state({ current: 0, total: 0 });
-	let activeTab = $state('vulnerabilities');
+	const urlTab = useUrlTab({
+		validTabs: () => ['vulnerabilities', 'ignored'],
+		defaultTab: () => 'vulnerabilities'
+	});
+	const activeTab = $derived(urlTab.value);
 	let scanPollTimeout: ReturnType<typeof setTimeout> | null = null;
 	// Set once on destroy so an in-flight poll tick can't re-arm a timer on a dead component.
 	let destroyed = false;
@@ -177,11 +182,17 @@
 	}
 
 	function handleTabChange(value: string) {
-		activeTab = value;
+		urlTab.select(value);
 		if (value === 'ignored' && ignoredVulnerabilities.data.length === 0) {
-			loadIgnoredVulnerabilities();
+			void loadIgnoredVulnerabilities();
 		}
 	}
+
+	onMount(() => {
+		if (activeTab === 'ignored' && ignoredVulnerabilities.data.length === 0) {
+			void loadIgnoredVulnerabilities();
+		}
+	});
 
 	useEnvironmentRefresh(refreshAll);
 

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -38,6 +38,7 @@
 	import { toGitCommitUrl } from '$lib/utils/navigation';
 	import { toSafeHref } from '$lib/utils/navigation';
 	import { PersistedState } from 'runed';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 	import ComposeFileEditorPanel from '$lib/components/compose-file-editor-panel.svelte';
 	import EditableName from '../components/EditableName.svelte';
 	import ProjectFileTreePanel from '../components/ProjectFileTreePanel.svelte';
@@ -268,7 +269,8 @@
 
 	let autoScrollStackLogs = $state(true);
 
-	let selectedTab = $state<'services' | 'compose' | 'logs'>('compose');
+	type ProjectTab = 'services' | 'compose' | 'logs';
+	let selectedTab = $state<ProjectTab>('compose');
 	let composeOpen = $state(true);
 	let envOpen = $state(true);
 	let overrideOpen = $state(false);
@@ -439,6 +441,12 @@
 
 	let prefs: PersistedState<ComposeUIPrefs> | null = null;
 	let lastPrefsProjectId = $state<string | null>(null);
+	const urlTab = useUrlTab<ProjectTab>({
+		validTabs: () => tabItems.map((tab) => tab.value as ProjectTab),
+		defaultTab: () => selectedTab,
+		ready: () => lastPrefsProjectId === project?.id
+	});
+	const activeTab = $derived(urlTab.value);
 
 	function ensureIncludeFileUiState(relativePath: string) {
 		if (includeFilesPanelStates[relativePath] === undefined) {
@@ -1307,9 +1315,10 @@
 		{backUrl}
 		backLabel={m.common_back()}
 		{tabItems}
-		{selectedTab}
+		selectedTab={activeTab}
 		onTabChange={(value: string) => {
-			selectedTab = value as 'services' | 'compose' | 'logs';
+			selectedTab = value as ProjectTab;
+			urlTab.select(value);
 			persistPrefs();
 		}}
 	>

--- a/frontend/src/routes/(app)/settings/authentication/+page.svelte
+++ b/frontend/src/routes/(app)/settings/authentication/+page.svelte
@@ -30,10 +30,10 @@
 	import { untrack } from 'svelte';
 	import IfPermitted from '$lib/components/if-permitted.svelte';
 	import { mergeProps } from 'bits-ui';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data }: PageProps = $props();
 	type AuthenticationTab = 'settings' | 'federated';
-	let activeTab: AuthenticationTab = $state(untrack(() => (data.activeAuthTab === 'federated' ? 'federated' : 'settings')));
 	const formState = getContext('settingsFormState') as
 		| {
 				hasChanges: boolean;
@@ -56,10 +56,11 @@
 				}
 			] satisfies TabItem[]
 	);
-
-	function handleAuthenticationTabChange(value: string) {
-		activeTab = value === 'federated' ? 'federated' : 'settings';
-	}
+	const urlTab = useUrlTab<AuthenticationTab>({
+		validTabs: () => authenticationTabItems.map((tab) => tab.value as AuthenticationTab),
+		defaultTab: () => 'settings'
+	});
+	const activeTab = $derived(urlTab.value);
 
 	// OIDC role mappings — co-located with the OIDC settings so admins
 	// configure the groups claim and the mappings that read it in one place.
@@ -319,7 +320,7 @@
 >
 	{#snippet mainContent()}
 		<Tabs.Root value={activeTab}>
-			<TabBar items={authenticationTabItems} value={activeTab} onValueChange={handleAuthenticationTabChange} />
+			<TabBar items={authenticationTabItems} value={activeTab} onValueChange={urlTab.select} />
 
 			<Tabs.Content value="settings" class="mt-6">
 				<fieldset disabled={isReadOnly} class="relative space-y-8">

--- a/frontend/src/routes/(app)/settings/authentication/+page.ts
+++ b/frontend/src/routes/(app)/settings/authentication/+page.ts
@@ -7,10 +7,9 @@ import type { SearchPaginationSortRequest } from '$lib/types/shared';
 import { resolveInitialTableRequest } from '$lib/utils/tables';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ parent, url }) => {
+export const load: PageLoad = async ({ parent }) => {
 	const parentData = await parent();
 	const { queryClient } = parentData;
-	const activeAuthTab = url.searchParams.get('tab') === 'federated' ? 'federated' : 'settings';
 	const federatedCredentialRequestOptions = resolveInitialTableRequest('arcane-federated-credentials-table', {
 		pagination: {
 			page: 1,
@@ -50,7 +49,6 @@ export const load: PageLoad = async ({ parent, url }) => {
 
 	return {
 		...parentData,
-		activeAuthTab,
 		oidcMappings: mappings,
 		federatedCredentials,
 		federatedCredentialRequestOptions,

--- a/frontend/src/routes/(app)/settings/notifications/+page.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/+page.svelte
@@ -7,6 +7,7 @@
 	import { SettingsPageLayout } from '$lib/layouts';
 	import settingsStore from '$lib/stores/config-store';
 	import { m } from '$lib/paraglide/messages';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 	import { notificationService } from '$lib/services/notification-service';
 	import type { NotificationSettings } from '$lib/types/notifications';
 	import {
@@ -53,7 +54,11 @@
 	let isTesting = $state(false);
 	let showUnsavedDialog = $state(false);
 	let pendingTestAction: (() => Promise<void>) | null = $state(null);
-	let providerTab = $state<NotificationProviderKey>('email');
+	const urlTab = useUrlTab<NotificationProviderKey>({
+		validTabs: () => NOTIFICATION_PROVIDER_KEYS,
+		defaultTab: () => 'email'
+	});
+	const providerTab = $derived(urlTab.value);
 
 	const isReadOnly = $derived.by(() => $settingsStore.uiConfigDisabled);
 
@@ -427,7 +432,7 @@
 >
 	{#snippet mainContent()}
 		<fieldset disabled={isReadOnly} class="relative w-full min-w-0">
-			<Tabs.Root bind:value={providerTab} class="flex min-h-0 w-full min-w-0 flex-col">
+			<Tabs.Root value={providerTab} onValueChange={urlTab.select} class="flex min-h-0 w-full min-w-0 flex-col">
 				<Tabs.List class="scrollbar-hide flex w-full max-w-full justify-start gap-4 overflow-x-auto">
 					{#each NOTIFICATION_PROVIDER_KEYS as provider (provider)}
 						<Tabs.Trigger value={provider} class="shrink-0">

--- a/frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/services/[serviceId]/+page.svelte
@@ -52,11 +52,11 @@
 	} from '$lib/utils/docker';
 	import { hasPermission } from '$lib/utils/auth';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 	let service = $derived(data?.service as SwarmServiceInspect);
 
-	let userSelectedTab = $state<string>('overview');
 	let userScaleReplicas = $state<number | null>(null);
 	let userScaleReplicasServiceId = $state<string | null>(null);
 	let isLoading = $state({ update: false, rollback: false, remove: false, scale: false });
@@ -182,13 +182,14 @@
 		...(hasMounts ? [{ value: 'storage', label: m.containers_nav_storage(), icon: VolumesIcon }] : [])
 	]);
 
-	const selectedTab = $derived.by(() => {
-		if (tabItems.some((tab) => tab.value === userSelectedTab)) return userSelectedTab;
-		return tabItems[0]?.value ?? 'overview';
+	const urlTab = useUrlTab({
+		validTabs: () => tabItems.map((tab) => tab.value),
+		defaultTab: () => 'overview'
 	});
+	const selectedTab = $derived(urlTab.value);
 
 	function onTabChange(value: string) {
-		userSelectedTab = value;
+		urlTab.select(value);
 	}
 
 	function onScaleReplicasInput(event: Event) {

--- a/frontend/src/routes/(app)/swarm/stacks/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/stacks/[name]/+page.svelte
@@ -21,6 +21,7 @@
 	import SwarmServicesTable from '../../services/services-table.svelte';
 	import SwarmTasksTable from '../../tasks/tasks-table.svelte';
 	import type { SwarmStackSource } from '$lib/types/swarm';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 
@@ -65,9 +66,6 @@
 	let servicesRequestOptions = $state(untrack(() => data.servicesRequestOptions));
 	let tasksRequestOptions = $state(untrack(() => data.tasksRequestOptions));
 	type StackTab = 'services' | 'tasks' | 'source';
-	let selectedTab = $state<StackTab>(
-		untrack(() => ((data.stack?.services ?? 0) > 0 ? 'services' : data.sourceState !== 'forbidden' ? 'source' : 'services'))
-	);
 	let isLoading = $state({ refresh: false, remove: false });
 
 	const stackName = $derived(stack?.name ?? data.stackName);
@@ -78,6 +76,11 @@
 		...(hasLiveStack ? [{ value: 'tasks', label: m.swarm_tasks_title(), icon: JobsIcon }] : []),
 		...(canViewSource ? [{ value: 'source', label: 'Source', icon: FileTextIcon }] : [])
 	]);
+	const urlTab = useUrlTab<StackTab>({
+		validTabs: () => tabItems.map((tab) => tab.value as StackTab),
+		defaultTab: () => (hasLiveStack ? 'services' : canViewSource ? 'source' : 'services')
+	});
+	const selectedTab = $derived(urlTab.value);
 	const totalServices = $derived(services?.pagination?.totalItems ?? services?.data?.length ?? 0);
 	const totalTasks = $derived(tasks?.pagination?.totalItems ?? tasks?.data?.length ?? 0);
 	const stackSubtitle = $derived(
@@ -154,13 +157,6 @@
 
 	onMount(() => {
 		void refreshSource();
-	});
-
-	$effect(() => {
-		const validTabs = tabItems.map((item) => item.value as StackTab);
-		if (validTabs.length > 0 && !validTabs.includes(selectedTab) && validTabs[0]) {
-			selectedTab = validTabs[0];
-		}
 	});
 
 	function handleDelete() {
@@ -242,7 +238,7 @@
 
 			<Tabs.Root value={selectedTab} class="flex min-h-0 flex-1 flex-col">
 				<div class="w-fit pb-3">
-					<TabBar items={tabItems} value={selectedTab} onValueChange={(value) => (selectedTab = value as StackTab)} />
+					<TabBar items={tabItems} value={selectedTab} onValueChange={urlTab.select} />
 				</div>
 
 				<Tabs.Content value="services" class="min-h-0 flex-1">

--- a/frontend/src/routes/(app)/updates/+page.svelte
+++ b/frontend/src/routes/(app)/updates/+page.svelte
@@ -19,6 +19,7 @@
 	import { ContainersIcon, ProjectsIcon, UpdateIcon } from '$lib/icons';
 	import { toast } from 'svelte-sonner';
 	import { ensureStandaloneContainerUpdatesFilter, ensureUpdatesFilter } from '$lib/utils/docker';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 
@@ -58,13 +59,6 @@
 	let projectSnapshot = $state<{ envId: string; value: Paginated<Project> } | null>(null);
 	let containerRequestOptions = $state(untrack(() => data.containerRequestOptions as ContainerListRequestOptions));
 	let projectRequestOptions = $state(untrack(() => data.projectRequestOptions as SearchPaginationSortRequest));
-	let activeTab = $state<'containers' | 'projects'>(
-		untrack(() =>
-			(data.containers.pagination?.totalItems ?? 0) > 0 || (data.projects.pagination?.totalItems ?? 0) === 0
-				? 'containers'
-				: 'projects'
-		)
-	);
 	const envId = $derived(environmentStore.selected?.id || '0');
 
 	const containersQuery = createQuery(() => ({
@@ -146,13 +140,16 @@
 			icon: ProjectsIcon
 		}
 	]);
-	const effectiveTab = $derived(
-		activeTab === 'containers' && containerCount === 0 && projectCount > 0
-			? 'projects'
-			: activeTab === 'projects' && projectCount === 0 && containerCount > 0
-				? 'containers'
-				: activeTab
-	);
+	type UpdateTab = 'containers' | 'projects';
+	const urlTab = useUrlTab<UpdateTab>({
+		validTabs: () => {
+			if (containerCount === 0 && projectCount > 0) return ['projects'];
+			if (projectCount === 0 && containerCount > 0) return ['containers'];
+			return ['containers', 'projects'];
+		},
+		defaultTab: () => (containerCount > 0 || projectCount === 0 ? 'containers' : 'projects')
+	});
+	const effectiveTab = $derived(urlTab.value);
 
 	async function refresh() {
 		containerSnapshot = null;
@@ -164,7 +161,7 @@
 	}
 
 	function handleTabChange(value: string) {
-		activeTab = value === 'projects' ? 'projects' : 'containers';
+		urlTab.select(value);
 	}
 
 	const actionButtons: ActionButton[] = $derived([

--- a/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
+++ b/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
@@ -22,6 +22,7 @@
 	import { activityToastOptions, extractActivityId } from '$lib/utils/activity-toast';
 	import PropertyItem from '$lib/components/property-item.svelte';
 	import KeyValueGridCard from '$lib/components/key-value-grid-card.svelte';
+	import { useUrlTab } from '$lib/hooks/use-url-tab.svelte';
 
 	let { data } = $props();
 	let volume = $state(untrack(() => data.volume));
@@ -36,13 +37,16 @@
 	let isLoading = $state({ remove: false });
 	const createdDate = $derived(volume.createdAt ? formatDateTimeShort(volume.createdAt) : m.common_unknown());
 
-	let selectedTab = $state('overview');
-
 	const tabItems = $derived([
 		{ value: 'overview', label: m.common_overview() },
 		{ value: 'browser', label: m.volumes_nav_browser() },
 		{ value: 'backups', label: m.volumes_nav_backups() }
 	]);
+	const urlTab = useUrlTab({
+		validTabs: () => tabItems.map((tab) => tab.value),
+		defaultTab: () => 'overview'
+	});
+	const selectedTab = $derived(urlTab.value);
 
 	async function handleRemoveVolumeConfirm(volumeName: string) {
 		const safeName = volumeName?.trim() || m.common_unknown();
@@ -88,7 +92,7 @@
 	);
 
 	function onTabChange(value: string) {
-		selectedTab = value;
+		urlTab.select(value);
 	}
 </script>
 

--- a/tests/spec/builds.spec.ts
+++ b/tests/spec/builds.spec.ts
@@ -148,6 +148,22 @@ async function mockDepotConfiguredSettings(page: Page) {
 }
 
 test.describe('Build workspace provider flows', () => {
+	test('persists the selected primary tab in the URL', async ({ page }) => {
+		await navigateToBuildWorkspace(page);
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('build');
+
+		const historyTab = page.getByRole('tab', { name: 'Build History', exact: true });
+		await historyTab.click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('history');
+		await expect(historyTab).toHaveAttribute('data-state', 'active');
+
+		await page.reload();
+		await expect(page.getByRole('tab', { name: 'Build History', exact: true })).toHaveAttribute(
+			'data-state',
+			'active'
+		);
+	});
+
 	test('submits remote git build context from the dedicated context mode', async ({ page }) => {
 		await navigateToBuildWorkspace(page);
 		await switchContextMode(page, 'Remote Git');

--- a/tests/spec/containers.spec.ts
+++ b/tests/spec/containers.spec.ts
@@ -40,7 +40,6 @@ test.describe('Containers Page', () => {
 		await navigateToContainers(page);
 		await expect(page.locator('table')).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Name' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'ID' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Image', exact: true })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'State' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Created' })).toBeVisible();

--- a/tests/spec/environment-settings.spec.ts
+++ b/tests/spec/environment-settings.spec.ts
@@ -79,6 +79,48 @@ async function selectSettingOption(page: Page, trigger: Locator, optionText: str
 test.describe('Environment Settings UI', () => {
 	test.describe.configure({ mode: 'serial' });
 
+	test('should keep primary tabs selectable and restore them from the URL', async ({ page }) => {
+		await page.goto('/settings');
+		await page.waitForLoadState('load');
+
+		const jobScheduleCategory = page
+			.getByRole('button')
+			.filter({ hasText: 'Job Schedule' })
+			.first();
+		await expect(jobScheduleCategory).toBeVisible();
+		await jobScheduleCategory.click();
+
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('jobs');
+		await expect(page.getByRole('tab', { name: 'Job Schedules', exact: true })).toHaveAttribute(
+			'data-state',
+			'active'
+		);
+
+		const generalTab = page.getByRole('tab', { name: 'General', exact: true });
+		await generalTab.click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('general');
+		await expect(generalTab).toHaveAttribute('data-state', 'active');
+
+		const dockerTab = page.getByRole('tab', { name: 'Docker Settings', exact: true });
+		await dockerTab.click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('docker');
+		await page.reload();
+		await expect(dockerTab).toHaveAttribute('data-state', 'active');
+
+		await page.goBack();
+		await expect(page).toHaveURL(/\/settings$/);
+
+		await page.goto(`/environments/${LOCAL_ENV_ID}?source=e2e&tab=invalid#tab-state`);
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('general');
+		const canonicalUrl = new URL(page.url());
+		expect(canonicalUrl.searchParams.get('source')).toBe('e2e');
+		expect(canonicalUrl.hash).toBe('#tab-state');
+		await expect(page.getByRole('tab', { name: 'General', exact: true })).toHaveAttribute(
+			'data-state',
+			'active'
+		);
+	});
+
 	test('should update and save environment details', async ({ page }) => {
 		test.setTimeout(120_000); // 120 seconds timeout for this lengthy UI workflow
 		const envName = `settings-ui-${Date.now().toString().slice(-5)}`;
@@ -87,7 +129,7 @@ test.describe('Environment Settings UI', () => {
 		try {
 			await createDirectEnvironmentViaUI(page, envName);
 			await page.getByRole('button', { name: envName, exact: true }).click();
-			await expect(page).toHaveURL(/\/environments\/[^/]+$/);
+			await expect(page).toHaveURL(/\/environments\/[^/?]+\?tab=general$/);
 
 			const environmentId = new URL(page.url()).pathname.split('/').pop()!;
 			const nameInput = page.locator('#env-name');

--- a/tests/spec/environment-switch-isolation.spec.ts
+++ b/tests/spec/environment-switch-isolation.spec.ts
@@ -251,7 +251,7 @@ test.describe('Environment switch isolation', () => {
 			document.body.append(link);
 		});
 		await page.locator('#same-route-navigation').click();
-		await expect(page).toHaveURL('/containers/route-b');
+		await expect(page).toHaveURL('/containers/route-b?tab=overview');
 		await expect(page.getByRole('heading', { name: 'Route B Container' })).toBeVisible();
 		await expect(page.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
 			'aria-selected',
@@ -261,7 +261,7 @@ test.describe('Environment switch isolation', () => {
 		await page.getByRole('button', { name: 'Redeploy', exact: true }).click();
 		const dialog = page.getByRole('dialog');
 		await dialog.getByRole('button', { name: 'Redeploy', exact: true }).click();
-		await expect(page).toHaveURL('/containers/route-redeployed');
+		await expect(page).toHaveURL('/containers/route-redeployed?tab=overview');
 		await expect(page.getByRole('heading', { name: 'Redeployed Container' })).toBeVisible();
 	});
 });

--- a/tests/spec/images.spec.ts
+++ b/tests/spec/images.spec.ts
@@ -60,6 +60,23 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Images Page', () => {
+	test('loads ignored vulnerabilities from a direct tab URL', async ({ page }) => {
+		const ignoredResponse = page.waitForResponse((response) => {
+			const request = response.request();
+			return (
+				request.method() === 'GET' &&
+				new URL(response.url()).pathname.endsWith('/vulnerabilities/ignored')
+			);
+		});
+
+		await page.goto('/images/vulnerabilities?tab=ignored');
+		const response = await ignoredResponse;
+		expect(response.ok()).toBeTruthy();
+		await expect(
+			page.getByRole('tab', { name: 'Ignored Vulnerabilities', exact: true })
+		).toHaveAttribute('data-state', 'active');
+	});
+
 	test('should display the images page title and description', async ({ page }) => {
 		await navigateToImages(page);
 

--- a/tests/spec/settings-notifications.spec.ts
+++ b/tests/spec/settings-notifications.spec.ts
@@ -92,6 +92,21 @@ test.describe('Notification settings', () => {
 		};
 	};
 
+	test('should persist the selected provider tab in the URL', async ({ page }) => {
+		await setupNotificationTest(page, 'discord');
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('email');
+
+		await openProviderTab(page, 'Discord');
+		await expect.poll(() => new URL(page.url()).searchParams.get('tab')).toBe('discord');
+
+		await page.reload();
+		await expect(page.getByRole('tab', { name: 'Discord' })).toHaveAttribute(
+			'data-state',
+			'active'
+		);
+		await expect(page.locator('h3').filter({ hasText: 'Discord' }).first()).toBeVisible();
+	});
+
 	test('should allow testing email notifications without state_unsafe_mutation errors', async ({
 		page
 	}) => {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3248

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds URL-backed tab selection across app pages. The main changes are:

- New shared `useUrlTab` hook for reading and writing the `tab` query parameter.
- Page tab state moved from local state to URL state across containers, images, settings, swarm, updates, volumes, projects, and templates.
- Tests added or updated for tab persistence, reload behavior, and direct tab URLs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Produced pre-exhaustion proofs and corresponding artifacts for the tab-routing run, including env, run, devserver, script-create logs, and the validation script.
- An attempt was made to collect a debug screenshot, but inspection of the image input could not be performed, and the run did not reach the before/after UI state.
- Identified remaining work to rerun with sufficient memory and Node \>= 26, or narrow the startup surface, so that valid-tab and invalid-tab before/after artifacts can be captured.

<a href="https://app.greptile.com/trex/runs/14169433/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: tab routing for all pages can cuase..."](https://github.com/getarcaneapp/arcane/commit/87d91ae0cb5fc8610cc69ac103bc36c304defe9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43678493)</sub>

<!-- /greptile_comment -->