### PR TITLE
fix: recover auth and reload after self-update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
   "tasks.statusbar.limit": 8,
   "github.copilot.chat.summarizeAgentConversationHistory.enabled": false,
   "snyk.advanced.autoSelectOrganization": false,
-  "js/ts.tsdk.path": "frontend/node_modules/typescript/lib"
+  "js/ts.tsdk.path": "node_modules/@typescript/native-preview"
 }

--- a/frontend/src/lib/components/dialogs/update-all-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/update-all-dialog.svelte
@@ -73,6 +73,13 @@
 			job = next;
 			if (next.status === 'completed' || next.status === 'failed') {
 				stopPolling();
+				const managerUpdated =
+					next.status === 'completed' &&
+					(next.results?.some((result) => result.environmentId === '0' && result.status === 'updated') ?? false);
+				if (managerUpdated) {
+					window.location.reload();
+					return;
+				}
 				BaseAPIService.setUpgradeInProgress(false);
 				phase = 'finished';
 				return;
@@ -100,6 +107,13 @@
 		if (phase !== 'running') return;
 
 		if (job && (job.status === 'completed' || job.status === 'failed')) {
+			const managerUpdated =
+				job.status === 'completed' &&
+				(job.results?.some((result) => result.environmentId === '0' && result.status === 'updated') ?? false);
+			if (managerUpdated) {
+				window.location.reload();
+				return;
+			}
 			BaseAPIService.setUpgradeInProgress(false);
 			phase = 'finished';
 			return;
@@ -110,17 +124,8 @@
 	}
 
 	async function handleClose() {
-		// Capture before resetState() clears the job: the manager (env "0") upgrading
-		// means our own frontend assets are now stale and need a reload.
-		const managerUpdated = job?.results?.some((r) => r.environmentId === '0' && r.status === 'updated') ?? false;
 		resetState();
 		open = false;
-		if (managerUpdated) {
-			// Reload to pick up the new frontend assets. The session survives — the
-			// cookie was re-minted by the recovered refresh during the restart.
-			window.location.reload();
-			return;
-		}
 		await onFinished?.();
 	}
 

--- a/frontend/src/lib/components/dialogs/update-center-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/update-center-dialog.svelte
@@ -108,10 +108,8 @@
 		}
 	});
 
-	let upgradeStatus = $state<'upgrading' | 'waiting' | 'ready' | 'countdown' | 'complete'>('upgrading');
-	let countdown = $state(10);
+	let upgradeStatus = $state<'upgrading' | 'waiting' | 'ready' | 'complete'>('upgrading');
 	let pollAbort = $state<{ aborted: boolean } | null>(null);
-	let countdownInterval: ReturnType<typeof setInterval> | null = null;
 	let fallbackTimeout: ReturnType<typeof setTimeout> | null = null;
 	let baselineVersionInfo = $state<AppVersionInformation | null>(null);
 	let consecutiveHealthyChecks = $state(0);
@@ -258,13 +256,11 @@
 						currentDigest: short(info.currentDigest)
 					});
 					upgradeStatus = 'ready';
-					setTimeout(() => {
-						if (isRemoteEnvironment) {
-							upgradeStatus = 'complete';
-						} else {
-							startCountdown();
-						}
-					}, 1500);
+					if (isRemoteEnvironment) {
+						setTimeout(() => (upgradeStatus = 'complete'), 1500);
+					} else {
+						reloadPage();
+					}
 					return;
 				}
 
@@ -306,6 +302,10 @@
 			if (isRemoteEnvironment) {
 				upgradeStatus = 'complete';
 			} else {
+				if (fallbackTimeout) {
+					clearTimeout(fallbackTimeout);
+					fallbackTimeout = null;
+				}
 				upgradeStatus = 'upgrading';
 				upgrading = false;
 				BaseAPIService.setUpgradeInProgress(false);
@@ -332,18 +332,6 @@
 			log('baseline-error', err);
 			baselineVersionInfo = null;
 		}
