### PR TITLE
perf: make API key usage updates request scoped

### DIFF
--- a/backend/internal/services/api_key_service.go
+++ b/backend/internal/services/api_key_service.go
@@ -100,16 +100,16 @@ func parseAPIKeyPrefixInternal(rawKey string) (string, error) {
 	return rawKey[:prefixLen], nil
 }
 
-func (s *ApiKeyService) markApiKeyUsedAsync(ctx context.Context, keyID string) {
-	go func(keyID string) {
-		bgCtx := context.WithoutCancel(ctx)
-		now := time.Now()
-		cutoff := now.Add(-apiKeyLastUsedWriteWindow)
-		s.db.WithContext(bgCtx).
-			Model(&models.ApiKey{}).
-			Where("id = ? AND (last_used_at IS NULL OR last_used_at < ?)", keyID, cutoff).
-			Update("last_used_at", now)
-	}(keyID)
+func (s *ApiKeyService) markApiKeyUsedInternal(ctx context.Context, keyID string) error {
+	now := time.Now()
+	cutoff := now.Add(-apiKeyLastUsedWriteWindow)
+	if err := s.db.WithContext(ctx).
+		Model(&models.ApiKey{}).
+		Where("id = ? AND (last_used_at IS NULL OR last_used_at < ?)", keyID, cutoff).
+		Update("last_used_at", now).Error; err != nil {
+		return fmt.Errorf("failed to update API key last-used timestamp: %w", err)
+	}
+	return nil
 }
 
 func (s *ApiKeyService) CreateApiKey(ctx context.Context, userID string, callerPerms *authz.PermissionSet, req apikey.CreateApiKey) (*apikey.ApiKeyCreatedDto, error) {
@@ -718,7 +718,9 @@ func (s *ApiKeyService) ValidateApiKeyWithID(ctx context.Context, rawKey string)
 				return nil, nil, ErrApiKeyInvalid
 			}
 
-			s.markApiKeyUsedAsync(ctx, apiKey.ID)
+			if err := s.markApiKeyUsedInternal(ctx, apiKey.ID); err != nil {
+				slog.WarnContext(ctx, "failed to persist API key usage", "api_key_id", apiKey.ID, "error", err)
+			}
 
 			user, err := s.userService.GetUserByID(ctx, *apiKey.UserID)
 			if err != nil {
@@ -750,7 +752,9 @@ func (s *ApiKeyService) GetEnvironmentByApiKey(ctx context.Context, rawKey strin
 				return nil, ErrApiKeyExpired
 			}
 
-			s.markApiKeyUsedAsync(ctx, apiKey.ID)
+			if err := s.markApiKeyUsedInternal(ctx, apiKey.ID); err != nil {
+				slog.WarnContext(ctx, "failed to persist API key usage", "api_key_id", apiKey.ID, "error", err)
+			}
 
 			return apiKey.EnvironmentID, nil
 		}

--- a/backend/internal/services/api_key_service_test.go
+++ b/backend/internal/services/api_key_service_test.go
@@ -3,13 +3,13 @@ package services
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	sqlite "github.com/libtnb/sqlite"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -73,33 +73,6 @@ func listAPIKeysForUser(t *testing.T, db *database.DB, userID string) []models.A
 	err := db.WithContext(context.Background()).Where("user_id = ?", userID).Order("created_at asc").Find(&apiKeys).Error
 	require.NoError(t, err)
 	return apiKeys
-}
-
-func requireAPIKeyLastUsedEventually(t *testing.T, db *database.DB, keyID string) models.ApiKey {
-	t.Helper()
-
-	var apiKey models.ApiKey
-	require.Eventually(t, func() bool {
-		err := db.WithContext(context.Background()).Where("id = ?", keyID).First(&apiKey).Error
-		return err == nil && apiKey.LastUsedAt != nil
-	}, time.Second, 10*time.Millisecond)
-
-	return apiKey
-}
-
-func assertAPIKeyLastUsedStable(t *testing.T, db *database.DB, keyID string, expected *time.Time, duration time.Duration) {
-	t.Helper()
-
-	assert.Never(t, func() bool {
-		apiKey := fetchAPIKey(t, db, keyID)
-		if expected == nil {
-			return apiKey.LastUsedAt != nil
-		}
-		if apiKey.LastUsedAt == nil {
-			return true
-		}
-		return apiKey.LastUsedAt.UTC().UnixNano() != expected.UTC().UnixNano()
-	}, duration, 10*time.Millisecond)
 }
 
 func invalidateAPIKey(rawKey string) string {
@@ -517,8 +490,100 @@ func TestValidateAPIKeyUpdatesLastUsedAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, user.ID, validatedUser.ID)
 
