### PR TITLE
fix: show correct host IP in service port tooltips

### DIFF
--- a/frontend/src/lib/components/badges/port-badge.svelte
+++ b/frontend/src/lib/components/badges/port-badge.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ContainerPorts } from '$lib/types/docker';
+	import type { ServicePort } from '$lib/types/swarm';
 	import { m } from '$lib/paraglide/messages';
 	import * as ArcaneTooltip from '$lib/components/arcane-tooltip';
 	import { badgeVariants } from '$lib/components/ui/badge';
@@ -9,13 +10,13 @@
 	import { mergeProps } from 'bits-ui';
 
 	let {
-		ports = [] as ContainerPorts[],
+		ports = [] as PortBadgePort[],
 		collapsible = true,
 		maxVisible = 3,
 		hideExposed = false,
 		wrap = true
 	} = $props<{
-		ports?: ContainerPorts[];
+		ports?: PortBadgePort[];
 		collapsible?: boolean;
 		maxVisible?: number;
 		hideExposed?: boolean;
@@ -26,6 +27,7 @@
 	let expanded = $state(false);
 
 	const baseServerUrl = $derived($settingsStore?.baseServerUrl ?? 'http://localhost');
+	type PortBadgePort = ContainerPorts | ServicePort;
 
 	type NormalizedPort = {
 		hostPort: string | null;
@@ -35,36 +37,39 @@
 		isPublished: boolean;
 	};
 
-	function getPublicPort(p: ContainerPorts): string | null {
-		const pub =
-			(p as any).publicPort?.toString?.() ?? (p as any).hostPort?.toString?.() ?? (p as any).published?.toString?.() ?? null;
+	function isContainerPort(p: PortBadgePort): p is ContainerPorts {
+		return 'privatePort' in p;
+	}
+
+	function getPublicPort(p: PortBadgePort): string | null {
+		const pub = isContainerPort(p) ? p.publicPort?.toString() : p.published?.toString();
 		return pub && pub !== '0' ? pub : null;
 	}
 
-	function getPrivatePort(p: ContainerPorts): string {
-		return ((p as any).privatePort ?? (p as any).target ?? '?').toString();
+	function getPrivatePort(p: PortBadgePort): string {
+		return (isContainerPort(p) ? p.privatePort : p.target).toString();
 	}
 
-	function getProto(p: ContainerPorts): string | undefined {
-		return (p as any).type ?? (p as any).protocol ?? undefined;
+	function getProto(p: PortBadgePort): string | undefined {
+		return isContainerPort(p) ? p.type : p.protocol;
 	}
 
-	function normalize(p: ContainerPorts): NormalizedPort {
+	function normalize(p: PortBadgePort): NormalizedPort {
 		const hostPort = getPublicPort(p);
 		return {
 			hostPort,
 			containerPort: getPrivatePort(p),
 			proto: getProto(p),
-			ip: (p as any).ip ?? null,
+			ip: (isContainerPort(p) ? p.ip : p.host_ip)?.trim() || null,
 			isPublished: hostPort !== null
 		};
 	}
 
-	function uniquePorts(list: ContainerPorts[]): NormalizedPort[] {
+	function uniquePorts(list: PortBadgePort[]): NormalizedPort[] {
 		const map = new Map<string, NormalizedPort>();
 		for (const p of list) {
 			const n = normalize(p);
-			const key = `${n.hostPort ?? ''}:${n.containerPort}/${n.proto ?? ''}`;
+			const key = `${n.ip ?? ''}:${n.hostPort ?? ''}:${n.containerPort}/${n.proto ?? ''}`;
 			if (!map.has(key)) map.set(key, n);
 		}
 		return Array.from(map.values()).sort((a, b) => {
@@ -116,7 +121,7 @@
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content>
 					<p class="text-xs">
-						Published: {p.ip ?? '0.0.0.0'}:{p.hostPort} → {p.containerPort}{p.proto ? `/${p.proto}` : ''}
+						{m.ports_published_label()}: {p.ip ?? '0.0.0.0'}:{p.hostPort} → {p.containerPort}{p.proto ? `/${p.proto}` : ''}
 					</p>
 				</ArcaneTooltip.Content>
 			</ArcaneTooltip.Root>
@@ -133,7 +138,7 @@
 				</ArcaneTooltip.Trigger>
 				<ArcaneTooltip.Content>
 					<p class="text-xs">
-						Exposed: {p.containerPort}{p.proto ? `/${p.proto}` : ''} (not published to host)
+						{m.ports_exposed_label()}: {p.containerPort}{p.proto ? `/${p.proto}` : ''} ({m.ports_no_host_binding()})
 					</p>
 				</ArcaneTooltip.Content>
 			</ArcaneTooltip.Root>

--- a/frontend/src/lib/types/swarm.ts
+++ b/frontend/src/lib/types/swarm.ts
@@ -514,6 +514,7 @@ export interface SwarmSecretUpdateRequest {
 
 export interface ServicePort {
 	mode?: string;
+	host_ip?: string;
 	target: number;
 	published?: string;
 	protocol?: string;

--- a/frontend/src/routes/(app)/projects/components/ProjectContainersTable.svelte
+++ b/frontend/src/routes/(app)/projects/components/ProjectContainersTable.svelte
@@ -344,7 +344,7 @@
 
 {#snippet PortsCell({ item }: { item: ServiceWithId })}
 	{#if item.serviceConfig?.ports && item.serviceConfig.ports.length > 0}
-		<PortBadge ports={item.serviceConfig.ports as any} wrap={false} />
+		<PortBadge ports={item.serviceConfig.ports} wrap={false} />
 	{:else if item.ports && item.ports.length > 0}
 		{@const parsedPorts = item.ports.map((p) => {
 			const [numsPart, proto] = p.split('/');

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -161,7 +161,11 @@ async function expectProjectCreateResponse(responsePromise: Promise<Response>) {
 	);
 }
 
-async function createProjectViaUI(page: Page, projectName: string) {
+async function createProjectViaUI(
+	page: Page,
+	projectName: string,
+	composeContent = TEST_COMPOSE_YAML
+) {
 	const containerName = `test-nginx-container-${Date.now()}`;
 	const envFile = TEST_ENV_FILE.replace(/CONTAINER_NAME=.*/m, `CONTAINER_NAME=${containerName}`);
 
@@ -178,13 +182,13 @@ async function createProjectViaUI(page: Page, projectName: string) {
 	await expect(composeEditor).toBeVisible();
 	await expect(envEditor).toBeVisible();
 
-	await setCodeMirrorValue(page, composeEditor, TEST_COMPOSE_YAML);
+	await setCodeMirrorValue(page, composeEditor, composeContent);
 	await setCodeMirrorValue(page, envEditor, envFile);
 	await expect
 		.poll(async () => (await getCodeMirrorValue(composeEditor)).trimEnd(), {
 			message: 'Expected compose editor to contain the exact test compose fixture before creation'
 		})
-		.toBe(TEST_COMPOSE_YAML.trimEnd());
+		.toBe(composeContent.trimEnd());
 
 	const createButton = page.locator('button[data-action="create"]');
 	await expect(createButton).toBeEnabled();
@@ -1222,6 +1226,37 @@ test.describe('Project Detail Page', () => {
 				await expect(anyServiceBadge).toBeVisible();
 			} else {
 				await expect(emptyState).toBeVisible();
+			}
+		}
+	});
+
+	test('should display the configured service port host IP', async ({ page }) => {
+		test.slow();
+
+		const projectName = `test-project-port-host-${Date.now()}`;
+		const composeContent = [
+			'services:',
+			'  web:',
+			'    image: public.ecr.aws/nginx/nginx:stable-alpine',
+			'    ports:',
+			'      - "127.0.0.1:8081:80"',
+			''
+		].join('\n');
+		let projectId = '';
+
+		try {
+			projectId = await createProjectViaUI(page, projectName, composeContent);
+			await page.getByRole('tab', { name: 'Services 1', exact: true }).click();
+
+			await page.getByText('8081:80', { exact: true }).hover();
+			await expect(
+				page.getByText('Published: 127.0.0.1:8081 → 80/tcp', { exact: true })
+			).toBeVisible();
+		} finally {
+			if (projectId) {
+				await destroyProjectByIdViaAPI(page, projectId);
+			} else {
+				await destroyProjectByNameViaUI(page, projectName);
 			}
 		}
 	});


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3280

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates service port tooltip display for project containers. The main changes are:

- `PortBadge` now accepts both container ports and service ports.
- Service port `host_ip` is normalized into the published-port tooltip.
- Project service port rendering no longer needs an `any` cast.
- A Playwright test checks the configured host IP in the tooltip.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the test flake risk.

The app changes are small and type-directed, with no verified functional bug found. The remaining issue is limited to test robustness around a fixed host port.

`tests/spec/project.spec.ts`
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the PortBadge change and confirmed it reads ServicePort.host\_ip during normalization and renders the tooltip as Published: {p.ip ?? '0.0.0.0'}:{p.hostPort} → {p.containerPort}/{proto}.
- Verified that ProjectContainersTable uses \<PortBadge ports={item.serviceConfig.ports} wrap={false} /\> when serviceConfig ports are present.
- Noted that runtime proof of the tooltip text was not captured because execution stopped before creating or running the Svelte and Playwright harness.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_show_correct_host_ip_in_service_port_tooltips%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_show_correct_host_ip_in_service_port_tooltips%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fspec%2Fproject.spec.ts%3A1242%0A**Avoid%20fixed%20host%20port**%0AThis%20test%20binds%20the%20real%20Docker%20project%20to%20host%20port%20%608081%60%2C%20so%20the%20scenario%20fails%20before%20reaching%20the%20UI%20assertion%20whenever%20another%20process%20or%20concurrent%20test%20already%20owns%20that%20port.%20Use%20a%20dynamically%20selected%2Ffree%20high%20port%20and%20interpolate%20the%20same%20value%20into%20the%20tooltip%20expectation%20to%20keep%20the%20test%20for%20this%20change%20without%20adding%20environment-dependent%20flakes.%0A%0A&repo=getarcaneapp%2Farcane&pr=3299&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fspec%2Fproject.spec.ts%3A1242%0A**Avoid%20fixed%20host%20port**%0AThis%20test%20binds%20the%20real%20Docker%20project%20to%20host%20port%20%608081%60%2C%20so%20the%20scenario%20fails%20before%20reaching%20the%20UI%20assertion%20whenever%20another%20process%20or%20concurrent%20test%20already%20owns%20that%20port.%20Use%20a%20dynamically%20selected%2Ffree%20high%20port%20and%20interpolate%20the%20same%20value%20into%20the%20tooltip%20expectation%20to%20keep%20the%20test%20for%20this%20change%20without%20adding%20environment-dependent%20flakes.%0A%0A&repo=getarcaneapp%2Farcane&pr=3299&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/spec/project.spec.ts:1242
**Avoid fixed host port**
This test binds the real Docker project to host port `8081`, so the scenario fails before reaching the UI assertion whenever another process or concurrent test already owns that port. Use a dynamically selected/free high port and interpolate the same value into the tooltip expectation to keep the test for this change without adding environment-dependent flakes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show correct host IP in service por..."](https://github.com/getarcaneapp/arcane/commit/2ee20551636cdc83c38eeaf243c25fa746622d67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44888062)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->