### PR TITLE
fix: prevent size volume sorting from blocking navigation

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -5333,7 +5333,6 @@ func (s *ProjectService) rollbackProjectRenameJournalInternal(ctx context.Contex
 		}
 	}
 
-	dockerutil.InvalidateVolumeUsageCache()
 	return directoryErr
 }
 
@@ -5398,7 +5397,7 @@ func (s *ProjectService) recoverProjectRenameRollbackCleanupInternal(ctx context
 		return err
 	}
 
-	dockerutil.InvalidateVolumeUsageCache()
+	dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	return s.clearProjectRenameRollbackCleanupInternal(ctx, cleanup.ProjectID)
 }
 

--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -105,7 +105,10 @@ func (s *VolumeService) GetVolumeByName(ctx context.Context, name string) (*volu
 		return nil, fmt.Errorf("volume not found: %w", err)
 	}
 
-	if usageVolumes, duErr := docker.GetVolumeUsageData(ctx, dockerClient); duErr == nil {
+	settings := s.settingsService.GetSettingsConfig()
+	usageCtx, usageCancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+	defer usageCancel()
+	if usageVolumes, ok := docker.GetVolumeUsageDataStaleWhileRevalidate(usageCtx, dockerClient); ok {
 		for _, uv := range usageVolumes {
 			if uv.Name == vol.Name && uv.UsageData != nil {
 				vol.UsageData = uv.UsageData
@@ -113,8 +116,6 @@ func (s *VolumeService) GetVolumeByName(ctx context.Context, name string) (*volu
 				break
 			}
 		}
-	} else {
-		slog.WarnContext(ctx, "failed to load volume usage data", "volume", vol.Name, "error", duErr.Error())
 	}
 
 	v := volumetypes.NewSummary(vol)
@@ -161,7 +162,7 @@ func (s *VolumeService) CreateVolume(ctx context.Context, options client.VolumeC
 		slog.WarnContext(ctx, "could not log volume creation action", "volume", vol.Volume.Name, "error", logErr.Error())
 	}
 
-	docker.InvalidateVolumeUsageCache()
+	docker.InvalidateVolumeUsageCache(dockerClient)
 
 	return new(volumetypes.NewSummary(vol.Volume)), nil
 }
@@ -196,6 +197,7 @@ func (s *VolumeService) DeleteVolume(ctx context.Context, name string, force boo
 	}
 
 	s.removeHelperEntry(name)
+	docker.InvalidateVolumeUsageCache(dockerClient)
 	return nil
 }
 
@@ -237,7 +239,7 @@ func (s *VolumeService) PruneVolumesWithOptions(ctx context.Context, all bool) (
 		s.removeHelperEntry(volumeName)
 	}
 