-	apiKey := requireAPIKeyLastUsedEventually(t, db, created.ID)
+	apiKey := fetchAPIKey(t, db, created.ID)
 	require.NotNil(t, apiKey.LastUsedAt)
+}
+
+func TestValidateAPIKeyLastUsedUpdateIsRequestScoped(t *testing.T) {
+	ctx := context.Background()
+	service, db, userService := setupAPIKeyService(t)
+	user := createTestAPIKeyUser(t, ctx, userService, "user-request-scoped")
+
+	created, err := service.CreateApiKey(ctx, user.ID, authz.SudoPermissionSet(), apikey.CreateApiKey{Name: "request-scoped-key"})
+	require.NoError(t, err)
+
+	updateStarted := make(chan struct{})
+	releaseUpdate := make(chan struct{})
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register("block_api_key_last_used_update", func(*gorm.DB) {
+		close(updateStarted)
+		<-releaseUpdate
+	}))
+
+	validationDone := make(chan error, 1)
+	go func() {
+		_, err := service.ValidateApiKey(ctx, created.Key)
+		validationDone <- err
+	}()
+
+	select {
+	case <-updateStarted:
+	case <-time.After(time.Second):
+		close(releaseUpdate)
+		t.Fatal("last-used update did not start")
+	}
+
+	select {
+	case err := <-validationDone:
+		close(releaseUpdate)
+		require.NoError(t, err)
+		t.Fatal("validation returned before its last-used update completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseUpdate)
+	require.NoError(t, <-validationDone)
+}
+
+func TestMarkAPIKeyUsedHonorsRequestCancellation(t *testing.T) {
+	ctx := context.Background()
+	service, db, userService := setupAPIKeyService(t)
+	user := createTestAPIKeyUser(t, ctx, userService, "user-canceled-usage")
+
+	created, err := service.CreateApiKey(ctx, user.ID, authz.SudoPermissionSet(), apikey.CreateApiKey{Name: "canceled-usage-key"})
+	require.NoError(t, err)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err = service.markApiKeyUsedInternal(canceledCtx, created.ID)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, fetchAPIKey(t, db, created.ID).LastUsedAt)
+}
+
+func TestMarkAPIKeyUsedReturnsDatabaseErrors(t *testing.T) {
+	ctx := context.Background()
+	service, db, userService := setupAPIKeyService(t)
+	user := createTestAPIKeyUser(t, ctx, userService, "user-usage-error")
+
+	created, err := service.CreateApiKey(ctx, user.ID, authz.SudoPermissionSet(), apikey.CreateApiKey{Name: "usage-error-key"})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	err = service.markApiKeyUsedInternal(ctx, created.ID)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to update API key last-used timestamp")
+}
+
+func TestValidateAPIKeyRepeatedAuthenticationDoesNotGrowGoroutines(t *testing.T) {
+	ctx := context.Background()
+	service, _, userService := setupAPIKeyService(t)
+	user := createTestAPIKeyUser(t, ctx, userService, "user-repeated-auth")
+
+	created, err := service.CreateApiKey(ctx, user.ID, authz.SudoPermissionSet(), apikey.CreateApiKey{Name: "repeated-auth-key"})
+	require.NoError(t, err)
+
+	before := runtime.NumGoroutine()
+	for range 20 {
+		validatedUser, err := service.ValidateApiKey(ctx, created.Key)
+		require.NoError(t, err)
+		require.Equal(t, user.ID, validatedUser.ID)
+	}
+	runtime.Gosched()
+	after := runtime.NumGoroutine()
+	t.Logf("goroutines before repeated authentication: %d; after: %d", before, after)
+	require.LessOrEqual(t, after, before+1)
 }
 
 func TestGetEnvironmentByAPIKeyUpdatesLastUsedAt(t *testing.T) {
@@ -535,7 +600,7 @@ func TestGetEnvironmentByAPIKeyUpdatesLastUsedAt(t *testing.T) {
 	require.NotNil(t, environmentID)
 	require.Equal(t, "env-123", *environmentID)
 
-	apiKey := requireAPIKeyLastUsedEventually(t, db, created.ID)
+	apiKey := fetchAPIKey(t, db, created.ID)
 	require.NotNil(t, apiKey.LastUsedAt)
 }
 
@@ -550,7 +615,6 @@ func TestValidateAPIKeyInvalidDoesNotUpdateLastUsedAt(t *testing.T) {
 	_, err = service.ValidateApiKey(ctx, invalidateAPIKey(created.Key))
 	require.ErrorIs(t, err, ErrApiKeyInvalid)
 
-	assertAPIKeyLastUsedStable(t, db, created.ID, nil, 500*time.Millisecond)
 	apiKey := fetchAPIKey(t, db, created.ID)
 	require.Nil(t, apiKey.LastUsedAt)
 }
@@ -578,7 +642,6 @@ func TestGetEnvironmentByAPIKeyExpiredDoesNotUpdateLastUsedAt(t *testing.T) {
 	_, err = service.GetEnvironmentByApiKey(ctx, created.Key)
 	require.ErrorIs(t, err, ErrApiKeyExpired)
 
-	assertAPIKeyLastUsedStable(t, db, created.ID, nil, 500*time.Millisecond)
 	apiKey := fetchAPIKey(t, db, created.ID)
 	require.Nil(t, apiKey.LastUsedAt)
 }
@@ -663,7 +726,6 @@ func TestGetEnvironmentByAPIKeyRecentLastUsedAtDoesNotRewriteImmediately(t *test
 	require.NotNil(t, environmentID)
 	require.Equal(t, "env-456", *environmentID)
 
-	assertAPIKeyLastUsedStable(t, db, created.ID, before.LastUsedAt, 2*time.Second)
 	after := fetchAPIKey(t, db, created.ID)
 	require.NotNil(t, after.LastUsedAt)
 	require.Equal(t, before.LastUsedAt.UTC().Unix(), after.LastUsedAt.UTC().Unix())


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes API key usage timestamp updates request scoped. The main changes are:

- Replaces detached goroutine updates with synchronous `last_used_at` writes using the caller context.
- Keeps API key authentication non-fatal when usage timestamp persistence fails.
- Updates tests to assert immediate timestamp writes and request-scoped behavior.
- Adds coverage for cancellation, database errors, and repeated authentication without goroutine growth.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to API key usage bookkeeping and preserves authentication behavior when timestamp writes fail. Tests cover the new request-scoped update behavior, cancellation, database errors, and goroutine stability.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Saved the exact focused command output with timestamps for the API key service tests.
- Captured the test run context, including the working directory, start and end times, and the verbose list of executed tests.
- Confirmed that the requested tests were executed and reported PASS.
- Verified the run ended with EXIT\_CODE: 0, indicating a successful completion.

<a href="https://app.greptile.com/trex/runs/14294804/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: make API key usage updates request..."](https://github.com/getarcaneapp/arcane/commit/ca667368c8e6368e5a8a6adbe355be90ccd4e58e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43929189)</sub>

<!-- /greptile_comment -->