### PR TITLE
fix: preserve IPAM fields in network inspect responses

### DIFF
--- a/backend/pkg/utils/mapper/mapper.go
+++ b/backend/pkg/utils/mapper/mapper.go
@@ -1,9 +1,45 @@
 package mapper
 
 import (
+	"fmt"
+	"net/netip"
+
 	"emperror.dev/errors"
 	"github.com/jinzhu/copier"
 )
+
+var typeConverters = []copier.TypeConverter{
+	{
+		SrcType: netip.Prefix{},
+		DstType: "",
+		Fn: func(src any) (any, error) {
+			prefix, ok := src.(netip.Prefix)
+			if !ok {
+				return nil, fmt.Errorf("expected netip.Prefix, got %T", src)
+			}
+			if !prefix.IsValid() {
+				return "", nil
+			}
+
+			return prefix.String(), nil
+		},
+	},
+	{
+		SrcType: netip.Addr{},
+		DstType: "",
+		Fn: func(src any) (any, error) {
+			addr, ok := src.(netip.Addr)
+			if !ok {
+				return nil, fmt.Errorf("expected netip.Addr, got %T", src)
+			}
+			if !addr.IsValid() {
+				return "", nil
+			}
+
+			return addr.String(), nil
+		},
+	},
+}
 
 func MapSlice[S any, D any](source []S) ([]D, error) {
 	dest := make([]D, len(source))
@@ -25,7 +61,8 @@ func MapOne[S any, D any](source S) (D, error) {
 
 func MapStruct(source any, destination any) error {
 	return copier.CopyWithOption(destination, source, copier.Option{
-		DeepCopy: true,
+		DeepCopy:   true,
+		Converters: typeConverters,
 	})
 }
 

--- a/backend/pkg/utils/mapper/mapper_test.go
+++ b/backend/pkg/utils/mapper/mapper_test.go
@@ -1,0 +1,44 @@
+package mapper
+
+import (
+	"net/netip"
+	"testing"
+
+	networktypes "github.com/getarcaneapp/arcane/types/v2/network"
+	dockernetwork "github.com/moby/moby/api/types/network"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapOneConvertsNetworkIPAMConfigInternal(t *testing.T) {
+	source := dockernetwork.Inspect{
+		Network: dockernetwork.Network{
+			IPAM: dockernetwork.IPAM{
+				Driver: "default",
+				Config: []dockernetwork.IPAMConfig{
+					{
+						Subnet:  netip.MustParsePrefix("172.16.5.0/24"),
+						Gateway: netip.MustParseAddr("172.16.5.1"),
+						AuxAddress: map[string]netip.Addr{
+							"dns":   netip.MustParseAddr("172.16.5.53"),
+							"unset": {},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mapped, err := MapOne[dockernetwork.Inspect, networktypes.Inspect](source)
+	require.NoError(t, err)
+	require.Equal(t, "default", mapped.IPAM.Driver)
+	require.Len(t, mapped.IPAM.Config, 1)
+
+	config := mapped.IPAM.Config[0]
+	require.Equal(t, "172.16.5.0/24", config.Subnet)
+	require.Equal(t, "172.16.5.1", config.Gateway)
+	require.Empty(t, config.IPRange)
+	require.Equal(t, map[string]string{
+		"dns":   "172.16.5.53",
+		"unset": "",
+	}, config.AuxAddress)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves Docker network IPAM values in inspect responses. The main changes are:

- Adds mapper converters from `netip.Prefix` and `netip.Addr` to strings.
- Keeps invalid zero-value IPAM fields as empty strings.
- Adds a regression test for subnet, gateway, IP range, and auxiliary address mapping.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is small and localized to mapper conversion behavior. The affected network inspect IPAM path has focused regression coverage. No correctness or security issues were identified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the mapper IPAM validation tests as part of PR verification and produced a test log.
- Reviewed the proof log to verify environment details such as command headers, working directory, Go version, verbose test output, and the regression test body.
- Confirmed both test commands completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15474695/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve IPAM fields in network ins..."](https://github.com/getarcaneapp/arcane/commit/399a3b78bbdcca378c733b36a05bc4cea40b66ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46436613)</sub>

<!-- /greptile_comment -->