### PR TITLE
fix: classify remote Compose build images as local only

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -184,7 +184,7 @@ func initializeStartupState(appCtx context.Context, cfg *config.Config, appServi
 		if err := appServices.Project.RecoverProjectRenameJournals(appCtx); err != nil {
 			slog.WarnContext(appCtx, "Failed to recover interrupted project rename operations on startup", "error", err)
 		}
-		go appServices.Project.BackfillProjectImageRefs(appCtx)
+		appServices.Project.BackfillProjectImageRefs(appCtx)
 	}
 
 	if !cfg.AgentMode {

--- a/backend/internal/database/database_test.go
+++ b/backend/internal/database/database_test.go
@@ -63,6 +63,26 @@ func TestMigrateDatabase_DowngradesWhenAllowed(t *testing.T) {
 	assert.Equal(t, targetVersion, readGooseSQLiteVersionInternal(t, dsn))
 }
 
+func TestMigration065_ProjectBuildImageRefs_UpAndDown(t *testing.T) {
+	ctx := context.Background()
+	rawDB, _ := newSQLiteSQLDBInternal(t, t.TempDir(), "arcane-project-build-refs.db")
+
+	require.NoError(t, migrateDatabaseToVersionInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{}, 64))
+	var columnCount int
+	require.NoError(t, rawDB.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('projects') WHERE name = 'build_image_refs_json'`).Scan(&columnCount))
+	assert.Zero(t, columnCount)
+
+	require.NoError(t, migrateDatabaseToVersionInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{}, 65))
+	var notNull int
+	require.NoError(t, rawDB.QueryRow(`SELECT COUNT(*), COALESCE(MAX("notnull"), 0) FROM pragma_table_info('projects') WHERE name = 'build_image_refs_json'`).Scan(&columnCount, &notNull))
+	assert.Equal(t, 1, columnCount)
+	assert.Zero(t, notNull)
+
+	require.NoError(t, migrateDatabaseToVersionInternal(ctx, rawDB, dbProviderSQLite, MigrationOptions{AllowDowngrade: true}, 64))
+	require.NoError(t, rawDB.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('projects') WHERE name = 'build_image_refs_json'`).Scan(&columnCount))
+	assert.Zero(t, columnCount)
+}
+
 func TestMigrateDatabase_BlocksFutureGooseVersionWithoutFlag(t *testing.T) {
 	ctx := context.Background()
 	rawDB, dsn := newSQLiteSQLDBInternal(t, t.TempDir(), "arcane-future.db")

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -27,6 +27,7 @@ type Project struct {
 	GitOpsManagedBy    *string       `json:"gitops_managed_by,omitempty" gorm:"column:gitops_managed_by"`
 	ComposeProjectName *string       `json:"compose_project_name,omitempty" gorm:"column:compose_project_name"`
 	ImageRefsJSON      string        `json:"image_refs_json,omitempty" gorm:"column:image_refs_json"`
+	BuildImageRefsJSON *string       `json:"-" gorm:"column:build_image_refs_json"`
 	IsArchived         bool          `json:"is_archived" gorm:"column:is_archived;default:false;index"`
 	ArchivedAt         *time.Time    `json:"archived_at,omitempty" gorm:"column:archived_at"`
 }

--- a/backend/internal/services/image_service_test.go
+++ b/backend/internal/services/image_service_test.go
@@ -114,7 +114,7 @@ func setupImageServiceAuthTest(t *testing.T) (*ImageService, *database.DB) {
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.ContainerRegistry{}, &models.KVEntry{}))
+	require.NoError(t, db.AutoMigrate(&models.ContainerRegistry{}, &models.KVEntry{}, &models.Project{}))
 
 	crypto.InitEncryption(&crypto.Config{
 		Environment:   string(config.AppEnvironmentTest),

--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/ratelimit"
 	registry "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/registryauth"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
+	projectspkg "github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
@@ -24,6 +25,7 @@ import (
 	"github.com/moby/moby/client"
 	"go.getarcane.app/sys/crypto"
 	updaterdigest "go.getarcane.app/updater/pkg/digest"
+	updaterrefs "go.getarcane.app/updater/pkg/refs"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 )
@@ -93,6 +95,35 @@ func (s *ImageUpdateService) dockerClientInternal(ctx context.Context) (*client.
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 	return dockerClient, nil
+}
+
+func (s *ImageUpdateService) composeBuildImageRefsInternal(ctx context.Context) (map[string]struct{}, error) {
+	refs := make(map[string]struct{})
+	if s == nil || s.db == nil {
+		return refs, nil
+	}
+
+	var projectRows []models.Project
+	if err := s.db.WithContext(ctx).
+		Select("id", "build_image_refs_json").
+		Where("build_image_refs_json IS NOT NULL AND build_image_refs_json <> ''").
+		Find(&projectRows).Error; err != nil {
+		return nil, fmt.Errorf("load project build image references: %w", err)
+	}
+
+	for i := range projectRows {
+		if projectRows[i].BuildImageRefsJSON == nil {
+			continue
+		}
+		for _, imageRef := range projectspkg.ParseImageRefsJSON(*projectRows[i].BuildImageRefsJSON) {
+			normalized := updaterrefs.NormalizeImageUpdateRef(imageRef)
+			if normalized != "" {
+				refs[normalized] = struct{}{}
+			}
+		}
+	}
+
+	return refs, nil
 }
 
 func (s *ImageUpdateService) startImageUpdateActivityInternal(ctx context.Context, resourceName string, count int) string {
@@ -207,7 +238,12 @@ func (s *ImageUpdateService) CheckImageUpdate(ctx context.Context, imageRef stri
 		return result, nil
 	}
 
-	digestResult, snapshot, err := s.checkDigestUpdateWithSnapshotInternal(ctx, parts)
+	composeBuildRefs, err := s.composeBuildImageRefsInternal(ctx)
+	var digestResult *imageupdate.Response
+	var snapshot *localImageSnapshot
+	if err == nil {
+		digestResult, snapshot, err = s.checkDigestUpdateWithSnapshotInternal(ctx, parts, composeBuildRefs)
+	}
 	if err != nil {
 		result := &imageupdate.Response{
 			Error:          err.Error(),
@@ -332,14 +368,14 @@ func digestPinnedImageUpdateResultInternal(imageRef string) (*imageupdate.Respon
 	}, true
 }
 
-func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.Context, parts *ImageParts) (*imageupdate.Response, *localImageSnapshot, error) {
+func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.Context, parts *ImageParts, composeBuildRefs map[string]struct{}) (*imageupdate.Response, *localImageSnapshot, error) {
 	if s.registryService == nil {
 		return nil, nil, errors.New("registry service unavailable")
 	}
 
 	imageRef := fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag)
 	start := time.Now()
-	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef, composeBuildRefs)
 	if err == nil && snapshot.IsLocalBuild {
 		return localBuildImageUpdateResultInternal(snapshot, int(time.Since(start).Milliseconds())), snapshot, nil
 	}
@@ -365,7 +401,7 @@ func (s *ImageUpdateService) checkDigestUpdateWithSnapshotInternal(ctx context.C
 	}
 
 	if snapshot == nil {
-		snapshot, err = s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+		snapshot, err = s.inspectLocalImageSnapshotInternal(ctx, imageRef, composeBuildRefs)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get local digest: %w", err)
 		}
@@ -604,7 +640,7 @@ func dedupeImageRefsFromSummariesInternal(images []image.Summary, limit int) []s
 	return imageRefs
 }
 
-func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Context, imageRef string) (*localImageSnapshot, error) {
+func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Context, imageRef string, composeBuildRefs map[string]struct{}) (*localImageSnapshot, error) {
 	dockerClient, err := s.dockerClientInternal(ctx)
 	if err != nil {
 		return nil, err
@@ -644,6 +680,10 @@ func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Conte
 		isLocalBuild = true
 		primaryDigest = inspectResponse.ID
 		allDigests = []string{primaryDigest}
+	}
+	if normalizedRef := updaterrefs.NormalizeImageUpdateRef(imageRef); normalizedRef != "" {
+		_, isComposeBuild := composeBuildRefs[normalizedRef]
+		isLocalBuild = isLocalBuild || isComposeBuild
 	}
 
 	repo, tag := extractRepoAndTagFromImage(inspectResponse.InspectResponse)
@@ -954,7 +994,7 @@ func (s *ImageUpdateService) MarkImageRefUpToDateAfterPull(ctx context.Context, 
 		return nil
 	}
 
-	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+	snapshot, err := s.inspectLocalImageSnapshotInternal(ctx, imageRef, nil)
 	if err != nil {
 		return fmt.Errorf("inspect pulled image: %w", err)
 	}
@@ -1106,7 +1146,7 @@ func (s *ImageUpdateService) parseAndGroupImagesInternal(imageRefs []string) (ma
 	return regRepos, results, images
 }
 
-func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context, externalCreds []containerregistry.Credential, parts *ImageParts) (*imageupdate.Response, *localImageSnapshot) {
+func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context, externalCreds []containerregistry.Credential, parts *ImageParts, composeBuildRefs map[string]struct{}) (*imageupdate.Response, *localImageSnapshot) {
 	if s.registryService == nil {
 		return &imageupdate.Response{
 			Error:          "registry service unavailable",
@@ -1117,7 +1157,7 @@ func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context
 
 	start := time.Now()
 	imageRef := fmt.Sprintf("%s/%s:%s", parts.Registry, parts.Repository, parts.Tag)
-	snapshot, ldErr := s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+	snapshot, ldErr := s.inspectLocalImageSnapshotInternal(ctx, imageRef, composeBuildRefs)
 	if ldErr == nil && snapshot.IsLocalBuild {
 		return localBuildImageUpdateResultInternal(snapshot, int(time.Since(start).Milliseconds())), snapshot
 	}
@@ -1141,7 +1181,7 @@ func (s *ImageUpdateService) checkSingleImageInBatchInternal(ctx context.Context
 	}
 
 	if ldErr != nil {
-		snapshot, ldErr = s.inspectLocalImageSnapshotInternal(ctx, imageRef)
+		snapshot, ldErr = s.inspectLocalImageSnapshotInternal(ctx, imageRef, composeBuildRefs)
 		if ldErr != nil {
 			return &imageupdate.Response{
 				Error:          ldErr.Error(),
@@ -1228,7 +1268,7 @@ func (s *ImageUpdateService) resolveBatchCredentialsInternal(ctx context.Context
 	return credentials
 }
 
-func (s *ImageUpdateService) checkBatchImageInternal(ctx context.Context, activityID string, resolvedCreds []containerregistry.Credential, img batchImage, recorder *batchImageProgressRecorder) error {
+func (s *ImageUpdateService) checkBatchImageInternal(ctx context.Context, activityID string, resolvedCreds []containerregistry.Credential, img batchImage, composeBuildRefs map[string]struct{}, recorder *batchImageProgressRecorder) error {
 	registry := img.parts.Registry
 
 	if err := s.registryLimiter.Acquire(ctx, registry); err != nil {
@@ -1251,7 +1291,7 @@ func (s *ImageUpdateService) checkBatchImageInternal(ctx context.Context, activi
 	}
 	defer s.registryLimiter.Release(registry)
 
-	res, snapshot := s.checkSingleImageInBatchInternal(ctx, resolvedCreds, img.parts)
+	res, snapshot := s.checkSingleImageInBatchInternal(ctx, resolvedCreds, img.parts, composeBuildRefs)
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -1306,6 +1346,13 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 		}
 	}
 
+	composeBuildRefs, err := s.composeBuildImageRefsInternal(ctx)
+	if err != nil {
+		wrappedErr := fmt.Errorf("prepare compose build image references: %w", err)
+		s.completeImageUpdateActivityInternal(ctx, activityID, false, "Image update check failed: "+wrappedErr.Error())
+		return results, wrappedErr
+	}
+
 	resolvedCreds := s.resolveBatchCredentialsInternal(ctx, externalCreds)
 
 	slog.DebugContext(ctx, "Resolved batch registry credentials", "credentialCount", len(resolvedCreds), "registryCount", len(regRepos))
@@ -1319,7 +1366,7 @@ func (s *ImageUpdateService) CheckMultipleImages(ctx context.Context, imageRefs 
 
 	for _, img := range images {
 		g.Go(func() error {
-			return s.checkBatchImageInternal(groupCtx, activityID, resolvedCreds, img, recorder)
+			return s.checkBatchImageInternal(groupCtx, activityID, resolvedCreds, img, composeBuildRefs, recorder)
 		})
 	}
 

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
+	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
 	sqlite "github.com/libtnb/sqlite"
 	dockertypescontainer "github.com/moby/moby/api/types/container"
@@ -367,8 +368,100 @@ func setupImageUpdateTestDB(t *testing.T) *database.DB {
 	dsn := fmt.Sprintf("file:image-update-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}))
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}, &models.Project{}))
 	return &database.DB{DB: db}
+}
+
+func newComposeBuildImageUpdateServiceInternal(t *testing.T) (*ImageUpdateService, *atomic.Int32) {
+	t.Helper()
+
+	db := setupImageUpdateTestDB(t)
+	buildRefsJSON := `["test2:latest"]`
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel:          models.BaseModel{ID: "compose-build-project"},
+		Name:               "compose-build-project",
+		BuildImageRefsJSON: &buildRefsJSON,
+	}).Error)
+
+	localDigest := digest.FromString("compose-build-local").String()
+	remoteDigest := digest.FromString("compose-build-remote").String()
+	dockerServer := newImageUpdateFallbackServer(t, "library/test2:latest", localDigest, remoteDigest)
+	t.Cleanup(dockerServer.Close)
+
+	var registryCalls atomic.Int32
+	registryService := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(context.Context, string, client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				registryCalls.Add(1)
+				return client.DistributionInspectResult{
+					DistributionInspect: dockerregistry.DistributionInspect{
+						Descriptor: ocispec.Descriptor{Digest: digest.Digest(remoteDigest)},
+					},
+				}, nil
+			},
+		}, nil
+	}, nil)
+
+	dockerService := &DockerClientService{client: newTestDockerClient(t, dockerServer)}
+	eventService := NewEventService(db, nil, nil)
+	return NewImageUpdateService(db, nil, registryService, dockerService, eventService, nil, nil), &registryCalls
+}
+
+func TestImageUpdateService_CheckImageUpdate_ComposeBuildSkipsRegistryWithRepoDigests(t *testing.T) {
+	svc, registryCalls := newComposeBuildImageUpdateServiceInternal(t)
+
+	result, err := svc.CheckImageUpdate(context.Background(), "test2:latest")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, models.UpdateTypeLocal, result.UpdateType)
+	assert.False(t, result.HasUpdate)
+	assert.Empty(t, result.Error)
+	assert.Zero(t, registryCalls.Load())
+
+	var saved models.ImageUpdateRecord
+	require.NoError(t, svc.db.First(&saved, "id = ?", "sha256:local-image-id").Error)
+	assert.Equal(t, models.UpdateTypeLocal, saved.UpdateType)
+	assert.Nil(t, saved.LastError)
+}
+
+func TestImageUpdateService_CheckMultipleImages_ComposeBuildSkipsRegistryWithRepoDigests(t *testing.T) {
+	svc, registryCalls := newComposeBuildImageUpdateServiceInternal(t)
+	credentials := []containerregistry.Credential{{
+		URL:      "https://index.docker.io/v1/",
+		Username: "unused",
+		Token:    "unused",
+		Enabled:  true,
+	}}
+
+	results, err := svc.CheckMultipleImages(context.Background(), []string{"test2:latest"}, credentials)
+	require.NoError(t, err)
+	result := results["test2:latest"]
+	require.NotNil(t, result)
+	assert.Equal(t, models.UpdateTypeLocal, result.UpdateType)
+	assert.False(t, result.HasUpdate)
+	assert.Empty(t, result.Error)
+	assert.Zero(t, registryCalls.Load())
+}
+
+func TestImageUpdateService_InspectLocalImageSnapshot_NoRepoDigestsRemainsLocal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json") {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:       "sha256:local-only-image",
+				RepoTags: []string{"local-only:latest"},
+			}))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := &ImageUpdateService{dockerService: &DockerClientService{client: newTestDockerClient(t, server)}}
+	snapshot, err := svc.inspectLocalImageSnapshotInternal(context.Background(), "local-only:latest", map[string]struct{}{})
+	require.NoError(t, err)
+	assert.True(t, snapshot.IsLocalBuild)
+	assert.Equal(t, "sha256:local-only-image", snapshot.PrimaryDigest)
 }
 
 func newImageUpdateFallbackServer(t *testing.T, repositoryTag, localDigest, remoteDigest string) *httptest.Server {
@@ -815,7 +908,7 @@ func TestImageUpdateService_InspectLocalImageSnapshotUsesDockerAPITimeoutInterna
 	defer cancel()
 
 	start := time.Now()
-	_, err := svc.inspectLocalImageSnapshotInternal(parentCtx, "registry.example.com/team/app:1.2.3")
+	_, err := svc.inspectLocalImageSnapshotInternal(parentCtx, "registry.example.com/team/app:1.2.3", nil)
 	elapsed := time.Since(start)
 
 	require.Error(t, err)
@@ -825,7 +918,7 @@ func TestImageUpdateService_InspectLocalImageSnapshotUsesDockerAPITimeoutInterna
 
 func TestImageUpdateService_CheckMultipleImages_UsesDockerHubCredentialsOnFirstAttempt(t *testing.T) {
 	_, db := setupImageServiceAuthTest(t)
-	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}))
+	require.NoError(t, db.AutoMigrate(&models.ImageUpdateRecord{}, &models.Event{}, &models.Project{}))
 	createTestPullRegistry(t, db, "https://index.docker.io/v1/", "docker-user", "docker-token")
 
 	localDigest := digest.FromString("batchlocal-rate-limit").String()

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -579,27 +579,39 @@ func (s *ProjectService) refreshProjectImageRefsInternal(ctx context.Context, pr
 	}
 
 	s.invalidateComposeCacheInternal(proj.ID)
