### PR TITLE
perf: batch API key permission hydration

### DIFF
--- a/backend/internal/models/api_key.go
+++ b/backend/internal/models/api_key.go
@@ -15,16 +15,17 @@ const (
 type ApiKey struct {
 	BaseModel
 
-	Name          string     `json:"name" gorm:"column:name;not null" sortable:"true"`
-	Description   *string    `json:"description,omitempty" gorm:"column:description"`
-	KeyHash       string     `json:"-" gorm:"column:key_hash;not null"`
-	KeyPrefix     string     `json:"keyPrefix" gorm:"column:key_prefix;not null"`
-	ManagedBy     *string    `json:"-" gorm:"column:managed_by"`
-	Kind          string     `json:"kind" gorm:"column:kind;not null;default:scoped"`
-	UserID        *string    `json:"userId,omitempty" gorm:"column:user_id"`
-	EnvironmentID *string    `json:"environmentId,omitempty" gorm:"column:environment_id"`
-	ExpiresAt     *time.Time `json:"expiresAt,omitempty" gorm:"column:expires_at" sortable:"true"`
-	LastUsedAt    *time.Time `json:"lastUsedAt,omitempty" gorm:"column:last_used_at" sortable:"true"`
+	Name             string             `json:"name" gorm:"column:name;not null" sortable:"true"`
+	Description      *string            `json:"description,omitempty" gorm:"column:description"`
+	KeyHash          string             `json:"-" gorm:"column:key_hash;not null"`
+	KeyPrefix        string             `json:"keyPrefix" gorm:"column:key_prefix;not null"`
+	ManagedBy        *string            `json:"-" gorm:"column:managed_by"`
+	Kind             string             `json:"kind" gorm:"column:kind;not null;default:scoped"`
+	UserID           *string            `json:"userId,omitempty" gorm:"column:user_id"`
+	EnvironmentID    *string            `json:"environmentId,omitempty" gorm:"column:environment_id"`
+	ExpiresAt        *time.Time         `json:"expiresAt,omitempty" gorm:"column:expires_at" sortable:"true"`
+	LastUsedAt       *time.Time         `json:"lastUsedAt,omitempty" gorm:"column:last_used_at" sortable:"true"`
+	PermissionGrants []ApiKeyPermission `json:"-" gorm:"foreignKey:ApiKeyID;references:ID;constraint:OnDelete:CASCADE"`
 }
 
 func (ApiKey) TableName() string {

--- a/backend/internal/services/api_key_service.go
+++ b/backend/internal/services/api_key_service.go
@@ -299,9 +299,15 @@ func toAPIKeyDTOInternal(ak *models.ApiKey) apikey.ApiKey {
 
 // toAPIKeyDTOWithPermissionsInternal is like toAPIKeyDTOInternal but
 // additionally attaches the key's persisted permission grants.
-func (s *ApiKeyService) toAPIKeyDTOWithPermissionsInternal(ctx context.Context, ak *models.ApiKey) apikey.ApiKey {
+func toAPIKeyDTOWithPermissionsInternal(ak *models.ApiKey) apikey.ApiKey {
 	dto := toAPIKeyDTOInternal(ak)
-	dto.Permissions = s.loadKeyGrantsInternal(ctx, ak.ID)
+	dto.Permissions = make([]apikey.PermissionGrant, len(ak.PermissionGrants))
+	for i, grant := range ak.PermissionGrants {
+		dto.Permissions[i] = apikey.PermissionGrant{
+			Permission:    grant.Permission,
+			EnvironmentID: grant.EnvironmentID,
+		}
+	}
 	return dto
 }
 
@@ -488,18 +494,25 @@ func (s *ApiKeyService) CreateEnvironmentApiKey(ctx context.Context, environment
 
 func (s *ApiKeyService) GetApiKey(ctx context.Context, id string) (*apikey.ApiKey, error) {
 	var ak models.ApiKey
-	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&ak).Error; err != nil {
+	query := s.db.WithContext(ctx)
+	if s.roleService != nil {
+		query = query.Preload("PermissionGrants")
+	}
+	if err := query.Where("id = ?", id).First(&ak).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrApiKeyNotFound
 		}
 		return nil, fmt.Errorf("failed to get API key: %w", err)
 	}
-	return new(s.toAPIKeyDTOWithPermissionsInternal(ctx, &ak)), nil
+	return new(toAPIKeyDTOWithPermissionsInternal(&ak)), nil
 }
 
 func (s *ApiKeyService) ListApiKeys(ctx context.Context, params pagination.QueryParams) ([]apikey.ApiKey, pagination.Response, error) {
 	var apiKeys []models.ApiKey
 	query := s.db.WithContext(ctx).Model(&models.ApiKey{})
+	if s.roleService != nil {
+		query = query.Preload("PermissionGrants")
+	}
 
 	if term := strings.TrimSpace(params.Search); term != "" {
 		searchPattern := "%" + term + "%"
@@ -519,7 +532,7 @@ func (s *ApiKeyService) ListApiKeys(ctx context.Context, params pagination.Query
 		// Include per-key permission grants so the edit form preloads with the
 		// key's actual current grants. Without this, the form starts empty and
 		// "Save" would wipe whatever grants the DB has.
-		result[i] = s.toAPIKeyDTOWithPermissionsInternal(ctx, &apiKeys[i])
+		result[i] = toAPIKeyDTOWithPermissionsInternal(&apiKeys[i])
 	}
 
 	return result, paginationResp, nil
@@ -529,7 +542,11 @@ func (s *ApiKeyService) ListApiKeys(ctx context.Context, params pagination.Query
 // userID. Used by the self-service personal-keys flow.
 func (s *ApiKeyService) ListApiKeysByUser(ctx context.Context, userID string) ([]apikey.ApiKey, error) {
 	var apiKeys []models.ApiKey
-	if err := s.db.WithContext(ctx).
+	query := s.db.WithContext(ctx)
+	if s.roleService != nil {
+		query = query.Preload("PermissionGrants")
+	}
+	if err := query.
 		Where("user_id = ?", userID).
 		Order("created_at DESC").
 		Find(&apiKeys).Error; err != nil {
@@ -541,7 +558,7 @@ func (s *ApiKeyService) ListApiKeysByUser(ctx context.Context, userID string) ([
 		if isStaticAPIKeyInternal(apiKeys[i]) || isEnvironmentBootstrapKeyInternal(apiKeys[i]) {
 			continue
 		}
-		result = append(result, s.toAPIKeyDTOWithPermissionsInternal(ctx, &apiKeys[i]))
+		result = append(result, toAPIKeyDTOWithPermissionsInternal(&apiKeys[i]))
 	}
 	return result, nil
 }

--- a/backend/internal/services/api_key_service_test.go
+++ b/backend/internal/services/api_key_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/apikey"
 )
 
@@ -123,6 +125,69 @@ func createDefaultAdminUser(t *testing.T, ctx context.Context, userService *User
 	created, err := userService.CreateUser(ctx, user)
 	require.NoError(t, err)
 	return created
+}
+
+func TestListApiKeysPermissionQueryCountIsConstant(t *testing.T) {
+	queryCounts := make(map[int]int64, 2)
+	userQueryCounts := make(map[int]int64, 2)
+
+	for _, keyCount := range []int{1, 5} {
+		t.Run(fmt.Sprintf("%d_keys", keyCount), func(t *testing.T) {
+			db := setupAuthServiceTestDB(t)
+			service := NewApiKeyService(db, NewUserService(db)).WithRoleService(NewRoleService(db))
+			userID := "query-count-user"
+
+			apiKeys := make([]models.ApiKey, keyCount)
+			permissions := make([]models.ApiKeyPermission, keyCount)
+			for i := range keyCount {
+				keyID := fmt.Sprintf("key-%d", i)
+				apiKeys[i] = models.ApiKey{
+					BaseModel: models.BaseModel{ID: keyID},
+					Name:      keyID,
+					KeyHash:   "hash",
+					KeyPrefix: fmt.Sprintf("arc_%04d", i),
+					Kind:      models.ApiKeyKindScoped,
+					UserID:    &userID,
+				}
+				permissions[i] = models.ApiKeyPermission{
+					BaseModel:  models.BaseModel{ID: fmt.Sprintf("permission-%d", i)},
+					ApiKeyID:   keyID,
+					Permission: authz.PermContainersList,
+				}
+			}
+			require.NoError(t, db.Create(&apiKeys).Error)
+			require.NoError(t, db.Create(&permissions).Error)
+
+			var queryCount atomic.Int64
+			require.NoError(t, db.Callback().Query().Before("gorm:query").Register("count_api_key_list_queries", func(*gorm.DB) {
+				queryCount.Add(1)
+			}))
+
+			result, _, err := service.ListApiKeys(context.Background(), pagination.QueryParams{
+				Params: pagination.Params{Limit: 100},
+			})
+			require.NoError(t, err)
+			require.Len(t, result, keyCount)
+			for _, apiKey := range result {
+				require.Len(t, apiKey.Permissions, 1)
+			}
+			queryCounts[keyCount] = queryCount.Load()
+
+			queryCount.Store(0)
+			result, err = service.ListApiKeysByUser(context.Background(), userID)
+			require.NoError(t, err)
+			require.Len(t, result, keyCount)
+			for _, apiKey := range result {
+				require.Len(t, apiKey.Permissions, 1)
+			}
+			userQueryCounts[keyCount] = queryCount.Load()
+		})
+	}
+
+	require.Equal(t, int64(3), queryCounts[1])
+	require.Equal(t, int64(3), queryCounts[5])
+	require.Equal(t, int64(2), userQueryCounts[1])
+	require.Equal(t, int64(2), userQueryCounts[5])
 }
 
 func TestCreateDefaultAdminAPIKeyUsesProvidedRawKey(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR batches API key permission hydration for API key read paths. The main changes are:

- Adds a GORM `PermissionGrants` association to `ApiKey`.
- Preloads permission grants for `GetApiKey`, `ListApiKeys`, and `ListApiKeysByUser`.
- Maps preloaded grants into API key DTO permissions.
- Adds query-count tests for list and user-list API key permission hydration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to replacing per-key permission lookups with GORM preloading while preserving empty-permissions behavior when the role service is absent. Targeted tests verify permission data is populated and list query counts stay constant as key count grows.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the focused API key permission hydration tests and verified the test run completed with EXIT\_CODE 0.
- The log shows the passing tests TestListApiKeysPermissionQueryCountIsConstant, TestCreateEnvironmentApiKeySeedsAllPermissionsScopedToEnv, and TestBackfillApiKeyPermissionsRepairsExistingBootstrapKey.
- Broader models/services compile tests were not run because the focused service test directly exercised the changed API key permission hydration behavior and succeeded.

<a href="https://app.greptile.com/trex/runs/14286871/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: batch API key permission hydration"](https://github.com/getarcaneapp/arcane/commit/a31a08f6964ce065a2aa446fe97e274b58c8b56e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43914068)</sub>

<!-- /greptile_comment -->