-	docker.InvalidateVolumeUsageCache()
+	docker.InvalidateVolumeUsageCache(dockerClient)
 
 	return &volumetypes.PruneReport{
 		VolumesDeleted: volumePruneResult.Report.VolumesDeleted,
@@ -1959,12 +1961,16 @@ type VolumeSizeData struct {
 // This is a slow operation as it calls Docker's DiskUsage API.
 func (s *VolumeService) GetVolumeSizes(ctx context.Context) (map[string]VolumeSizeData, error) {
 	slog.DebugContext(ctx, "volume service: get volume sizes")
-	dockerClient, err := s.dockerService.GetClient(ctx)
+	settings := s.settingsService.GetSettingsConfig()
+	apiCtx, cancel := timeouts.WithTimeout(ctx, settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+	defer cancel()
+
+	dockerClient, err := s.dockerService.GetClient(apiCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Docker: %w", err)
 	}
 
-	usageVolumes, err := docker.GetVolumeUsageData(ctx, dockerClient)
+	usageVolumes, err := docker.GetVolumeUsageData(apiCtx, dockerClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volume usage data: %w", err)
 	}
@@ -1983,7 +1989,6 @@ func (s *VolumeService) GetVolumeSizes(ctx context.Context) (map[string]VolumeSi
 }
 
 func (s *VolumeService) enrichVolumesWithUsageDataInternal(volumes []volume.Volume, usageVolumes []volume.Volume) []volume.Volume {
-	slog.Debug("volume service: enrich volumes with usage data", "volumes", len(volumes), "usage_volumes", len(usageVolumes))
 	usageByName := make(map[string]*volume.UsageData, len(usageVolumes))
 	for _, uv := range usageVolumes {
 		if uv.Name == "" || uv.UsageData == nil {
@@ -2007,7 +2012,6 @@ func (s *VolumeService) enrichVolumesWithUsageDataInternal(volumes []volume.Volu
 }
 
 func (s *VolumeService) buildVolumeContainerMapInternal(ctx context.Context, dockerClient *client.Client) (map[string][]string, error) {
-	slog.DebugContext(ctx, "volume service: build volume container map")
 	containers, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %w", err)
@@ -2026,7 +2030,6 @@ func (s *VolumeService) buildVolumeContainerMapInternal(ctx context.Context, doc
 }
 
 func (s *VolumeService) buildVolumePaginationConfigInternal() pagination.Config[volumetypes.Volume] {
-	slog.Debug("volume service: build volume pagination config")
 	return pagination.Config[volumetypes.Volume]{
 		SearchAccessors: []pagination.SearchAccessor[volumetypes.Volume]{
 			func(v volumetypes.Volume) (string, error) { return v.Name, nil },
@@ -2040,7 +2043,6 @@ func (s *VolumeService) buildVolumePaginationConfigInternal() pagination.Config[
 }
 
 func (s *VolumeService) buildVolumeSortBindingsInternal() []pagination.SortBinding[volumetypes.Volume] {
-	slog.Debug("volume service: build volume sort bindings")
 	createdSortFn := s.compareVolumeCreatedInternal
 
 	return []pagination.SortBinding[volumetypes.Volume]{
@@ -2088,7 +2090,6 @@ func (s *VolumeService) buildVolumeSortBindingsInternal() []pagination.SortBindi
 }
 
 func (s *VolumeService) compareVolumeSizesInternal(a, b volumetypes.Volume) int {
-	slog.Debug("volume service: compare volume sizes")
 	aSize := a.Size
 	bSize := b.Size
 
@@ -2100,7 +2101,7 @@ func (s *VolumeService) compareVolumeSizesInternal(a, b volumetypes.Volume) int 
 	}
 
 	if aSize == bSize {
-		return 0
+		return strings.Compare(a.Name, b.Name)
 	}
 	if aSize < bSize {
 		return -1
@@ -2109,7 +2110,6 @@ func (s *VolumeService) compareVolumeSizesInternal(a, b volumetypes.Volume) int 
 }
 
 func (s *VolumeService) compareVolumeCreatedInternal(a, b volumetypes.Volume) int {
-	slog.Debug("volume service: compare volume created time")
 	aTime, aOk := s.parseVolumeCreatedAtInternal(a.CreatedAt)
 	bTime, bOk := s.parseVolumeCreatedAtInternal(b.CreatedAt)
 	if aOk && bOk {
@@ -2138,7 +2138,6 @@ func (s *VolumeService) parseVolumeCreatedAtInternal(createdAt string) (time.Tim
 }
 
 func (s *VolumeService) buildVolumeFilterAccessorsInternal() []pagination.FilterAccessor[volumetypes.Volume] {
-	slog.Debug("volume service: build volume filter accessors")
 	return []pagination.FilterAccessor[volumetypes.Volume]{
 		{
 			Key: "inUse",
@@ -2156,7 +2155,6 @@ func (s *VolumeService) buildVolumeFilterAccessorsInternal() []pagination.Filter
 }
 
 func (s *VolumeService) calculateVolumeUsageCountsInternal(items []volumetypes.Volume) volumetypes.UsageCounts {
-	slog.Debug("volume service: calculate volume usage counts", "items", len(items))
 	counts := volumetypes.UsageCounts{
 		Total: len(items),
 	}
@@ -2179,6 +2177,7 @@ func (s *VolumeService) isInternalVolumeInternal(v volumetypes.Volume) bool {
 }
 
 func (s *VolumeService) ListVolumesPaginated(ctx context.Context, params pagination.QueryParams, includeInternal bool) ([]volumetypes.Volume, pagination.Response, volumetypes.UsageCounts, error) {
+	startedAt := time.Now()
 	slog.DebugContext(ctx, "volume service: list volumes paginated", "search", params.Search, "sort", params.Sort, "order", params.Order, "start", params.Start, "limit", params.Limit, "include_internal", includeInternal)
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
@@ -2225,13 +2224,20 @@ func (s *VolumeService) ListVolumesPaginated(ctx context.Context, params paginat
 		volumeContainerMap = make(map[string][]string)
 	}
 
-	// Fetch usage data if sorting by size is requested
+	effectiveParams := params
+	usageCacheSnapshot := "not_requested"
+
+	// Size sorting consumes the current cache snapshot and refreshes it in the
+	// background so this list request never waits for Docker's DiskUsage call.
 	var usageVolumes []volume.Volume
 	if params.Sort == "size" {
-		if uv, err := docker.GetVolumeUsageData(apiCtx, dockerClient); err == nil {
+		if uv, found := docker.GetVolumeUsageDataStaleWhileRevalidate(apiCtx, dockerClient); found && (len(uv) > 0 || len(volResult.volumes) == 0) {
 			usageVolumes = uv
+			usageCacheSnapshot = "available"
 		} else {
-			slog.WarnContext(ctx, "failed to get volume usage data for sorting", "error", err.Error())
+			usageCacheSnapshot = "missing"
+			effectiveParams.Sort = "name"
+			effectiveParams.Order = pagination.SortAsc
 		}
 	}
 
@@ -2253,9 +2259,27 @@ func (s *VolumeService) ListVolumesPaginated(ctx context.Context, params paginat
 	}
 
 	config := s.buildVolumePaginationConfigInternal()
-	result := pagination.SearchOrderAndPaginate(items, params, config)
+	result := pagination.SearchOrderAndPaginate(items, effectiveParams, config)
 	counts := s.calculateVolumeUsageCountsInternal(items)
-	paginationResp := pagination.BuildResponseFromFilterResult(result, params)
+	paginationResp := pagination.BuildResponseFromFilterResult(result, effectiveParams)
+	slog.DebugContext(ctx, "volume service: listed volumes",
+		"docker_host", dockerClient.DaemonHost(),
+		"requested_sort", params.Sort,
+		"requested_order", params.Order,
+		"effective_sort", effectiveParams.Sort,
+		"effective_order", effectiveParams.Order,
+		"usage_cache_snapshot", usageCacheSnapshot,
+		"docker_volumes", len(volResult.volumes),
+		"usage_volumes", len(usageVolumes),
+		"included_volumes", len(items),
+		"matched_volumes", result.TotalCount,
+		"returned_volumes", len(result.Items),
+		"container_volume_count", len(volumeContainerMap),
+		"filter_count", len(params.Filters),
+		"current_page", paginationResp.CurrentPage,
+		"total_pages", paginationResp.TotalPages,
+		"duration", time.Since(startedAt),
+	)
 
 	return result.Items, paginationResp, counts, nil
 }

--- a/backend/pkg/dockerutil/volume_utils.go
+++ b/backend/pkg/dockerutil/volume_utils.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -14,29 +15,186 @@ import (
 )
 
 var (
-	volumeUsageCache      []volume.Volume
-	volumeUsageCacheMutex sync.RWMutex
-	volumeUsageCacheTime  time.Time
-	volumeUsageCacheTTL   = 30 * time.Second
+	volumeUsageCacheMutex       sync.RWMutex
+	volumeUsageCacheEntries     = make(map[string]*volumeUsageCacheEntryInternal)
+	volumeUsageCacheGenerations = make(map[string]uint64)
 )
 
+const (
+	volumeUsageCacheTTL               = 30 * time.Second
+	volumeUsageRefreshFallbackTimeout = 30 * time.Second
+)
+
+type volumeUsageCacheEntryInternal struct {
+	volumes     []volume.Volume
+	refreshedAt time.Time
+	generation  uint64
+	refresh     *volumeUsageRefreshInternal
+}
+
+type volumeUsageRefreshInternal struct {
+	done chan struct{}
+	err  error
+}
+
+// GetVolumeUsageData returns current volume usage data, sharing an in-flight
+// refresh with concurrent callers while allowing each caller to honor its own context.
 func GetVolumeUsageData(ctx context.Context, dockerClient *client.Client) ([]volume.Volume, error) {
-	volumeUsageCacheMutex.RLock()
-	if time.Since(volumeUsageCacheTime) < volumeUsageCacheTTL && volumeUsageCache != nil {
-		cached := volumeUsageCache
-		volumeUsageCacheMutex.RUnlock()
-		slog.DebugContext(ctx, "returning cached volume usage data", "volume_count", len(cached))
-		return cached, nil
+	if dockerClient == nil {
+		return nil, errors.New("failed to get disk usage: Docker client is nil")
 	}
-	volumeUsageCacheMutex.RUnlock()
 
+	key := volumeUsageCacheKeyInternal(dockerClient)
+	for {
+		cached, _, fresh := volumeUsageCacheSnapshotInternal(key)
+		if fresh {
+			slog.DebugContext(ctx, "returning cached volume usage data", "volume_count", len(cached), "docker_host", key)
+			return cached, nil
+		}
+
+		refresh := startVolumeUsageRefreshInternal(ctx, key, dockerClient)
+		select {
+		case <-ctx.Done():
+			if stale, staleFound, _ := volumeUsageCacheSnapshotInternal(key); staleFound {
+				slog.WarnContext(ctx, "volume usage refresh timed out; returning stale cache", "error", ctx.Err(), "volume_count", len(stale), "docker_host", key)
+				return stale, nil
+			}
+			return nil, ctx.Err()
+		case <-refresh.done:
+			updated, updatedFound, _ := volumeUsageCacheSnapshotInternal(key)
+			if updatedFound {
+				if refresh.err != nil {
+					slog.WarnContext(ctx, "volume usage refresh failed; returning stale cache", "error", refresh.err, "volume_count", len(updated), "docker_host", key)
+				}
+				return updated, nil
+			}
+			if refresh.err != nil {
+				return nil, refresh.err
+			}
+			// The cache was invalidated while the refresh was running. Retry against
+			// the new generation rather than publishing obsolete usage data.
+		}
+	}
+}
+
+// GetVolumeUsageDataStaleWhileRevalidate returns immediately with any cached
+// snapshot and starts a bounded refresh when the snapshot is stale or missing.
+func GetVolumeUsageDataStaleWhileRevalidate(ctx context.Context, dockerClient *client.Client) ([]volume.Volume, bool) {
+	if dockerClient == nil {
+		return nil, false
+	}
+
+	key := volumeUsageCacheKeyInternal(dockerClient)
+	cached, found, fresh := volumeUsageCacheSnapshotInternal(key)
+	cacheState := "miss"
+	if found {
+		cacheState = "stale"
+		if fresh {
+			cacheState = "fresh"
+		}
+	}
+	slog.DebugContext(ctx, "volume usage cache lookup",
+		"docker_host", key,
+		"cache_state", cacheState,
+		"volume_count", len(cached),
+		"refresh_requested", !fresh,
+	)
+	if !fresh {
+		startVolumeUsageRefreshInternal(ctx, key, dockerClient)
+	}
+	return cached, found
+}
+
+// InvalidateVolumeUsageCache invalidates usage data for the Docker daemon used by dockerClient.
+func InvalidateVolumeUsageCache(dockerClient *client.Client) {
+	if dockerClient == nil {
+		return
+	}
+
+	key := volumeUsageCacheKeyInternal(dockerClient)
 	volumeUsageCacheMutex.Lock()
-	defer volumeUsageCacheMutex.Unlock()
+	volumeUsageCacheGenerations[key]++
+	delete(volumeUsageCacheEntries, key)
+	volumeUsageCacheMutex.Unlock()
+}
 
-	if time.Since(volumeUsageCacheTime) < volumeUsageCacheTTL && volumeUsageCache != nil {
-		slog.DebugContext(ctx, "returning cached volume usage data after lock", "volume_count", len(volumeUsageCache))
-		return volumeUsageCache, nil
+func volumeUsageCacheKeyInternal(dockerClient *client.Client) string {
+	host := dockerClient.DaemonHost()
+	if host != "" {
+		return host
 	}
+	return fmt.Sprintf("client:%p", dockerClient)
+}
+
+func volumeUsageCacheSnapshotInternal(key string) ([]volume.Volume, bool, bool) {
+	volumeUsageCacheMutex.RLock()
+	entry := volumeUsageCacheEntries[key]
+	if entry == nil || entry.volumes == nil {
+		volumeUsageCacheMutex.RUnlock()
+		return nil, false, false
+	}
+	volumes := append([]volume.Volume(nil), entry.volumes...)
+	fresh := time.Since(entry.refreshedAt) < volumeUsageCacheTTL
+	volumeUsageCacheMutex.RUnlock()
+	return volumes, true, fresh
+}
+
+func startVolumeUsageRefreshInternal(ctx context.Context, key string, dockerClient *client.Client) *volumeUsageRefreshInternal {
+	volumeUsageCacheMutex.Lock()
+	generation := volumeUsageCacheGenerations[key]
+	entry := volumeUsageCacheEntries[key]
+	if entry == nil || entry.generation != generation {
+		entry = &volumeUsageCacheEntryInternal{generation: generation}
+		volumeUsageCacheEntries[key] = entry
+	}
+	if entry.refresh != nil {
+		refresh := entry.refresh
+		volumeUsageCacheMutex.Unlock()
+		return refresh
+	}
+
+	refresh := &volumeUsageRefreshInternal{done: make(chan struct{})}
+	entry.refresh = refresh
+	volumeUsageCacheMutex.Unlock()
+
+	refreshCtx, cancel := volumeUsageRefreshContextInternal(ctx)
+	go func() {
+		defer cancel()
+
+		volumes, err := fetchVolumeUsageDataInternal(refreshCtx, dockerClient)
+
+		volumeUsageCacheMutex.Lock()
+		current := volumeUsageCacheEntries[key]
+		if current != nil && current.generation == generation && current.refresh == refresh {
+			if err == nil {
+				current.volumes = volumes
+				current.refreshedAt = time.Now()
+			}
+			current.refresh = nil
+		}
+		refresh.err = err
+		close(refresh.done)
+		volumeUsageCacheMutex.Unlock()
+
+		if err != nil {
+			slog.WarnContext(refreshCtx, "failed to refresh volume usage cache", "error", err, "docker_host", key)
+			return
+		}
+		slog.DebugContext(refreshCtx, "refreshed volume usage cache", "volume_count", len(volumes), "docker_host", key)
+	}()
+
+	return refresh
+}
+
+func volumeUsageRefreshContextInternal(ctx context.Context) (context.Context, context.CancelFunc) {
+	detached := context.WithoutCancel(ctx)
+	if deadline, ok := ctx.Deadline(); ok {
+		return context.WithDeadline(detached, deadline)
+	}
+	return context.WithTimeout(detached, volumeUsageRefreshFallbackTimeout)
+}
+
+func fetchVolumeUsageDataInternal(ctx context.Context, dockerClient *client.Client) ([]volume.Volume, error) {
 	diskUsage, err := dockerClient.DiskUsage(ctx, client.DiskUsageOptions{
 		Volumes: true,
 		Verbose: true,
@@ -46,26 +204,7 @@ func GetVolumeUsageData(ctx context.Context, dockerClient *client.Client) ([]vol
 	}
 
 	slog.DebugContext(ctx, "disk usage returned volumes", "volume_count", len(diskUsage.Volumes.Items))
-
-	if len(diskUsage.Volumes.Items) == 0 {
-		return []volume.Volume{}, nil
-	}
-
-	volumes := make([]volume.Volume, 0, len(diskUsage.Volumes.Items))
-	volumes = append(volumes, diskUsage.Volumes.Items...)
-
-	volumeUsageCache = volumes
-	volumeUsageCacheTime = time.Now()
-	slog.DebugContext(ctx, "refreshed volume usage cache", "volume_count", len(volumes))
-
-	return volumes, nil
-}
-
-func InvalidateVolumeUsageCache() {
-	volumeUsageCacheMutex.Lock()
-	defer volumeUsageCacheMutex.Unlock()
-	volumeUsageCache = nil
-	volumeUsageCacheTime = time.Time{}
+	return append([]volume.Volume{}, diskUsage.Volumes.Items...), nil
 }
 
 // FilterContainersUsingVolume returns the IDs of containers in the provided slice that mount the named volume.

--- a/backend/pkg/dockerutil/volume_utils_test.go
+++ b/backend/pkg/dockerutil/volume_utils_test.go
@@ -1,0 +1,175 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVolumeUsageCacheBehaviorInternal(t *testing.T) {
+	t.Run("deduplicates refresh and honors waiter context", func(t *testing.T) {
+		resetVolumeUsageCacheForTestInternal()
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var startedOnce sync.Once
+		var requests atomic.Int32
+		dockerClient := newVolumeUsageTestClientInternal(t, func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			startedOnce.Do(func() { close(started) })
+			select {
+			case <-release:
+				writeVolumeUsageResponseInternal(t, w, "shared", 42)
+			case <-r.Context().Done():
+			}
+		})
+
+		firstResult := make(chan error, 1)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, err := GetVolumeUsageData(ctx, dockerClient)
+			firstResult <- err
+		}()
+
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("volume usage refresh did not start")
+		}
+
+		waiterCtx, waiterCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer waiterCancel()
+		waiterStartedAt := time.Now()
+		_, err := GetVolumeUsageData(waiterCtx, dockerClient)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, time.Since(waiterStartedAt), 250*time.Millisecond)
+
+		close(release)
+		require.NoError(t, <-firstResult)
+		require.Equal(t, int32(1), requests.Load())
+	})
+
+	t.Run("serves stale data while one refresh runs", func(t *testing.T) {
+		resetVolumeUsageCacheForTestInternal()
+
+		secondStarted := make(chan struct{})
+		releaseSecond := make(chan struct{})
+		var requests atomic.Int32
+		dockerClient := newVolumeUsageTestClientInternal(t, func(w http.ResponseWriter, r *http.Request) {
+			requestNumber := requests.Add(1)
+			if requestNumber == 1 {
+				writeVolumeUsageResponseInternal(t, w, "stale", 10)
+				return
+			}
+			if requestNumber == 2 {
+				close(secondStarted)
+			}
+			select {
+			case <-releaseSecond:
+				writeVolumeUsageResponseInternal(t, w, "fresh", 20)
+			case <-r.Context().Done():
+			}
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := GetVolumeUsageData(ctx, dockerClient)
+		require.NoError(t, err)
+
+		key := volumeUsageCacheKeyInternal(dockerClient)
+		volumeUsageCacheMutex.Lock()
+		volumeUsageCacheEntries[key].refreshedAt = time.Now().Add(-volumeUsageCacheTTL)
+		volumeUsageCacheMutex.Unlock()
+
+		startedAt := time.Now()
+		stale, found := GetVolumeUsageDataStaleWhileRevalidate(ctx, dockerClient)
+		require.True(t, found)
+		require.Len(t, stale, 1)
+		require.Equal(t, "stale", stale[0].Name)
+		require.Less(t, time.Since(startedAt), 250*time.Millisecond)
+
+		select {
+		case <-secondStarted:
+		case <-time.After(time.Second):
+			t.Fatal("background volume usage refresh did not start")
+		}
+		_, _ = GetVolumeUsageDataStaleWhileRevalidate(ctx, dockerClient)
+		require.Equal(t, int32(2), requests.Load())
+
+		close(releaseSecond)
+		fresh, err := GetVolumeUsageData(ctx, dockerClient)
+		require.NoError(t, err)
+		require.Len(t, fresh, 1)
+		require.Equal(t, "fresh", fresh[0].Name)
+	})
+
+	t.Run("isolates and invalidates by daemon host", func(t *testing.T) {
+		resetVolumeUsageCacheForTestInternal()
+
+		clientA := newVolumeUsageTestClientInternal(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeVolumeUsageResponseInternal(t, w, "host-a", 1)
+		})
+		clientB := newVolumeUsageTestClientInternal(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeVolumeUsageResponseInternal(t, w, "host-b", 2)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := GetVolumeUsageData(ctx, clientA)
+		require.NoError(t, err)
+		_, err = GetVolumeUsageData(ctx, clientB)
+		require.NoError(t, err)
+
+		cachedA, foundA, _ := volumeUsageCacheSnapshotInternal(volumeUsageCacheKeyInternal(clientA))
+		cachedB, foundB, _ := volumeUsageCacheSnapshotInternal(volumeUsageCacheKeyInternal(clientB))
+		require.True(t, foundA)
+		require.True(t, foundB)
+		require.Equal(t, "host-a", cachedA[0].Name)
+		require.Equal(t, "host-b", cachedB[0].Name)
+
+		InvalidateVolumeUsageCache(clientA)
+		_, foundA, _ = volumeUsageCacheSnapshotInternal(volumeUsageCacheKeyInternal(clientA))
+		cachedB, foundB, _ = volumeUsageCacheSnapshotInternal(volumeUsageCacheKeyInternal(clientB))
+		require.False(t, foundA)
+		require.True(t, foundB)
+		require.Equal(t, "host-b", cachedB[0].Name)
+	})
+}
+
+func newVolumeUsageTestClientInternal(t *testing.T, handler http.HandlerFunc) *client.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	dockerClient, err := client.New(
+		client.WithHost(server.URL),
+		client.WithAPIVersion("1.55"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dockerClient.Close()) })
+	return dockerClient
+}
+
+func writeVolumeUsageResponseInternal(t *testing.T, w http.ResponseWriter, name string, size int64) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_, err := fmt.Fprintf(w, `{"VolumeUsage":{"Items":[{"Name":%q,"UsageData":{"Size":%d,"RefCount":1}}]}}`, name, size)
+	require.NoError(t, err)
+}
+
+func resetVolumeUsageCacheForTestInternal() {
+	volumeUsageCacheMutex.Lock()
+	volumeUsageCacheEntries = make(map[string]*volumeUsageCacheEntryInternal)
+	volumeUsageCacheGenerations = make(map[string]uint64)
+	volumeUsageCacheMutex.Unlock()
+}

--- a/backend/pkg/libarcane/volumes/volume_rename.go
+++ b/backend/pkg/libarcane/volumes/volume_rename.go
@@ -181,7 +181,7 @@ func (m *dockerProjectVolumeRenameMigrationInternal) Apply(ctx context.Context) 
 		}
 	}
 
-	dockerutil.InvalidateVolumeUsageCache()
+	dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	slog.InfoContext(ctx, "copied project compose volumes for rename", "oldProject", m.oldComposeName, "newProject", m.newComposeName, "count", len(m.entries))
 	return nil
 }
@@ -207,7 +207,7 @@ func (m *dockerProjectVolumeRenameMigrationInternal) Commit(ctx context.Context)
 		m.removedOld = append(m.removedOld, entry)
 	}
 
-	dockerutil.InvalidateVolumeUsageCache()
+	dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	slog.InfoContext(ctx, "renamed project compose volumes", "oldProject", m.oldComposeName, "newProject", m.newComposeName, "count", len(m.entries))
 	return nil
 }
@@ -290,7 +290,7 @@ func (m *dockerProjectVolumeRenameMigrationInternal) Rollback(ctx context.Contex
 
 	rollbackErr = errors.Join(rollbackErr, m.rollbackCreatedTargetsPreserving(ctx, dockerClient, preservedTargets))
 	if rollbackErr == nil {
-		dockerutil.InvalidateVolumeUsageCache()
+		dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	}
 	return rollbackErr
 }
@@ -584,7 +584,7 @@ func RemoveSourceVolumes(ctx context.Context, dockerClient *client.Client, volum
 			return NewSourceCleanupError(vol.OldName, err)
 		}
 	}
-	dockerutil.InvalidateVolumeUsageCache()
+	dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	return nil
 }
 
@@ -594,6 +594,9 @@ func RollbackVolumes(ctx context.Context, dockerClient *client.Client, volumes [
 		if err := RollbackVolume(ctx, dockerClient, vol); err != nil {
 			rollbackErr = errors.Join(rollbackErr, err)
 		}
+	}
+	if len(volumes) > 0 {
+		dockerutil.InvalidateVolumeUsageCache(dockerClient)
 	}
 	return rollbackErr
 }

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -15,6 +15,7 @@
 		type FieldSpec,
 		type GroupedData,
 		type GroupSelectionState,
+		type SortState,
 		encodeHidden,
 		applyHiddenPatch,
 		encodeFilters,
@@ -54,6 +55,8 @@
 		customTableView,
 		customSettings = $bindable<Record<string, unknown>>({}),
 		columnVisibility = $bindable<ColumnVisibilityState>({}),
+		preferencesReady = $bindable(false),
+		hiddenSortFallback,
 		groupedRows = null,
 		// Grouping props
 		groupBy,
@@ -96,6 +99,8 @@
 		>;
 		customSettings?: Record<string, unknown>;
 		columnVisibility?: ColumnVisibilityState;
+		preferencesReady?: boolean;
+		hiddenSortFallback?: SortState;
 		groupedRows?: GroupedData<TData>[] | null;
 		// Grouping props
 		groupBy?: (item: TData) => string;
@@ -156,7 +161,10 @@
 		}
 
 		// Then restore preferences
-		if (!enablePersist) return;
+		if (!enablePersist) {
+			preferencesReady = true;
+			return;
+		}
 		const snapshot = extractPersistedPreferences(prefs?.current, getEffectiveLimit());
 
 		const patchedVisibility = { ...columnVisibility };
@@ -212,10 +220,15 @@
 		const persistedSort = snapshot.sort;
 		const currentSort = requestOptions?.sort;
 		if (persistedSort) {
-			if (currentSort?.column !== persistedSort.column || currentSort?.direction !== persistedSort.direction) {
+			const restoredSort =
+				patchedVisibility[persistedSort.column] === false && hiddenSortFallback ? hiddenSortFallback : persistedSort;
+			if (restoredSort !== persistedSort && prefs) {
+				prefs.current = { ...prefs.current, s: encodeSort(restoredSort) };
+			}
+			if (currentSort?.column !== restoredSort.column || currentSort?.direction !== restoredSort.direction) {
 				requestOptions = {
 					...requestOptions,
-					sort: persistedSort,
+					sort: restoredSort,
 					pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
 				};
 				shouldRefresh = true;
@@ -230,6 +243,8 @@
 		if (snapshot.customSettings && Object.keys(snapshot.customSettings).length > 0) {
 			customSettings = { ...snapshot.customSettings };
 		}
+
+		preferencesReady = true;
 	});
 
 	function updatePagination(patch: Partial<{ page: number; limit: number }>) {
@@ -489,10 +504,28 @@
 			onRefresh(requestOptions);
 		},
 		onColumnVisibilityChange: (updater) => {
-			columnVisibility = typeof updater === 'function' ? updater(columnVisibility) : updater;
+			const nextVisibility = typeof updater === 'function' ? updater(columnVisibility) : updater;
+			columnVisibility = nextVisibility;
 			// Persist visibility
 			if (enablePersist && prefs) {
 				prefs.current = { ...prefs.current, v: encodeHidden(columnVisibility) };
+			}
+
+			const activeSort = requestOptions?.sort;
+			if (activeSort && nextVisibility[activeSort.column] === false && hiddenSortFallback) {
+				sorting = [{ id: hiddenSortFallback.column, desc: hiddenSortFallback.direction === 'desc' }];
+				requestOptions = {
+					...requestOptions,
+					sort: hiddenSortFallback,
+					pagination: {
+						page: 1,
+						limit: requestOptions?.pagination?.limit ?? items?.pagination?.itemsPerPage ?? 10
+					}
+				};
+				if (enablePersist && prefs) {
+					prefs.current = { ...prefs.current, s: encodeSort(hiddenSortFallback) };
+				}
+				onRefresh(requestOptions);
 			}
 		},
 		onGlobalFilterChange: (value) => {

--- a/frontend/src/lib/services/volume-service.ts
+++ b/frontend/src/lib/services/volume-service.ts
@@ -52,9 +52,8 @@ class VolumeService extends BaseAPIService {
 		return res.data.data;
 	}
 
-	async getVolumeSizes(): Promise<VolumeSizeInfo[]> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
-		const res = await this.api.get(`/environments/${envId}/volumes/sizes`);
+	async getVolumeSizes(environmentId: string): Promise<VolumeSizeInfo[]> {
+		const res = await this.api.get(`/environments/${environmentId}/volumes/sizes`);
 		return res.data.data;
 	}
 

--- a/frontend/src/lib/utils/tables.ts
+++ b/frontend/src/lib/utils/tables.ts
@@ -64,7 +64,8 @@ function normalizeSearch(value: unknown): string | undefined {
 
 export function resolveInitialTableRequest(
 	persistKey: string,
-	defaults: SearchPaginationSortRequest
+	defaults: SearchPaginationSortRequest,
+	options: { deferredSortColumns?: readonly string[] } = {}
 ): SearchPaginationSortRequest {
 	const base = cloneRequest(defaults);
 	const fallbackLimit = base.pagination?.limit ?? DEFAULT_LIMIT;
@@ -106,7 +107,7 @@ export function resolveInitialTableRequest(
 		}
 
 		const sort = decodeSort(current.s);
-		if (sort) {
+		if (sort && !options.deferredSortColumns?.includes(sort.column)) {
 			base.sort = sort;
 		}
 	} catch (error) {

--- a/frontend/src/routes/(app)/volumes/+page.ts
+++ b/frontend/src/routes/(app)/volumes/+page.ts
@@ -9,16 +9,20 @@ export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 	const envId = await environmentStore.getCurrentEnvironmentId();
 
-	const volumeRequestOptions = resolveInitialTableRequest('arcane-volumes-table', {
-		pagination: {
-			page: 1,
-			limit: 20
-		},
-		sort: {
-			column: 'name',
-			direction: 'asc'
-		}
-	} satisfies SearchPaginationSortRequest);
+	const volumeRequestOptions = resolveInitialTableRequest(
+		'arcane-volumes-table',
+		{
+			pagination: {
+				page: 1,
+				limit: 20
+			},
+			sort: {
+				column: 'name',
+				direction: 'asc'
+			}
+		} satisfies SearchPaginationSortRequest,
+		{ deferredSortColumns: ['size'] }
+	);
 
 	// Single API call - counts are included in the response
 	const volumes = await queryClient.fetchQuery({

--- a/frontend/src/routes/(app)/volumes/volume-table.svelte
+++ b/frontend/src/routes/(app)/volumes/volume-table.svelte
@@ -20,8 +20,9 @@
 	import { TrashIcon, InspectIcon, VolumesIcon, CalendarIcon } from '$lib/icons';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import settingsStore from '$lib/stores/config-store';
-	import { onMount } from 'svelte';
+	import { untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
+	import type { ColumnVisibilityState } from '@tanstack/table-core';
 	import { environmentStore } from '$lib/stores/environment.store.svelte';
 	import { hasPermission } from '$lib/utils/auth';
 	import { activityToastOptions, extractActivityId } from '$lib/utils/activity-toast';
@@ -50,13 +51,15 @@
 		return (customSettings['showInternalVolumes'] as boolean) ?? false;
 	});
 
-	async function refreshVolumes(options: SearchPaginationSortRequest = requestOptions) {
+	async function refreshVolumes(options: SearchPaginationSortRequest = requestOptions, refreshSizes = true) {
 		if (onRefreshData) {
 			await onRefreshData(options);
 		} else {
 			volumes = await volumeService.getVolumes(options);
 		}
-		void loadVolumeSizes();
+		if (refreshSizes && tablePreferencesReady && columnVisibility['size'] !== false) {
+			void loadVolumeSizes(currentEnvId);
+		}
 	}
 
 	function getCurrentLimit() {
@@ -84,21 +87,43 @@
 
 	// Lazy load volume sizes - this is a slow operation
 	let sizesMap = new SvelteMap<string, VolumeSizeInfo>();
+	let sizeLoadPromises = new SvelteMap<string, Promise<void>>();
 	let sizesLoading = $state(false);
+	let columnVisibility = $state<ColumnVisibilityState>({});
+	let tablePreferencesReady = $state(false);
 
-	async function loadVolumeSizes(): Promise<void> {
-		sizesLoading = true;
-		try {
-			const sizes = await volumeService.getVolumeSizes();
-			sizesMap.clear();
-			for (const s of sizes) {
-				sizesMap.set(s.name, s);
+	function loadVolumeSizes(environmentId: string): Promise<void> {
+		const existing = sizeLoadPromises.get(environmentId);
+		if (existing) return existing;
+
+		const request = (async () => {
+			if (currentEnvId === environmentId) {
+				sizesLoading = true;
 			}
-		} catch (error) {
-			console.error('Failed to load volume sizes:', error);
-		} finally {
-			sizesLoading = false;
-		}
+			try {
+				const sizes = await volumeService.getVolumeSizes(environmentId);
+				if (currentEnvId !== environmentId || columnVisibility['size'] === false) return;
+
+				sizesMap.clear();
+				for (const s of sizes) {
+					sizesMap.set(s.name, s);
+				}
+
+				if (requestOptions?.sort?.column === 'size') {
+					await refreshVolumes(requestOptions, false);
+				}
+			} catch (error) {
+				console.error('Failed to load volume sizes:', error);
+			} finally {
+				sizeLoadPromises.delete(environmentId);
+				if (currentEnvId === environmentId) {
+					sizesLoading = false;
+				}
+			}
+		})();
+
+		sizeLoadPromises.set(environmentId, request);
+		return request;
 	}
 
 	async function handleRemoveVolumeConfirm(name: string) {
@@ -190,14 +215,29 @@
 
 	let mobileFieldVisibility = $state<Record<string, boolean>>({});
 
-	onMount(() => {
-		const persistedInternal = (customSettings['showInternalVolumes'] as boolean) ?? false;
-		const currentInternal = requestOptions?.includeInternal ?? false;
-		if (persistedInternal !== currentInternal) {
-			setShowInternal(persistedInternal);
-			// refreshVolumes (called by setShowInternal) already calls loadVolumeSizes
+	let persistedSettingsApplied = false;
+	$effect(() => {
+		if (!tablePreferencesReady) return;
+
+		const environmentId = currentEnvId;
+		const sizeVisible = columnVisibility['size'] !== false;
+		if (!sizeVisible) {
+			sizesMap.clear();
+			sizesLoading = false;
 		} else {
-			void loadVolumeSizes();
+			untrack(() => {
+				sizesMap.clear();
+				void loadVolumeSizes(environmentId);
+			});
+		}
+
+		if (!persistedSettingsApplied) {
+			persistedSettingsApplied = true;
+			const persistedInternal = (customSettings['showInternalVolumes'] as boolean) ?? false;
+			const currentInternal = requestOptions?.includeInternal ?? false;
+			if (persistedInternal !== currentInternal) {
+				untrack(() => setShowInternal(persistedInternal));
+			}
 		}
 	});
 </script>
@@ -301,6 +341,9 @@
 	bind:selectedIds
 	bind:mobileFieldVisibility
 	bind:customSettings
+	bind:columnVisibility
+	bind:preferencesReady={tablePreferencesReady}
+	hiddenSortFallback={{ column: 'name', direction: 'asc' }}
 	{bulkActions}
 	onRefresh={async (options) => {
 		requestOptions = options;

--- a/tests/spec/volumes.spec.ts
+++ b/tests/spec/volumes.spec.ts
@@ -107,6 +107,85 @@ async function ensureFacetOpen(page: Page, title: string) {
 }
 
 test.describe('Volumes Page', () => {
+	test('Persisted Size sort does not block navigation', async ({ page, context }) => {
+		await page.goto('/dashboard');
+		await page.evaluate(() => {
+			localStorage.setItem(
+				'arcane-volumes-table',
+				JSON.stringify({ v: [], f: [], g: '', l: 20, s: ['size', 'desc'] })
+			);
+		});
+
+		let releaseSizeSort: () => void = () => undefined;
+		const sizeSortGate = new Promise<void>((resolve) => {
+			releaseSizeSort = resolve;
+		});
+		let sizeSortRequests = 0;
+		await context.route('**/api/environments/*/volumes**', async (route) => {
+			const request = route.request();
+			const url = new URL(request.url());
+			if (
+				request.method() === 'GET' &&
+				/^\/api\/environments\/[^/]+\/volumes$/.test(url.pathname) &&
+				url.searchParams.get('sort') === 'size'
+			) {
+				sizeSortRequests += 1;
+				await sizeSortGate;
+			}
+			await route.continue();
+		});
+
+		try {
+			await page.goto('/volumes');
+			await expect(page.getByRole('heading', { name: 'Volumes', level: 1 })).toBeVisible({
+				timeout: 2000
+			});
+			await expect.poll(() => sizeSortRequests).toBeGreaterThan(0);
+		} finally {
+			releaseSizeSort();
+		}
+
+		await expect
+			.poll(() =>
+				page.evaluate(() => {
+					const stored = localStorage.getItem('arcane-volumes-table');
+					const sort = stored ? JSON.parse(stored).s : undefined;
+					return Array.isArray(sort) ? sort.join(':') : '';
+				})
+			)
+			.toBe('size:desc');
+	});
+
+	test('Hidden Size column skips usage loading and resets its sort', async ({ page, context }) => {
+		await page.goto('/dashboard');
+		await page.evaluate(() => {
+			localStorage.setItem(
+				'arcane-volumes-table',
+				JSON.stringify({ v: ['size'], f: [], g: '', l: 20, s: ['size', 'desc'] })
+			);
+		});
+
+		let sizeRequests = 0;
+		await context.route('**/api/environments/*/volumes/sizes', async (route) => {
+			sizeRequests += 1;
+			await route.continue();
+		});
+
+		await page.goto('/volumes');
+		await expect(page.getByRole('heading', { name: 'Volumes', level: 1 })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Size', exact: true })).toHaveCount(0);
+		await expect
+			.poll(() =>
+				page.evaluate(() => {
+					const stored = localStorage.getItem('arcane-volumes-table');
+					const sort = stored ? JSON.parse(stored).s : undefined;
+					return Array.isArray(sort) ? sort.join(':') : '';
+				})
+			)
+			.toBe('name:asc');
+		expect(sizeRequests).toBe(0);
+	});
+
 	test('Volume Page Display', async ({ page }) => {
 		await page.goto('/volumes');
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->

<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3314

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents volume size sorting from blocking the volumes page. The main changes are:

- Use cached stale-while-revalidate Docker volume usage data for size sorting.
- Defer restored `size` sort during the initial volumes page load.
- Skip volume size loading when the Size column is hidden.
- Scope volume usage cache invalidation to the active Docker daemon.
- Add backend cache tests and frontend navigation coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The changed paths avoid blocking navigation on Docker `DiskUsage`, preserve explicit size-sort behavior after mount, and include targeted backend and frontend tests.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Playwright script attempted to load the /volumes page but timed out waiting for the Volumes heading.
- The frontend dev server became ready under Vite, then was killed with exit status 137 during dependency optimization, explaining the UI blocker.
- The arcane-tests check ran via pnpm --filter arcane-tests check and exited with code 0.
- Artifacts were collected to support verification, including the volume load log, frontend server log, tests log, and a frontend JavaScript artifact.

<a href="https://app.greptile.com/trex/runs/15047741/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent size volume sorting from bl..."](https://github.com/getarcaneapp/arcane/commit/b901ddb4d1439921c2147522cdc9a64924aff98d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45505445)</sub>

<!-- /greptile_comment -->