### PR TITLE
fix: prevent credential reuse after target URL changes

### DIFF
--- a/backend/internal/services/container_registry_service.go
+++ b/backend/internal/services/container_registry_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/cache"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
@@ -188,15 +189,28 @@ func (s *ContainerRegistryService) UpdateRegistry(ctx context.Context, id string
 		return nil, err
 	}
 
+	if err := s.applyRegistryTypeUpdateInternal(registry, req.RegistryType); err != nil {
+		return nil, err
+	}
+
+	if registry.RegistryType != registryTypeECR {
+		if err := validation.ValidateCredentialTargetChange(
+			"registry URL",
+			registry.URL,
+			req.URL,
+			normalizeRegistryServerAddressInternal,
+			map[string]bool{"token": registry.Token != ""},
+			map[string]bool{"token": req.Token != nil && *req.Token != ""},
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	// Update common fields
 	utils.UpdateIfChanged(&registry.URL, req.URL)
 	utils.UpdateIfChanged(&registry.Description, req.Description)
 	utils.UpdateIfChanged(&registry.Insecure, req.Insecure)
 	utils.UpdateIfChanged(&registry.Enabled, req.Enabled)
-
-	if err := s.applyRegistryTypeUpdateInternal(registry, req.RegistryType); err != nil {
-		return nil, err
-	}
 
 	if registry.RegistryType == registryTypeECR {
 		if err := s.updateECRRegistryFieldsInternal(registry, req); err != nil {

--- a/backend/internal/services/container_registry_service_test.go
+++ b/backend/internal/services/container_registry_service_test.go
@@ -433,6 +433,89 @@ func TestContainerRegistryService_UpdateRegistry_KeepsExistingTokenWhenNotProvid
 	assert.Equal(t, originalToken, updated.Token)
 }
 
+func TestContainerRegistryService_UpdateRegistry_RejectsTargetChangeWhenStoredTokenWouldBeReused(t *testing.T) {
+	tests := []struct {
+		name  string
+		token *string
+	}{
+		{name: "omitted token"},
+		{name: "empty token", token: new("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, db := setupImageServiceAuthTest(t)
+			svc := NewContainerRegistryService(db, nil, nil)
+
+			registry, err := svc.CreateRegistry(context.Background(), models.CreateContainerRegistryRequest{
+				URL:      "https://registry.example.com",
+				Username: "my-user",
+				Token:    "my-token",
+			})
+			require.NoError(t, err)
+			originalToken := registry.Token
+
+			_, err = svc.UpdateRegistry(context.Background(), registry.ID, models.UpdateContainerRegistryRequest{
+				URL:   new("https://attacker.example.com"),
+				Token: tt.token,
+			})
+			require.Error(t, err)
+
+			var validationErr *models.ValidationError
+			require.ErrorAs(t, err, &validationErr)
+			assert.Equal(t, "token", validationErr.Field)
+
+			stored, loadErr := svc.GetRegistryByID(context.Background(), registry.ID)
+			require.NoError(t, loadErr)
+			assert.Equal(t, "https://registry.example.com", stored.URL)
+			assert.Equal(t, originalToken, stored.Token)
+		})
+	}
+}
+
+func TestContainerRegistryService_UpdateRegistry_AllowsPathChangeOnSameHostWithoutToken(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	svc := NewContainerRegistryService(db, nil, nil)
+
+	registry, err := svc.CreateRegistry(context.Background(), models.CreateContainerRegistryRequest{
+		URL:      "https://registry.example.com/one",
+		Username: "my-user",
+		Token:    "my-token",
+	})
+	require.NoError(t, err)
+	originalToken := registry.Token
+
+	updated, err := svc.UpdateRegistry(context.Background(), registry.ID, models.UpdateContainerRegistryRequest{
+		URL: new("REGISTRY.EXAMPLE.COM/two"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "REGISTRY.EXAMPLE.COM/two", updated.URL)
+	assert.Equal(t, originalToken, updated.Token)
+}
+
+func TestContainerRegistryService_UpdateRegistry_AllowsTargetChangeWhenTokenIsResupplied(t *testing.T) {
+	_, db := setupImageServiceAuthTest(t)
+	svc := NewContainerRegistryService(db, nil, nil)
+
+	registry, err := svc.CreateRegistry(context.Background(), models.CreateContainerRegistryRequest{
+		URL:      "https://registry.example.com",
+		Username: "my-user",
+		Token:    "my-token",
+	})
+	require.NoError(t, err)
+
+	updated, err := svc.UpdateRegistry(context.Background(), registry.ID, models.UpdateContainerRegistryRequest{
+		URL:   new("https://registry.example.net"),
+		Token: new("new-token"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://registry.example.net", updated.URL)
+
+	decryptedToken, decryptErr := crypto.Decrypt(updated.Token)
+	require.NoError(t, decryptErr)
+	assert.Equal(t, "new-token", decryptedToken)
+}
+
 func TestContainerRegistryService_UpdateRegistry_RejectsChangingRegistryType(t *testing.T) {
 	_, db := setupImageServiceAuthTest(t)
 	svc := NewContainerRegistryService(db, nil, nil)

--- a/backend/internal/services/git_repository_service.go
+++ b/backend/internal/services/git_repository_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
 	"github.com/getarcaneapp/arcane/types/v2/gitops"
 	contextsource "go.getarcane.app/builds/pkg/utils/contextsource"
 	"go.getarcane.app/sys/crypto"
@@ -170,7 +171,20 @@ func (s *GitRepositoryService) UpdateRepository(ctx context.Context, id string, 
 		return nil, err
 	}
 
-	if err := validateGitRepositoryCredentialChangeInternal(repository, req); err != nil {
+	if err := validation.ValidateCredentialTargetChange(
+		"repository URL",
+		repository.URL,
+		req.URL,
+		nil,
+		map[string]bool{
+			"sshKey": repository.SSHKey != "",
+			"token":  repository.Token != "",
+		},
+		map[string]bool{
+			"sshKey": req.SSHKey != nil,
+			"token":  req.Token != nil,
+		},
+	); err != nil {
 		return nil, err
 	}
 
@@ -242,39 +256,6 @@ func (s *GitRepositoryService) UpdateRepository(ctx context.Context, id string, 
 	}
 
 	return s.GetRepositoryByID(ctx, id)
-}
-
-func validateGitRepositoryCredentialChangeInternal(repository *models.GitRepository, req models.UpdateGitRepositoryRequest) error {
-	if repository == nil || req.URL == nil || *req.URL == repository.URL {
-		return nil
-	}
-
-	missingFields := make([]string, 0, 2)
-	missingCredentialLabels := make([]string, 0, 2)
-
-	if repository.Token != "" && req.Token == nil {
-		missingFields = append(missingFields, "token")
-		missingCredentialLabels = append(missingCredentialLabels, "token")
-	}
-
-	if repository.SSHKey != "" && req.SSHKey == nil {
-		missingFields = append(missingFields, "sshKey")
-		missingCredentialLabels = append(missingCredentialLabels, "SSH key")
-	}
-
-	if len(missingFields) == 0 {
-		return nil
-	}
-
-	if len(missingFields) == 1 {
-		field := missingFields[0]
-		return &models.ValidationError{Field: field, Message: "Changing repository URL requires re-supplying or clearing the " + missingCredentialLabels[0]}
-	}
-
-	return models.NewValidationError(
-		"Changing repository URL requires re-supplying or clearing all stored credentials: "+strings.Join(missingCredentialLabels, " and "),
-		map[string]any{"fields": missingFields},
-	)
 }
 
 func (s *GitRepositoryService) DeleteRepository(ctx context.Context, id string, actor models.User) error {

--- a/backend/internal/services/git_repository_service_test.go
+++ b/backend/internal/services/git_repository_service_test.go
@@ -78,7 +78,7 @@ func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredTokenWo
 	var validationErr *models.ValidationError
 	require.ErrorAs(t, err, &validationErr)
 	assert.Equal(t, "token", validationErr.Field)
-	assert.Contains(t, validationErr.Message, "re-supplying or clearing the token")
+	assert.Contains(t, validationErr.Message, "repository URL")
 
 	stored, loadErr := svc.GetRepositoryByID(context.Background(), repo.ID)
 	require.NoError(t, loadErr)
@@ -103,7 +103,7 @@ func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredSSHKeyW
 	var validationErr *models.ValidationError
 	require.ErrorAs(t, err, &validationErr)
 	assert.Equal(t, "sshKey", validationErr.Field)
-	assert.Contains(t, validationErr.Message, "re-supplying or clearing the SSH key")
+	assert.Contains(t, validationErr.Message, "repository URL")
 
 	stored, loadErr := svc.GetRepositoryByID(context.Background(), repo.ID)
 	require.NoError(t, loadErr)
@@ -130,8 +130,8 @@ func TestGitRepositoryService_UpdateRepository_RejectsURLChangeWhenStoredTokenAn
 	var apiErr *models.APIError
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, models.APIErrorCodeValidationError, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "token and SSH key")
-	assert.Equal(t, map[string]any{"fields": []string{"token", "sshKey"}}, apiErr.Details)
+	assert.Contains(t, apiErr.Message, "repository URL")
+	assert.Equal(t, map[string]any{"fields": []string{"sshKey", "token"}}, apiErr.Details)
 }
 
 func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsResupplied(t *testing.T) {

--- a/backend/pkg/utils/validation/credential_target.go
+++ b/backend/pkg/utils/validation/credential_target.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+)
+
+// ValidateCredentialTargetChange prevents stored credentials from being reused
+// against a changed target unless the update explicitly handles them.
+func ValidateCredentialTargetChange(
+	targetName string,
+	currentTarget string,
+	nextTarget *string,
+	normalize func(string) string,
+	storedCredentials map[string]bool,
+	updatedCredentials map[string]bool,
+) error {
+	if nextTarget == nil {
+		return nil
+	}
+
+	if normalize == nil {
+		normalize = func(value string) string { return value }
+	}
+	if normalize(currentTarget) == normalize(*nextTarget) {
+		return nil
+	}
+
+	missingFields := make([]string, 0, len(storedCredentials))
+	for field, stored := range storedCredentials {
+		if stored && !updatedCredentials[field] {
+			missingFields = append(missingFields, field)
+		}
+	}
+	if len(missingFields) == 0 {
+		return nil
+	}
+
+	slices.Sort(missingFields)
+	if len(missingFields) == 1 {
+		return &models.ValidationError{
+			Field:   missingFields[0],
+			Message: fmt.Sprintf("Changing %s requires re-supplying or clearing the %s", targetName, missingFields[0]),
+		}
+	}
+
+	return models.NewValidationError(
+		fmt.Sprintf("Changing %s requires updating all stored credentials", targetName),
+		map[string]any{"fields": missingFields},
+	)
+}

--- a/backend/pkg/utils/validation/credential_target_test.go
+++ b/backend/pkg/utils/validation/credential_target_test.go
@@ -1,0 +1,107 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCredentialTargetChange(t *testing.T) {
+	normalizeHost := func(value string) string {
+		return strings.TrimPrefix(strings.ToLower(value), "https://")
+	}
+
+	tests := []struct {
+		name               string
+		currentTarget      string
+		nextTarget         *string
+		normalize          func(string) string
+		storedCredentials  map[string]bool
+		updatedCredentials map[string]bool
+		wantField          string
+		wantFields         []string
+	}{
+		{
+			name:              "omitted target",
+			currentTarget:     "registry.example.com",
+			storedCredentials: map[string]bool{"token": true},
+		},
+		{
+			name:              "identical target",
+			currentTarget:     "registry.example.com",
+			nextTarget:        new("registry.example.com"),
+			storedCredentials: map[string]bool{"token": true},
+		},
+		{
+			name:              "normalized target alias",
+			currentTarget:     "https://registry.example.com",
+			nextTarget:        new("REGISTRY.EXAMPLE.COM"),
+			normalize:         normalizeHost,
+			storedCredentials: map[string]bool{"token": true},
+		},
+		{
+			name:          "changed target without stored credentials",
+			currentTarget: "registry.example.com",
+			nextTarget:    new("registry.example.net"),
+		},
+		{
+			name:               "changed target with replacement",
+			currentTarget:      "registry.example.com",
+			nextTarget:         new("registry.example.net"),
+			storedCredentials:  map[string]bool{"token": true},
+			updatedCredentials: map[string]bool{"token": true},
+		},
+		{
+			name:               "changed target with clearing",
+			currentTarget:      "git.example.com/repo",
+			nextTarget:         new("git.example.net/repo"),
+			storedCredentials:  map[string]bool{"sshKey": true},
+			updatedCredentials: map[string]bool{"sshKey": true},
+		},
+		{
+			name:              "changed target with one missing credential",
+			currentTarget:     "registry.example.com",
+			nextTarget:        new("registry.example.net"),
+			storedCredentials: map[string]bool{"token": true},
+			wantField:         "token",
+		},
+		{
+			name:              "missing fields are deterministic",
+			currentTarget:     "git.example.com/repo",
+			nextTarget:        new("git.example.net/repo"),
+			storedCredentials: map[string]bool{"token": true, "sshKey": true},
+			wantFields:        []string{"sshKey", "token"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCredentialTargetChange(
+				"credential target",
+				tt.currentTarget,
+				tt.nextTarget,
+				tt.normalize,
+				tt.storedCredentials,
+				tt.updatedCredentials,
+			)
+
+			switch {
+			case tt.wantField != "":
+				var validationErr *models.ValidationError
+				require.ErrorAs(t, err, &validationErr)
+				assert.Equal(t, tt.wantField, validationErr.Field)
+				assert.Equal(t, "Changing credential target requires re-supplying or clearing the token", validationErr.Message)
+			case len(tt.wantFields) > 0:
+				var apiErr *models.APIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, models.APIErrorCodeValidationError, apiErr.Code)
+				assert.Equal(t, map[string]any{"fields": tt.wantFields}, apiErr.Details)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents stored credentials from being reused after credential target URLs change. The main changes are:

- Adds shared credential-target validation for URL updates.
- Applies the validation to git repository updates for stored tokens and SSH keys.
- Applies the validation to generic container registry updates for stored tokens.
- Adds tests for rejected target changes, explicit credential replacement or clearing, and normalized same-target updates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The change is focused, covered by targeted tests, and no correctness or security regressions were identified in the changed credential-update paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the Go version used for the credential target build by inspecting the Go version log, which shows the exact version command and an exit code of 0.
- Observed that the validation utility pre-test path failed before running tests due to a JSON v2 build-constraint setup failure.
- Observed that the affected services pre-test path failed before tests due to a JSON v2/jsontext build-constraint setup failure.
- Recorded a GOEXPERIMENT=jsonv2 retry path that failed before tests with a nil pointer panic during cmd/go FIPS initialization.

<a href="https://app.greptile.com/trex/runs/15047570/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent credential reuse after targ..."](https://github.com/getarcaneapp/arcane/commit/1b58f17fa5b6a7aaa4fc4806f556edf934c4643f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45550692)</sub>

<!-- /greptile_comment -->