-	}
-
-	function startCountdown() {
-		upgradeStatus = 'countdown';
-		countdown = 10;
-		countdownInterval = setInterval(() => {
-			countdown--;
-			if (countdown <= 0) {
-				if (countdownInterval) clearInterval(countdownInterval);
-				reloadPage();
-			}
-		}, 1000);
 	}
 
 	function reloadPage() {
@@ -403,7 +391,7 @@
 				log('fallback-timeout', { reason: 'timeout', isRemoteEnvironment });
 				if (isRemoteEnvironment) {
 					if (upgradeStatus !== 'complete') upgradeStatus = 'complete';
-				} else if (upgradeStatus !== 'countdown') {
+				} else {
 					reloadPage();
 				}
 			},
@@ -449,8 +437,6 @@
 					return 1;
 				case 'ready':
 					return 2;
-				case 'countdown':
-					return 3;
 				case 'complete':
 					return labels.length;
 				default:
@@ -467,7 +453,6 @@
 
 	onDestroy(() => {
 		log('destroy');
-		if (countdownInterval) clearInterval(countdownInterval);
 		if (fallbackTimeout) clearTimeout(fallbackTimeout);
 		if (pollAbort) pollAbort.aborted = true;
 		BaseAPIService.setUpgradeInProgress(false);
@@ -522,14 +507,7 @@
 					{/each}
 				</ol>
 
-				{#if upgradeStatus === 'countdown'}
-					<div class="mt-4 flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-3 py-2.5">
-						<p class="text-sm font-medium text-green-700 dark:text-green-400">
-							{m.upgrade_reload_auto({ countdown })}
-						</p>
-						<ArcaneButton action="base" onclick={reloadPage} size="sm" customLabel={m.upgrade_reload_now()} />
-					</div>
-				{:else if upgradeStatus === 'complete'}
+				{#if upgradeStatus === 'complete'}
 					<div class="mt-4 flex items-center justify-between rounded-lg border border-green-500/20 bg-green-500/5 px-3 py-2.5">
 						<p class="flex items-center gap-2 text-sm font-medium text-green-700 dark:text-green-400">
 							<SuccessIcon class="size-4" />

--- a/frontend/src/lib/services/activity-service.ts
+++ b/frontend/src/lib/services/activity-service.ts
@@ -55,6 +55,9 @@ class ActivityService extends BaseAPIService {
 			if (action === 'redirect') {
 				return new Promise<Response>(() => {});
 			}
+			if (action === 'reload') {
+				return new Promise<Response>(() => {});
+			}
 		}
 		if (!response.ok) {
 			throw new Error(`Activity stream failed with status ${response.status}`);

--- a/frontend/src/lib/services/api-service.ts
+++ b/frontend/src/lib/services/api-service.ts
@@ -167,6 +167,7 @@ let tokenRefreshHandler: (() => Promise<string | null>) | null = null;
 // window the backend briefly restarts and returns version-mismatch 401s; we must not
 // bounce the user to /login — the session is recoverable once the backend is back.
 let upgradeInProgressInternal = false;
+let upgradeReloadStartedInternal = false;
 const skipAuthPathsInternal = [
 	'/auth/login',
 	'/auth/logout',
@@ -179,7 +180,7 @@ const skipAuthPathsInternal = [
 	'/settings/public'
 ];
 
-type UnauthorizedActionInternal = 'none' | 'redirect' | 'retry';
+type UnauthorizedActionInternal = 'none' | 'redirect' | 'reload' | 'retry';
 
 function isAuthPagePathInternal(pathname: string): boolean {
 	return (
@@ -208,19 +209,27 @@ export async function handleUnauthorizedResponseInternal(
 		return 'none';
 	}
 
-	// During a server self-update the backend briefly returns version-mismatch 401s
-	// (and is momentarily unreachable mid-restart). The session is recoverable — the
-	// refresh path rotates the token across the version change — so never bounce to
-	// /login for these: refresh and retry when possible, otherwise let the caller
-	// (e.g. the update poller) keep retrying until the backend is back.
+	// During a server self-update the backend briefly returns version-mismatch 401s.
+	// Refresh first so the new backend rotates both tokens, then replace the stale
+	// frontend document exactly once. Only transport failures are recoverable restart
+	// noise; a rejected or missing refresh token is a terminal authentication failure.
 	const recoverable = isVersionMismatch || upgradeInProgressInternal;
 
 	if (tokenRefreshHandler) {
 		try {
 			await tokenRefreshHandler();
+			if (isVersionMismatch && upgradeInProgressInternal) {
+				if (!upgradeReloadStartedInternal) {
+					upgradeReloadStartedInternal = true;
+					window.location.reload();
+				}
+				return 'reload';
+			}
 			return 'retry';
-		} catch {
-			if (recoverable) {
+		} catch (error) {
+			const isTransientRefreshFailure =
+				error instanceof APIError && (error.name === 'NetworkError' || error.name === 'TimeoutError');
+			if (recoverable && isTransientRefreshFailure) {
 				return 'none';
 			}
 			const redirectTo = encodeURIComponent(pathname);
@@ -316,6 +325,9 @@ class APIClient {
 					if (action === 'redirect') {
 						return new Promise(() => {});
 					}
+					if (action === 'reload') {
+						return new Promise(() => {});
+					}
 				}
 
 				if (errorResponse.status === 403 && typeof window !== 'undefined' && !config.suppressAccessDeniedToast) {
@@ -405,6 +417,12 @@ abstract class BaseAPIService {
 	// Toggled by the update flows (Update All / local update center) so an in-progress
 	// self-update restart is treated as a recoverable reconnect, not a logout.
 	static setUpgradeInProgress(value: boolean) {
+		if (value && !upgradeInProgressInternal) {
+			upgradeReloadStartedInternal = false;
+		}
+		if (!value) {
+			upgradeReloadStartedInternal = false;
+		}
 		upgradeInProgressInternal = value;
 	}
 

--- a/tests/spec/system-upgrade.spec.ts
+++ b/tests/spec/system-upgrade.spec.ts
@@ -1,0 +1,399 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+const REFRESH_TOKEN_KEY = 'arcane_refresh_token';
+const TOKEN_EXPIRY_KEY = 'arcane_token_expiry';
+const REFRESH_COOKIE = 'arcane_refresh_test=complete';
+const RELOAD_COUNT_KEY = 'arcane_upgrade_reload_count';
+
+type ManagerStatus = 'updated' | 'failed' | 'updating';
+type JobStatus = 'running' | 'completed' | 'failed';
+
+function updateAllJob(status: JobStatus, managerStatus: ManagerStatus) {
+	return {
+		id: 'playwright-update-all',
+		status,
+		results: [
+			{
+				environmentId: '0',
+				environmentName: 'Manager',
+				status: managerStatus,
+				...(managerStatus === 'failed' ? { error: 'Manager update failed' } : {})
+			}
+		],
+		createdAt: new Date().toISOString(),
+		...(status === 'completed' || status === 'failed'
+			? { completedAt: new Date().toISOString() }
+			: {})
+	};
+}
+
+function versionInfo(currentVersion: string, newestVersion = '2.0.0') {
+	return {
+		currentVersion,
+		displayVersion: currentVersion,
+		revision: currentVersion === newestVersion ? 'new-revision' : 'old-revision',
+		shortRevision: currentVersion === newestVersion ? 'new-rev' : 'old-rev',
+		goVersion: 'go-test',
+		nodeVersion: 'node-test',
+		svelteKitVersion: 'svelte-test',
+		isSemverVersion: true,
+		newestVersion,
+		updateAvailable: currentVersion !== newestVersion
+	};
+}
+
+function dashboardSnapshot() {
+	const pagination = { totalPages: 0, totalItems: 0, currentPage: 1, itemsPerPage: 20 };
+	return {
+		containers: {
+			data: [],
+			pagination,
+			counts: { runningContainers: 0, stoppedContainers: 0, totalContainers: 0 }
+		},
+		images: { data: [], pagination },
+		imageUsageCounts: { imagesInuse: 0, imagesUnused: 0, totalImages: 0, totalImageSize: 0 },
+		actionItems: { items: [] },
+		settings: {},
+		versionInfo: versionInfo('1.0.0')
+	};
+}
+
+async function registerReloadCounter(page: Page) {
+	await page.addInitScript((key: string) => {
+		const count = Number(sessionStorage.getItem(key) ?? '0');
+		sessionStorage.setItem(key, String(count + 1));
+	}, RELOAD_COUNT_KEY);
+}
+
+async function registerTokenSeeding(page: Page) {
+	await page.addInitScript(
+		([tokenKey, expiryKey]: [string, string]) => {
+			if (!sessionStorage.getItem(tokenKey)) {
+				sessionStorage.setItem(tokenKey, 'playwright-test-refresh-token');
+				sessionStorage.setItem(expiryKey, new Date(Date.now() + 3_600_000).toISOString());
+			}
+		},
+		[REFRESH_TOKEN_KEY, TOKEN_EXPIRY_KEY]
+	);
+}
+
+async function fulfillJob(route: Route, status: JobStatus, managerStatus: ManagerStatus) {
+	await route.fulfill({
+		status: route.request().method() === 'POST' ? 202 : 200,
+		contentType: 'application/json',
+		body: JSON.stringify({ success: true, data: updateAllJob(status, managerStatus) })
+	});
+}
+
+async function openAndConfirmUpdateAll(page: Page) {
+	await page.getByRole('button', { name: 'Update All', exact: true }).first().click();
+	const dialog = page.getByRole('dialog');
+	await expect(dialog.getByRole('heading', { name: 'Update all environments' })).toBeVisible();
+	await dialog.getByRole('button', { name: 'Update All', exact: true }).click();
+}
+
+async function currentReloadCount(page: Page) {
+	return page.evaluate(
+		(key: string) => Number(sessionStorage.getItem(key) ?? '0'),
+		RELOAD_COUNT_KEY
+	);
+}
+
+test.describe('Manager self-update recovery', () => {
+	test('Update All reloads automatically when the manager is updated', async ({ page }) => {
+		await registerReloadCounter(page);
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await fulfillJob(route, 'completed', 'updated');
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+
+		await expect.poll(() => currentReloadCount(page), { timeout: 10_000 }).toBe(2);
+		await expect(page).toHaveURL('/environments');
+	});
+
+	test('Update All leaves failed manager results visible without reloading', async ({ page }) => {
+		await registerReloadCounter(page);
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await fulfillJob(route, 'failed', 'failed');
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+
+		await expect(page.getByRole('heading', { name: 'Update all failed' })).toBeVisible({
+			timeout: 10_000
+		});
+		await expect(page.getByText('Manager update failed')).toBeVisible();
+		await expect.poll(() => currentReloadCount(page)).toBe(1);
+	});
+
+	test('the single-manager flow reloads immediately after version verification', async ({
+		page
+	}) => {
+		await registerReloadCounter(page);
+		const snapshot = dashboardSnapshot();
+		let upgradeTriggered = false;
+
+		await page.route(/\/api\/dashboard\/stream\?/, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/x-json-stream',
+				body: `${JSON.stringify({
+					type: 'snapshot',
+					environmentId: '0',
+					snapshot,
+					timestamp: new Date().toISOString()
+				})}\n`
+			});
+		});
+		await page.route(/\/api\/environments\/0\/dashboard(?:\?.*)?$/, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ success: true, data: snapshot })
+			});
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/check$/, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ canUpgrade: true, error: false, message: '' })
+			});
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade$/, async (route) => {
+			upgradeTriggered = true;
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ success: true, message: 'Upgrade started' })
+			});
+		});
+		await page.route(/\/api\/health$/, async (route) => {
+			await route.fulfill({ status: 200, body: '' });
+		});
+		await page.route(/\/api\/app-version$/, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(versionInfo(upgradeTriggered ? '2.0.0' : '1.0.0'))
+			});
+		});
+
+		await page.goto('/dashboard');
+		const versionBadge = page.getByText('v1.0.0', { exact: true }).first();
+		await expect(versionBadge).toBeVisible();
+		await versionBadge.hover();
+		const upgradeButton = page.getByRole('button', { name: 'Update to 2.0.0', exact: true });
+		await expect(upgradeButton).toBeVisible();
+		await upgradeButton.click();
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: 'Update to 2.0.0', exact: true }).click();
+
+		await expect.poll(() => currentReloadCount(page), { timeout: 10_000 }).toBe(2);
+		await expect(page).toHaveURL('/dashboard');
+	});
+
+	test('status and activity 401s share one refresh before the upgrade reload', async ({ page }) => {
+		await registerReloadCounter(page);
+		await registerTokenSeeding(page);
+
+		let releaseActivity: () => void = () => {};
+		const activityRelease = new Promise<void>((resolve) => {
+			releaseActivity = resolve;
+		});
+		await page.route(/\/api\/activities\/stream\?/, async (route) => {
+			await activityRelease;
+			if (route.request().headers()['cookie']?.includes(REFRESH_COOKIE)) {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/x-json-stream',
+					body: `${JSON.stringify({ type: 'snapshot', activities: [] })}\n`
+				});
+				return;
+			}
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Application has been updated. Refreshing session.' })
+			});
+		});
+
+		let refreshCalls = 0;
+		await page.route(/\/api\/auth\/refresh$/, async (route) => {
+			refreshCalls++;
+			await new Promise((resolve) => setTimeout(resolve, 3500));
+			await route.fulfill({
+				status: 200,
+				headers: {
+					'content-type': 'application/json',
+					'set-cookie': `${REFRESH_COOKIE}; Path=/; SameSite=Lax`
+				},
+				body: JSON.stringify({
+					success: true,
+					data: {
+						token: 'mocked-access-token',
+						refreshToken: 'mocked-refresh-token',
+						expiresAt: new Date(Date.now() + 3_600_000).toISOString()
+					}
+				})
+			});
+		});
+
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Application has been updated. Refreshing session.' })
+			});
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+		releaseActivity();
+
+		await expect.poll(() => currentReloadCount(page), { timeout: 15_000 }).toBe(2);
+		expect(refreshCalls).toBe(1);
+		await expect(page).toHaveURL('/environments');
+	});
+
+	test('a transient refresh failure keeps the token and recovers on the next poll', async ({
+		page
+	}) => {
+		await registerReloadCounter(page);
+		await registerTokenSeeding(page);
+
+		let refreshCalls = 0;
+		await page.route(/\/api\/auth\/refresh$/, async (route) => {
+			refreshCalls++;
+			if (refreshCalls === 1) {
+				await route.abort('connectionfailed');
+				return;
+			}
+			await route.fulfill({
+				status: 200,
+				headers: {
+					'content-type': 'application/json',
+					'set-cookie': `${REFRESH_COOKIE}; Path=/; SameSite=Lax`
+				},
+				body: JSON.stringify({
+					success: true,
+					data: {
+						token: 'mocked-access-token',
+						refreshToken: 'mocked-refresh-token',
+						expiresAt: new Date(Date.now() + 3_600_000).toISOString()
+					}
+				})
+			});
+		});
+
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Application has been updated. Refreshing session.' })
+			});
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+
+		await expect.poll(() => refreshCalls, { timeout: 10_000 }).toBe(1);
+		await expect
+			.poll(() => page.evaluate((key: string) => sessionStorage.getItem(key), REFRESH_TOKEN_KEY))
+			.toBe('playwright-test-refresh-token');
+		await expect.poll(() => currentReloadCount(page), { timeout: 15_000 }).toBe(2);
+		expect(refreshCalls).toBe(2);
+	});
+
+	test('a rejected refresh during an upgrade redirects to login instead of polling', async ({
+		page
+	}) => {
+		await registerTokenSeeding(page);
+		let refreshCalls = 0;
+
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Application has been updated. Refreshing session.' })
+			});
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+		await page.route(/\/api\/auth\/refresh$/, async (route) => {
+			refreshCalls++;
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Invalid or expired refresh token' })
+			});
+		});
+		await page.route(/\/api\/auth\/me$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Authentication required' })
+			});
+		});
+
+		await page.waitForURL(/\/login(?:\?|$)/, { timeout: 10_000 });
+		expect(refreshCalls).toBe(1);
+		await expect(
+			page.getByRole('button', { name: 'Sign in to Arcane', exact: true })
+		).toBeVisible();
+	});
+
+	test('a missing refresh token during an upgrade redirects to login instead of polling', async ({
+		page
+	}) => {
+		let refreshCalls = 0;
+		await page.route(/\/api\/auth\/refresh$/, async (route) => {
+			refreshCalls++;
+			await route.continue();
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all$/, async (route) => {
+			await fulfillJob(route, 'running', 'updating');
+		});
+		await page.route(/\/api\/environments\/0\/system\/upgrade\/all\/status$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Application has been updated. Refreshing session.' })
+			});
+		});
+
+		await page.goto('/environments');
+		await openAndConfirmUpdateAll(page);
+		await page.route(/\/api\/auth\/me$/, async (route) => {
+			await route.fulfill({
+				status: 401,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Authentication required' })
+			});
+		});
+
+		await page.waitForURL(/\/login(?:\?|$)/, { timeout: 10_000 });
+		expect(refreshCalls).toBe(0);
+		await expect(
+			page.getByRole('button', { name: 'Sign in to Arcane', exact: true })
+		).toBeVisible();
+	});
+});