-	refs, err := s.getProjectImageRefsFromComposeInternal(ctx, *proj, nil)
+	refs, buildRefs, err := s.getProjectImageRefsFromComposeInternal(ctx, *proj, nil)
 	if err != nil {
 		if dbErr := s.db.WithContext(ctx).
 			Model(&models.Project{}).
 			Where("id = ?", proj.ID).
-			Update("image_refs_json", "").Error; dbErr != nil {
+			Updates(map[string]any{
+				"image_refs_json":       "",
+				"build_image_refs_json": nil,
+			}).Error; dbErr != nil {
 			slog.WarnContext(ctx, "failed to clear stale project image refs", "projectID", proj.ID, "error", dbErr)
 		}
 		proj.ImageRefsJSON = ""
+		proj.BuildImageRefsJSON = nil
 		slog.WarnContext(ctx, "failed to refresh project image refs", "projectID", proj.ID, "projectName", proj.Name, "error", err)
 		return
 	}
 	imageRefsJSON := projects.MarshalImageRefsJSON(refs)
+	buildImageRefsJSON := projects.MarshalImageRefsJSON(buildRefs)
+	if buildImageRefsJSON == "" {
+		buildImageRefsJSON = "[]"
+	}
 	if err := s.db.WithContext(ctx).
 		Model(&models.Project{}).
 		Where("id = ?", proj.ID).
-		Update("image_refs_json", imageRefsJSON).Error; err != nil {
+		Updates(map[string]any{
+			"image_refs_json":       imageRefsJSON,
+			"build_image_refs_json": buildImageRefsJSON,
+		}).Error; err != nil {
 		slog.WarnContext(ctx, "failed to persist project image refs", "projectID", proj.ID, "error", err)
 		return
 	}
 	proj.ImageRefsJSON = imageRefsJSON
+	proj.BuildImageRefsJSON = new(buildImageRefsJSON)
 }
 
 func (s *ProjectService) HandleProjectFilesChanged(ctx context.Context, paths []string) {
@@ -625,7 +637,7 @@ func (s *ProjectService) BackfillProjectImageRefs(ctx context.Context) {
 
 	var projectsList []models.Project
 	if err := s.db.WithContext(ctx).
-		Where("image_refs_json = '' OR image_refs_json IS NULL").
+		Where("build_image_refs_json IS NULL").
 		Find(&projectsList).Error; err != nil {
 		slog.WarnContext(ctx, "failed to list projects for image ref backfill", "error", err)
 		return
@@ -1328,7 +1340,7 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 			}
 			defer func() { <-sem }()
 
-			refs, err := s.getProjectImageRefsFromComposeInternal(ctx, proj, cfg)
+			refs, _, err := s.getProjectImageRefsFromComposeInternal(ctx, proj, cfg)
 			if err != nil {
 				slog.WarnContext(ctx, "failed to resolve project image refs for update summary", "projectID", proj.ID, "projectName", proj.Name, "error", err)
 				return
@@ -1361,13 +1373,13 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	}
 }
 
-func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project, cfg *models.Settings) ([]string, error) {
+func (s *ProjectService) getProjectImageRefsFromComposeInternal(ctx context.Context, proj models.Project, cfg *models.Settings) ([]string, []string, error) {
 	composeProject, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("load compose project: %w", err)
+		return nil, nil, fmt.Errorf("load compose project: %w", err)
 	}
 
-	return projects.ImageRefsFromComposeServices(composeProject.Services), nil
+	return projects.ImageRefsFromComposeServices(composeProject.Services), projects.BuildImageRefsFromComposeProject(composeProject), nil
 }
 
 func buildProjectUpdateInfoSummaryInternal(

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -78,6 +78,97 @@ func setupProjectTestDB(t *testing.T) *database.DB {
 	return &database.DB{DB: db}
 }
 
+func TestProjectService_RefreshProjectImageRefs_PersistsBuildMetadata(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	projectPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte(`services:
+  explicit:
+    build: .
+    image: test2:latest
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+  regular:
+    image: postgres:17
+`), 0o644))
+
+	proj := &models.Project{
+		BaseModel: models.BaseModel{ID: "project-build-image-refs"},
+		Name:      "demo",
+		Path:      projectPath,
+	}
+	require.NoError(t, db.Create(proj).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
+	svc.refreshProjectImageRefsInternal(ctx, proj)
+
+	var saved models.Project
+	require.NoError(t, db.First(&saved, "id = ?", proj.ID).Error)
+	assert.ElementsMatch(t, []string{"test2:latest", "postgres:17"}, projects.ParseImageRefsJSON(saved.ImageRefsJSON))
+	require.NotNil(t, saved.BuildImageRefsJSON)
+	assert.ElementsMatch(t, []string{"test2:latest", "demo-worker"}, projects.ParseImageRefsJSON(*saved.BuildImageRefsJSON))
+}
+
+func TestProjectService_BackfillProjectImageRefs_RetriesOnlyMissingMetadata(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	settingsService, err := NewSettingsService(ctx, db)
+	require.NoError(t, err)
+
+	validPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(validPath, "compose.yaml"), []byte(`services:
+  app:
+    build: .
+    image: local-app:latest
+`), 0o644))
+	invalidPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(invalidPath, "compose.yaml"), []byte("services: [\n"), 0o644))
+	regularPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(regularPath, "compose.yaml"), []byte(`services:
+  app:
+    image: nginx:latest
+`), 0o644))
+
+	valid := &models.Project{BaseModel: models.BaseModel{ID: "backfill-valid"}, Name: "valid", Path: validPath}
+	invalid := &models.Project{BaseModel: models.BaseModel{ID: "backfill-invalid"}, Name: "invalid", Path: invalidPath}
+	regular := &models.Project{BaseModel: models.BaseModel{ID: "backfill-regular"}, Name: "regular", Path: regularPath}
+	require.NoError(t, db.Create(valid).Error)
+	require.NoError(t, db.Create(invalid).Error)
+	require.NoError(t, db.Create(regular).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
+	svc.BackfillProjectImageRefs(ctx)
+
+	var savedValid models.Project
+	require.NoError(t, db.First(&savedValid, "id = ?", valid.ID).Error)
+	require.NotNil(t, savedValid.BuildImageRefsJSON)
+	assert.Equal(t, []string{"local-app:latest"}, projects.ParseImageRefsJSON(*savedValid.BuildImageRefsJSON))
+
+	var savedInvalid models.Project
+	require.NoError(t, db.First(&savedInvalid, "id = ?", invalid.ID).Error)
+	assert.Nil(t, savedInvalid.BuildImageRefsJSON)
+
+	var savedRegular models.Project
+	require.NoError(t, db.First(&savedRegular, "id = ?", regular.ID).Error)
+	require.NotNil(t, savedRegular.BuildImageRefsJSON)
+	assert.Equal(t, "[]", *savedRegular.BuildImageRefsJSON)
+
+	require.NoError(t, os.Remove(filepath.Join(validPath, "compose.yaml")))
+	require.NoError(t, os.Remove(filepath.Join(regularPath, "compose.yaml")))
+	svc.BackfillProjectImageRefs(ctx)
+	require.NoError(t, db.First(&savedValid, "id = ?", valid.ID).Error)
+	require.NotNil(t, savedValid.BuildImageRefsJSON)
+	assert.Equal(t, []string{"local-app:latest"}, projects.ParseImageRefsJSON(*savedValid.BuildImageRefsJSON))
+	require.NoError(t, db.First(&savedRegular, "id = ?", regular.ID).Error)
+	require.NotNil(t, savedRegular.BuildImageRefsJSON)
+	assert.Equal(t, "[]", *savedRegular.BuildImageRefsJSON)
+}
+
 func setupProjectDestroyTestServiceInternal(t *testing.T) (*ProjectService, *database.DB, string) {
 	t.Helper()
 

--- a/backend/pkg/projects/image_refs.go
+++ b/backend/pkg/projects/image_refs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	composeapi "github.com/docker/compose/v5/pkg/api"
 	projecttypes "github.com/getarcaneapp/arcane/types/v2/project"
 )
 
