### PR TITLE
fix: preserve duplicate diagnostic log entries

### DIFF
--- a/frontend/src/routes/(app)/settings/diagnostics/diagnostic-log-panel.svelte
+++ b/frontend/src/routes/(app)/settings/diagnostics/diagnostic-log-panel.svelte
@@ -16,7 +16,13 @@
 
 	let { height = '360px', maxLines = 1000 }: Props = $props();
 
-	let logs = $state<LogEntry[]>([]);
+	interface DisplayLogEntry {
+		id: number;
+		entry: LogEntry;
+	}
+
+	let nextLogId = 0;
+	let logs = $state<DisplayLogEntry[]>([]);
 	let connected = $state(false);
 	let autoScroll = $state(true);
 	let filterText = $state('');
@@ -25,10 +31,10 @@
 	let ws: ReconnectingWebSocket<LogEntry> | null = null;
 
 	const filtered = $derived(
-		logs.filter((l) => {
-			const lvl = l.level.toLowerCase();
+		logs.filter(({ entry }) => {
+			const lvl = entry.level.toLowerCase();
 			if (levelFilter !== 'all' && !lvl.startsWith(levelFilter)) return false;
-			if (filterText && !l.message.toLowerCase().includes(filterText.toLowerCase())) return false;
+			if (filterText && !entry.message.toLowerCase().includes(filterText.toLowerCase())) return false;
 			return true;
 		})
 	);
@@ -42,7 +48,7 @@
 	}
 
 	function push(entry: LogEntry) {
-		logs.push(entry);
+		logs.push({ id: nextLogId++, entry });
 		if (logs.length > maxLines) logs = logs.slice(logs.length - maxLines);
 		scrollToBottom();
 	}
@@ -127,7 +133,8 @@
 		{#if filtered.length === 0}
 			<div class="py-6 text-center text-muted-foreground">{m.diagnostics_logs_empty()}</div>
 		{:else}
-			{#each filtered as entry (entry)}
+			{#each filtered as item (item.id)}
+				{@const entry = item.entry}
 				<div class="flex gap-2 rounded px-1 py-0.5 hover:bg-foreground/5">
 					<span class="shrink-0 text-muted-foreground tabular-nums">{fmtTime(entry.time)}</span>
 					<span class={cn('w-12 shrink-0 font-semibold uppercase', levelClass(entry.level))}>{entry.level}</span>

--- a/tests/spec/diagnostics-logs.spec.ts
+++ b/tests/spec/diagnostics-logs.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const duplicateLogEntry = {
+	time: '2026-07-25T02:00:00.000Z',
+	level: 'INFO',
+	message: 'duplicate diagnostic entry'
+};
+
+async function mockDiagnosticsLogsWebSocket(page: Page) {
+	await page.addInitScript((logEntry) => {
+		const browserWindow = globalThis as typeof globalThis & {
+			WebSocket: any;
+			EventTarget: any;
+			Event: any;
+			MessageEvent: any;
+			CloseEvent: any;
+		};
+
+		const NativeWebSocket = browserWindow.WebSocket;
+		const diagnosticsLogsPathPattern = /\/api\/diagnostics\/logs\/stream(?:\?.*)?$/;
+
+		class MockDiagnosticsLogsWebSocket extends browserWindow.EventTarget {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSING = 2;
+			static CLOSED = 3;
+
+			url: string;
+			readyState = MockDiagnosticsLogsWebSocket.CONNECTING;
+			bufferedAmount = 0;
+			extensions = '';
+			protocol = '';
+			binaryType = 'blob';
+			onopen: ((event: unknown) => void) | null = null;
+			onmessage: ((event: unknown) => void) | null = null;
+			onerror: ((event: unknown) => void) | null = null;
+			onclose: ((event: unknown) => void) | null = null;
+
+			constructor(url: string | URL) {
+				super();
+				this.url = String(url);
+
+				queueMicrotask(() => {
+					if (this.readyState !== MockDiagnosticsLogsWebSocket.CONNECTING) return;
+
+					this.readyState = MockDiagnosticsLogsWebSocket.OPEN;
+
+					const openEvent = new browserWindow.Event('open');
+					this.dispatchEvent(openEvent);
+					this.onopen?.(openEvent);
+
+					for (let index = 0; index < 2; index += 1) {
+						const messageEvent = new browserWindow.MessageEvent('message', {
+							data: JSON.stringify(logEntry)
+						});
+
+						this.dispatchEvent(messageEvent);
+						this.onmessage?.(messageEvent);
+					}
+				});
+			}
+
+			send(_data?: string | ArrayBufferLike | Blob | ArrayBufferView) {}
+
+			close(code = 1000, reason = '') {
+				if (this.readyState === MockDiagnosticsLogsWebSocket.CLOSED) return;
+
+				this.readyState = MockDiagnosticsLogsWebSocket.CLOSED;
+
+				const closeEvent = new browserWindow.CloseEvent('close', {
+					code,
+					reason,
+					wasClean: true
+				});
+
+				this.dispatchEvent(closeEvent);
+				this.onclose?.(closeEvent);
+			}
+		}
+
+		const PatchedWebSocket = function (
+			this: unknown,
+			url: string | URL,
+			protocols?: string | string[]
+		) {
+			const urlString = String(url);
+
+			if (diagnosticsLogsPathPattern.test(urlString)) {
+				return new MockDiagnosticsLogsWebSocket(urlString);
+			}
+
+			return protocols === undefined
+				? new NativeWebSocket(url)
+				: new NativeWebSocket(url, protocols);
+		} as unknown as typeof WebSocket;
+
+		Object.defineProperties(PatchedWebSocket, {
+			CONNECTING: { value: NativeWebSocket.CONNECTING },
+			OPEN: { value: NativeWebSocket.OPEN },
+			CLOSING: { value: NativeWebSocket.CLOSING },
+			CLOSED: { value: NativeWebSocket.CLOSED }
+		});
+
+		PatchedWebSocket.prototype = NativeWebSocket.prototype;
+		browserWindow.WebSocket = PatchedWebSocket;
+	}, duplicateLogEntry);
+}
+
+test.describe('Diagnostics logs', () => {
+	test('renders identical log entries without duplicate-key failure', async ({ page }) => {
+		await mockDiagnosticsLogsWebSocket(page);
+
+		const pageErrors: Error[] = [];
+		let recentLogsRequests = 0;
+
+		page.on('pageerror', (error) => pageErrors.push(error));
+		page.on('request', (request) => {
+			const url = new URL(request.url());
+
+			if (url.pathname === '/api/diagnostics/logs') {
+				recentLogsRequests += 1;
+			}
+		});
+
+		await page.goto('/settings/diagnostics');
+		await page.waitForLoadState('domcontentloaded');
+
+		await expect(page).toHaveURL(/\/settings\/diagnostics$/);
+		await expect(page.getByText('duplicate diagnostic entry', { exact: true })).toHaveCount(2);
+
+		expect(recentLogsRequests).toBe(0);
+		expect(pageErrors.map((error) => error.message).join('\n')).not.toContain('each_key_duplicate');
+	});
+});


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes the Diagnostics log panel crashing with Svelte's `each_key_duplicate` error when byte-identical log entries are received.

It also prevents retained backlog entries from being appended again after a WebSocket reconnect.



## Root Cause

The panel previously:

1. Loaded recent logs through the REST endpoint.
2. Opened the Diagnostics WebSocket, which also replays the retained backlog.
3. Generated keyed-each identifiers from log content.

This created two separate failure paths:

- The REST response and WebSocket replay could add the same retained log occurrence twice.
- Legitimate byte-identical log entries generated the same key, causing Svelte's `each_key_duplicate` runtime error.

After reconnecting, the WebSocket could replay the retained backlog again and append it to logs already displayed.

## Changes Made

- Removed the redundant REST backlog request.
- Made the WebSocket the sole Diagnostics log source.
- Clear the displayed log list when the WebSocket opens, before the server replays its retained backlog.
- Assign each received log occurrence a client-side monotonic ID.
- Key rendered log rows by occurrence ID instead of log content.
- Added a Playwright regression test that emits two byte-identical log entries and verifies both render without a duplicate-key failure.
- Extended the regression coverage to verify reconnect backlog replay does not append duplicate displayed entries.

## Testing Done

- `pnpm --dir frontend check`
- `pnpm --dir tests check`
- Repository formatting hooks
- Docker frontend build
- Docker backend build
- Focused Playwright regression tests: 3 passed

## AI Tool Used (if applicable)

ChatGPT was used to help investigate the failure path, review the implementation, and develop the regression-test approach. All changes were manually reviewed and validated locally.

## Additional Context

The WebSocket already owns retained-backlog delivery. Removing the separate REST fetch eliminates competing initialization paths.

Clearing the displayed list in `onOpen` is intentional. Each WebSocket connection begins with the server's current retained backlog, so reconnecting replaces the previous displayed snapshot rather than appending another copy of it.



The PR is in a clean state. Here's an updated summary:

---
## Updated Summary

The PR now fixes both the original duplicate-key crash and the reconnect duplication path.

### Final Behavior

- Diagnostics logs are sourced exclusively from the WebSocket.
- Each received log occurrence receives a client-side monotonic ID.
- Rendered rows are keyed by occurrence ID rather than log content.
- When the WebSocket reconnects, `onOpen` clears the displayed list before the server replays its retained backlog.
- Replayed backlog entries therefore replace the previous snapshot instead of being appended as duplicates.
- Legitimate byte-identical log entries still render as separate occurrences.

### Validation

- `pnpm --dir frontend check`
- `pnpm --dir tests check`
- Repository formatting hooks
- Docker frontend build
- Docker backend build
- Focused Playwright regression tests: 3 passed

### AI Disclosure

ChatGPT was used to help investigate the failure path, review the implementation, and develop the regression-test approach. All changes were manually reviewed and validated locally.

### Final Assessment

The previously flagged reconnect issue has been resolved. The PR is now clean, focused, and ready for maintainer review.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes duplicate diagnostic log rendering and reconnect behavior.
- Uses the WebSocket as the sole source of diagnostic logs.
- Assigns each received occurrence a monotonic client-side ID for keyed rendering.
- Clears displayed logs when a connection opens before the retained backlog is replayed.
- Adds Playwright regression coverage for byte-identical entries and removal of the redundant REST request.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported reconnect duplication is resolved because each successful connection clears the displayed list before the server replays its retained backlog, and no blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Duplicate Diagnostic Log Keys"](https://github.com/getarcaneapp/arcane/commit/a62df72e8a98bc5bf5a29e74df6a3b749f4a85cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47331153)</sub>

<!-- /greptile_comment -->