--- a/tests/spec/token-refresh.spec.ts
+++ b/tests/spec/token-refresh.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 const REFRESH_TOKEN_KEY = 'arcane_refresh_token';
 const TOKEN_EXPIRY_KEY = 'arcane_token_expiry';
+const REFRESH_COOKIE = 'arcane_refresh_test=complete';
 
 /**
  * Register an addInitScript that plants a fake refresh token in sessionStorage
@@ -19,15 +20,13 @@ async function registerTokenSeeding(page: Page) {
 }
 
 /**
- * Intercept the FIRST request matching urlPattern with a 401 version-mismatch
- * body. All subsequent requests (e.g. the interceptor's automatic retry) pass
- * through. Uses a flag rather than unroute() to avoid "Route is already handled".
+ * Keep returning a version-mismatch 401 until the refresh response's cookie is
+ * present. This verifies that a retry is authenticated by refreshed browser state
+ * instead of passing merely because it happens to be the second request.
  */
-async function injectVersionMismatch401Once(page: Page, urlPattern: string | RegExp) {
-	let fired = false;
+async function injectVersionMismatchUntilRefresh(page: Page, urlPattern: string | RegExp) {
 	await page.route(urlPattern, async (route) => {
-		if (!fired) {
-			fired = true;
+		if (!route.request().headers()['cookie']?.includes(REFRESH_COOKIE)) {
 			await route.fulfill({
 				status: 401,
 				contentType: 'application/json',
@@ -56,16 +55,22 @@ async function injectExpired401Always(page: Page, urlPattern: string | RegExp) {
 }
 
 /**
- * Mock /auth/refresh to return a synthetic 200. Returns a getter to assert
- * whether the endpoint was called.
+ * Mock /auth/refresh to return a synthetic 200 and browser cookie. Returns a
+ * getter to assert how many refresh requests were made.
  */
-async function mockRefreshSuccess(page: Page): Promise<() => boolean> {
-	let called = false;
+async function mockRefreshSuccess(page: Page, delayMs = 0): Promise<() => number> {
+	let callCount = 0;
 	await page.route(/\/api\/auth\/refresh$/, async (route) => {
-		called = true;
+		callCount++;
+		if (delayMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
 		await route.fulfill({
 			status: 200,
-			contentType: 'application/json',
+			headers: {
+				'content-type': 'application/json',
+				'set-cookie': `${REFRESH_COOKIE}; Path=/; SameSite=Lax`
+			},
 			body: JSON.stringify({
 				success: true,
 				data: {
@@ -76,7 +81,7 @@ async function mockRefreshSuccess(page: Page): Promise<() => boolean> {
 			})
 		});
 	});
-	return () => called;
+	return () => callCount;
 }
 
 test.describe('Token refresh behaviour', () => {
@@ -84,13 +89,13 @@ test.describe('Token refresh behaviour', () => {
 		page
 	}) => {
 		await registerTokenSeeding(page);
-		const wasRefreshCalled = await mockRefreshSuccess(page);
-		await injectVersionMismatch401Once(page, /\/api\/auth\/me(?:\?.*)?$/);
+		const refreshCallCount = await mockRefreshSuccess(page);
+		await injectVersionMismatchUntilRefresh(page, /\/api\/auth\/me(?:\?.*)?$/);
 
 		await page.goto('/dashboard');
 		await page.waitForLoadState('load');
 
-		await expect.poll(() => wasRefreshCalled()).toBe(true);
+		await expect.poll(() => refreshCallCount()).toBe(1);
 		await expect(page).toHaveURL('/dashboard');
 		await expect(page.getByRole('button', { name: 'Sign in to Arcane' })).not.toBeVisible();
 	});
@@ -99,13 +104,13 @@ test.describe('Token refresh behaviour', () => {
 		page
 	}) => {
 		await registerTokenSeeding(page);
-		const wasRefreshCalled = await mockRefreshSuccess(page);
-		await injectVersionMismatch401Once(page, /\/api\/environments\/[^/]+\/containers/);
+		const refreshCallCount = await mockRefreshSuccess(page);
+		await injectVersionMismatchUntilRefresh(page, /\/api\/environments\/[^/]+\/containers/);
 
 		await page.goto('/containers');
 		await page.waitForLoadState('load');
 
-		await expect.poll(() => wasRefreshCalled()).toBe(true);
+		await expect.poll(() => refreshCallCount()).toBe(1);
 		await expect(page).toHaveURL('/containers');
 		await expect(page.getByRole('heading', { name: 'Containers', level: 1 })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Sign in to Arcane' })).not.toBeVisible();


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves frontend recovery after a manager self-update. The main changes are:

- Automatic reloads after local manager upgrade verification.
- Shared auth refresh handling for upgrade-related `401` responses.
- Activity stream handling for the new reload auth action.
- Playwright coverage for update reloads, refresh retries, and auth failure paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are focused on self-update recovery and include targeted tests for the main success and failure paths. No current functional or security issues were identified in the changed code.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the dev server startup and reload sequence using the update-reload-devserver.log to confirm the environment came up during the update flow.
- Investigated the Docker/global-setup blocker and analyzed the narrowed Playwright execution log in update-reload-02-after.log to understand test constraints.
- Validated the test evidence by inspecting captured real-app Playwright videos, traces, and error contexts from the narrowed manager self-update tests.
- Linked and reviewed all uploaded artifacts (logs, videos, and bundles) to enable end-to-end validation of the contract validation.

<a href="https://app.greptile.com/trex/runs/14626506/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(frontend): recover auth and reload a..."](https://github.com/getarcaneapp/arcane/commit/de828fabc12baee606972fe13a389b538bb60fe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44651958)</sub>

<!-- /greptile_comment -->