### PR TITLE
fix: tear down abandoned dashboard and activity streams promptly

### DIFF
--- a/backend/api/handlers/activities.go
+++ b/backend/api/handlers/activities.go
@@ -299,6 +299,8 @@ func (h *ActivityHandler) StreamAllActivities(ctx context.Context, input *Stream
 // environment and every enabled remote environment over a single response so
 // the browser needs one connection regardless of environment count.
 func (h *ActivityHandler) streamAllActivitiesInternal(ctx context.Context, ps *authz.PermissionSet, limit int, writer io.Writer, flush func()) {
+	// RunAuthorizedAggregateStream logs how the stream ended; there is nothing
+	// left to report to a client whose response headers were sent long ago.
 	_ = httpx.RunAuthorizedAggregateStream(ctx, ps, authz.PermActivitiesRead, agg.Config[activity.StreamEvent]{
 		Writer:            writer,
 		Flush:             flush,

--- a/backend/api/handlers/dashboard.go
+++ b/backend/api/handlers/dashboard.go
@@ -126,6 +126,8 @@ func (h *DashboardHandler) StreamAllDashboards(ctx context.Context, input *Strea
 // environment and every enabled remote environment over a single response so
 // the browser needs one connection regardless of environment count.
 func (h *DashboardHandler) streamAllDashboardsInternal(ctx context.Context, ps *authz.PermissionSet, debugAllGood bool, writer io.Writer, flush func()) {
+	// RunAuthorizedAggregateStream logs how the stream ended; there is nothing
+	// left to report to a client whose response headers were sent long ago.
 	_ = httpx.RunAuthorizedAggregateStream(ctx, ps, authz.PermDashboardRead, agg.Config[dashboardtypes.StreamEvent]{
 		Writer:            writer,
 		Flush:             flush,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -68,6 +68,7 @@ require (
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.82.1
@@ -234,7 +235,6 @@ require (
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -40,6 +40,12 @@ var loggerSkipPatterns = []string{
 	"GET /api/environments/*/ws/containers/*/terminal",
 	"GET /api/environments/*/ws/projects/*/logs",
 	"GET /api/environments/*/ws/system/stats",
+	// Long-lived aggregate streams. The access log only fires when the stream
+	// ends, so it reports the full connection lifetime as request latency —
+	// which reads as a multi-minute hung request. The handlers log their own
+	// termination instead.
+	"GET /api/dashboard/stream",
+	"GET /api/activities/stream",
 	"GET /_app/*",
 	"GET /img",
 	"GET /api/health",

--- a/backend/internal/bootstrap/server_bootstrap.go
+++ b/backend/internal/bootstrap/server_bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
 	tunnelpb "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge/proto/tunnel/v1"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
 	"github.com/labstack/echo/v5"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -189,6 +190,9 @@ func newHTTPServerInternal(baseCtx context.Context, listenAddr string, handler h
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		BaseContext:       func(net.Listener) context.Context { return baseCtx },
+		// Long-lived stream handlers tune dead-peer detection for their own
+		// connection; see httpx.SetDeadPeerTimeout.
+		ConnContext: httpx.WithConn,
 	}
 	if !useTLS {
 		return srv, nil

--- a/backend/pkg/utils/httpx/aggregate_stream.go
+++ b/backend/pkg/utils/httpx/aggregate_stream.go
@@ -2,10 +2,20 @@ package httpx
 
 import (
 	"context"
+	"log/slog"
+	"time"
+
+	"emperror.dev/errors"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"go.getarcane.app/streams/agg"
 )
+
+// streamDeadPeerTimeout is how long an aggregate stream's writes may stay
+// unacknowledged before the connection is torn down. A client that has
+// acknowledged nothing for this long is gone: healthy ones acknowledge the
+// heartbeat every 15 seconds.
+const streamDeadPeerTimeout = 45 * time.Second
 
 // RunAuthorizedAggregateStream selects local and remote producers from the
 // caller's effective permissions before starting an aggregate stream. Remote
@@ -25,5 +35,23 @@ func RunAuthorizedAggregateStream[T any](
 	if ps.AllowsAny(permission) {
 		config.Producers = append(config.Producers, remoteProducer)
 	}
-	return agg.Run(ctx, config)
+
+	releaseDeadPeerTimeout, timeoutErr := AcquireDeadPeerTimeout(ctx, streamDeadPeerTimeout)
+	if timeoutErr != nil {
+		slog.DebugContext(ctx, "could not bound stream dead-peer timeout", "permission", permission, "error", timeoutErr)
+	}
+	defer releaseDeadPeerTimeout()
+
+	startedAt := time.Now()
+	err := agg.Run(ctx, config)
+
+	// Once the response headers are sent there is no way to report a failure to
+	// the client, and the access log only records the connection's total
+	// lifetime — so a client that vanishes mid-write is invisible without this.
+	if err != nil && !errors.Is(err, context.Canceled) {
+		slog.WarnContext(ctx, "aggregate stream ended with error", "permission", permission, "error", err, "duration", time.Since(startedAt))
+		return err
+	}
+	slog.DebugContext(ctx, "aggregate stream closed", "permission", permission, "duration", time.Since(startedAt), "context_error", ctx.Err())
+	return err
 }

--- a/backend/pkg/utils/httpx/conn_context.go
+++ b/backend/pkg/utils/httpx/conn_context.go
@@ -1,0 +1,115 @@
+package httpx
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+)
+
+type connContextKeyInternal struct{}
+
+// connStateInternal tracks per-connection socket tuning. HTTP/2 multiplexes
+// every stream a client opens onto one TCP connection, so the dead-peer
+// timeout has to outlive whichever stream happens to finish first.
+type connStateInternal struct {
+	conn net.Conn
+
+	mu      sync.Mutex
+	holders int
+}
+
+// WithConn stores an accepted connection on its base context. Wire it up as
+// http.Server.ConnContext so long-lived handlers can tune socket options for
+// their own connection without affecting every other client.
+func WithConn(ctx context.Context, conn net.Conn) context.Context {
+	return context.WithValue(ctx, connContextKeyInternal{}, &connStateInternal{conn: conn})
+}
+
+// AcquireDeadPeerTimeout bounds how long data written to the request's
+// connection may stay unacknowledged before the kernel tears it down, and
+// returns a release function restoring the system default once every caller
+// sharing the connection has released it.
+//
+// Long-lived streams need this because they write on their own schedule into a
+// connection the client may have silently abandoned: left to the defaults the
+// kernel retransmits until tcp_retries2 is exhausted, roughly eleven minutes.
+// TCP keepalive does not cover the case, since probes only fire while a
+// connection is idle and a stream with an unacknowledged write in flight never
+// is.
+//
+// It is deliberately scoped to one connection rather than the listener: the
+// same listener carries edge tunnel gRPC streams, which tolerate up to
+// edge.TunnelStaleTimeout of silence and would be reset by a shared timeout.
+//
+// The release function is always safe to call, including when acquisition
+// failed or the request never passed through WithConn.
+func AcquireDeadPeerTimeout(ctx context.Context, timeout time.Duration) (func(), error) {
+	state, _ := ctx.Value(connContextKeyInternal{}).(*connStateInternal)
+	if state == nil {
+		return func() {}, nil
+	}
+	return state.acquire(timeout)
+}
+
+func (s *connStateInternal) acquire(timeout time.Duration) (func(), error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Callers share a single timeout value, so only the first has to apply it.
+	if s.holders == 0 {
+		if err := setDeadPeerTimeoutOnConnInternal(s.conn, timeout); err != nil {
+			return func() {}, err
+		}
+	}
+	s.holders++
+
+	var once sync.Once
+	return func() {
+		once.Do(s.release)
+	}, nil
+}
+
+func (s *connStateInternal) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.holders--
+	if s.holders > 0 {
+		return
+	}
+	// HTTP keep-alive can hand this connection to ordinary requests once the
+	// last stream ends, so give back the system default.
+	_ = setDeadPeerTimeoutOnConnInternal(s.conn, 0)
+}
+
+func setDeadPeerTimeoutOnConnInternal(conn net.Conn, timeout time.Duration) error {
+	tcpConn := tcpConnFromInternal(conn)
+	if tcpConn == nil {
+		return nil
+	}
+
+	rawConn, err := tcpConn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setDeadPeerTimeoutInternal(rawConn, timeout)
+}
+
+// tcpConnFromInternal unwraps transport wrappers (TLS, most notably) to reach
+// the underlying TCP connection. Returns nil when there isn't one.
+func tcpConnFromInternal(conn net.Conn) *net.TCPConn {
+	for range 4 {
+		switch typed := conn.(type) {
+		case nil:
+			return nil
+		case *net.TCPConn:
+			return typed
+		case interface{ NetConn() net.Conn }:
+			conn = typed.NetConn()
+		default:
+			return nil
+		}
+	}
+	return nil
+}

--- a/backend/pkg/utils/httpx/conn_context_test.go
+++ b/backend/pkg/utils/httpx/conn_context_test.go
@@ -1,0 +1,59 @@
+package httpx
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newConnContextForTest(t *testing.T) context.Context {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return WithConn(context.Background(), conn)
+}
+
+// HTTP/2 multiplexes the dashboard and activity streams onto one connection, so
+// the first to finish must not restore the default timeout out from under the
+// other.
+func TestAcquireDeadPeerTimeoutHoldsUntilLastRelease(t *testing.T) {
+	ctx := newConnContextForTest(t)
+	state, _ := ctx.Value(connContextKeyInternal{}).(*connStateInternal)
+	require.NotNil(t, state)
+
+	releaseFirst, err := AcquireDeadPeerTimeout(ctx, 45*time.Second)
+	require.NoError(t, err)
+	releaseSecond, err := AcquireDeadPeerTimeout(ctx, 45*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, 2, state.holders)
+
+	releaseFirst()
+	require.Equal(t, 1, state.holders, "connection must stay bounded while a stream is still running")
+
+	releaseSecond()
+	require.Equal(t, 0, state.holders)
+
+	// Releasing twice must not drop the count below zero and re-arm the socket
+	// for the next acquirer.
+	releaseSecond()
+	require.Equal(t, 0, state.holders)
+}
+
+// Handlers reached over a non-TCP transport (or a request whose base context
+// never passed through WithConn) must degrade quietly rather than fail the
+// stream.
+func TestAcquireDeadPeerTimeoutIgnoresMissingConn(t *testing.T) {
+	release, err := AcquireDeadPeerTimeout(context.Background(), 45*time.Second)
+	require.NoError(t, err)
+	require.NotPanics(t, release)
+}

--- a/backend/pkg/utils/httpx/socket_linux.go
+++ b/backend/pkg/utils/httpx/socket_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package httpx
+
+import (
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setDeadPeerTimeoutInternal(rawConn syscall.RawConn, timeout time.Duration) error {
+	var setErr error
+	if err := rawConn.Control(func(fd uintptr) {
+		setErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout.Milliseconds()))
+	}); err != nil {
+		return err
+	}
+	return setErr
+}

--- a/backend/pkg/utils/httpx/socket_other.go
+++ b/backend/pkg/utils/httpx/socket_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package httpx
+
+import (
+	"syscall"
+	"time"
+)
+
+// setDeadPeerTimeoutInternal is a no-op outside Linux. TCP_USER_TIMEOUT has no
+// portable equivalent, and Arcane only ships Linux images; local dev builds
+// keep the OS default retransmission behaviour.
+func setDeadPeerTimeoutInternal(_ syscall.RawConn, _ time.Duration) error {
+	return nil
+}

--- a/frontend/src/lib/services/activity-service.ts
+++ b/frontend/src/lib/services/activity-service.ts
@@ -48,14 +48,17 @@ class ActivityService extends BaseAPIService {
 			signal
 		});
 		if (response.status === 401) {
+			// Nothing reads this body, so release its connection before deciding
+			// what to do next.
+			await response.body?.cancel().catch(() => {});
 			const action = await handleUnauthorizedResponseInternal('/activities/stream', retry);
 			if (action === 'retry') {
 				return this.openActivityStream(signal, limit, true);
 			}
-			if (action === 'redirect') {
-				return new Promise<Response>(() => {});
-			}
-			if (action === 'reload') {
+			// The document is being replaced (login redirect, or the reload that
+			// follows a backend self-update). Never settling stops the caller
+			// from opening a fresh stream against a page that is going away.
+			if (action === 'redirect' || action === 'reload') {
 				return new Promise<Response>(() => {});
 			}
 		}

--- a/frontend/src/lib/services/dashboard-service.ts
+++ b/frontend/src/lib/services/dashboard-service.ts
@@ -30,11 +30,17 @@ class DashboardService extends BaseAPIService {
 			signal
 		});
 		if (response.status === 401) {
+			// Nothing reads this body, so release its connection before deciding
+			// what to do next.
+			await response.body?.cancel().catch(() => {});
 			const action = await handleUnauthorizedResponseInternal('/dashboard/stream', retry);
 			if (action === 'retry') {
 				return this.openDashboardStream(signal, debugAllGood, true);
 			}
-			if (action === 'redirect') {
+			// The document is being replaced (login redirect, or the reload that
+			// follows a backend self-update). Never settling stops the caller
+			// from opening a fresh stream against a page that is going away.
+			if (action === 'redirect' || action === 'reload') {
 				return new Promise<Response>(() => {});
 			}
 		}

--- a/frontend/src/lib/stores/environment-stream.svelte.ts
+++ b/frontend/src/lib/stores/environment-stream.svelte.ts
@@ -67,6 +67,7 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 	// connections would multiply requests and exhaust the browser's
 	// 6-per-origin HTTP/1.1 limit.
 	let streamAbortController: AbortController | null = null;
+	let removePageLifecycleListeners: (() => void) | null = null;
 	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	let reconnectAttempt = 0;
 	let streamGeneration = 0;
@@ -140,6 +141,30 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 		_streamConnected = false;
 	}
 
+	// Closing a tab leaves teardown to whenever the browser gets around to
+	// dropping the socket. Until it does, the server keeps writing heartbeats
+	// into a connection nobody is reading — so tear down explicitly instead.
+	function watchPageLifecycle() {
+		if (!browser || removePageLifecycleListeners) {
+			return;
+		}
+
+		const onPageHide = () => abortStream();
+		// A bfcache restore comes back with the stream already torn down.
+		const onPageShow = (event: PageTransitionEvent) => {
+			if (event.persisted && started && !streamAbortController) {
+				void connectStream(nextGeneration());
+			}
+		};
+
+		window.addEventListener('pagehide', onPageHide);
+		window.addEventListener('pageshow', onPageShow);
+		removePageLifecycleListeners = () => {
+			window.removeEventListener('pagehide', onPageHide);
+			window.removeEventListener('pageshow', onPageShow);
+		};
+	}
+
 	function removeEnvironment(environmentId: string) {
 		const nextStates = { ..._environmentStates };
 		delete nextStates[environmentId];
@@ -157,11 +182,20 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 			return;
 		}
 
+		// Overlapping connects would otherwise strand the previous controller:
+		// abortStream() only ever reaches the newest one, so the older request
+		// would keep an open connection the server has no way to notice.
+		streamAbortController?.abort();
+
 		const controller = new AbortController();
 		streamAbortController = controller;
 		try {
 			const response = await config.openStream(controller.signal);
 			if (!isCurrentGeneration(generation) || !response.body) {
+				// The response body is live even though nobody will read it;
+				// dropping it on the floor leaves the server streaming into a
+				// connection that stays open until its TCP timers expire.
+				controller.abort();
 				if (streamAbortController === controller) {
 					streamAbortController = null;
 				}
@@ -186,6 +220,9 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 				if (!controller.signal.aborted) {
 					scheduleReconnect(generation);
 				}
+			} else if (!controller.signal.aborted) {
+				// A superseded generation has no owner left to abort it.
+				controller.abort();
 			}
 		}
 	}
@@ -215,6 +252,10 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 				handleStreamLine(buffer);
 			}
 		} finally {
+			// The loop also exits when the generation advances, with the stream
+			// still open. Cancelling is what actually closes the fetch and lets
+			// the server see the disconnect; releaseLock alone does not.
+			await reader.cancel().catch(() => {});
 			reader.releaseLock();
 		}
 	}
@@ -353,6 +394,7 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 				return;
 			}
 			config.onSelectedEnvironment?.(environmentStore.selected);
+			watchPageLifecycle();
 			reconcileEnvironments();
 			const generation = nextGeneration();
 			if (config.refreshOnStart) {
@@ -372,6 +414,8 @@ export function createEnvironmentStreamStore<TState extends StreamEnvStateBase, 
 			unsubscribeEnvironment = null;
 			unsubscribeEnvironmentFilter?.();
 			unsubscribeEnvironmentFilter = null;
+			removePageLifecycleListeners?.();
+			removePageLifecycleListeners = null;
 			nextGeneration();
 			abortStream();
 			reconnectAttempt = 0;

--- a/go.work.sum
+++ b/go.work.sum
@@ -1035,8 +1035,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
-github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
 github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
@@ -1743,8 +1742,6 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
-github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=
-github.com/prometheus/client_golang v1.24.1/go.mod h1:F+oSRECHg4sse5ucfYpYDeIv/hu68Zo0uoHKetWnzcE=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -1753,8 +1750,6 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
-github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi/PY=
-github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/otlptranslator v0.0.2 h1:+1CdeLVrRQ6Psmhnobldo0kTp96Rj80DRXRd5OSnMEQ=
 github.com/prometheus/otlptranslator v0.0.2/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
 github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEoIwkU+A6qos=
@@ -1768,8 +1763,6 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
-github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/prometheus/prometheus v0.51.0 h1:aRdjTnmHLved29ILtdzZN2GNvOjWATtA/z+3fYuexOc=
 github.com/prometheus/prometheus v0.51.0/go.mod h1:yv4MwOn3yHMQ6MZGHPg/U7Fcyqf+rxqiZfSur6myVtc=
 github.com/pseudomuto/protoc-gen-doc v1.5.1 h1:Ah259kcrio7Ix1Rhb6u8FCaOkzf9qRBqXnvAufg061w=
@@ -2123,8 +2116,6 @@ go.getarcane.app/updater v0.3.6 h1:+BqoycaRsHj+cLVSzcYQuqbHxUKbtmaozMNblz5bVSw=
 go.getarcane.app/updater v0.3.6/go.mod h1:2ENitZR/lA5MuBn60OZYR5wvU3ZCE+pAgfrebfOlRDA=
 go.getarcane.app/updater v0.3.7 h1:WqHsxudvt8gvCR7iSHdxdzwH0+hM0FAh64bSypBX9Mo=
 go.getarcane.app/updater v0.3.7/go.mod h1:9RZOKaBbpUJfVA4Q9/jvqtjvWBwCnVw0OkPeQCnqAAo=
-go.getarcane.app/updater v0.7.0 h1:Rd6qJGtdJrMJ8SxfGpuP1+ZpJ604BNnhYb9UsB6O0Mg=
-go.getarcane.app/updater v0.7.0/go.mod h1:6b8zVFJEUMhLzDOi4jwKBA/GmbVgguv0FeGOoO67JW8=
 go.mongodb.org/mongo-driver v1.7.5 h1:ny3p0reEpgsR2cfA5cjgwFZg3Cv/ofFh/8jbhGtz9VI=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3386

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves teardown and dead-peer detection for abandoned dashboard and activity streams.
- Adds per-connection, reference-counted Linux `TCP_USER_TIMEOUT` handling for multiplexed aggregate streams.
- Cancels superseded and page-hidden frontend streams and reconnects streams restored from the back-forward cache.
- Releases unread unauthorized-response bodies and suppresses misleading access logs for long-lived stream routes.
- Adds connection-lifecycle tests and promotes `golang.org/x/sys` to a direct backend dependency.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain in the fixes related to the previous stream-timeout review threads.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Backend test for TestAcquireDeadPeerTimeoutHoldsUntilLastRelease was executed and failed due to an environment/toolchain setup issue.
- Frontend type-check using pnpm exec svelte-check-rs completed successfully.
- A combined log containing command outputs, working directories, and exit codes was attached for review.

<a href="https://app.greptile.com/trex/runs/15870103/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: tear down abandoned dashboard and a..."](https://github.com/getarcaneapp/arcane/commit/e8a8cfb8efa488d77cd1dae28b9c05b42c55ebe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47241305)</sub>

<!-- /greptile_comment -->