### PR TITLE
perf: parallelize root data loading

### DIFF
--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -34,32 +34,28 @@ const queryClient = new QueryClient({
 let authenticatedUserId: string | null | undefined;
 
 export const load = async () => {
-	// Step 1: Check authentication first
-	let user = await userService.getCurrentUser().catch(() => null);
+	const versionInformationRequest = versionService.getVersionInformation();
+	const autoLoginConfigRequest = browser
+		? queryClient.fetchQuery({
+				queryKey: queryKeys.auth.autoLoginConfig(),
+				queryFn: () => authService.getAutoLoginConfig()
+			})
+		: Promise.resolve(null);
+	let [user, autoLoginConfig] = await Promise.all([userService.getCurrentUser().catch(() => null), autoLoginConfigRequest]);
 
-	// Step 1.5: Check auto-login config (and attempt auto-login if enabled)
-	if (browser) {
-		const autoLoginConfig = await queryClient.fetchQuery({
-			queryKey: queryKeys.auth.autoLoginConfig(),
-			queryFn: () => authService.getAutoLoginConfig()
-		});
-
-		if (autoLoginConfig) {
-			if (autoLoginConfig.enabled) {
-				settingsStore.autoLoginEnabled.set(true);
-				settingsStore.autoLoginEnabled.clearDisabledCache();
-				if (!user) {
-					// Attempt auto-login using server-configured credentials
-					user = await queryClient.fetchQuery({
-						queryKey: queryKeys.auth.autoLoginAttempt(),
-						queryFn: () => authService.attemptAutoLogin()
-					});
-				}
-			} else {
-				settingsStore.autoLoginEnabled.set(false);
-				// Cache that auto-login is disabled to avoid checking on every page load
-				settingsStore.autoLoginEnabled.cacheDisabled();
+	if (autoLoginConfig) {
+		if (autoLoginConfig.enabled) {
+			settingsStore.autoLoginEnabled.set(true);
+			settingsStore.autoLoginEnabled.clearDisabledCache();
+			if (!user) {
+				user = await queryClient.fetchQuery({
+					queryKey: queryKeys.auth.autoLoginAttempt(),
+					queryFn: () => authService.attemptAutoLogin()
+				});
 			}
+		} else {
+			settingsStore.autoLoginEnabled.set(false);
+			settingsStore.autoLoginEnabled.cacheDisabled();
 		}
 	}
 
@@ -69,7 +65,6 @@ export const load = async () => {
 	}
 	authenticatedUserId = nextAuthenticatedUserId;
 
-	// Step 2: Only fetch authenticated data if user is logged in
 	let settings = null;
 	let swarmEnabled = false;
 	let permissionsManifest: PermissionsManifest | null = null;
@@ -83,19 +78,19 @@ export const load = async () => {
 			}
 		};
 
-		const environments = await tryCatch(environmentManagementService.getEnvironments(environmentRequestOptions));
+		const environmentsRequest = tryCatch(environmentManagementService.getEnvironments(environmentRequestOptions));
+		const permissionsManifestRequest = roleService.getPermissionsManifest().catch((): PermissionsManifest | null => null);
+		const environments = await environmentsRequest;
 		if (!environments.error) {
 			await environmentStore.initialize(environments.data.data);
 		} else {
 			await environmentStore.initialize([]);
 		}
 
-		// Fetch settings after environment store is initialized
-		// Settings service depends on environmentStore.getCurrentEnvironmentId()
 		const [loadedSettings, loadedSwarmStatus, loadedPermissionsManifest] = await Promise.all([
 			settingsService.getSettings().catch(() => null),
 			swarmService.getSwarmStatus().catch(() => null),
-			roleService.getPermissionsManifest().catch((): PermissionsManifest | null => null)
+			permissionsManifestRequest
 		]);
 		settings = loadedSettings;
 		swarmEnabled = loadedSwarmStatus?.enabled === true;
@@ -109,7 +104,6 @@ export const load = async () => {
 		settings = await settingsService.getPublicSettings().catch(() => null);
 	}
 
-	// Step 3: Update stores with fetched data (always, even if null)
 	if (user) {
 		await userStore.setUser(user);
 	} else {
@@ -120,7 +114,6 @@ export const load = async () => {
 		settingsStore.set(settings);
 	}
 
-	// Step 4: Fetch version information (independent, works for all users)
 	let versionInformation: AppVersionInformation = {
 		currentVersion: versionService.getCurrentVersion(),
 		displayVersion: versionService.getCurrentVersion(),
@@ -134,7 +127,7 @@ export const load = async () => {
 	};
 
 	try {
-		const info = await versionService.getVersionInformation();
+		const info = await versionInformationRequest;
 		versionInformation = {
 			currentVersion: info.currentVersion,
 			currentTag: info.currentTag,

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
 		: [['line'], ['html', { open: 'never', outputFolder: '.report' }]],
 	use: {
 		baseURL,
+		serviceWorkers: 'block',
 		trace: 'on-first-retry',
 		video: 'retain-on-failure'
 	},

--- a/tests/spec/activity-center.spec.ts
+++ b/tests/spec/activity-center.spec.ts
@@ -451,7 +451,7 @@ test.describe('Activity Center', () => {
 		await expect(activityRow(activityCenter, 'remote-network')).toBeVisible();
 		await expect(activityCenter.getByText('Local').first()).toBeVisible();
 		await expect(activityCenter.getByText('Remote Lab').first()).toBeVisible();
-		await expect(page.getByRole('button', { name: /Local/ }).first()).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Local', exact: false }).first()).toBeVisible();
 	});
 
 	test('keeps reachable activity visible when a configured environment fails', async ({ page }) => {
@@ -559,7 +559,7 @@ test.describe('Activity Center', () => {
 			await expect(activityItem).toContainText('Resource Action');
 			await expect(activityItem).toContainText('Success');
 			await expect(activityItem).toContainText('Local');
-			await expect(activityItem).toContainText(/Started by/i);
+			await expect(activityItem).toContainText('Started by');
 
 			await activityItem.click();
 			await expect(activityCenter.getByText('Output', { exact: true })).toBeVisible();

--- a/tests/spec/api-keys.spec.ts
+++ b/tests/spec/api-keys.spec.ts
@@ -44,10 +44,10 @@ test.describe('API Keys Page', () => {
 		await expect(dialog).toBeVisible();
 
 		// Try to submit without filling required name field
-		await dialog.getByRole('button', { name: /Create API Key/i }).click();
+		await dialog.getByRole('button', { name: 'Create API Key', exact: true }).click();
 
 		// Should show validation error for name field
-		await expect(dialog.getByText(/is required/i)).toBeVisible();
+		await expect(dialog.getByText('Name is required', { exact: true })).toBeVisible();
 	});
 
 	test('should create a new API key and show the key dialog', async ({ page }) => {
@@ -60,44 +60,58 @@ test.describe('API Keys Page', () => {
 		const apiKeyName = `test-key-${Date.now()}`;
 
 		// Fill in the name field
-		await createDialog.getByLabel(/Name/i).fill(apiKeyName);
+		await createDialog.getByLabel('Name', { exact: true }).fill(apiKeyName);
 
 		// Optionally fill description
-		const descInput = createDialog.getByLabel(/Description/i);
+		const descInput = createDialog.getByLabel('Description', { exact: true });
 		if (await descInput.count()) {
 			await descInput.fill('E2E test API key');
 		}
 
 		// Select at least one permission (form requires min 1)
-		await createDialog.getByPlaceholder(/Filter permissions/i).fill('containers:list');
+		await createDialog
+			.getByPlaceholder('Filter permissions…', { exact: true })
+			.fill('containers:list');
 		await createDialog.getByRole('checkbox', { name: 'Select all' }).check();
 
 		// Submit the form
-		await createDialog.getByRole('button', { name: /Create API Key/i }).click();
+		await createDialog.getByRole('button', { name: 'Create API Key', exact: true }).click();
 
 		// Should show success toast
-		await expect(page.locator('li[data-sonner-toast][data-type="success"]').first()).toBeVisible({
-			timeout: 10000
-		});
+		await expect(
+			page
+				.getByRole('region', { name: 'Notifications alt+T', exact: true })
+				.getByRole('listitem')
+				.first()
+		).toBeVisible({ timeout: 10000 });
 
 		// Should show the API key reveal dialog
 		await expect(page.getByText('API Key Created')).toBeVisible();
-		await expect(page.getByText(/Copy your API key now/i)).toBeVisible();
+		await expect(
+			page.getByText("Copy your API key now. You won't be able to see it again!", {
+				exact: true
+			})
+		).toBeVisible();
 
 		// The key should be visible in a code/snippet element
-		await expect(page.locator('code, [data-snippet]').first()).toBeVisible();
+		await expect(page.locator('code').first()).toBeVisible();
 
 		// Close the dialog
 		await page.getByRole('button', { name: 'Done' }).click();
 
 		// The new key should appear in the table
-		await expect(page.locator(`tr:has-text("${apiKeyName}")`)).toBeVisible();
+		await expect(
+			page.getByRole('row').filter({ has: page.getByText(apiKeyName, { exact: true }) })
+		).toBeVisible();
 	});
 
 	test('should open edit dialog from row actions', async ({ page }) => {
 		await navigateToApiKeys(page);
 
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
 		await expect(firstRow).toBeVisible();
 
 		const menu = await openRowActionsMenu(page, firstRow);
@@ -113,15 +127,25 @@ test.describe('API Keys Page', () => {
 	test('should open delete confirmation dialog from row actions', async ({ page }) => {
 		await navigateToApiKeys(page);
 
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
 		await expect(firstRow).toBeVisible();
 
 		const menu = await openRowActionsMenu(page, firstRow);
 		await menu.getByRole('menuitem', { name: 'Delete' }).click();
 
 		// Should show confirmation dialog
-		await expect(page.getByText(/Delete API Key/i)).toBeVisible();
-		await expect(page.getByText(/Are you sure/i)).toBeVisible();
+		const confirmationDialog = page.getByRole('dialog');
+		await expect(
+			confirmationDialog.getByRole('heading', { name: 'Delete API Key', exact: false })
+		).toBeVisible();
+		await expect(
+			confirmationDialog.getByText('Are you sure you want to delete the API key', {
+				exact: false
+			})
+		).toBeVisible();
 
 		// Cancel the deletion
 		await page.getByRole('button', { name: 'Cancel' }).click();
@@ -135,13 +159,15 @@ test.describe('API Keys Page', () => {
 		const createDialog = page.getByRole('dialog');
 
 		const apiKeyName = `delete-test-${Date.now()}`;
-		await createDialog.getByLabel(/Name/i).fill(apiKeyName);
+		await createDialog.getByLabel('Name', { exact: true }).fill(apiKeyName);
 
 		// Select at least one permission (form requires min 1)
-		await createDialog.getByPlaceholder(/Filter permissions/i).fill('containers:list');
+		await createDialog
+			.getByPlaceholder('Filter permissions…', { exact: true })
+			.fill('containers:list');
 		await createDialog.getByRole('checkbox', { name: 'Select all' }).check();
 
-		await createDialog.getByRole('button', { name: /Create API Key/i }).click();
+		await createDialog.getByRole('button', { name: 'Create API Key', exact: true }).click();
 
 		// Wait for creation success and close reveal dialog
 		await expect(page.getByText('API Key Created')).toBeVisible({ timeout: 10000 });
@@ -151,18 +177,24 @@ test.describe('API Keys Page', () => {
 		await page.waitForTimeout(1000);
 
 		// Now delete the key
-		const keyRow = page.locator(`tr:has-text("${apiKeyName}")`);
+		const keyRow = page
+			.getByRole('row')
+			.filter({ has: page.getByText(apiKeyName, { exact: true }) });
 		await expect(keyRow).toBeVisible();
 
 		const menu = await openRowActionsMenu(page, keyRow);
 		await menu.getByRole('menuitem', { name: 'Delete' }).click();
 
 		// Confirm deletion
-		await expect(page.getByText(/Delete API Key/i)).toBeVisible();
+		await expect(
+			page.getByRole('heading', { name: `Delete API Key "${apiKeyName}"?`, exact: true })
+		).toBeVisible();
 		await page.getByRole('button', { name: 'Delete' }).click();
 
 		// Should show success toast for deletion
-		await expect(page.getByText(/deleted successfully/i)).toBeVisible({ timeout: 10000 });
+		await expect(
+			page.getByText(`API key "${apiKeyName}" deleted successfully`, { exact: true })
+		).toBeVisible({ timeout: 10000 });
 
 		// Key should no longer be in the table
 		await expect(keyRow).toBeHidden();
@@ -172,7 +204,10 @@ test.describe('API Keys Page', () => {
 		await navigateToApiKeys(page);
 
 		// Select first two checkboxes
-		const checkboxes = page.locator('tbody tr input[type="checkbox"]');
+		const checkboxes = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.getByRole('checkbox');
 		const checkboxCount = await checkboxes.count();
 
 		if (checkboxCount < 2) {
@@ -184,14 +219,19 @@ test.describe('API Keys Page', () => {
 		await checkboxes.nth(1).check();
 
 		// Remove Selected button should appear
-		const removeSelectedBtn = page.getByRole('button', { name: /Remove Selected/i });
+		const removeSelectedBtn = page.getByRole('button', {
+			name: 'Remove Selected (2)',
+			exact: true
+		});
 		await expect(removeSelectedBtn).toBeVisible();
 
 		// Click it to open confirmation
 		await removeSelectedBtn.click();
 
 		// Should show bulk delete confirmation
-		await expect(page.getByText(/Delete.*API Key/i)).toBeVisible();
+		await expect(
+			page.getByRole('heading', { name: 'Delete 2 API Key(s)?', exact: true })
+		).toBeVisible();
 
 		// Cancel
 		await page.getByRole('button', { name: 'Cancel' }).click();
@@ -201,13 +241,13 @@ test.describe('API Keys Page', () => {
 		await navigateToApiKeys(page);
 
 		// Check if Active badge is visible
-		await expect(page.locator('text="Active"').first()).toBeVisible();
+		await expect(page.getByText('Active', { exact: true }).first()).toBeVisible();
 	});
 
 	test('should display "Never" for keys without expiration', async ({ page }) => {
 		await navigateToApiKeys(page);
 
 		// Test keys created without expiration should show "Never"
-		await expect(page.locator('text="Never"').first()).toBeVisible();
+		await expect(page.getByText('Never', { exact: true }).first()).toBeVisible();
 	});
 });

--- a/tests/spec/builds.spec.ts
+++ b/tests/spec/builds.spec.ts
@@ -21,7 +21,9 @@ const FIELD_LABELS = {
 async function navigateToBuildWorkspace(page: Page) {
 	await page.goto(ROUTES.page);
 	await page.waitForLoadState('load');
-	await expect(page.getByRole('heading', { level: 1, name: /Build Workspace/i })).toBeVisible();
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Build Workspace', exact: true })
+	).toBeVisible();
 }
 
 async function ensureSwitchState(toggle: Locator, desired: boolean) {
@@ -48,10 +50,7 @@ async function openAdvancedBuildOptions(page: Page) {
 		return;
 	}
 
-	await page
-		.getByRole('button', { name: /Advanced/i })
-		.first()
-		.click();
+	await page.getByRole('button', { name: 'Advanced', exact: true }).first().click();
 	await expect(dockerfileInput).toBeVisible();
 }
 
@@ -400,7 +399,7 @@ test.describe('Build workspace provider flows', () => {
 
 		await getBuildButton(page).click();
 		const localUnsupportedToast = getToastTitle(page).filter({
-			hasText: /Unsupported build options for provider local:/
+			hasText: 'Unsupported build options for provider local:'
 		});
 		await expect(localUnsupportedToast.first()).toBeVisible();
 		const localUnsupportedText = await localUnsupportedToast.first().innerText();

--- a/tests/spec/containers.spec.ts
+++ b/tests/spec/containers.spec.ts
@@ -38,7 +38,7 @@ test.describe('Containers Page', () => {
 
 	test('should display the container table with columns', async ({ page }) => {
 		await navigateToContainers(page);
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Name' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Image', exact: true })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'State' })).toBeVisible();
@@ -49,7 +49,10 @@ test.describe('Containers Page', () => {
 		test.skip(containersData.data.length === 0, 'No containers available');
 		await navigateToContainers(page);
 
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
 		const menu = await openRowActionsMenu(page, firstRow);
 		await menu.getByRole('menuitem', { name: 'Inspect', exact: true }).click();
 
@@ -70,14 +73,10 @@ test.describe('Containers Page', () => {
 
 		await page.getByRole('tab', { name: 'Logs' }).click();
 
-		await expect(page.locator('[data-testid="container-log-cpu-monitor"]')).toBeVisible();
-		await expect(page.locator('[data-testid="container-log-memory-monitor"]')).toBeVisible();
-		await expect(page.locator('[data-testid="container-log-cpu-monitor"]')).not.toContainText(
-			'N/A'
-		);
-		await expect(page.locator('[data-testid="container-log-memory-monitor"]')).not.toContainText(
-			'N/A'
-		);
+		await expect(page.getByTestId('container-log-cpu-monitor')).toBeVisible();
+		await expect(page.getByTestId('container-log-memory-monitor')).toBeVisible();
+		await expect(page.getByTestId('container-log-cpu-monitor')).not.toContainText('N/A');
+		await expect(page.getByTestId('container-log-memory-monitor')).not.toContainText('N/A');
 	});
 
 	test('should show non-live fallback monitors on the logs tab for stopped containers', async ({
@@ -91,10 +90,10 @@ test.describe('Containers Page', () => {
 
 		await page.getByRole('tab', { name: 'Logs' }).click();
 
-		await expect(page.locator('[data-testid="container-log-cpu-monitor"]')).toBeVisible();
-		await expect(page.locator('[data-testid="container-log-memory-monitor"]')).toBeVisible();
-		await expect(page.locator('[data-testid="container-log-cpu-monitor"]')).toContainText('N/A');
-		await expect(page.locator('[data-testid="container-log-memory-monitor"]')).toContainText('N/A');
+		await expect(page.getByTestId('container-log-cpu-monitor')).toBeVisible();
+		await expect(page.getByTestId('container-log-memory-monitor')).toBeVisible();
+		await expect(page.getByTestId('container-log-cpu-monitor')).toContainText('N/A');
+		await expect(page.getByTestId('container-log-memory-monitor')).toContainText('N/A');
 	});
 
 	test('should show correct actions based on container state (without changing state)', async ({
@@ -106,7 +105,10 @@ test.describe('Containers Page', () => {
 		await navigateToContainers(page);
 
 		if (running) {
-			const row = page.locator(`tr:has(a[href="/containers/${running.id}"])`);
+			const runningName = running.names[0]?.replace(/^\/+/, '') ?? running.id;
+			const row = page
+				.getByRole('row')
+				.filter({ has: page.getByRole('link', { name: runningName, exact: true }) });
 			const menu = await openRowActionsMenu(page, row);
 			await expect(menu.getByRole('menuitem', { name: 'Restart', exact: true })).toBeVisible();
 			await expect(menu.getByRole('menuitem', { name: 'Stop', exact: true })).toBeVisible();
@@ -119,7 +121,10 @@ test.describe('Containers Page', () => {
 		}
 
 		if (stopped) {
-			const row = page.locator(`tr:has(a[href="/containers/${stopped.id}"])`);
+			const stoppedName = stopped.names[0]?.replace(/^\/+/, '') ?? stopped.id;
+			const row = page
+				.getByRole('row')
+				.filter({ has: page.getByRole('link', { name: stoppedName, exact: true }) });
 			const menu = await openRowActionsMenu(page, row);
 			await expect(menu.getByRole('menuitem', { name: 'Start', exact: true })).toBeVisible();
 			await page.keyboard.press('Escape');
@@ -137,14 +142,18 @@ test.describe('Containers Page', () => {
 
 		await navigateToContainers(page);
 
-		const row = page.locator(`tr:has(a[href="/containers/${any.id}"])`);
+		const containerName = any.names[0]?.replace(/^\/+/, '') ?? any.id;
+		const row = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('link', { name: containerName, exact: true }) });
 		const menu = await openRowActionsMenu(page, row);
 		await menu.getByRole('menuitem', { name: 'Remove', exact: true }).click();
 
-		const dialog = page.locator(
-			'div[role="heading"][aria-level="2"][data-dialog-title]:has-text("Confirm Container Removal")'
-		);
+		const dialog = page.getByRole('dialog');
 		await expect(dialog).toBeVisible();
+		await expect(
+			dialog.getByRole('heading', { name: 'Confirm Container Removal', exact: true })
+		).toBeVisible();
 
 		await page.getByRole('button', { name: 'Cancel' }).click();
 		await expect(dialog).toBeHidden();
@@ -217,7 +226,7 @@ test.describe('Containers Page network IP addresses', () => {
 
 		await navigateToContainers(page);
 
-		const row = page.locator('tbody tr').filter({
+		const row = page.getByRole('row').filter({
 			has: page.getByRole('link', { name: 'wordpress', exact: true })
 		});
 

--- a/tests/spec/converter.spec.ts
+++ b/tests/spec/converter.spec.ts
@@ -13,9 +13,9 @@ const ROUTES = {
 };
 
 const SELECTORS = {
-	convertButton: (name = 'Convert to Compose') => ({ name }),
+	convertButton: (name = 'Convert to Compose') => ({ name, exact: true }),
 	textareaPlaceholder: 'docker run -d --name my-app -p 8080:80 nginx:alpine',
-	exampleButtonName: /docker run -d --name nginx/,
+	exampleButtonName: 'docker run -d --name nginx',
 	successToast: 'Docker run command converted successfully!',
 	exampleCommandExpected:
 		'docker run -d --name nginx -p 8080:80 -v nginx_data:/usr/share/nginx/html nginx:alpine',
@@ -27,15 +27,15 @@ async function openConvertFromDockerRun(page: Page) {
 
 	const createProjectGroup = page
 		.getByRole('group')
-		.filter({ has: page.getByRole('button', { name: 'Create Project' }) })
+		.filter({ has: page.locator('button[data-action="create"]') })
 		.first();
-	const dropdownTrigger = createProjectGroup.locator('button').last();
+	const dropdownTrigger = createProjectGroup.getByRole('button').last();
 	await expect(dropdownTrigger).toBeVisible();
 	await dropdownTrigger.click();
 
-	const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last();
+	const menu = page.getByRole('menu').filter({ visible: true }).last();
 	await expect(menu).toBeVisible();
-	await menu.getByRole('menuitem', { name: /Convert from Docker Run/i }).click();
+	await menu.getByRole('menuitem', { name: 'Convert from Docker Run', exact: true }).click();
 
 	await expect(page.getByRole('button', SELECTORS.convertButton())).toBeVisible();
 }

--- a/tests/spec/dashboard-system-stats.spec.ts
+++ b/tests/spec/dashboard-system-stats.spec.ts
@@ -204,7 +204,7 @@ test.describe('Dashboard system stats websocket', () => {
 			)
 			.toBe(1);
 
-		await page.getByRole('button', { name: /^Close$/ }).click();
+		await page.getByRole('button', { name: 'Close', exact: true }).click();
 		await expect(page.getByRole('dialog')).not.toBeVisible();
 
 		await page.getByRole('button', { name: 'Inspect' }).first().click();

--- a/tests/spec/edge-agent.spec.ts
+++ b/tests/spec/edge-agent.spec.ts
@@ -106,7 +106,7 @@ test.describe('Edge Agent Environment', () => {
 			await submitButton.click();
 
 			const sheetTitle = page.locator('[data-slot="sheet-title"]');
-			await expect(sheetTitle).toContainText(/Environment Created/i);
+			await expect(sheetTitle).toContainText('Environment Created');
 			await expect(
 				page.getByText('Edge agent - connects outbound to manager', { exact: true })
 			).toBeVisible();

--- a/tests/spec/environment-settings.spec.ts
+++ b/tests/spec/environment-settings.spec.ts
@@ -5,7 +5,7 @@ const LOCAL_ENV_ID = '0';
 async function openEnvironment(page: Page, environmentId: string) {
 	await page.goto(`/environments/${environmentId}`);
 	await page.waitForLoadState('load');
-	await expect(page.locator('#env-name')).toBeVisible();
+	await expect(page.getByLabel('Name', { exact: true })).toBeVisible();
 	await expect(page.getByRole('button', { name: 'Save', exact: true }).first()).toBeVisible();
 }
 
@@ -16,11 +16,14 @@ async function createDirectEnvironmentViaUI(page: Page, environmentName: string)
 	await page.getByRole('button', { name: 'Add Environment', exact: true }).click();
 	await expect(page.getByText('Create New Agent Environment')).toBeVisible();
 
-	await page.locator('input#name:visible').first().fill(environmentName);
-	await page.locator('#new-agent-api-url').fill('localhost:3552');
+	const dialog = page.getByRole('dialog');
+	await dialog.getByLabel('Name', { exact: true }).fill(environmentName);
+	await dialog.getByLabel('Agent Address', { exact: true }).fill('localhost:3552');
 	await page.getByRole('button', { name: 'Generate Agent Configuration', exact: true }).click();
 
-	await expect(page.locator('[data-slot="sheet-title"]')).toContainText(/Environment Created/i);
+	await expect(
+		page.getByRole('heading', { name: 'Environment Created Successfully', exact: true })
+	).toBeVisible();
 	await page.getByRole('button', { name: 'Done', exact: true }).click();
 	await expect(page.getByRole('button', { name: environmentName, exact: true })).toBeVisible();
 }
@@ -29,7 +32,7 @@ async function deleteEnvironmentViaUI(page: Page, environmentName: string) {
 	await page.goto('/environments');
 	await page.waitForLoadState('load');
 
-	const envRow = page.locator('tr').filter({
+	const envRow = page.getByRole('row').filter({
 		has: page.getByRole('button', { name: environmentName, exact: true })
 	});
 
@@ -38,7 +41,7 @@ async function deleteEnvironmentViaUI(page: Page, environmentName: string) {
 	}
 
 	await envRow.hover();
-	await envRow.getByRole('button', { name: /open menu/i }).click();
+	await envRow.getByRole('button', { name: 'Open menu', exact: true }).click();
 	await page.getByRole('menuitem', { name: 'Delete', exact: true }).click();
 	await page.getByRole('button', { name: 'Remove', exact: true }).click();
 	await expect(page.getByRole('button', { name: environmentName, exact: true })).toHaveCount(0);
@@ -68,10 +71,7 @@ async function saveAndWaitForPut(page: Page, expectedPath: string) {
 async function selectSettingOption(page: Page, trigger: Locator, optionText: string) {
 	await expect(trigger).toBeVisible();
 	await trigger.click();
-	const option = page
-		.locator('[data-slot="select-item"], [data-slot="command-item"]')
-		.filter({ hasText: optionText })
-		.first();
+	const option = page.getByRole('option').filter({ hasText: optionText }).first();
 	await expect(option).toBeVisible();
 	await option.click();
 }
@@ -254,7 +254,7 @@ test.describe('Environment Settings UI', () => {
 	}) => {
 		await openLocalEnvironment(page);
 
-		const dockerTab = page.getByRole('tab', { name: /Docker/i }).first();
+		const dockerTab = page.getByRole('tab', { name: 'Docker Settings', exact: true });
 		await dockerTab.click();
 		const pullPolicyTrigger = page.locator('#defaultDeployPullPolicy');
 		await expect(pullPolicyTrigger).toBeVisible();
@@ -268,19 +268,13 @@ test.describe('Environment Settings UI', () => {
 			await saveAndWaitForPut(page, `/api/environments/${LOCAL_ENV_ID}/settings`);
 
 			await page.reload();
-			await page
-				.getByRole('tab', { name: /Docker/i })
-				.first()
-				.click();
+			await page.getByRole('tab', { name: 'Docker Settings', exact: true }).click();
 			await expect(page.locator('#defaultDeployPullPolicy')).toContainText(updatedValue, {
 				timeout: 15000
 			});
 		} finally {
 			if (!page.isClosed()) {
-				await page
-					.getByRole('tab', { name: /Docker/i })
-					.first()
-					.click();
+				await page.getByRole('tab', { name: 'Docker Settings', exact: true }).click();
 				const currentValue = (
 					(await page.locator('#defaultDeployPullPolicy').textContent()) || ''
 				).trim();

--- a/tests/spec/image-updates.spec.ts
+++ b/tests/spec/image-updates.spec.ts
@@ -60,13 +60,9 @@ async function fetchImagesTotal(page: Page, updatesFilter?: string): Promise<num
 }
 
 async function getCheckUpdatesAction(page: Page): Promise<Locator> {
-	const pageHeader = page
-		.locator('main header')
-		.filter({ has: page.getByRole('heading', { name: 'Images', exact: true }) })
-		.first();
-	await expect(pageHeader).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Images', exact: true })).toBeVisible();
 
-	const directButton = pageHeader
+	const directButton = page
 		.getByRole('button', { name: 'Check Updates', exact: true })
 		.filter({ visible: true })
 		.first();
@@ -82,14 +78,14 @@ async function getCheckUpdatesAction(page: Page): Promise<Locator> {
 		return directButton;
 	}
 
-	const menuTrigger = pageHeader
+	const menuTrigger = page
 		.getByRole('button', { name: 'More actions' })
 		.filter({ visible: true })
 		.first();
 	await expect(menuTrigger).toBeVisible();
 	await menuTrigger.click();
 
-	const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last();
+	const menu = page.getByRole('menu').filter({ visible: true }).last();
 	await expect(menu).toBeVisible();
 	const menuItem = menu.getByRole('menuitem', { name: 'Check Updates', exact: true }).first();
 	await expect(menuItem).toBeVisible();
@@ -135,7 +131,9 @@ test.describe('Image Update UI - Check All Updates Button', () => {
 		expect(checkAllResponse.ok()).toBeTruthy();
 
 		// Eventually a success or completion toast should appear
-		await expect(page.locator('li[data-sonner-toast]')).toBeVisible({ timeout: 60000 });
+		await expect(
+			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
+		).toBeVisible({ timeout: 60000 });
 	});
 });
 
@@ -146,11 +144,11 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 		await navigateToImages(page);
 
 		// Wait for the table to load
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 
 		// Check that image rows exist
-		const rows = page.locator('tbody tr');
-		await expect(rows.first()).toBeVisible();
+		const rows = page.getByRole('table').getByRole('row');
+		await expect(rows.nth(1)).toBeVisible();
 	});
 
 	test('should show hover card tooltip when hovering over update status icon', async ({ page }) => {
@@ -159,14 +157,17 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 		await navigateToImages(page);
 
 		// Wait for images table
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 
 		// Find the first row's update status area (the Updates column)
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByTestId('image-update-trigger') })
+			.first();
 		await expect(firstRow).toBeVisible();
 
 		// Look for the update status icon trigger element (Tooltip.Trigger wraps a span)
-		const updateStatusTrigger = firstRow.locator('[data-testid="image-update-trigger"]').first();
+		const updateStatusTrigger = firstRow.getByTestId('image-update-trigger').first();
 		const hasTrigger = await updateStatusTrigger.isVisible().catch(() => false);
 
 		if (hasTrigger) {
@@ -177,7 +178,7 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 			await page.waitForTimeout(500);
 
 			// Check if tooltip/hover card content appeared
-			const tooltipContent = page.locator('[data-radix-popper-content-wrapper], [role="tooltip"]');
+			const tooltipContent = page.getByRole('tooltip');
 			const tooltipVisible = await tooltipContent.isVisible().catch(() => false);
 
 			// The hover card should be visible after hovering
@@ -199,20 +200,22 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 		test.skip(!testImage, 'No suitable image found for update check');
 
 		await navigateToImages(page);
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 
 		// Find the row for our test image or the first row with a valid image
-		const rows = page.locator('tbody tr');
-		const firstRow = rows.first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByTestId('image-update-trigger') })
+			.first();
 		await expect(firstRow).toBeVisible();
 
 		// Look for the update status trigger (could be a button or icon)
-		const updateTrigger = firstRow.locator('[data-testid="image-update-trigger"]').first();
+		const updateTrigger = firstRow.getByTestId('image-update-trigger').first();
 		const hasUpdateTrigger = await updateTrigger.isVisible().catch(() => false);
 
 		if (hasUpdateTrigger) {
 			// If it's a clickable button (for unchecked images), click it
-			const updateButton = updateTrigger.locator('button').first();
+			const updateButton = updateTrigger.getByRole('button').first();
 			const hasButton = await updateButton.isVisible().catch(() => false);
 
 			if (hasButton) {
@@ -220,7 +223,9 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 
 				// Wait for checking to complete (either a toast or state change)
 				await expect(async () => {
-					const toast = page.locator('li[data-sonner-toast]');
+					const toast = page
+						.getByRole('region', { name: 'Notifications alt+T', exact: true })
+						.getByRole('listitem');
 					const toastVisible = await toast.isVisible().catch(() => false);
 					expect(toastVisible).toBeTruthy();
 				}).toPass({ timeout: 30000 });
@@ -230,9 +235,7 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 				await page.waitForTimeout(500);
 
 				// Look for the recheck button in the tooltip
-				const recheckButton = page
-					.locator('[data-radix-popper-content-wrapper] button, [role="tooltip"] button')
-					.first();
+				const recheckButton = page.getByRole('tooltip').getByRole('button').first();
 				const hasRecheckButton = await recheckButton.isVisible().catch(() => false);
 
 				if (hasRecheckButton) {
@@ -240,7 +243,9 @@ test.describe('Image Update UI - Individual Image Update Check via Hover Card', 
 
 					// Wait for the check to complete
 					await expect(async () => {
-						const toast = page.locator('li[data-sonner-toast]');
+						const toast = page
+							.getByRole('region', { name: 'Notifications alt+T', exact: true })
+							.getByRole('listitem');
 						const toastVisible = await toast.isVisible().catch(() => false);
 						expect(toastVisible).toBeTruthy();
 					}).toPass({ timeout: 30000 });
@@ -310,11 +315,11 @@ test.describe('Image Update UI Integration', () => {
 		await navigateToImages(page);
 
 		// Wait for the table to load
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 
 		// Check that image rows exist
-		const rows = page.locator('tbody tr');
-		await expect(rows.first()).toBeVisible();
+		const rows = page.getByRole('table').getByRole('row');
+		await expect(rows.nth(1)).toBeVisible();
 	});
 
 	test('should display update information in image detail page', async ({ page }) => {
@@ -330,7 +335,7 @@ test.describe('Image Update UI Integration', () => {
 		await page.waitForLoadState('load');
 
 		// The detail page should load
-		await expect(page.locator('h1, h2, [data-testid="image-detail"]').first()).toBeVisible({
+		await expect(page.getByRole('heading').first()).toBeVisible({
 			timeout: 10000
 		});
 	});

--- a/tests/spec/images.spec.ts
+++ b/tests/spec/images.spec.ts
@@ -88,7 +88,7 @@ test.describe('Images Page', () => {
 		await navigateToImages(page);
 
 		await expect(page.getByText(`${imageCounts.totalImages} Total Images`)).toBeVisible();
-		await expect(page.getByText(/Total Size/i)).toBeVisible();
+		await expect(page.getByText('Total Size', { exact: true })).toBeVisible();
 	});
 
 	test('should align /images/counts with usage derived from /images list', async ({ page }) => {
@@ -106,16 +106,14 @@ test.describe('Images Page', () => {
 	test('should display the image table when images exist', async ({ page }) => {
 		await navigateToImages(page);
 
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Repository' })).toBeVisible();
 	});
 
 	test('should open the Pull Image dialog', async ({ page }) => {
 		await navigateToImages(page);
 		await page.getByRole('button', { name: 'Pull Image' }).click();
-		await expect(
-			page.locator('div[role="heading"][aria-level="2"][data-dialog-title]:has-text("Pull Image")')
-		).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Pull Image', exact: true })).toBeVisible();
 	});
 
 	test('should open the Prune Unused Images dialog', async ({ page }) => {
@@ -131,16 +129,17 @@ test.describe('Images Page', () => {
 
 		await pruneButton.click();
 		await expect(
-			page.locator(
-				'div[role="heading"][aria-level="2"][data-dialog-title]:has-text("Prune Unused Images")'
-			)
+			page.getByRole('heading', { name: 'Prune Unused Images', exact: true })
 		).toBeVisible();
 	});
 
 	test('should navigate to image details on inspect click', async ({ page }) => {
 		await navigateToImages(page);
 
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
 		const menu = await openRowActionsMenu(page, firstRow);
 		await menu.getByRole('menuitem', { name: 'Inspect' }).click();
 	});
@@ -149,14 +148,17 @@ test.describe('Images Page', () => {
 		test.skip(!realImages.length, 'No images available for pull API test');
 		await navigateToImages(page);
 
-		const firstRow = page.locator('tbody tr').first();
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
 		const menu = await openRowActionsMenu(page, firstRow);
 		await menu.getByRole('menuitem', { name: 'Pull' }).click();
 
 		await page.waitForLoadState('load');
 
 		await expect(
-			page.locator(`li[data-sonner-toast][data-type="success"] div[data-title]`)
+			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 		).toBeVisible();
 	});
 
@@ -164,25 +166,47 @@ test.describe('Images Page', () => {
 		test.skip(!realImages.length, 'No images available for remove API test');
 		await navigateToImages(page);
 
-		const deleteableImage = realImages.find((img) =>
-			img.repoTags?.[0]?.includes('ghcr.io/linuxserver/radarr')
+		const removableImage = realImages.find((image) => image.repo && image.repo !== '<none>');
+		test.skip(!removableImage, 'No removable images available');
+		const removePath = `/api/environments/0/images/${removableImage.id}`;
+
+		let removeRequestCount = 0;
+		await page.route(
+			(url) => decodeURIComponent(url.pathname) === removePath,
+			async (route) => {
+				if (route.request().method() !== 'DELETE') {
+					await route.continue();
+					return;
+				}
+
+				removeRequestCount += 1;
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						success: true,
+						data: { message: 'Image removed successfully' }
+					})
+				});
+			}
 		);
-		test.skip(!deleteableImage, 'No deletable images available');
 
-		const firstRow = await page.getByRole('row', { name: 'ghcr.io/linuxserver/radarr' });
-		const menu = await openRowActionsMenu(page, firstRow);
-		await menu.getByRole('menuitem', { name: 'Remove' }).click();
+		const imageRow = page
+			.getByRole('row')
+			.filter({
+				has: page.getByRole('link', { name: removableImage.repo, exact: true })
+			})
+			.first();
+		const menu = await openRowActionsMenu(page, imageRow);
+		await menu.getByRole('menuitem', { name: 'Remove', exact: true }).click();
+
+		const dialog = page.getByRole('dialog', { name: 'Remove image', exact: true });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
+		await expect.poll(() => removeRequestCount).toBe(1);
 
 		await expect(
-			page.locator(
-				'div[role="heading"][aria-level="2"][data-dialog-title]:has-text("Remove Image")'
-			)
-		).toBeVisible();
-
-		await page.locator('button:has-text("Remove")').click();
-
-		await expect(
-			page.locator('li[data-sonner-toast][data-type="success"] div[data-title]')
+			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 		).toBeVisible();
 	});
 
@@ -199,16 +223,17 @@ test.describe('Images Page', () => {
 
 		await pruneButton.click();
 
+		const dialog = page.getByRole('dialog');
 		await expect(
-			page.locator(
-				'div[role="heading"][aria-level="2"][data-dialog-title]:has-text("Prune Unused Images")'
-			)
+			dialog.getByRole('heading', { name: 'Prune Unused Images', exact: true })
 		).toBeVisible();
-
-		await page.locator('button:has-text("Prune Images")').click();
+		await dialog.getByRole('button', { name: 'Prune Images', exact: true }).click();
 
 		await expect(
-			page.locator(`li[data-sonner-toast][data-type="success"] div[data-title]:has-text("pruned")`)
+			page
+				.getByRole('region', { name: 'Notifications alt+T', exact: true })
+				.getByRole('listitem')
+				.filter({ hasText: 'pruned' })
 		).toBeVisible({
 			timeout: 10000
 		});

--- a/tests/spec/network.spec.ts
+++ b/tests/spec/network.spec.ts
@@ -15,7 +15,7 @@ async function createNetworkViaUI(page: Page, networkName: string) {
 	await page.getByRole('button', { name: 'Create Network' }).first().click();
 	await expect(page.getByRole('dialog')).toBeVisible();
 	await expect(page.getByRole('heading', { name: 'Create New Network' })).toBeVisible();
-	await page.locator('#network-name').fill(networkName);
+	await page.getByLabel('Network Name *').fill(networkName);
 
 	const createRequest = page.waitForResponse(
 		(response) => {
@@ -57,17 +57,23 @@ async function createNetworkViaApi(page: Page, networkName: string) {
 
 async function findNetworkRow(page: Page, networkName: string, maxRetries = 10) {
 	for (let i = 0; i < maxRetries; i++) {
-		const searchInput = page.getByPlaceholder(/Search/i).first();
+		const searchInput = page.getByPlaceholder('Search…').first();
 		if (await searchInput.isVisible().catch(() => false)) {
 			await searchInput.fill(networkName);
 		}
 
-		const row = page.locator('tbody tr', { has: page.getByText(networkName) }).first();
+		const row = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('link', { name: networkName, exact: true }) })
+			.first();
 		if (await row.isVisible().catch(() => false)) return row;
 		await page.waitForTimeout(500);
 		await navigateToNetworks(page);
 	}
-	return page.locator('tbody tr', { has: page.getByText(networkName) }).first();
+	return page
+		.getByRole('row')
+		.filter({ has: page.getByRole('link', { name: networkName, exact: true }) })
+		.first();
 }
 
 async function removeNetworkViaApi(page: Page, networkName: string) {
@@ -101,7 +107,7 @@ test.describe('Networks Page', () => {
 		try {
 			await createNetworkViaApi(page, networkName);
 			await navigateToNetworks(page);
-			await expect(page.locator('table')).toBeVisible();
+			await expect(page.getByRole('table')).toBeVisible();
 			await expect(page.getByRole('button', { name: 'Name' })).toBeVisible();
 			await expect(await findNetworkRow(page, networkName)).toBeVisible();
 		} finally {
@@ -142,7 +148,7 @@ test.describe('Networks Page', () => {
 		await page.getByRole('button', { name: 'Remove', exact: true }).click();
 		await page.getByRole('button', { name: 'Remove', exact: true }).last().click();
 		await expect(
-			page.locator('li[data-sonner-toast][data-type="success"] div[data-title]')
+			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 		).toBeVisible();
 
 		await expect
@@ -157,11 +163,10 @@ test.describe('Networks Page', () => {
 
 	test('Default networks cannot be removed on details page', async ({ page }) => {
 		await navigateToNetworks(page);
-		const bridgeRow = page
-			.locator('tbody tr', { has: page.getByText('bridge', { exact: true }) })
-			.first();
+		const bridgeLink = page.getByRole('link', { name: 'bridge', exact: true });
+		const bridgeRow = page.getByRole('row').filter({ has: bridgeLink }).first();
 		await expect(bridgeRow).toBeVisible();
-		await bridgeRow.locator('a[href*="/networks/"]').first().click();
+		await bridgeLink.click();
 		await page.waitForLoadState('load');
 
 		const removeBtn = page.getByRole('button', { name: 'Remove' });

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -3,6 +3,7 @@ import { fetchProjectCountsWithRetry, fetchProjectsWithRetry } from '../utils/fe
 import type { Activity } from '../types/activity.type';
 import { Project, ProjectStatusCounts } from 'types/project.type';
 import { TEST_COMPOSE_YAML, TEST_ENV_FILE } from '../setup/project.data';
+import { openRowActionsMenu } from '../utils/table-actions.util';
 
 const ROUTES = {
 	page: '/projects',
@@ -42,24 +43,10 @@ async function getCodeMirrorValue(editor: Locator) {
 	});
 }
 
-async function openDropdownMenu(page: Page, trigger: Locator) {
-	await expect(trigger).toBeVisible();
-	const row = trigger.locator('xpath=ancestor::tr[1]');
-	if ((await row.count()) > 0) {
-		await row.hover();
-	}
-	await trigger.click();
-
-	const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last();
-	await expect(menu).toBeVisible();
-
-	return menu;
-}
-
 async function clickProjectsPageUpdateAction(page: Page) {
 	const updateProjectsButton = page
-		.locator('main button:visible')
-		.filter({ hasText: 'Update Projects' })
+		.getByRole('button', { name: 'Update Projects', exact: true })
+		.filter({ visible: true })
 		.first();
 	await expect(updateProjectsButton).toBeVisible();
 	await updateProjectsButton.click();
@@ -185,7 +172,7 @@ async function createProjectViaUI(page: Page, projectName: string) {
 	await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
 	await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-	const visibleEditors = page.locator('.cm-editor:visible');
+	const visibleEditors = page.locator('.cm-editor').filter({ visible: true });
 	const composeEditor = visibleEditors.first();
 	const envEditor = visibleEditors.nth(1);
 	await expect(composeEditor).toBeVisible();
@@ -199,9 +186,7 @@ async function createProjectViaUI(page: Page, projectName: string) {
 		})
 		.toBe(TEST_COMPOSE_YAML.trimEnd());
 
-	const createButton = page.locator('button[data-slot="arcane-button"]', {
-		hasText: 'Create Project'
-	});
+	const createButton = page.locator('button[data-action="create"]');
 	await expect(createButton).toBeEnabled();
 	const createResponsePromise = page.waitForResponse(
 		(response) =>
@@ -249,19 +234,20 @@ async function destroyProjectByNameViaUI(page: Page, projectName: string) {
 		await searchInput.fill(projectName);
 	}
 
-	const row = page.locator('tbody tr').filter({ hasText: projectName }).first();
+	const projectLink = page.getByRole('link', { name: projectName, exact: true });
+	const row = page.getByRole('row').filter({ has: projectLink }).first();
 	if (!(await row.isVisible().catch(() => false))) {
 		return;
 	}
 
-	const menu = await openDropdownMenu(page, row.getByRole('button', { name: 'Open menu' }));
+	const menu = await openRowActionsMenu(page, row);
 	await menu.getByRole('menuitem', { name: 'Destroy', exact: true }).click();
 
 	const dialog = page.getByRole('dialog');
 	await expect(dialog).toBeVisible();
 	await dialog.getByRole('button', { name: 'Destroy', exact: true }).click();
 
-	await expect(page.locator('tbody tr').filter({ hasText: projectName })).toHaveCount(0, {
+	await expect(page.getByRole('row').filter({ has: projectLink })).toHaveCount(0, {
 		timeout: 15000
 	});
 }
@@ -329,7 +315,7 @@ test.describe('Projects Page', () => {
 	});
 
 	test('should display projects list', async ({ page }) => {
-		await expect(page.locator('table')).toBeVisible();
+		await expect(page.getByRole('table')).toBeVisible();
 	});
 
 	test('should display the updates column', async ({ page }) => {
@@ -340,8 +326,11 @@ test.describe('Projects Page', () => {
 		test.skip(!realProjects.length, 'No projects available for actions menu test');
 
 		await page.waitForLoadState('load');
-		const firstRow = page.locator('tbody tr').first();
-		const menu = await openDropdownMenu(page, firstRow.getByRole('button', { name: 'Open menu' }));
+		const firstRow = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.first();
+		const menu = await openRowActionsMenu(page, firstRow);
 
 		await expect(menu.getByRole('menuitem', { name: 'Edit' })).toBeVisible();
 		// Check for at least one of the state action buttons (Up/Down/Restart)
@@ -375,15 +364,16 @@ test.describe('Projects Page', () => {
 
 			await page.goto(ROUTES.page);
 			await page.waitForLoadState('load');
-			await expect(page.locator('tbody tr').filter({ hasText: projectName })).toHaveCount(0);
+			const projectLink = page.getByRole('link', { name: projectName, exact: true });
+			await expect(page.getByRole('row').filter({ has: projectLink })).toHaveCount(0);
 
 			await page.getByLabel('Show archived').check();
 			await expect(page).toHaveURL(/archived=true/);
-			const row = page.locator('tbody tr').filter({ hasText: projectName }).first();
+			const row = page.getByRole('row').filter({ has: projectLink }).first();
 			await expect(row).toBeVisible();
 			await expect(row.getByText('Archived', { exact: true })).toBeVisible();
 
-			const menu = await openDropdownMenu(page, row.getByRole('button', { name: 'Open menu' }));
+			const menu = await openRowActionsMenu(page, row);
 			await menu.getByRole('menuitem', { name: 'Unarchive', exact: true }).click();
 			await expect(page.getByText('Project unarchived successfully.')).toBeVisible({
 				timeout: 10000
@@ -405,18 +395,12 @@ test.describe('Projects Page', () => {
 		test.skip(!realProjects.length, 'No projects available for navigation test');
 
 		await page.waitForLoadState('load');
-		// Get the first project link that points to /projects/ (not the "Git" indicator link)
-		const firstProjectLink = page
-			.locator('tbody tr')
-			.first()
-			.getByRole('link')
-			.filter({ hasText: /^(?!Git$)/ })
-			.first();
-		const projectName = await firstProjectLink.textContent();
+		const projectName = realProjects[0].name;
+		const firstProjectLink = page.getByRole('link', { name: projectName, exact: true }).first();
 
 		await firstProjectLink.click();
 		await expect(page).toHaveURL(/\/projects\/.+/);
-		await expect(page.getByRole('button', { name: new RegExp(`${projectName}`) })).toBeVisible();
+		await expect(page.getByRole('button', { name: projectName, exact: true })).toBeVisible();
 	});
 
 	test('should allow searching/filtering projects', async ({ page }) => {
@@ -470,11 +454,11 @@ test.describe('Projects Page', () => {
 		const stoppedProjects = realProjects.filter((p) => p.status === 'stopped');
 
 		if (runningProjects.length > 0) {
-			await expect(page.locator('text="Running"').first()).toBeVisible();
+			await expect(page.getByText('Running', { exact: true }).first()).toBeVisible();
 		}
 
 		if (stoppedProjects.length > 0) {
-			await expect(page.locator('text="Stopped"').first()).toBeVisible();
+			await expect(page.getByText('Stopped', { exact: true }).first()).toBeVisible();
 		}
 	});
 });
@@ -494,7 +478,7 @@ test.describe('New Compose Project Page', () => {
 	test('should preserve YAML indentation when pressing Enter in compose editor', async ({
 		page
 	}) => {
-		const composeEditor = page.locator('.cm-editor:visible').first();
+		const composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 		const composeContent = composeEditor.locator('.cm-content').first();
 
 		await expect(composeContent).toBeVisible();
@@ -510,9 +494,7 @@ test.describe('New Compose Project Page', () => {
 	});
 
 	test('should validate required fields', async ({ page }) => {
-		const createButton = page.locator('button[data-slot="arcane-button"]', {
-			hasText: 'Create Project'
-		});
+		const createButton = page.locator('button[data-action="create"]');
 		await expect(createButton).toBeDisabled();
 
 		await page.getByRole('button', { name: 'My New Project' }).click();
@@ -531,9 +513,7 @@ test.describe('New Compose Project Page', () => {
 			if (msg.type() === 'error') observedErrors.push(msg.text());
 		});
 
-		const createButton = page.locator('button[data-slot="arcane-button"]', {
-			hasText: 'Create Project'
-		});
+		const createButton = page.locator('button[data-action="create"]');
 
 		await expect(createButton).toBeVisible();
 
@@ -559,18 +539,14 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill('syntax-check-project');
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor:visible').first();
+		const composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 		await expect(composeEditor).toBeVisible();
 
 		await setCodeMirrorValue(page, composeEditor, 'services:\n\tredis:\n\t\timage: redis:latest\n');
-		await expect(
-			page.locator('button[data-slot="arcane-button"]').filter({ hasText: 'Create Project' })
-		).toHaveCount(0);
+		await expect(page.locator('button[data-action="create"]')).toHaveCount(0);
 
 		await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
-		const createButton = page
-			.locator('button[data-slot="arcane-button"]')
-			.filter({ hasText: 'Create Project' });
+		const createButton = page.locator('button[data-action="create"]');
 		await expect(createButton).toBeVisible();
 		await expect(createButton).toBeEnabled();
 	});
@@ -582,7 +558,7 @@ test.describe('New Compose Project Page', () => {
 		await page.getByRole('textbox', { name: 'My New Project' }).fill('env-check-project');
 		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const visibleEditors = page.locator('.cm-editor:visible');
+		const visibleEditors = page.locator('.cm-editor').filter({ visible: true });
 		const composeEditor = visibleEditors.first();
 		const envEditor = visibleEditors.nth(1);
 		await expect(composeEditor).toBeVisible();
@@ -590,14 +566,10 @@ test.describe('New Compose Project Page', () => {
 
 		await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
 		await setCodeMirrorValue(page, envEditor, 'NOT VALID LINE');
-		await expect(
-			page.locator('button[data-slot="arcane-button"]').filter({ hasText: 'Create Project' })
-		).toHaveCount(0);
+		await expect(page.locator('button[data-action="create"]')).toHaveCount(0);
 
 		await setCodeMirrorValue(page, envEditor, TEST_ENV_FILE);
-		const createButton = page
-			.locator('button[data-slot="arcane-button"]')
-			.filter({ hasText: 'Create Project' });
+		const createButton = page.locator('button[data-action="create"]');
 		await expect(createButton).toBeVisible();
 		await expect(createButton).toBeEnabled();
 	});
@@ -611,131 +583,137 @@ test.describe('New Compose Project Page', () => {
 		let createdProjectId: string | null = null;
 		let projectPullRequestCount = 0;
 
-		await page.getByRole('button', { name: 'My New Project' }).click();
-		await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
-		await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
+		try {
+			await page.getByRole('button', { name: 'My New Project' }).click();
+			await page.getByRole('textbox', { name: 'My New Project' }).fill(projectName);
+			await page.getByRole('textbox', { name: 'My New Project' }).press('Enter');
 
-		const composeEditor = page.locator('.cm-editor:visible').first();
-		await expect(composeEditor).toBeVisible();
-		await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
-		await expect(composeEditor).toContainText(/nginx/i);
-		await expect
-			.poll(async () => (await getCodeMirrorValue(composeEditor)).trimEnd(), {
-				message: 'Expected compose editor to contain the exact test compose fixture before creation'
-			})
-			.toBe(TEST_COMPOSE_YAML.trimEnd());
+			const composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
+			await expect(composeEditor).toBeVisible();
+			await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
+			await expect(composeEditor).toContainText('nginx');
+			await expect
+				.poll(async () => (await getCodeMirrorValue(composeEditor)).trimEnd(), {
+					message:
+						'Expected compose editor to contain the exact test compose fixture before creation'
+				})
+				.toBe(TEST_COMPOSE_YAML.trimEnd());
 
-		const envEditor = page.locator('.cm-editor:visible').nth(1);
-		await expect(envEditor).toBeVisible();
-		await setCodeMirrorValue(page, envEditor, envFile);
-		await expect(envEditor).toContainText(/nginx/i);
+			const envEditor = page.locator('.cm-editor').filter({ visible: true }).nth(1);
+			await expect(envEditor).toBeVisible();
+			await setCodeMirrorValue(page, envEditor, envFile);
+			await expect(envEditor).toContainText('nginx');
 
-		await page.route('/api/environments/*/projects', async (route) => {
-			if (route.request().method() === 'POST') {
-				const response = await route.fetch();
-				const responseBody = await response.text();
+			await page.route('/api/environments/*/projects', async (route) => {
+				if (route.request().method() === 'POST') {
+					const response = await route.fetch();
+					const responseBody = await response.text();
 
-				try {
-					const parsed = JSON.parse(responseBody);
-					createdProjectId = parsed.data?.id ?? parsed.id;
-				} catch {
-					// Keep existing createdProjectId value if parsing fails
+					try {
+						const parsed = JSON.parse(responseBody);
+						createdProjectId = parsed.data?.id ?? parsed.id;
+					} catch {
+						// Keep existing createdProjectId value if parsing fails
+					}
+
+					await route.fulfill({
+						status: response.status(),
+						headers: response.headers(),
+						body: responseBody
+					});
+				} else {
+					await route.continue();
 				}
+			});
 
-				await route.fulfill({
-					status: response.status(),
-					headers: response.headers(),
-					body: responseBody
-				});
+			const createButton = page.locator('button[data-action="create"]');
+			const createResponsePromise = page.waitForResponse(
+				(response) =>
+					response.request().method() === 'POST' &&
+					/\/api\/environments\/[^/]+\/projects$/.test(getPathname(response.url()))
+			);
+			await createButton.click();
+			await expectProjectCreateResponse(createResponsePromise);
+
+			await page.waitForURL(/\/projects\/.+/, { timeout: 10000 });
+
+			if (createdProjectId) {
+				await expect(page).toHaveURL(new RegExp(`/projects/${createdProjectId}`));
 			} else {
-				await route.continue();
+				await expect(page).toHaveURL(new RegExp(`/projects/[a-f0-9\\-]{36}`));
 			}
-		});
 
-		const createButton = page.locator('button[data-slot="arcane-button"]', {
-			hasText: 'Create Project'
-		});
-		const createResponsePromise = page.waitForResponse(
-			(response) =>
-				response.request().method() === 'POST' &&
-				/\/api\/environments\/[^/]+\/projects$/.test(getPathname(response.url()))
-		);
-		await createButton.click();
-		await expectProjectCreateResponse(createResponsePromise);
+			await expect(page.getByRole('button', { name: projectName, exact: true })).toBeVisible();
 
-		await page.waitForURL(/\/projects\/.+/, { timeout: 10000 });
+			await page.getByRole('tab', { name: 'Services 1', exact: true }).click();
+			await page.waitForLoadState('load');
 
-		if (createdProjectId) {
-			await expect(page).toHaveURL(new RegExp(`/projects/${createdProjectId}`));
-		} else {
-			await expect(page).toHaveURL(new RegExp(`/projects/[a-f0-9\\-]{36}`));
-		}
+			const serviceTable = page.getByRole('table');
+			const serviceNameWhenStopped = serviceTable.getByText('nginx', {
+				exact: true
+			});
+			const emptyServicesState = page.getByText('No services found for this project', {
+				exact: true
+			});
 
-		await expect(page.getByRole('button', { name: projectName })).toBeVisible();
+			if ((await serviceNameWhenStopped.count()) > 0) {
+				await expect(serviceNameWhenStopped.first()).toBeVisible();
+			} else {
+				await expect(emptyServicesState).toBeVisible();
+			}
 
-		await page.getByRole('tab', { name: 'Services' }).click();
-		await page.waitForLoadState('load');
+			await page.route('**/api/environments/*/projects/*/pull', async (route) => {
+				projectPullRequestCount += 1;
+				await route.continue();
+			});
 
-		const serviceTable = page.getByRole('table');
-		const serviceNameWhenStopped = serviceTable.getByText('nginx', {
-			exact: true
-		});
-		const emptyServicesState = page.getByText(/No services found for this project/i);
+			const deployButton = page
+				.getByRole('button', { name: 'Up', exact: true })
+				.filter({ visible: true })
+				.first();
+			const deployResponsePromise = page.waitForResponse(
+				(response) =>
+					response.request().method() === 'POST' &&
+					/\/api\/environments\/[^/]+\/projects\/[^/]+\/up$/.test(getPathname(response.url()))
+			);
+			await deployButton.click();
 
-		if ((await serviceNameWhenStopped.count()) > 0) {
-			await expect(serviceNameWhenStopped.first()).toBeVisible();
-		} else {
-			await expect(emptyServicesState).toBeVisible();
-		}
+			const deployResponse = await deployResponsePromise;
+			expect(deployResponse.ok()).toBe(true);
+			// Don't await deployResponse.finished() here: for a chunked NDJSON stream
+			// consumed via fetch().body, Playwright's network-layer finished() doesn't
+			// reliably resolve even after the server closes the response and the UI
+			// updates to "running" — it hangs until the test timeout. Deploy completion
+			// is verified below via the running-status poll and the activity-success check.
 
-		await page.route('**/api/environments/*/projects/*/pull', async (route) => {
-			projectPullRequestCount += 1;
-			await route.continue();
-		});
+			const projectId = createdProjectId ?? getProjectIdFromPageUrl(page.url());
+			await expect
+				.poll(async () => (await fetchProjectDetail(page, projectId))?.status, {
+					message: 'Expected project to be running after deploy',
+					timeout: 60000
+				})
+				.toBe('running');
+			await expectProjectDeployActivitySucceeded(page, projectId);
 
-		const deployButton = page
-			.getByRole('button', { name: 'Up', exact: true })
-			.filter({ hasText: 'Up' })
-			.last();
-		const deployResponsePromise = page.waitForResponse(
-			(response) =>
-				response.request().method() === 'POST' &&
-				/\/api\/environments\/[^/]+\/projects\/[^/]+\/up$/.test(getPathname(response.url()))
-		);
-		await deployButton.click();
-
-		const deployResponse = await deployResponsePromise;
-		expect(deployResponse.ok()).toBe(true);
-		// Don't await deployResponse.finished() here: for a chunked NDJSON stream
-		// consumed via fetch().body, Playwright's network-layer finished() doesn't
-		// reliably resolve even after the server closes the response and the UI
-		// updates to "running" — it hangs until the test timeout. Deploy completion
-		// is verified below via the running-status poll and the activity-success check.
-
-		const projectId = createdProjectId ?? getProjectIdFromPageUrl(page.url());
-		await expect
-			.poll(async () => (await fetchProjectDetail(page, projectId))?.status, {
-				message: 'Expected project to be running after deploy',
-				timeout: 60000
-			})
-			.toBe('running');
-		await expectProjectDeployActivitySucceeded(page, projectId);
-		await expect(page.getByRole('button', { name: 'Down', exact: true })).toBeVisible({
-			timeout: 30000
-		});
-
-		expect(projectPullRequestCount).toBe(0);
-		await page.reload();
-		await expect(page).toHaveURL(new RegExp(`/projects/${projectId}`));
-		await expect
-			.poll(async () => (await fetchProjectDetail(page, projectId))?.status, {
-				message: 'Expected project to still be running after reload',
+			expect(projectPullRequestCount).toBe(0);
+			// The activity record is committed before the streamed response reaches EOF in
+			// the browser, so polling the API can beat the detail page's local state update.
+			// Reload from the completed server state before asserting the rendered action.
+			await page.reload();
+			await expect(page).toHaveURL(new RegExp(`/projects/${projectId}`));
+			await expect
+				.poll(async () => (await fetchProjectDetail(page, projectId))?.status, {
+					message: 'Expected project to still be running after reload',
+					timeout: 30000
+				})
+				.toBe('running');
+			await expect(page.getByRole('button', { name: 'Down', exact: true })).toBeVisible({
 				timeout: 30000
-			})
-			.toBe('running');
-		await expect(page.getByRole('button', { name: 'Down', exact: true })).toBeVisible({
-			timeout: 30000
-		});
+			});
+		} finally {
+			const projectId = createdProjectId ?? getProjectIdFromPageUrl(page.url());
+			await destroyProjectByIdViaAPI(page, projectId);
+		}
 	});
 
 	test('should send selected deploy split-button options in the up request', async ({ page }) => {
@@ -760,18 +738,22 @@ test.describe('New Compose Project Page', () => {
 			});
 
 			const deployButtonGroup = page
-				.locator('[data-slot="button-group"]')
+				.getByRole('group')
 				.filter({ has: page.getByRole('button', { name: 'Up', exact: true }) })
 				.first();
 			const deployMenuTrigger = deployButtonGroup.getByRole('button', {
-				name: 'Open menu'
+				name: 'Open menu',
+				exact: true
 			});
 
 			await expect(deployMenuTrigger).toBeVisible();
 
 			// Open dropdown and select "Always" pull policy
 			await deployMenuTrigger.click();
-			const alwaysItem = page.getByRole('menuitemradio', { name: /Always/i });
+			const alwaysItem = page.getByRole('menuitemradio', {
+				name: 'Always Always pull latest',
+				exact: true
+			});
 			await expect(alwaysItem).toBeVisible();
 			await alwaysItem.click();
 			// Wait for the dropdown to fully close before reopening
@@ -780,7 +762,8 @@ test.describe('New Compose Project Page', () => {
 			// Reopen dropdown and toggle "Force recreate containers"
 			await deployMenuTrigger.click();
 			const forceRecreateItem = page.getByRole('menuitemcheckbox', {
-				name: /Force recreate containers/i
+				name: 'Force recreate containers',
+				exact: true
 			});
 			await expect(forceRecreateItem).toBeVisible();
 			await forceRecreateItem.click();
@@ -824,50 +807,58 @@ test.describe('New Compose Project Page', () => {
 
 		const projectName = `test-redeploy-timeout-${Date.now()}`;
 		let redeployRequestStartedAt: number | undefined;
+		const redeployPathPattern = /\/api\/environments\/[^/]+\/projects\/[^/]+\/redeploy$/;
 
 		try {
 			await createProjectViaUI(page, projectName);
 			await page.goto(ROUTES.page);
 			await page.waitForLoadState('load');
 
-			await page.route('**/api/environments/*/projects/*/redeploy', async (route) => {
-				if (route.request().method() !== 'POST') {
-					await route.continue();
-					return;
-				}
+			await page.route(
+				(url) => redeployPathPattern.test(url.pathname),
+				async (route) => {
+					if (route.request().method() !== 'POST') {
+						await route.continue();
+						return;
+					}
 
-				redeployRequestStartedAt = Date.now();
-				await new Promise((resolve) => setTimeout(resolve, 11_000));
-				await route.fulfill({
-					status: 200,
-					contentType: 'application/json',
-					body: JSON.stringify({
-						success: true,
-						data: {
-							message: 'Project redeployed successfully'
-						}
-					})
-				});
-			});
+					redeployRequestStartedAt = Date.now();
+					await new Promise((resolve) => setTimeout(resolve, 11_000));
+					await route.fulfill({
+						status: 200,
+						contentType: 'application/json',
+						body: JSON.stringify({
+							success: true,
+							data: {
+								message: 'Project redeployed successfully'
+							}
+						})
+					});
+				}
+			);
 
 			const searchInput = page.getByPlaceholder('Search…');
 			await expect(searchInput).toBeVisible();
-			const filteredProjectsResponse = page.waitForResponse((response) => {
-				if (response.request().method() !== 'GET') return false;
-				return (
-					/\/api\/environments\/[^/]+\/projects(?:\?|$)/.test(response.url()) &&
-					response.url().includes(`search=${projectName}`)
-				);
-			});
 			await searchInput.fill(projectName);
-			await filteredProjectsResponse;
+			await searchInput.press('Enter');
 
-			const row = page.locator('tbody tr').filter({ hasText: projectName }).first();
+			const row = page
+				.getByRole('row')
+				.filter({ has: page.getByRole('link', { name: projectName, exact: true }) })
+				.first();
 			await expect(row).toBeVisible();
-			const menu = await openDropdownMenu(page, row.getByRole('button', { name: 'Open menu' }));
-			const redeployMenuItem = menu.getByRole('menuitem', { name: 'Pull & Redeploy' });
+			const menu = await openRowActionsMenu(page, row);
+			const redeployMenuItem = menu.getByRole('menuitem', {
+				name: 'Pull & Redeploy',
+				exact: true
+			});
 			await expect(redeployMenuItem).toBeVisible();
+			const redeployRequestPromise = page.waitForRequest(
+				(request) =>
+					request.method() === 'POST' && redeployPathPattern.test(getPathname(request.url()))
+			);
 			await redeployMenuItem.click();
+			await redeployRequestPromise;
 
 			await expect
 				.poll(() => redeployRequestStartedAt, {
@@ -904,16 +895,21 @@ test.describe('New Compose Project Page', () => {
 
 test.describe('GitOps Managed Project', () => {
 	test('should navigate back to gitops when opened from the git syncs page', async ({ page }) => {
+		const gitOpsProject = realProjects.find((project) => project.gitOpsManagedBy);
+		test.skip(!gitOpsProject, 'No GitOps project links found');
+
 		await page.goto('/environments/0/gitops');
 		await page.waitForLoadState('load');
 
-		const projectLink = page.locator('tbody tr').locator('a[href^="/projects/"]').first();
-		test.skip((await projectLink.count()) === 0, 'No GitOps project links found');
+		const projectLink = page.getByRole('link', {
+			name: gitOpsProject!.name,
+			exact: true
+		});
 
 		await projectLink.click();
 		await page.waitForURL(/\/projects\/.+/, { timeout: 10000 });
 
-		const backLink = page.getByRole('link', { name: /^Back$/i }).first();
+		const backLink = page.getByRole('link', { name: 'Back', exact: true }).first();
 		await expect(backLink).toBeVisible();
 		await backLink.click();
 
@@ -929,13 +925,18 @@ test.describe('GitOps Managed Project', () => {
 		await page.waitForLoadState('load');
 
 		// Navigate to Configuration tab
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
 		// Verify the GitOps read-only alert is visible (title contains "Git" and "Read-only")
 		await expect(page.getByText('Git Read-only')).toBeVisible();
-		await expect(page.getByText(/managed by Git/i)).toBeVisible();
+		await expect(
+			page.getByRole('alert').filter({
+				hasText:
+					'This project is managed by Git. The compose file and project name cannot be edited here. Changes must be made in the connected Git repository.'
+			})
+		).toBeVisible();
 	});
 
 	test('should display Sync from Git button when GitOps managed', async ({ page }) => {
@@ -945,7 +946,7 @@ test.describe('GitOps Managed Project', () => {
 		await page.goto(`/projects/${gitOpsProject!.id}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
@@ -962,7 +963,7 @@ test.describe('GitOps Managed Project', () => {
 
 		// The commit hash should be visible somewhere on the page
 		const commitHash = gitOpsProject!.lastSyncCommit!.substring(0, 7);
-		await expect(page.getByText(new RegExp(commitHash))).toBeVisible();
+		await expect(page.getByText(commitHash)).toBeVisible();
 	});
 
 	test('should disable name editing when GitOps managed', async ({ page }) => {
@@ -984,12 +985,16 @@ test.describe('GitOps Managed Project', () => {
 		await page.goto(`/projects/${gitOpsProject!.id}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
 		await page.waitForTimeout(800);
-		const composeContent = page.locator('.cm-editor:visible').first().locator('.cm-content');
+		const composeContent = page
+			.locator('.cm-editor')
+			.filter({ visible: true })
+			.first()
+			.locator('.cm-content');
 		await expect(composeContent).toHaveAttribute('aria-readonly', 'true');
 	});
 
@@ -1002,12 +1007,13 @@ test.describe('GitOps Managed Project', () => {
 		await page.goto(`/projects/${gitOpsProject!.id}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
 		const layoutSwitch = page.getByRole('switch', {
-			name: /workspace/i
+			name: 'Toggle workspace mode',
+			exact: true
 		});
 		const projectFilesLabel = page.getByText('Project Files', { exact: true });
 		// Projects with extra files default to tree view; start from classic.
@@ -1017,7 +1023,7 @@ test.describe('GitOps Managed Project', () => {
 		}
 
 		await page.waitForTimeout(800);
-		const envEditor = page.locator('.cm-editor:visible').nth(1);
+		const envEditor = page.locator('.cm-editor').filter({ visible: true }).nth(1);
 		const marker = `ARCANE_E2E_${Date.now()}`;
 		const envContent = envEditor.locator('.cm-content');
 		const originalEnv = await getCodeMirrorValue(envEditor);
@@ -1037,7 +1043,7 @@ test.describe('GitOps Managed Project', () => {
 			await expect(envFileButton).toBeVisible();
 			await envFileButton.click();
 
-			const treeEnvEditor = page.locator('.cm-editor:visible').first();
+			const treeEnvEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 			const treeEnvContent = treeEnvEditor.locator('.cm-content');
 			await expect(treeEnvContent).not.toHaveAttribute('aria-readonly', 'true');
 			await expect(treeEnvEditor).toContainText(marker);
@@ -1056,7 +1062,7 @@ test.describe('GitOps Managed Project', () => {
 		await expect(nameButton).toBeEnabled();
 
 		// Navigate to Configuration tab
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
@@ -1076,12 +1082,17 @@ test.describe('GitOps Managed Project', () => {
 		await page.goto(`/projects/${regularProject!.id}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
 		// Verify no GitOps-related UI elements
-		await expect(page.getByText(/managed by Git\./i)).not.toBeVisible();
+		await expect(
+			page.getByText(
+				'This project is managed by Git. The compose file and project name cannot be edited here. Changes must be made in the connected Git repository.',
+				{ exact: true }
+			)
+		).not.toBeVisible();
 		await expect(page.getByRole('button', { name: 'Sync from Git' })).not.toBeVisible();
 	});
 });
@@ -1094,7 +1105,7 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${firstProject.id || firstProject.name}`);
 		await page.waitForLoadState('load');
 
-		const backLink = page.getByRole('link', { name: /^Back$/i }).first();
+		const backLink = page.getByRole('link', { name: 'Back', exact: true }).first();
 		await expect(backLink).toBeVisible();
 		await backLink.click();
 
@@ -1109,11 +1120,16 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${firstProject.id || firstProject.name}`);
 		await page.waitForLoadState('load');
 
-		await expect(page.getByRole('button', { name: firstProject.name, exact: false })).toBeVisible();
+		await expect(page.getByRole('button', { name: firstProject.name, exact: true })).toBeVisible();
 
-		await expect(page.getByRole('tab', { name: /Services/i })).toBeVisible();
-		await expect(page.getByRole('tab', { name: /Configuration|Config/i })).toBeVisible();
-		await expect(page.getByRole('tab', { name: /Logs/i })).toBeVisible();
+		await expect(
+			page.getByRole('tab', {
+				name: `Services ${firstProject.serviceCount ?? 0}`,
+				exact: true
+			})
+		).toBeVisible();
+		await expect(page.getByRole('tab', { name: 'Configuration', exact: true })).toBeVisible();
+		await expect(page.getByRole('tab', { name: 'Logs', exact: true })).toBeVisible();
 	});
 
 	test('should display tabs navigation', async ({ page }) => {
@@ -1122,9 +1138,14 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${firstProject.id || firstProject.name}`);
 		await page.waitForLoadState('load');
 
-		await expect(page.getByRole('tab', { name: /Services/i })).toBeVisible();
-		await expect(page.getByRole('tab', { name: /Configuration|Config/i })).toBeVisible();
-		await expect(page.getByRole('tab', { name: /Logs/i })).toBeVisible();
+		await expect(
+			page.getByRole('tab', {
+				name: `Services ${firstProject.serviceCount ?? 0}`,
+				exact: true
+			})
+		).toBeVisible();
+		await expect(page.getByRole('tab', { name: 'Configuration', exact: true })).toBeVisible();
+		await expect(page.getByRole('tab', { name: 'Logs', exact: true })).toBeVisible();
 	});
 
 	test('should check updates for the current project via the image batch endpoint', async ({
@@ -1179,15 +1200,24 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${projectWithServices.id || projectWithServices.name}`);
 		await page.waitForLoadState('load');
 
-		await page.getByRole('tab', { name: /Services/i }).click();
+		await page
+			.getByRole('tab', {
+				name: `Services ${projectWithServices.serviceCount ?? 0}`,
+				exact: true
+			})
+			.click();
 
-		const nginxService = page.getByRole('heading', { name: /nginx/i });
-		const emptyState = page.getByText(/No services found/i);
+		const nginxService = page.getByRole('heading', { name: 'nginx', exact: true });
+		const emptyState = page.getByText('No services found for this project', { exact: true });
 
 		if ((await nginxService.count()) > 0) {
 			await expect(nginxService.first()).toBeVisible();
 		} else {
-			const anyServiceBadge = page.locator('text=/running|stopped|unknown/i').first();
+			const anyServiceBadge = page
+				.getByText('Running', { exact: true })
+				.or(page.getByText('Stopped', { exact: true }))
+				.or(page.getByText('Unknown', { exact: true }))
+				.first();
 			if ((await anyServiceBadge.count()) > 0) {
 				await expect(anyServiceBadge).toBeVisible();
 			} else {
@@ -1203,7 +1233,7 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${firstProject.id || firstProject.name}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 
 		// The project config editor supports two layouts:
@@ -1234,7 +1264,8 @@ test.describe('Project Detail Page', () => {
 
 			// Also validate that we can switch to tree view and see the file list.
 			const layoutSwitch = page.getByRole('switch', {
-				name: /workspace/i
+				name: 'Toggle workspace mode',
+				exact: true
 			});
 			if (await layoutSwitch.count()) {
 				await layoutSwitch.click();
@@ -1261,12 +1292,13 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${regularProject!.id || regularProject!.name}`);
 		await page.waitForLoadState('load');
 
-		const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 		await configTab.click();
 		await page.waitForLoadState('load');
 
 		let layoutSwitch = page.getByRole('switch', {
-			name: /workspace/i
+			name: 'Toggle workspace mode',
+			exact: true
 		});
 		test.skip(
 			(await layoutSwitch.count()) === 0,
@@ -1283,7 +1315,10 @@ test.describe('Project Detail Page', () => {
 		await page.reload();
 		await page.waitForLoadState('load');
 
-		const restoredConfigTab = page.getByRole('tab', { name: /Configuration|Config/i });
+		const restoredConfigTab = page.getByRole('tab', {
+			name: 'Configuration',
+			exact: true
+		});
 		if ((await restoredConfigTab.getAttribute('aria-selected')) !== 'true') {
 			await restoredConfigTab.click();
 			await page.waitForLoadState('load');
@@ -1292,7 +1327,7 @@ test.describe('Project Detail Page', () => {
 		await expect(projectFilesLabel).toBeVisible();
 		await expect(page.locator('[data-tab-key="compose"][data-active="true"]')).toBeVisible();
 
-		const treeComposeEditor = page.locator('.cm-editor:visible').first();
+		const treeComposeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 		await expect(treeComposeEditor).toBeVisible();
 
 		const marker = `ARCANE_TREE_SAVE_${Date.now()}`;
@@ -1308,7 +1343,8 @@ test.describe('Project Detail Page', () => {
 		await expect(envFileButton).toBeVisible();
 
 		layoutSwitch = page.getByRole('switch', {
-			name: /workspace/i
+			name: 'Toggle workspace mode',
+			exact: true
 		});
 		await layoutSwitch.click();
 		await expect(page.getByRole('heading', { name: 'compose.yaml' })).toBeVisible();
@@ -1321,11 +1357,11 @@ test.describe('Project Detail Page', () => {
 		await createProjectViaUI(page, projectName);
 
 		try {
-			const configTab = page.getByRole('tab', { name: /Configuration|Config/i });
+			const configTab = page.getByRole('tab', { name: 'Configuration', exact: true });
 			await configTab.click();
 			await page.waitForLoadState('load');
 
-			let composeEditor = page.locator('.cm-editor:visible').first();
+			let composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 			await expect(composeEditor).toBeVisible();
 
 			const marker = `ARCANE_SAVE_PERSIST_${Date.now()}`;
@@ -1341,7 +1377,7 @@ test.describe('Project Detail Page', () => {
 
 			await expect(saveButtons).toHaveCount(0);
 
-			composeEditor = page.locator('.cm-editor:visible').first();
+			composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 			await expect
 				.poll(async () => getCodeMirrorValue(composeEditor), {
 					message: 'expected saved compose editor content to remain visible'
@@ -1349,13 +1385,14 @@ test.describe('Project Detail Page', () => {
 				.toContain(marker);
 
 			const layoutSwitch = page.getByRole('switch', {
-				name: /workspace/i
+				name: 'Toggle workspace mode',
+				exact: true
 			});
 			if (await layoutSwitch.count()) {
 				await layoutSwitch.click();
-				await expect(page.locator('.cm-editor:visible').first()).toBeVisible();
+				await expect(page.locator('.cm-editor').filter({ visible: true }).first()).toBeVisible();
 
-				composeEditor = page.locator('.cm-editor:visible').first();
+				composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 				await expect
 					.poll(async () => getCodeMirrorValue(composeEditor), {
 						message: 'expected saved compose editor content to persist across layout changes'
@@ -1366,13 +1403,16 @@ test.describe('Project Detail Page', () => {
 			await page.reload();
 			await page.waitForLoadState('load');
 
-			const restoredConfigTab = page.getByRole('tab', { name: /Configuration|Config/i });
+			const restoredConfigTab = page.getByRole('tab', {
+				name: 'Configuration',
+				exact: true
+			});
 			if ((await restoredConfigTab.getAttribute('aria-selected')) !== 'true') {
 				await restoredConfigTab.click();
 				await page.waitForLoadState('load');
 			}
 
-			composeEditor = page.locator('.cm-editor:visible').first();
+			composeEditor = page.locator('.cm-editor').filter({ visible: true }).first();
 			await expect(composeEditor).toBeVisible();
 			await expect
 				.poll(async () => getCodeMirrorValue(composeEditor), {
@@ -1394,14 +1434,19 @@ test.describe('Project Detail Page', () => {
 		await page.goto(`/projects/${targetProject.id || targetProject.name}`);
 		await page.waitForLoadState('load');
 
-		const logsTab = page.getByRole('tab', { name: /Logs/i });
+		const logsTab = page.getByRole('tab', { name: 'Logs', exact: true });
 		await expect(logsTab).toBeEnabled();
 		await logsTab.click();
 
 		const logsSelected = await logsTab.getAttribute('aria-selected');
 		if (logsSelected === 'true') {
-			await expect(page.getByText(/Real-time project logs/i)).toBeVisible();
-			await expect(page.getByRole('button', { name: /^(Start|Stop)$/i })).toBeVisible();
+			await expect(page.getByText('Real-time project logs', { exact: true })).toBeVisible();
+			await expect(
+				page
+					.getByRole('button', { name: 'Start', exact: true })
+					.or(page.getByRole('button', { name: 'Stop', exact: true }))
+					.first()
+			).toBeVisible();
 			await expect(page.getByTitle('Refresh')).toBeVisible();
 
 			const startButton = page.getByRole('button', {
@@ -1412,7 +1457,11 @@ test.describe('Project Detail Page', () => {
 				await startButton.click();
 			}
 
-			await expect(page.getByText(/No project selected/i)).not.toBeVisible();
+			await expect(
+				page.getByText('No project selected. Please select a project to view logs.', {
+					exact: true
+				})
+			).not.toBeVisible();
 		} else {
 			await expect(logsTab).toBeEnabled();
 		}

--- a/tests/spec/registries.spec.ts
+++ b/tests/spec/registries.spec.ts
@@ -96,7 +96,10 @@ test.describe('Container Registries', () => {
 
 		await page.getByRole('button', { name: 'Refresh' }).click();
 		await expect(
-			page.locator('li[data-sonner-toast]').filter({ hasText: 'Registries Refreshed!' })
+			page
+				.getByRole('region', { name: 'Notifications alt+T', exact: true })
+				.getByRole('listitem')
+				.filter({ hasText: 'Registries Refreshed!' })
 		).toBeVisible({ timeout: 10000 });
 	});
 
@@ -107,8 +110,8 @@ test.describe('Container Registries', () => {
 		await expect(dialog).toBeVisible();
 
 		// Submit without URL -> expect validation error
-		await dialog.getByRole('button', { name: /Add Registry|Save Changes/ }).click();
-		await expect(dialog.getByText(/Registry URL is required/i)).toBeVisible();
+		await dialog.getByRole('button', { name: 'Add Registry', exact: true }).click();
+		await expect(dialog.getByText('Registry URL is required', { exact: true })).toBeVisible();
 
 		// Close dialog
 		await page.keyboard.press('Escape');
@@ -148,24 +151,27 @@ test.describe('Container Registries', () => {
 		const url = `e2e.example.com-${Date.now()}`;
 
 		// URL
-		await dialog.getByLabel(/Registry URL|^URL$/i).fill(url);
+		await dialog.getByLabel('Registry URL', { exact: true }).fill(url);
 		// Username (frontend requires it)
-		await dialog.getByLabel(/^Username$/i).fill('e2e');
+		await dialog.getByLabel('Username', { exact: true }).fill('e2e');
 		// Token (backend needs it to avoid 400)
-		const tokenInput = dialog.getByLabel(/token|access token/i);
+		const tokenInput = dialog.getByLabel('Token', { exact: true });
 		await tokenInput.fill(TOKEN);
 
 		// Optional description
-		const desc = dialog.getByLabel(/^Description$/i);
+		const desc = dialog.getByLabel('Description', { exact: true });
 		if (await desc.count()) await desc.fill('E2E test registry');
 
-		await dialog.getByRole('button', { name: /Add Registry/ }).click();
+		await dialog.getByRole('button', { name: 'Add Registry', exact: true }).click();
 
 		// Creation complete when dialog closes
 		await expect(dialog).toBeHidden({ timeout: 10000 });
 
 		// Row should appear
-		const row = page.locator('tbody tr', { hasText: url }).first();
+		const row = page
+			.getByRole('row')
+			.filter({ has: page.getByText(url, { exact: true }) })
+			.first();
 		await expect(row).toBeVisible();
 
 		// Test Connection (accept either success or failure toast)
@@ -174,18 +180,25 @@ test.describe('Container Registries', () => {
 	});
 
 	test('should open Remove Selected dialog and cancel (no mutation)', async ({ page }) => {
-		const firstRowCheckbox = page.locator('tbody tr input[type="checkbox"]').first();
+		const firstRowCheckbox = page
+			.getByRole('row')
+			.filter({ has: page.getByRole('button', { name: 'Open menu', exact: true }) })
+			.getByRole('checkbox')
+			.first();
 		if (await firstRowCheckbox.count()) {
 			await firstRowCheckbox.check();
 
-			const removeSelected = page.getByRole('button', { name: /Remove Selected/i });
+			const removeSelected = page.getByRole('button', {
+				name: 'Remove Selected (1)',
+				exact: true
+			});
 			if (await removeSelected.count()) {
 				await removeSelected.click();
 
-				const confirm = page.locator(
-					'div[role="heading"][aria-level="2"][data-dialog-title], [role="dialog"] >> text=Remove'
-				);
-				await expect(confirm).toBeVisible();
+				const confirm = page.getByRole('dialog');
+				await expect(
+					confirm.getByRole('heading', { name: 'Remove 1 Registry(ies)', exact: true })
+				).toBeVisible();
 
 				await page.getByRole('button', { name: 'Cancel' }).click();
 				await expect(confirm).toBeHidden();

--- a/tests/spec/volumes.spec.ts
+++ b/tests/spec/volumes.spec.ts
@@ -29,7 +29,7 @@ async function openCreateVolumeSheet(page: Page) {
 
 async function createVolumeViaUI(page: Page, volumeName: string) {
 	await openCreateVolumeSheet(page);
-	await page.getByRole('dialog').locator('input[type="text"]').first().fill(volumeName);
+	await page.getByRole('dialog').getByLabel('Volume Name *').fill(volumeName);
 	const createRequest = page.waitForResponse(
 		(response) => {
 			const request = response.request();
@@ -48,7 +48,7 @@ async function createVolumeViaUI(page: Page, volumeName: string) {
 		);
 	}
 	await expect(
-		page.locator('li[data-sonner-toast][data-type="success"] div[data-title]')
+		page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 	).toBeVisible();
 }
 
@@ -131,8 +131,8 @@ test.describe('Volumes Page', () => {
 		await page.waitForLoadState('load');
 
 		const { content } = await ensureFacetOpen(page, 'Usage');
-		await expect(content.getByRole('option', { name: /In Use\b/i })).toBeVisible();
-		await expect(content.getByRole('option', { name: /Unused\b/i })).toBeVisible();
+		await expect(content.getByRole('option', { name: 'In Use' })).toBeVisible();
+		await expect(content.getByRole('option', { name: 'Unused' })).toBeVisible();
 	});
 
 	test('Inspect Volume', async ({ page }) => {
@@ -153,11 +153,11 @@ test.describe('Volumes Page', () => {
 		await page.waitForLoadState('load');
 
 		await expect(page).toHaveURL(new RegExp(`/volumes/.+`));
-		await page.locator('button[data-slot="arcane-button"][data-action="remove"]').click();
-		await page.getByRole('button', { name: 'Remove', exact: true }).last().click();
+		await page.getByRole('button', { name: 'Remove', exact: true }).click();
+		await page.getByRole('dialog').getByRole('button', { name: 'Remove', exact: true }).click();
 
 		await expect(
-			page.locator('li[data-sonner-toast][data-type="success"] div[data-title]')
+			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 		).toBeVisible();
 	});
 

--- a/tests/utils/table-actions.util.ts
+++ b/tests/utils/table-actions.util.ts
@@ -5,11 +5,11 @@ export async function openRowActionsMenu(page: Page, row: Locator) {
 	await expect(targetRow).toBeVisible();
 	await targetRow.hover();
 
-	const trigger = targetRow.getByRole('button', { name: /open menu/i }).first();
+	const trigger = targetRow.getByRole('button', { name: 'Open menu', exact: true }).first();
 	await expect(trigger).toBeVisible();
 	await trigger.click();
 
-	const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last();
+	const menu = page.getByRole('menu').filter({ visible: true }).last();
 	await expect(menu).toBeVisible();
 	return menu;
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR parallelizes root layout data loading to reduce startup latency. The main changes are:

- Starts version information and auto-login config requests earlier.
- Loads current user and auto-login config together.
- Begins permissions manifest loading while environments are being fetched.
- Keeps settings loading sequenced after environment initialization.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changed root layout logic preserves the dependency that settings load after `environmentStore` initialization. No concrete correctness or security issues were identified in the changed file or its direct service dependencies.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team ran the type-check and partial build steps to collect contract-validation artifacts for the T-Rex proof.
- The harness source was generated from the partial build to enable the test harness execution.
- We reviewed the before harness command outputs to establish the initial state before event sequencing.
- We reviewed the after harness command outputs and confirmed that versionInfo, autoLoginConfig, and currentUser appear by events 1–3 and that permissionsManifest is authenticated before environments completes, showing the requested overlap from the layout change.

<a href="https://app.greptile.com/trex/runs/14267922/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: parallelize root data loading"](https://github.com/getarcaneapp/arcane/commit/281417cfe4673c943addfeab671d004a9282695b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43878056)</sub>

<!-- /greptile_comment -->