### PR TITLE
feat: persist per-user table preferences in the database

### DIFF
--- a/backend/api/handlers/users.go
+++ b/backend/api/handlers/users.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	humamw "github.com/getarcaneapp/arcane/backend/v2/api/middleware"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
@@ -81,6 +82,18 @@ type GetUserAvatarOutput struct {
 	CacheControl        string `header:"Cache-Control"`
 	XContentTypeOptions string `header:"X-Content-Type-Options"`
 	Body                []byte
+}
+
+type GetMyPreferencesOutput struct {
+	Body base.ApiResponse[user.Preferences]
+}
+
+type UpdateMyPreferencesInput struct {
+	Body user.Preferences
+}
+
+type UpdateMyPreferencesOutput struct {
+	Body base.ApiResponse[base.MessageResponse]
 }
 
 // ============================================================================
@@ -157,11 +170,84 @@ func RegisterUsers(api huma.API, userService *services.UserService, authService 
 		Tags:        []string{"Users"},
 		Security:    []map[string][]string{},
 	}, h.GetUserAvatar)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getMyPreferences",
+		Method:      "GET",
+		Path:        "/auth/me/prefs",
+		Summary:     "Get preferences",
+		Description: "Get the current user's saved preferences",
+		Tags:        []string{"Users"},
+		Security:    defaultOperationSecurityInternal(),
+	}, h.GetMyPreferences)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "updateMyPreferences",
+		Method:      "PATCH",
+		Path:        "/auth/me/prefs",
+		Summary:     "Update preferences",
+		Description: "Partially update the current user's saved preferences",
+		Tags:        []string{"Users"},
+		Security:    defaultOperationSecurityInternal(),
+	}, h.UpdateMyPreferences)
 }
 
 // ============================================================================
 // Handler Methods
 // ============================================================================
+
+func (h *UserHandler) GetMyPreferences(ctx context.Context, _ *struct{}) (*GetMyPreferencesOutput, error) {
+	currentUser, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if h.userService == nil {
+		return nil, huma.Error500InternalServerError("User service is unavailable")
+	}
+
+	prefs, err := h.userService.GetPreferences(ctx, currentUser.ID)
+	if err != nil {
+		if errors.Is(err, services.ErrUserNotFound) {
+			return nil, huma.Error404NotFound("User not found")
+		}
+		return nil, huma.Error500InternalServerError("Failed to get preferences")
+	}
+
+	return &GetMyPreferencesOutput{
+		Body: base.ApiResponse[user.Preferences]{
+			Success: true,
+			Data:    prefs,
+		},
+	}, nil
+}
+
+func (h *UserHandler) UpdateMyPreferences(ctx context.Context, input *UpdateMyPreferencesInput) (*UpdateMyPreferencesOutput, error) {
+	currentUser, err := requireUserInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if h.userService == nil {
+		return nil, huma.Error500InternalServerError("User service is unavailable")
+	}
+
+	if err := h.userService.UpdatePreferences(ctx, currentUser.ID, input.Body); err != nil {
+		switch {
+		case errors.Is(err, common.ErrValidation):
+			return nil, huma.Error400BadRequest(err.Error())
+		case errors.Is(err, services.ErrUserNotFound):
+			return nil, huma.Error404NotFound("User not found")
+		default:
+			return nil, huma.Error500InternalServerError("Failed to update preferences")
+		}
+	}
+
+	return &UpdateMyPreferencesOutput{
+		Body: base.ApiResponse[base.MessageResponse]{
+			Success: true,
+			Data:    base.MessageResponse{Message: "Preferences updated"},
+		},
+	}, nil
+}
 
 // ListUsers returns a paginated list of users.
 func (h *UserHandler) ListUsers(ctx context.Context, input *ListUsersInput) (*ListUsersOutput, error) {

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -9,17 +9,18 @@ import (
 type User struct {
 	BaseModel
 
-	Username               string          `json:"username" sortable:"true"`
-	PasswordHash           string          `json:"-" gorm:"column:password_hash"`
-	DisplayName            *string         `json:"displayName,omitempty" gorm:"column:display_name" sortable:"true"`
-	Email                  *string         `json:"email,omitempty" sortable:"true"`
-	OidcSubjectId          *string         `json:"oidcSubjectId,omitempty" gorm:"column:oidc_subject_id"`
-	LastLogin              *time.Time      `json:"lastLogin,omitempty" gorm:"column:last_login" sortable:"true"`
-	Locale                 *string         `json:"locale,omitempty" gorm:"column:locale"`
-	TimeFormat             user.TimeFormat `json:"timeFormat" gorm:"column:time_format;not null;default:auto"`
-	FontSize               *int            `json:"fontSize,omitempty" gorm:"column:font_size"`
-	RequiresPasswordChange bool            `json:"requiresPasswordChange" gorm:"column:requires_password_change"`
-	IsServiceAccount       bool            `json:"isServiceAccount" gorm:"column:is_service_account;not null;default:false"`
+	Username               string                `json:"username" sortable:"true"`
+	PasswordHash           string                `json:"-" gorm:"column:password_hash"`
+	DisplayName            *string               `json:"displayName,omitempty" gorm:"column:display_name" sortable:"true"`
+	Email                  *string               `json:"email,omitempty" sortable:"true"`
+	OidcSubjectId          *string               `json:"oidcSubjectId,omitempty" gorm:"column:oidc_subject_id"`
+	LastLogin              *time.Time            `json:"lastLogin,omitempty" gorm:"column:last_login" sortable:"true"`
+	Locale                 *string               `json:"locale,omitempty" gorm:"column:locale"`
+	TimeFormat             user.TimeFormat       `json:"timeFormat" gorm:"column:time_format;not null;default:auto"`
+	FontSize               *int                  `json:"fontSize,omitempty" gorm:"column:font_size"`
+	TablePrefs             user.TablePreferences `json:"-" gorm:"column:table_prefs;type:jsonb;serializer:json"`
+	RequiresPasswordChange bool                  `json:"requiresPasswordChange" gorm:"column:requires_password_change"`
+	IsServiceAccount       bool                  `json:"isServiceAccount" gorm:"column:is_service_account;not null;default:false"`
 
 	// Avatar metadata
 	HasAvatar bool `json:"hasAvatar" gorm:"column:has_avatar;not null;default:false"`

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -5,9 +5,12 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	json "encoding/json/v2"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"emperror.dev/errors"
 
@@ -16,6 +19,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
@@ -49,6 +53,13 @@ type UserService struct {
 }
 
 const ErrCannotRemoveLastAdmin = errors.Sentinel("cannot remove the last admin user")
+
+const (
+	tablePreferenceKeyMaxLength    = 200
+	tablePreferenceValueMaxBytes   = 16 * 1024
+	tablePreferencesTotalMaxBytes  = 256 * 1024
+	tablePreferencePatchMaxEntries = 200
+)
 
 func NewUserService(db *database.DB) *UserService {
 	return &UserService{
@@ -164,6 +175,130 @@ func (s *UserService) GetUserByID(ctx context.Context, id string) (*models.User,
 	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "id = ?", id)
 }
 
+func (s *UserService) GetPreferences(ctx context.Context, userID string) (user.Preferences, error) {
+	var userModel models.User
+	if err := s.db.WithContext(ctx).
+		Select("table_prefs").
+		Where("id = ?", userID).
+		First(&userModel).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return user.Preferences{}, ErrUserNotFound
+		}
+		return user.Preferences{}, fmt.Errorf("get preferences: %w", err)
+	}
+
+	prefs := user.Preferences{Tables: user.TablePreferences{}}
+	if userModel.TablePrefs == nil {
+		return prefs, nil
+	}
+	prefs.Tables = userModel.TablePrefs
+	return prefs, nil
+}
+
+func (s *UserService) UpdatePreferences(ctx context.Context, userID string, prefs user.Preferences) error {
+	if len(prefs.Tables) == 0 {
+		return nil
+	}
+	if len(prefs.Tables) > tablePreferencePatchMaxEntries {
+		return common.Classify(common.ErrValidation, fmt.Errorf("preference patch exceeds %d table entries", tablePreferencePatchMaxEntries))
+	}
+
+	keys := make([]string, 0, len(prefs.Tables))
+	for key := range prefs.Tables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var expression string
+	var sizeExpression string
+	var setExpressionFormat string
+	var deleteExpressionFormat string
+	switch s.db.Name() {
+	case "postgres":
+		expression = "COALESCE(table_prefs, '{}'::jsonb)"
+		sizeExpression = "octet_length(CAST(table_prefs AS text))"
+		setExpressionFormat = "(%s || jsonb_build_object(?, CAST(? AS jsonb)))"
+		deleteExpressionFormat = "(%s - ?)"
+	case "sqlite":
+		expression = "COALESCE(table_prefs, '{}')"
+		sizeExpression = "length(CAST(table_prefs AS BLOB))"
+		setExpressionFormat = "json_set(%s, '$.' || json_quote(?), json(?))"
+		deleteExpressionFormat = "json_remove(%s, '$.' || json_quote(?))"
+	default:
+		return fmt.Errorf("update preferences: unsupported database dialect %q", s.db.Name())
+	}
+
+	args := make([]any, 0, len(keys)*2)
+	for _, key := range keys {
+		if !strings.HasPrefix(key, "arcane-") || utf8.RuneCountInString(key) > tablePreferenceKeyMaxLength {
+			return common.Classify(common.ErrValidation, fmt.Errorf("table preference key must start with arcane- and be at most %d characters", tablePreferenceKeyMaxLength))
+		}
+
+		value := prefs.Tables[key]
+		if value == nil {
+			expression = fmt.Sprintf(deleteExpressionFormat, expression)
+			args = append(args, key)
+			continue
+		}
+
+		valueJSON, err := encodeTablePreferenceInternal(key, value)
+		if err != nil {
+			return err
+		}
+
+		expression = fmt.Sprintf(setExpressionFormat, expression)
+		args = append(args, key, string(valueJSON))
+	}
+
+	return dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
+		result := tx.Model(&models.User{}).
+			Where("id = ?", userID).
+			UpdateColumn("table_prefs", gorm.Expr(expression, args...))
+		if result.Error != nil {
+			return fmt.Errorf("update preferences: %w", result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return ErrUserNotFound
+		}
+
+		var storedBytes int64
+		if err := tx.Model(&models.User{}).
+			Select(sizeExpression).
+			Where("id = ?", userID).
+			Scan(&storedBytes).Error; err != nil {
+			return fmt.Errorf("measure preferences: %w", err)
+		}
+		if storedBytes > tablePreferencesTotalMaxBytes {
+			return common.Classify(common.ErrValidation, fmt.Errorf("table preferences exceed %d bytes", tablePreferencesTotalMaxBytes))
+		}
+		return nil
+	})
+}
+
+func encodeTablePreferenceInternal(key string, value *user.TablePreference) ([]byte, error) {
+	if value.Sort != nil {
+		column, direction := value.Sort[0], value.Sort[1]
+		if strings.TrimSpace(column) == "" || (direction != "asc" && direction != "desc") {
+			return nil, common.Classify(common.ErrValidation, fmt.Errorf("table preference %q has an invalid sort", key))
+		}
+	}
+	for _, filter := range value.Filters {
+		column, ok := filter[0].(string)
+		if !ok || strings.TrimSpace(column) == "" {
+			return nil, common.Classify(common.ErrValidation, fmt.Errorf("table preference %q has an invalid filter", key))
+		}
+	}
+
+	valueJSON, err := json.Marshal(value)
+	if err != nil {
+		return nil, common.Classify(common.ErrValidation, fmt.Errorf("encode table preference %q: %w", key, err))
+	}
+	if len(valueJSON) > tablePreferenceValueMaxBytes {
+		return nil, common.Classify(common.ErrValidation, fmt.Errorf("table preference %q exceeds %d bytes", key, tablePreferenceValueMaxBytes))
+	}
+	return valueJSON, nil
+}
+
 func (s *UserService) GetUserByOidcSubjectId(ctx context.Context, subjectId string) (*models.User, error) {
 	return dbutil.FirstWhere[models.User](ctx, s.db.DB, ErrUserNotFound, "oidc_subject_id = ?", subjectId)
 }
@@ -183,7 +318,7 @@ func (s *UserService) UpdateUser(ctx context.Context, user *models.User) (*model
 			}
 			return errors.WrapIf(err, "failed to load user")
 		}