@@ -51,6 +52,34 @@ func ImageRefsFromComposeServices(services composetypes.Services) []string {
 	}
 
 	return ImageRefsFromComposeConfigs(serviceConfigs)
+}
+
+// BuildImageRefsFromComposeProject returns the image references produced by
+// services with build directives, including Compose's default image name when
+// a service does not declare image explicitly.
+func BuildImageRefsFromComposeProject(project *composetypes.Project) []string {
+	if project == nil {
+		return nil
+	}
+
+	serviceNames := make([]string, 0, len(project.Services))
+	for name := range project.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+
+	return uniqueImageRefsInternal(len(serviceNames), func(yield func(string)) {
+		for _, name := range serviceNames {
+			svc := project.Services[name]
+			if svc.Build == nil {
+				continue
+			}
+			if svc.Name == "" {
+				svc.Name = name
+			}
+			yield(composeapi.GetImageNameOrDefault(svc, project.Name))
+		}
+	})
 }
 
 // ImageRefsFromComposeConfigs returns unique, non-empty image references from

--- a/backend/pkg/projects/image_refs_test.go
+++ b/backend/pkg/projects/image_refs_test.go
@@ -1,0 +1,61 @@
+package projects
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildImageRefsFromComposeProject(t *testing.T) {
+	project := &composetypes.Project{
+		Name: "demo",
+		Services: composetypes.Services{
+			"regular": {
+				Name:  "regular",
+				Image: "postgres:17",
+			},
+			"explicit": {
+				Name:  "explicit",
+				Image: "test2:latest",
+				Build: &composetypes.BuildConfig{Context: "."},
+			},
+			"duplicate": {
+				Name:  "duplicate",
+				Image: "test2:latest",
+				Build: &composetypes.BuildConfig{Context: "./duplicate"},
+			},
+			"default": {
+				Build: &composetypes.BuildConfig{Context: "./default"},
+			},
+		},
+	}
+
+	assert.Equal(t, []string{"demo-default", "test2:latest"}, BuildImageRefsFromComposeProject(project))
+}
+
+func TestBuildImageRefsFromComposeProject_NilProject(t *testing.T) {
+	assert.Nil(t, BuildImageRefsFromComposeProject(nil))
+}
+
+func TestBuildImageRefsFromComposeProject_UsesMergedComposeOverrides(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte(`services:
+  app:
+    image: overridden-app:latest
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "compose.override.yaml"), []byte(`services:
+  app:
+    build: ./app
+`), 0o644))
+
+	project, err := LoadComposeProject(context.Background(), composePath, "override-demo", dir, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"overridden-app:latest"}, BuildImageRefsFromComposeProject(project))
+}

--- a/backend/resources/migrations/postgres/065_add_project_build_image_refs.sql
+++ b/backend/resources/migrations/postgres/065_add_project_build_image_refs.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS build_image_refs_json TEXT;
+
+-- +goose Down
+ALTER TABLE projects DROP COLUMN IF EXISTS build_image_refs_json;

--- a/backend/resources/migrations/sqlite/065_add_project_build_image_refs.sql
+++ b/backend/resources/migrations/sqlite/065_add_project_build_image_refs.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE projects ADD COLUMN build_image_refs_json TEXT;
+
+-- +goose Down
+ALTER TABLE projects DROP COLUMN build_image_refs_json;


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3295

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stores Compose build-image metadata and uses it during image update checks. The main changes are:

- Adds a nullable `build_image_refs_json` column to projects for SQLite and Postgres.
- Persists build-produced image refs when project compose files are refreshed or backfilled.
- Treats matching Compose build images as local builds before registry digest checks.
- Adds regression coverage for migrations, project metadata refresh, backfill, and single/batch update checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

No bugs were identified in the changed code. The schema/model change has matching migrations, nil and empty metadata paths are handled, and tests cover the key new workflows.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- TestBuildImageRefsFromComposeProject, nil-project handling, and merged Compose override build refs passed, proving build image refs are detected separately in helper code.
- TestProjectService\_RefreshProjectImageRefs\_PersistsBuildMetadata passed, proving deployable refs (test2:latest, postgres:17) and build refs (test2:latest, generated demo-worker) are persisted separately.
- TestImageUpdateService\_CheckImageUpdate\_ComposeBuildSkipsRegistryWithRepoDigests and CheckMultipleImages passed with registry calls remaining zero, proving compose build images are treated as local-only instead of normal remote refs needing registry checks.

<a href="https://app.greptile.com/trex/runs/14748832/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: classify remote Compose build image..."](https://github.com/getarcaneapp/arcane/commit/1d2e181ba547fa0a4f5c8a1e6fa6beb7e3685350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44900191)</sub>

<!-- /greptile_comment -->