-		if err := tx.Save(user).Error; err != nil {
+		if err := tx.Omit("table_prefs").Save(user).Error; err != nil {
 			return errors.WrapIf(err, "failed to update user")
 		}
 		return nil
@@ -227,7 +362,7 @@ func (s *UserService) AttachOidcSubjectTransactional(ctx context.Context, userID
 			updateFn(&u)
 		}
 
-		if err := tx.Save(&u).Error; err != nil {
+		if err := tx.Omit("table_prefs").Save(&u).Error; err != nil {
 			// Bubble up uniqueness violations with a clearer message
 			if strings.Contains(strings.ToLower(err.Error()), "unique") || strings.Contains(strings.ToLower(err.Error()), "duplicate key") {
 				return errors.WrapIf(err, "oidc subject is already linked to another user")

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
@@ -184,4 +186,78 @@ func TestUpdateUserPersistsTimeFormatAndMapsToDto(t *testing.T) {
 			require.Equal(t, timeFormat, dto.TimeFormat)
 		})
 	}
+}
+
+func TestUserTablePreferences(t *testing.T) {
+	userSvc, _ := setupUserAndRoleServices(t)
+	ctx := context.Background()
+	firstUser := createTestUser(t, userSvc, "user-1", "first-user")
+	secondUser := createTestUser(t, userSvc, "user-2", "second-user")
+	volumeSearch := "volume search"
+	volumeSort := user.TableSortPreference{"name", "asc"}
+
+	require.NoError(t, userSvc.UpdatePreferences(ctx, firstUser.ID, user.Preferences{
+		Tables: user.TablePreferences{
+			"arcane-volumes-table": {
+				GlobalSearch: &volumeSearch,
+				Sort:         &volumeSort,
+			},
+		},
+	}))
+
+	prefs, err := userSvc.GetPreferences(ctx, firstUser.ID)
+	require.NoError(t, err)
+	require.Contains(t, prefs.Tables, "arcane-volumes-table")
+
+	imageSearch := "alpine"
+	pageSize := 50
+	require.NoError(t, userSvc.UpdatePreferences(ctx, firstUser.ID, user.Preferences{
+		Tables: user.TablePreferences{
+			"arcane-volumes-table": {PageSize: &pageSize},
+			"arcane-images-table":  {GlobalSearch: &imageSearch},
+		},
+	}))
+	otherUserSearch := "other user"
+	require.NoError(t, userSvc.UpdatePreferences(ctx, secondUser.ID, user.Preferences{
+		Tables: user.TablePreferences{
+			"arcane-volumes-table": {GlobalSearch: &otherUserSearch},
+		},
+	}))
+
+	prefs, err = userSvc.GetPreferences(ctx, firstUser.ID)
+	require.NoError(t, err)
+	volumePrefs := prefs.Tables["arcane-volumes-table"]
+	require.NotNil(t, volumePrefs)
+	require.Nil(t, volumePrefs.GlobalSearch)
+	require.Equal(t, 50, *volumePrefs.PageSize)
+	require.Contains(t, prefs.Tables, "arcane-images-table")
+
+	updatedDisplayName := "Updated user"
+	firstUser.DisplayName = &updatedDisplayName
+	_, err = userSvc.UpdateUser(ctx, firstUser)
+	require.NoError(t, err)
+	prefs, err = userSvc.GetPreferences(ctx, firstUser.ID)
+	require.NoError(t, err)
+	require.Contains(t, prefs.Tables, "arcane-volumes-table")
+	require.Contains(t, prefs.Tables, "arcane-images-table")
+
+	require.NoError(t, userSvc.UpdatePreferences(ctx, firstUser.ID, user.Preferences{
+		Tables: user.TablePreferences{"arcane-volumes-table": nil},
+	}))
+	prefs, err = userSvc.GetPreferences(ctx, firstUser.ID)
+	require.NoError(t, err)
+	require.NotContains(t, prefs.Tables, "arcane-volumes-table")
+	require.Contains(t, prefs.Tables, "arcane-images-table")
+
+	secondUserPrefs, err := userSvc.GetPreferences(ctx, secondUser.ID)
+	require.NoError(t, err)
+	require.Contains(t, secondUserPrefs.Tables, "arcane-volumes-table")
+
+	oversizedSearch := strings.Repeat("x", tablePreferenceValueMaxBytes)
+	err = userSvc.UpdatePreferences(ctx, firstUser.ID, user.Preferences{
+		Tables: user.TablePreferences{
+			"arcane-too-large-table": {GlobalSearch: &oversizedSearch},
+		},
+	})
+	require.ErrorIs(t, err, common.ErrValidation)
 }

--- a/backend/resources/migrations/postgres/068_add_user_table_prefs.sql
+++ b/backend/resources/migrations/postgres/068_add_user_table_prefs.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN table_prefs JSONB;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN table_prefs;

--- a/backend/resources/migrations/sqlite/068_add_user_table_prefs.sql
+++ b/backend/resources/migrations/sqlite/068_add_user_table_prefs.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN table_prefs TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN table_prefs;

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -9,9 +9,7 @@
 	import type { ColumnSpec } from './arcane-table.types.svelte';
 	import TableCheckbox from './arcane-table-checkbox.svelte';
 	import { m } from '#lib/paraglide/messages';
-	import { PersistedState } from 'runed';
 	import {
-		type CompactTablePrefs,
 		type FieldSpec,
 		type GroupedData,
 		type GroupSelectionState,
@@ -31,6 +29,7 @@
 	import ArcaneTableCell from './arcane-table-cell.svelte';
 	import ArcaneTableDesktopView from './arcane-table-desktop-view.svelte';
 	import ArcaneTableMobileView from './arcane-table-mobile-view.svelte';
+	import { tablePreferences } from '#lib/stores/table-preferences.store.svelte';
 
 	let {
 		items,
@@ -122,7 +121,6 @@
 
 	const enablePersist = $derived(!!persistKey);
 	const getEffectiveLimit = () => requestOptions?.pagination?.limit ?? items?.pagination?.itemsPerPage ?? DEFAULT_LIMIT;
-	let prefs = $state<PersistedState<CompactTablePrefs> | null>(null);
 
 	// Expandable row state
 	let expandedRows = $state<Set<string>>(new Set());
@@ -151,100 +149,102 @@
 	const canNext = $derived(currentPage < totalPages);
 
 	onMount(() => {
-		// Initialize prefs first
-		if (persistKey && !prefs) {
-			prefs = new PersistedState<CompactTablePrefs>(
-				persistKey,
-				{ v: [], f: [], g: '', l: getEffectiveLimit() },
-				{ syncTabs: false }
-			);
-		}
-
-		// Then restore preferences
-		if (!enablePersist) {
+		if (!enablePersist || !persistKey) {
 			preferencesReady = true;
 			return;
 		}
-		const snapshot = extractPersistedPreferences(prefs?.current, getEffectiveLimit());
 
-		const patchedVisibility = { ...columnVisibility };
-		applyHiddenPatch(patchedVisibility, snapshot.hiddenColumns);
-		columnVisibility = patchedVisibility;
+		let cancelled = false;
+		const preferenceKey = persistKey;
+		void (async () => {
+			await tablePreferences.ready();
+			if (cancelled) return;
 
-		let shouldRefresh = false;
-		const { restoredFilters, filtersMap } = snapshot;
-		if (restoredFilters.length) {
-			columnFilters = restoredFilters;
-		}
-		if (Object.keys(filtersMap).length > 0) {
-			if (!filterMapsEqual(filtersMap, requestOptions?.filters)) {
+			const snapshot = extractPersistedPreferences(tablePreferences.get(preferenceKey), getEffectiveLimit());
+
+			const patchedVisibility = { ...columnVisibility };
+			applyHiddenPatch(patchedVisibility, snapshot.hiddenColumns);
+			columnVisibility = patchedVisibility;
+
+			let shouldRefresh = false;
+			const { restoredFilters, filtersMap } = snapshot;
+			if (restoredFilters.length) {
+				columnFilters = restoredFilters;
+			}
+			if (Object.keys(filtersMap).length > 0) {
+				if (!filterMapsEqual(filtersMap, requestOptions?.filters)) {
+					requestOptions = {
+						...requestOptions,
+						filters: filtersMap,
+						pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
+					};
+					shouldRefresh = true;
+				}
+			} else if (requestOptions?.filters && Object.keys(requestOptions.filters).length > 0) {
 				requestOptions = {
 					...requestOptions,
-					filters: filtersMap,
+					filters: undefined,
 					pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
 				};
 				shouldRefresh = true;
 			}
-		} else if (requestOptions?.filters && Object.keys(requestOptions.filters).length > 0) {
-			requestOptions = {
-				...requestOptions,
-				filters: undefined,
-				pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
-			};
-			shouldRefresh = true;
-		}
 
-		const persistedSearch = snapshot.search;
-		const currentSearch = (requestOptions?.search ?? '').trim();
-		// Incoming requestOptions.search (e.g. from URL param) takes priority over persisted state
-		const effectiveSearch = currentSearch || persistedSearch;
-		if (effectiveSearch !== globalFilter) {
-			globalFilter = effectiveSearch;
-		}
-		if (effectiveSearch !== currentSearch) {
-			requestOptions = {
-				...requestOptions,
-				search: effectiveSearch || undefined,
-				pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
-			};
-			shouldRefresh = true;
-		}
-
-		const persistedLimit = snapshot.limit ?? getEffectiveLimit();
-		const currentLimit = requestOptions?.pagination?.limit ?? getEffectiveLimit();
-		if (persistedLimit !== currentLimit) {
-			requestOptions = { ...requestOptions, pagination: { page: 1, limit: persistedLimit } };
-			shouldRefresh = true;
-		}
-
-		const persistedSort = snapshot.sort;
-		const currentSort = requestOptions?.sort;
-		if (persistedSort) {
-			const restoredSort =
-				patchedVisibility[persistedSort.column] === false && hiddenSortFallback ? hiddenSortFallback : persistedSort;
-			if (restoredSort !== persistedSort && prefs) {
-				prefs.current = { ...prefs.current, s: encodeSort(restoredSort) };
+			const persistedSearch = snapshot.search;
+			const currentSearch = (requestOptions?.search ?? '').trim();
+			// Incoming requestOptions.search (e.g. from URL param) takes priority over persisted state
+			const effectiveSearch = currentSearch || persistedSearch;
+			if (effectiveSearch !== globalFilter) {
+				globalFilter = effectiveSearch;
 			}
-			if (currentSort?.column !== restoredSort.column || currentSort?.direction !== restoredSort.direction) {
+			if (effectiveSearch !== currentSearch) {
 				requestOptions = {
 					...requestOptions,
-					sort: restoredSort,
+					search: effectiveSearch || undefined,
 					pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
 				};
 				shouldRefresh = true;
 			}
-		}
-		if (shouldRefresh) onRefresh(requestOptions);
 
-		if (mobileFields.length && !Object.keys(mobileFieldVisibility).length) {
-			mobileFieldVisibility = buildMobileVisibility(mobileFields, snapshot.mobileVisibility);
-		}
+			const persistedLimit = snapshot.limit ?? getEffectiveLimit();
+			const currentLimit = requestOptions?.pagination?.limit ?? getEffectiveLimit();
+			if (persistedLimit !== currentLimit) {
+				requestOptions = { ...requestOptions, pagination: { page: 1, limit: persistedLimit } };
+				shouldRefresh = true;
+			}
 
-		if (snapshot.customSettings && Object.keys(snapshot.customSettings).length > 0) {
-			customSettings = { ...snapshot.customSettings };
-		}
+			const persistedSort = snapshot.sort;
+			const currentSort = requestOptions?.sort;
+			if (persistedSort) {
+				const restoredSort =
+					patchedVisibility[persistedSort.column] === false && hiddenSortFallback ? hiddenSortFallback : persistedSort;
+				if (restoredSort !== persistedSort) {
+					tablePreferences.update(preferenceKey, { s: encodeSort(restoredSort) });
+				}
+				if (currentSort?.column !== restoredSort.column || currentSort?.direction !== restoredSort.direction) {
+					requestOptions = {
+						...requestOptions,
+						sort: restoredSort,
+						pagination: { page: 1, limit: requestOptions?.pagination?.limit ?? getEffectiveLimit() }
+					};
+					shouldRefresh = true;
+				}
+			}
+			if (shouldRefresh) onRefresh(requestOptions);
 
-		preferencesReady = true;
+			if (mobileFields.length && !Object.keys(mobileFieldVisibility).length) {
+				mobileFieldVisibility = buildMobileVisibility(mobileFields, snapshot.mobileVisibility);
+			}
+
+			if (snapshot.customSettings && Object.keys(snapshot.customSettings).length > 0) {
+				customSettings = { ...snapshot.customSettings };
+			}
+
+			preferencesReady = true;
+		})();
+
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	function updatePagination(patch: Partial<{ page: number; limit: number }>) {
@@ -265,7 +265,7 @@
 
 	function setPageSize(limit: number) {
 		// Persist page size
-		if (enablePersist && prefs) prefs.current = { ...prefs.current, l: limit };
+		if (enablePersist && persistKey) tablePreferences.update(persistKey, { l: limit });
 		updatePagination({ limit, page: 1 });
 	}
 
@@ -461,11 +461,8 @@
 			const sortState = first
 				? { column: String(first.id), direction: (first.desc ? 'desc' : 'asc') as 'asc' | 'desc' }
 				: undefined;
-			if (enablePersist && prefs) {
-				prefs.current = {
-					...prefs.current,
-					s: encodeSort(sortState)
-				};
+			if (enablePersist && persistKey) {
+				tablePreferences.update(persistKey, { s: encodeSort(sortState) });
 			}
 			if (sortState) {
 				requestOptions = {
@@ -490,8 +487,8 @@
 		},
 		onColumnFiltersChange: (updater) => {
 			columnFilters = typeof updater === 'function' ? updater(columnFilters) : updater;
-			if (enablePersist && prefs) {
-				prefs.current = { ...prefs.current, f: encodeFilters(columnFilters) };
+			if (enablePersist && persistKey) {
+				tablePreferences.update(persistKey, { f: encodeFilters(columnFilters) });
 			}
 			requestOptions = {
 				...requestOptions,
@@ -507,8 +504,8 @@
 			const nextVisibility = typeof updater === 'function' ? updater(columnVisibility) : updater;
 			columnVisibility = nextVisibility;
 			// Persist visibility
-			if (enablePersist && prefs) {
-				prefs.current = { ...prefs.current, v: encodeHidden(columnVisibility) };
+			if (enablePersist && persistKey) {
+				tablePreferences.update(persistKey, { v: encodeHidden(columnVisibility) });
 			}
 
 			const activeSort = requestOptions?.sort;
@@ -522,8 +519,8 @@
 						limit: requestOptions?.pagination?.limit ?? items?.pagination?.itemsPerPage ?? 10
 					}
 				};
-				if (enablePersist && prefs) {
-					prefs.current = { ...prefs.current, s: encodeSort(hiddenSortFallback) };
+				if (enablePersist && persistKey) {
+					tablePreferences.update(persistKey, { s: encodeSort(hiddenSortFallback) });
 				}
 				onRefresh(requestOptions);
 			}
@@ -537,8 +534,8 @@
 				pagination: { page: 1, limit }
 			};
 			// Persist global filter
-			if (enablePersist && prefs) {
-				prefs.current = { ...prefs.current, g: globalFilter };
+			if (enablePersist && persistKey) {
+				tablePreferences.update(persistKey, { g: globalFilter });
 			}
 			onRefresh(requestOptions);
 		}
@@ -555,8 +552,8 @@
 			[fieldId]: !mobileFieldVisibility[fieldId]
 		};
 		// Persist mobile field visibility
-		if (enablePersist && prefs) {
-			prefs.current = { ...prefs.current, m: encodeMobileVisibility(mobileFieldVisibility) };
+		if (enablePersist && persistKey) {
+			tablePreferences.update(persistKey, { m: encodeMobileVisibility(mobileFieldVisibility) });
 		}
 	}
 
@@ -667,7 +664,7 @@
 	let persistTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	$effect(() => {
-		if (!enablePersist || !prefs) return;
+		if (!enablePersist || !persistKey || !preferencesReady) return;
 
 		// Read current settings without creating dependency on the stringified value
 		const currentSettings = customSettings;
@@ -681,9 +678,9 @@
 
 		persistTimeout = setTimeout(() => {
 			untrack(() => {
-				if (prefs && settingsJson !== lastPersistedSettings) {
+				if (settingsJson !== lastPersistedSettings) {
 					lastPersistedSettings = settingsJson;
-					prefs.current = { ...prefs.current, c: currentSettings };
+					tablePreferences.update(persistKey, { c: currentSettings });
 				}
 			});
 		}, 100);

--- a/frontend/src/lib/services/api-service.ts
+++ b/frontend/src/lib/services/api-service.ts
@@ -193,6 +193,7 @@ const skipAuthPathsInternal = [
 	'/auth/oidc/callback',
 	'/auth/auto-login',
 	'/auth/auto-login-config',
+	'/auth/me/prefs',
 	'/settings/public'
 ];
 

--- a/frontend/src/lib/services/preferences-service.ts
+++ b/frontend/src/lib/services/preferences-service.ts
@@ -1,0 +1,14 @@
+import BaseAPIService from './api-service';
+import type { UserPreferences, UserPreferencesPatch } from '#lib/types/user-preferences';
+
+class PreferencesService extends BaseAPIService {
+	async getMyPreferences(): Promise<UserPreferences> {
+		return this.handleResponse(this.api.get('/auth/me/prefs'));
+	}
+
+	async updateMyPreferences(prefs: UserPreferencesPatch): Promise<void> {
+		await this.handleResponse(this.api.patch('/auth/me/prefs', prefs));
+	}
+}
+
+export const preferencesService = new PreferencesService();

--- a/frontend/src/lib/stores/table-preferences.store.svelte.ts
+++ b/frontend/src/lib/stores/table-preferences.store.svelte.ts
@@ -1,0 +1,115 @@
+import { browser } from '$app/env';
+import type { CompactTablePrefs } from '#lib/components/arcane-table/arcane-table.types.svelte';
+import { preferencesService } from '#lib/services/preferences-service';
+import type { TablePreferences, TablePreferencesPatch } from '#lib/types/user-preferences';
+
+const COMPACT_PREFERENCE_FIELDS = new Set(['v', 'f', 'g', 's', 'l', 'm', 'c']);
+const WRITE_DEBOUNCE_MS = 500;
+
+class TablePreferencesStore {
+	#prefs = $state<TablePreferences>({});
+	#readyPromise: Promise<void> | null = null;
+	#authenticated = false;
+	#generation = 0;
+	#pendingPatch: TablePreferencesPatch = {};
+	#writeTimer: ReturnType<typeof setTimeout> | null = null;
+
+	ready(): Promise<void> {
+		if (!browser) return Promise.resolve();
+		if (this.#readyPromise) return this.#readyPromise;
+
+		const generation = this.#generation;
+		this.#readyPromise = (async () => {
+			try {
+				const serverPrefs = (await preferencesService.getMyPreferences()).tables ?? {};
+				if (generation !== this.#generation) return;
+
+				this.#authenticated = true;
+				this.#prefs = { ...serverPrefs };
+
+				const localPrefs = this.#readLocalPreferences();
+				if (Object.keys(serverPrefs).length === 0) {
+					this.#prefs = { ...localPrefs };
+					if (Object.keys(localPrefs).length > 0) {
+						try {
+							await preferencesService.updateMyPreferences({ tables: localPrefs });
+							if (generation === this.#generation) {
+								for (const key of Object.keys(localPrefs)) localStorage.removeItem(key);
+							}
+						} catch (error) {
+							console.debug('Failed to import local table preferences', error);
+						}
+					}
+				} else {
+					for (const key of Object.keys(localPrefs)) localStorage.removeItem(key);
+				}
+			} catch (error) {
+				if (generation !== this.#generation) return;
+				this.#authenticated = false;
+				this.#prefs = {};
+				console.debug('Failed to load table preferences', error);
+			}
+		})();
+
+		return this.#readyPromise;
+	}
+
+	reset(): void {
+		this.#generation += 1;
+		this.#authenticated = false;
+		this.#prefs = {};
+		this.#readyPromise = null;
+		this.#pendingPatch = {};
+		if (this.#writeTimer) clearTimeout(this.#writeTimer);
+		this.#writeTimer = null;
+	}
+
+	get(key: string): CompactTablePrefs | undefined {
+		return this.#prefs[key];
+	}
+
+	set(key: string, prefs: CompactTablePrefs): void {
+		const next = { ...prefs };
+		this.#prefs = { ...this.#prefs, [key]: next };
+
+		if (!browser || !this.#authenticated) return;
+		this.#pendingPatch = { ...this.#pendingPatch, [key]: next };
+		if (this.#writeTimer) clearTimeout(this.#writeTimer);
+
+		const generation = this.#generation;
+		this.#writeTimer = setTimeout(() => {
+			this.#writeTimer = null;
+			if (generation !== this.#generation || !this.#authenticated) return;
+
+			const patch = this.#pendingPatch;
+			this.#pendingPatch = {};
+			void preferencesService
+				.updateMyPreferences({ tables: patch })
+				.catch((error) => console.debug('Failed to save table preferences', error));
+		}, WRITE_DEBOUNCE_MS);
+	}
+
+	update(key: string, patch: Partial<CompactTablePrefs>): void {
+		this.set(key, { ...(this.get(key) ?? {}), ...patch });
+	}
+
+	#readLocalPreferences(): TablePreferences {
+		const prefs: TablePreferences = {};
+		for (let index = 0; index < localStorage.length; index += 1) {
+			const key = localStorage.key(index);
+			if (!key?.startsWith('arcane-') || key.length > 200) continue;
+
+			try {
+				const value = JSON.parse(localStorage.getItem(key) ?? 'null');
+				if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+				if (!Object.keys(value).every((field) => COMPACT_PREFERENCE_FIELDS.has(field))) continue;
+				prefs[key] = value as CompactTablePrefs;
+			} catch {
+				// Ignore unrelated or malformed local storage entries.
+			}
+		}
+		return prefs;
+	}
+}
+
+export const tablePreferences = new TablePreferencesStore();

--- a/frontend/src/lib/types/user-preferences.ts
+++ b/frontend/src/lib/types/user-preferences.ts
@@ -1,0 +1,12 @@
+import type { CompactTablePrefs } from '#lib/components/arcane-table/arcane-table.types.svelte';
+
+export type TablePreferences = Record<string, CompactTablePrefs>;
+export type TablePreferencesPatch = Record<string, CompactTablePrefs | null>;
+
+export type UserPreferences = {
+	tables: TablePreferences;
+};
+
+export type UserPreferencesPatch = {
+	tables: TablePreferencesPatch;
+};

--- a/frontend/src/lib/utils/tables.ts
+++ b/frontend/src/lib/utils/tables.ts
@@ -1,8 +1,8 @@
 import { browser } from '$app/env';
-import { PersistedState } from 'runed';
-import { decodeSort, type CompactTablePrefs } from '#lib/components/arcane-table/arcane-table.types.svelte';
+import { decodeSort } from '#lib/components/arcane-table/arcane-table.types.svelte';
 import { TABLE_PAGE_SIZE_ALL, TABLE_PAGE_SIZE_OPTIONS } from '#lib/constants/table-pagination';
 import { environmentStore } from '#lib/stores/environment.store.svelte';
+import { tablePreferences } from '#lib/stores/table-preferences.store.svelte';
 import type { FilterMap, FilterValue, SearchPaginationSortRequest } from '#lib/types/shared';
 
 const DEFAULT_LIMIT = 20;
@@ -62,11 +62,11 @@ function normalizeSearch(value: unknown): string | undefined {
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function resolveInitialTableRequest(
+export async function resolveInitialTableRequest(
 	persistKey: string,
 	defaults: SearchPaginationSortRequest,
 	options: { deferredSortColumns?: readonly string[] } = {}
-): SearchPaginationSortRequest {
+): Promise<SearchPaginationSortRequest> {
 	const base = cloneRequest(defaults);
 	const fallbackLimit = base.pagination?.limit ?? DEFAULT_LIMIT;
 
@@ -82,12 +82,8 @@ export function resolveInitialTableRequest(
 	if (!browser) return base;
 
 	try {
-		const persisted = new PersistedState<CompactTablePrefs>(
-			persistKey,
-			{ v: [], f: [], g: '', l: fallbackLimit },
-			{ syncTabs: false }
-		);
-		const current = persisted.current ?? {};
+		await tablePreferences.ready();
+		const current = tablePreferences.get(persistKey) ?? {};
 
 		const filters = buildFilterMap(current.f);
 		if (Object.keys(filters).length > 0) {
@@ -117,11 +113,11 @@ export function resolveInitialTableRequest(
 	return base;
 }
 
-export function resolveInitialListPageRequest(
+export async function resolveInitialListPageRequest(
 	persistKey: string,
 	sort: NonNullable<SearchPaginationSortRequest['sort']>,
 	limit = 20
-): SearchPaginationSortRequest {
+): Promise<SearchPaginationSortRequest> {
 	return resolveInitialTableRequest(persistKey, {
 		pagination: {
 			page: 1,
@@ -145,7 +141,7 @@ export async function resolveListPageLoadContext(
 ) {
 	const parentData = (await parent()) as { queryClient: QueryClientLike };
 	const envId = await environmentStore.getCurrentEnvironmentId();
-	const requestOptions = resolveInitialListPageRequest(persistKey, sort, limit);
+	const requestOptions = await resolveInitialListPageRequest(persistKey, sort, limit);
 
 	return {
 		queryClient: parentData.queryClient,

--- a/frontend/src/routes/(app)/containers/+page.ts
+++ b/frontend/src/routes/(app)/containers/+page.ts
@@ -10,7 +10,7 @@ export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 	const envId = await environmentStore.getCurrentEnvironmentId();
 
-	const containerRequestOptions = resolveInitialTableRequest('arcane-container-table', {
+	const containerRequestOptions = await resolveInitialTableRequest('arcane-container-table', {
 		pagination: { page: 1, limit: 20 },
 		sort: { column: 'created', direction: 'desc' }
 	} satisfies SearchPaginationSortRequest);

--- a/frontend/src/routes/(app)/customize/git-repositories/+page.ts
+++ b/frontend/src/routes/(app)/customize/git-repositories/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const repositoryRequestOptions = resolveInitialTableRequest('arcane-git-repositories-table', {
+	const repositoryRequestOptions = await resolveInitialTableRequest('arcane-git-repositories-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/customize/registries/+page.ts
+++ b/frontend/src/routes/(app)/customize/registries/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const registryRequestOptions = resolveInitialTableRequest('arcane-registries-table', {
+	const registryRequestOptions = await resolveInitialTableRequest('arcane-registries-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/customize/templates/+page.ts
+++ b/frontend/src/routes/(app)/customize/templates/+page.ts
@@ -14,7 +14,7 @@ export const load: PageLoad = async ({
 }> => {
 	const { queryClient } = await parent();
 
-	const templateRequestOptions = resolveInitialTableRequest('arcane-template-gallery', {
+	const templateRequestOptions = await resolveInitialTableRequest('arcane-template-gallery', {
 		pagination: { page: 1, limit: 20 },
 		sort: { column: 'name', direction: 'asc' }
 	} satisfies SearchPaginationSortRequest);

--- a/frontend/src/routes/(app)/customize/templates/components/template-gallery.svelte
+++ b/frontend/src/routes/(app)/customize/templates/components/template-gallery.svelte
@@ -12,12 +12,11 @@
 	import { debounced } from '#lib/utils/ws';
 	import { hasPermission } from '#lib/utils/auth';
 	import { m } from '#lib/paraglide/messages';
-	import { PersistedState } from 'runed';
-	import { onMount, untrack } from 'svelte';
-	import type { CompactTablePrefs } from '#lib/components/arcane-table/arcane-table.types.svelte';
+	import { untrack } from 'svelte';
 	import type { Paginated, SearchPaginationSortRequest } from '#lib/types/shared';
 	import type { Template } from '#lib/types/swarm';
 	import { SearchIcon, TemplateIcon } from '#lib/icons';
+	import { tablePreferences } from '#lib/stores/table-preferences.store.svelte';
 
 	let {
 		templates = $bindable(),
@@ -32,8 +31,6 @@
 	let searchValue = $state(untrack(() => requestOptions.search ?? ''));
 	let typeFilter = $state(untrack(() => (requestOptions.filters?.['type'] as string) ?? 'all'));
 
-	let prefs = $state<PersistedState<CompactTablePrefs> | null>(null);
-
 	const currentPage = $derived(templates.pagination?.currentPage ?? requestOptions.pagination?.page ?? 1);
 	const totalPages = $derived(templates.pagination?.totalPages ?? 1);
 	const totalItems = $derived(templates.pagination?.totalItems ?? 0);
@@ -42,14 +39,6 @@
 	const canCreateTemplate = $derived(hasPermission('templates:create'));
 
 	const typeFilterLabel = $derived(templateTypeFilters.find((f) => f.value === typeFilter)?.label ?? m.common_all());
-
-	onMount(() => {
-		prefs = new PersistedState<CompactTablePrefs>(
-			'arcane-template-gallery',
-			{ v: [], f: [], g: '', l: pageSize },
-			{ syncTabs: false }
-		);
-	});
 
 	async function refetch() {
 		templates = await templateService.getTemplates(requestOptions);
@@ -62,7 +51,7 @@
 			search: search || undefined,
 			pagination: { page: 1, limit: pageSize }
 		};
-		if (prefs) prefs.current = { ...prefs.current, g: search };
+		tablePreferences.update('arcane-template-gallery', { g: search });
 		refetch();
 	}
 
@@ -81,7 +70,7 @@
 			filters,
 			pagination: { page: 1, limit: pageSize }
 		};
-		if (prefs) prefs.current = { ...prefs.current, f: value === 'all' ? [] : [['type', value]] };
+		tablePreferences.update('arcane-template-gallery', { f: value === 'all' ? [] : [['type', value]] });
 		refetch();
 	}
 
@@ -93,7 +82,7 @@
 	}
 
 	function setPageSize(limit: number) {
-		if (prefs) prefs.current = { ...prefs.current, l: limit };
+		tablePreferences.update('arcane-template-gallery', { l: limit });
 		requestOptions = { ...requestOptions, pagination: { page: 1, limit } };
 		refetch();
 	}

--- a/frontend/src/routes/(app)/environments/+page.ts
+++ b/frontend/src/routes/(app)/environments/+page.ts
@@ -8,7 +8,7 @@ import { throwPageLoadError } from '#lib/utils/api';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const environmentRequestOptions = resolveInitialTableRequest('arcane-environments-table', {
+	const environmentRequestOptions = await resolveInitialTableRequest('arcane-environments-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/environments/[id]/gitops/+page.ts
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/+page.ts
@@ -10,7 +10,7 @@ export const load: PageLoad = async ({ params, parent }) => {
 
 	const environmentId = params.id;
 
-	const syncRequestOptions = resolveInitialTableRequest('arcane-gitops-syncs-table', {
+	const syncRequestOptions = await resolveInitialTableRequest('arcane-gitops-syncs-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/events/+page.ts
+++ b/frontend/src/routes/(app)/events/+page.ts
@@ -8,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const eventRequestOptions = resolveInitialTableRequest('arcane-events-table', {
+	const eventRequestOptions = await resolveInitialTableRequest('arcane-events-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/images/vulnerabilities/+page.ts
+++ b/frontend/src/routes/(app)/images/vulnerabilities/+page.ts
@@ -11,7 +11,7 @@ export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 	const envId = await environmentStore.getCurrentEnvironmentId();
 
-	const vulnerabilityRequestOptions = resolveInitialTableRequest('arcane-security-vuln-table', {
+	const vulnerabilityRequestOptions = await resolveInitialTableRequest('arcane-security-vuln-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/projects/+page.ts
+++ b/frontend/src/routes/(app)/projects/+page.ts
@@ -11,7 +11,7 @@ export const load: PageLoad = async ({ parent, url }) => {
 	const envId = await environmentStore.getCurrentEnvironmentId();
 	const showArchived = url.searchParams.get('archived') === 'true';
 
-	const projectRequestOptions = resolveInitialTableRequest('arcane-project-table', {
+	const projectRequestOptions = await resolveInitialTableRequest('arcane-project-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/settings/api-keys/+page.ts
+++ b/frontend/src/routes/(app)/settings/api-keys/+page.ts
@@ -8,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const apiKeyRequestOptions = resolveInitialTableRequest('arcane-api-keys-table', {
+	const apiKeyRequestOptions = await resolveInitialTableRequest('arcane-api-keys-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/settings/authentication/+page.ts
+++ b/frontend/src/routes/(app)/settings/authentication/+page.ts
@@ -10,7 +10,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const parentData = await parent();
 	const { queryClient } = parentData;
-	const federatedCredentialRequestOptions = resolveInitialTableRequest('arcane-federated-credentials-table', {
+	const federatedCredentialRequestOptions = await resolveInitialTableRequest('arcane-federated-credentials-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/settings/roles/+page.ts
+++ b/frontend/src/routes/(app)/settings/roles/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const rolesRequestOptions = resolveInitialTableRequest('arcane-roles-table', {
+	const rolesRequestOptions = await resolveInitialTableRequest('arcane-roles-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/settings/users/+page.ts
+++ b/frontend/src/routes/(app)/settings/users/+page.ts
@@ -9,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 
-	const userRequestOptions = resolveInitialTableRequest('arcane-users-table', {
+	const userRequestOptions = await resolveInitialTableRequest('arcane-users-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/swarm/nodes/+page.ts
+++ b/frontend/src/routes/(app)/swarm/nodes/+page.ts
@@ -4,7 +4,7 @@ import { resolveInitialTableRequest } from '#lib/utils/tables';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	const requestOptions = resolveInitialTableRequest('arcane-swarm-nodes-table', {
+	const requestOptions = await resolveInitialTableRequest('arcane-swarm-nodes-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/swarm/services/+page.ts
+++ b/frontend/src/routes/(app)/swarm/services/+page.ts
@@ -3,7 +3,7 @@ import { resolveInitialListPageRequest } from '#lib/utils/tables';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	const requestOptions = resolveInitialListPageRequest('arcane-swarm-services-table', {
+	const requestOptions = await resolveInitialListPageRequest('arcane-swarm-services-table', {
 		column: 'name',
 		direction: 'asc'
 	});

--- a/frontend/src/routes/(app)/swarm/stacks/+page.ts
+++ b/frontend/src/routes/(app)/swarm/stacks/+page.ts
@@ -3,7 +3,7 @@ import { resolveInitialListPageRequest } from '#lib/utils/tables';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	const requestOptions = resolveInitialListPageRequest('arcane-swarm-stacks-table', {
+	const requestOptions = await resolveInitialListPageRequest('arcane-swarm-stacks-table', {
 		column: 'name',
 		direction: 'asc'
 	});

--- a/frontend/src/routes/(app)/swarm/stacks/[name]/+page.ts
+++ b/frontend/src/routes/(app)/swarm/stacks/[name]/+page.ts
@@ -8,7 +8,7 @@ type StackSourceState = 'loading' | 'available' | 'missing' | 'forbidden' | 'err
 
 export const load: PageLoad = async ({ params }) => {
 	const stackName = decodeURIComponent(params.name);
-	const servicesRequestOptions = resolveInitialTableRequest(`arcane-swarm-stack-services-table-${stackName}`, {
+	const servicesRequestOptions = await resolveInitialTableRequest(`arcane-swarm-stack-services-table-${stackName}`, {
 		pagination: {
 			page: 1,
 			limit: 20
@@ -18,7 +18,7 @@ export const load: PageLoad = async ({ params }) => {
 			direction: 'asc'
 		}
 	} satisfies SearchPaginationSortRequest);
-	const tasksRequestOptions = resolveInitialTableRequest(`arcane-swarm-stack-tasks-table-${stackName}`, {
+	const tasksRequestOptions = await resolveInitialTableRequest(`arcane-swarm-stack-tasks-table-${stackName}`, {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/swarm/tasks/+page.ts
+++ b/frontend/src/routes/(app)/swarm/tasks/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ url }) => {
 	const searchParam = url.searchParams.get('search') || '';
 	const nodeId = url.searchParams.get('nodeId') || '';
-	const requestOptions = resolveInitialTableRequest('arcane-swarm-tasks-table', {
+	const requestOptions = await resolveInitialTableRequest('arcane-swarm-tasks-table', {
 		pagination: {
 			page: 1,
 			limit: 20

--- a/frontend/src/routes/(app)/updates/+page.ts
+++ b/frontend/src/routes/(app)/updates/+page.ts
@@ -13,14 +13,14 @@ export const load: PageLoad = async ({ parent }) => {
 	const envId = await environmentStore.getCurrentEnvironmentId();
 
 	const containerRequestOptions = ensureStandaloneContainerUpdatesFilter(
-		resolveInitialTableRequest('arcane-updates-container-table', {
+		await resolveInitialTableRequest('arcane-updates-container-table', {
 			pagination: { page: 1, limit: 100 },
 			sort: { column: 'created', direction: 'desc' }
 		} satisfies SearchPaginationSortRequest)
 	) as ContainerListRequestOptions;
 
 	const projectRequestOptions = ensureUpdatesFilter(
-		resolveInitialTableRequest('arcane-updates-project-table', {
+		await resolveInitialTableRequest('arcane-updates-project-table', {
 			pagination: { page: 1, limit: 20 },
 			sort: { column: 'name', direction: 'asc' }
 		} satisfies SearchPaginationSortRequest)

--- a/frontend/src/routes/(app)/volumes/+page.ts
+++ b/frontend/src/routes/(app)/volumes/+page.ts
@@ -9,7 +9,7 @@ export const load: PageLoad = async ({ parent }) => {
 	const { queryClient } = await parent();
 	const envId = await environmentStore.getCurrentEnvironmentId();
 
-	const volumeRequestOptions = resolveInitialTableRequest(
+	const volumeRequestOptions = await resolveInitialTableRequest(
 		'arcane-volumes-table',
 		{
 			pagination: {

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -15,6 +15,7 @@ import { authService } from '#lib/services/auth-service';
 import { tryCatch } from '#lib/utils/api';
 import { QueryClient } from '@tanstack/svelte-query';
 import { queryKeys } from '#lib/query/query-keys';
+import { tablePreferences } from '#lib/stores/table-preferences.store.svelte';
 
 export const ssr = false;
 
@@ -61,6 +62,7 @@ export const load = async () => {
 
 	const nextAuthenticatedUserId = user?.id ?? null;
 	if (authenticatedUserId !== undefined && authenticatedUserId !== nextAuthenticatedUserId) {
+		tablePreferences.reset();
 		authService.resetAuthenticatedState(queryClient, { restartMountedStores: user !== null });
 	}
 	authenticatedUserId = nextAuthenticatedUserId;
@@ -90,13 +92,15 @@ export const load = async () => {
 		const [loadedSettings, loadedSwarmStatus, loadedPermissionsManifest] = await Promise.all([
 			settingsService.getSettings().catch(() => null),
 			swarmService.getSwarmStatus().catch(() => null),
-			permissionsManifestRequest
+			permissionsManifestRequest,
+			tablePreferences.ready()
 		]);
 		settings = loadedSettings;
 		swarmEnabled = loadedSwarmStatus?.enabled === true;
 		permissionsManifest = loadedPermissionsManifest;
 		permissionsManifestLoadFailed = loadedPermissionsManifest === null;
 	} else {
+		tablePreferences.reset();
 		// Initialize empty environment store for unauthenticated users
 		await environmentStore.initialize([]);
 

--- a/tests/spec/container-grouped-pagination.spec.ts
+++ b/tests/spec/container-grouped-pagination.spec.ts
@@ -65,8 +65,11 @@ function buildContainersResponse(containers: MockContainer[], start: number, lim
 }
 
 test('grouped containers do not split the same project across pages', async ({ page, context }) => {
+	const response = await page.request.patch('/api/auth/me/prefs', {
+		data: { tables: { 'arcane-container-table': null } }
+	});
+	expect(response.ok(), `Failed to clear container preferences: ${response.status()}`).toBeTruthy();
 	await page.addInitScript(() => {
-		localStorage.removeItem('arcane-container-table');
 		localStorage.setItem('container-groups-collapsed', JSON.stringify({ immich: false }));
 		localStorage.removeItem('collapsible-cards-expanded');
 	});

--- a/tests/spec/containers.spec.ts
+++ b/tests/spec/containers.spec.ts
@@ -165,9 +165,13 @@ test.describe('Containers Page network IP addresses', () => {
 		page,
 		context
 	}) => {
-		await page.addInitScript(() => {
-			localStorage.removeItem('arcane-container-table');
+		const response = await page.request.patch('/api/auth/me/prefs', {
+			data: { tables: { 'arcane-container-table': null } }
 		});
+		expect(
+			response.ok(),
+			`Failed to clear container preferences: ${response.status()}`
+		).toBeTruthy();
 
 		await context.route('**/api/environments/*/containers**', async (route) => {
 			if (route.request().method() !== 'GET') {

--- a/tests/spec/environment-switch-isolation.spec.ts
+++ b/tests/spec/environment-switch-isolation.spec.ts
@@ -79,9 +79,12 @@ function containerDetails(id: string, name: string) {
 }
 
 async function mockEnvironmentCatalog(page: Page) {
+	const response = await page.request.patch('/api/auth/me/prefs', {
+		data: { tables: { 'arcane-container-table': null } }
+	});
+	expect(response.ok(), `Failed to clear container preferences: ${response.status()}`).toBeTruthy();
 	await page.addInitScript(() => {
 		localStorage.removeItem('selectedEnvironmentId');
-		localStorage.removeItem('arcane-container-table');
 	});
 	await page.context().route(/\/api\/environments(?:\?.*)?$/, async (route) => {
 		await route.fulfill({

--- a/tests/spec/volumes.spec.ts
+++ b/tests/spec/volumes.spec.ts
@@ -3,8 +3,36 @@ import { fetchVolumeCountsWithRetry } from '../utils/fetch.util';
 import { VolumeUsageCounts } from 'types/volumes.type';
 
 let volumeCount: VolumeUsageCounts = { inuse: 0, unused: 0, total: 0 };
+const VOLUMES_PREFERENCE_KEY = 'arcane-volumes-table';
+
+async function setVolumesPreference(page: Page, prefs: Record<string, unknown>) {
+	const response = await page.request.patch('/api/auth/me/prefs', {
+		data: { tables: { [VOLUMES_PREFERENCE_KEY]: prefs } }
+	});
+	if (!response.ok()) {
+		throw new Error(
+			`Failed to seed volume preferences: ${response.status()} ${await response.text()}`
+		);
+	}
+}
+
+async function getPersistedVolumesSort(page: Page): Promise<string> {
+	const response = await page.request.get('/api/auth/me/prefs');
+	if (!response.ok()) return '';
+	const body = await response.json();
+	const sort = body?.data?.tables?.[VOLUMES_PREFERENCE_KEY]?.s;
+	return Array.isArray(sort) ? sort.join(':') : '';
+}
 
 test.beforeEach(async ({ page }) => {
+	const response = await page.request.patch('/api/auth/me/prefs', {
+		data: { tables: { [VOLUMES_PREFERENCE_KEY]: null } }
+	});
+	if (!response.ok()) {
+		throw new Error(
+			`Failed to clear volume preferences: ${response.status()} ${await response.text()}`
+		);
+	}
 	await page.goto('/volumes');
 	volumeCount = await fetchVolumeCountsWithRetry(page);
 });
@@ -108,13 +136,7 @@ async function ensureFacetOpen(page: Page, title: string) {
 
 test.describe('Volumes Page', () => {
 	test('Persisted Size sort does not block navigation', async ({ page, context }) => {
-		await page.goto('/dashboard');
-		await page.evaluate(() => {
-			localStorage.setItem(
-				'arcane-volumes-table',
-				JSON.stringify({ v: [], f: [], g: '', l: 20, s: ['size', 'desc'] })
-			);
-		});
+		await setVolumesPreference(page, { v: [], f: [], g: '', l: 20, s: ['size', 'desc'] });
 
 		let releaseSizeSort: () => void = () => undefined;
 		const sizeSortGate = new Promise<void>((resolve) => {
@@ -145,25 +167,11 @@ test.describe('Volumes Page', () => {
 			releaseSizeSort();
 		}
 
-		await expect
-			.poll(() =>
-				page.evaluate(() => {
-					const stored = localStorage.getItem('arcane-volumes-table');
-					const sort = stored ? JSON.parse(stored).s : undefined;
-					return Array.isArray(sort) ? sort.join(':') : '';
-				})
-			)
-			.toBe('size:desc');
+		await expect.poll(() => getPersistedVolumesSort(page)).toBe('size:desc');
 	});
 
 	test('Hidden Size column skips usage loading and resets its sort', async ({ page, context }) => {
-		await page.goto('/dashboard');
-		await page.evaluate(() => {
-			localStorage.setItem(
-				'arcane-volumes-table',
-				JSON.stringify({ v: ['size'], f: [], g: '', l: 20, s: ['size', 'desc'] })
-			);
-		});
+		await setVolumesPreference(page, { v: ['size'], f: [], g: '', l: 20, s: ['size', 'desc'] });
 
 		let sizeRequests = 0;
 		await context.route('**/api/environments/*/volumes/sizes', async (route) => {
@@ -174,15 +182,7 @@ test.describe('Volumes Page', () => {
 		await page.goto('/volumes');
 		await expect(page.getByRole('heading', { name: 'Volumes', level: 1 })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Size', exact: true })).toHaveCount(0);
-		await expect
-			.poll(() =>
-				page.evaluate(() => {
-					const stored = localStorage.getItem('arcane-volumes-table');
-					const sort = stored ? JSON.parse(stored).s : undefined;
-					return Array.isArray(sort) ? sort.join(':') : '';
-				})
-			)
-			.toBe('name:asc');
+		await expect.poll(() => getPersistedVolumesSort(page)).toBe('name:asc');
 		expect(sizeRequests).toBe(0);
 	});
 

--- a/types/user/preferences.go
+++ b/types/user/preferences.go
@@ -1,0 +1,27 @@
+package user
+
+// TableFilterPreference stores a table filter as its column ID and value.
+type TableFilterPreference [2]any
+
+// TableSortPreference stores a table sort column and direction.
+type TableSortPreference [2]string
+
+// TablePreference contains the persisted presentation state for one table.
+type TablePreference struct {
+	GlobalSearch     *string                 `json:"g,omitempty" doc:"Global table search"`
+	Sort             *TableSortPreference    `json:"s,omitempty" doc:"Sort column and direction"`
+	PageSize         *int                    `json:"l,omitempty" doc:"Rows displayed per page"`
+	HiddenColumns    []string                `json:"v,omitempty" doc:"Hidden table column IDs"`
+	Filters          []TableFilterPreference `json:"f,omitempty" doc:"Active table filters"`
+	MobileVisibility []string                `json:"m,omitempty" doc:"Encoded mobile table field visibility"`
+	CustomSettings   map[string]any          `json:"c,omitempty" doc:"Table-specific settings"`
+}
+
+// TablePreferences maps table persistence keys to their state. A nil value in
+// a PATCH request deletes that table's saved preference.
+type TablePreferences map[string]*TablePreference
+
+// Preferences contains the current user's persisted application preferences.
+type Preferences struct {
+	Tables TablePreferences `json:"tables" doc:"Table preferences keyed by persistence key"`
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves table preferences from browser-only storage into per-user database storage. The main changes are:

- New backend preferences endpoints for reading and patching the current user’s table preferences.
- A `table_prefs` user column with Postgres and SQLite migrations.
- Shared Go preference DTOs for compact table state.
- A frontend table preferences store that loads server state, imports legacy local preferences, and debounces writes.
- Table and page load updates to restore saved filters, sorting, page size, visibility, and custom settings through the shared store.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR has one contained issue that should be fixed before merging.

The database-backed preferences flow is mostly coherent, but the frontend auth skip entry breaks refresh-and-retry behavior for the new authenticated endpoint.

`frontend/src/lib/services/api-service.ts`
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the auth-guard behavior by running a focused TSX harness against the real api-service.ts with mocked fetch responses.
- Observed that /auth/me/prefs returned 401 Unauthorized with 0 refresh-handler calls and only 1 fetch attempt.
- Observed that /users/me starts with 401, then a single refresh run, a retry, and a 200 OK.
- Collected and reviewed end-to-end repro artifacts, including the mock API script, harness outputs, and Playwright scripts/run logs, along with the frontend server startup and termination details.

<a href="https://app.greptile.com/trex/runs/15514115/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat_persist_per-user_table_preferences_in_the_database%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat_persist_per-user_table_preferences_in_the_database%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fservices%2Fapi-service.ts%3A196%0A**Do%20not%20skip%20auth**%0AAdding%20%60%2Fauth%2Fme%2Fprefs%60%20to%20%60skipAuthPathsInternal%60%20prevents%20the%20API%20client%20from%20running%20the%20existing%20401%20refresh%20flow%20for%20this%20authenticated%20endpoint.%20When%20an%20access%20token%20expires%2C%20%60tablePreferences.ready%28%29%60%20receives%20the%20401%20directly%2C%20marks%20the%20store%20unauthenticated%2C%20and%20subsequent%20table%20preference%20writes%20are%20dropped%20instead%20of%20refreshing%20and%20retrying%20like%20other%20protected%20requests.%0A%0A&repo=getarcaneapp%2Farcane&pr=3366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afrontend%2Fsrc%2Flib%2Fservices%2Fapi-service.ts%3A196%0A**Do%20not%20skip%20auth**%0AAdding%20%60%2Fauth%2Fme%2Fprefs%60%20to%20%60skipAuthPathsInternal%60%20prevents%20the%20API%20client%20from%20running%20the%20existing%20401%20refresh%20flow%20for%20this%20authenticated%20endpoint.%20When%20an%20access%20token%20expires%2C%20%60tablePreferences.ready%28%29%60%20receives%20the%20401%20directly%2C%20marks%20the%20store%20unauthenticated%2C%20and%20subsequent%20table%20preference%20writes%20are%20dropped%20instead%20of%20refreshing%20and%20retrying%20like%20other%20protected%20requests.%0A%0A&repo=getarcaneapp%2Farcane&pr=3366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
frontend/src/lib/services/api-service.ts:196
**Do not skip auth**
Adding `/auth/me/prefs` to `skipAuthPathsInternal` prevents the API client from running the existing 401 refresh flow for this authenticated endpoint. When an access token expires, `tablePreferences.ready()` receives the 401 directly, marks the store unauthenticated, and subsequent table preference writes are dropped instead of refreshing and retrying like other protected requests.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: persist per-user table preferences..."](https://github.com/getarcaneapp/arcane/commit/d2a7f0a38539872b4902f80a7cab8e9dbdafcbc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46534199)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: When implementing a feature, modify and reus... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=0983d2ab-8ef9-4463-85d5-a790cefce423))

<!-- /greptile_comment -->