### PR TITLE
fix: support Gotify v3 application tokens

### DIFF
--- a/backend/pkg/utils/notifications/gotify_sender.go
+++ b/backend/pkg/utils/notifications/gotify_sender.go
@@ -1,8 +1,13 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
+	json "encoding/json/v2"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -10,13 +15,16 @@ import (
 	"emperror.dev/errors"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
-	"github.com/nicholas-fedor/shoutrrr"
-	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
 )
 
-// BuildGotifyURL converts GotifyConfig to Shoutrrr URL format
-// URL example: gotify://host[:port][/path]/token[?query]
-func BuildGotifyURL(config models.GotifyConfig) (string, error) {
+type gotifyMessageRequest struct {
+	Message  string `json:"message"`
+	Title    string `json:"title,omitempty"`
+	Priority int    `json:"priority"`
+}
+
+// buildGotifyEndpointInternal converts GotifyConfig into the native Gotify message API endpoint.
+func buildGotifyEndpointInternal(config models.GotifyConfig) (string, error) {
 	if config.Host == "" {
 		return "", errors.New("gotify host is required")
 	}
@@ -25,58 +33,97 @@ func BuildGotifyURL(config models.GotifyConfig) (string, error) {
 		return "", errors.New("gotify token is required")
 	}
 
-	u := &url.URL{
-		Scheme: "gotify",
+	scheme := "https"
+	if config.DisableTLS {
+		scheme = "http"
 	}
 
 	host := config.Host
 	if config.Port > 0 {
-		u.Host = fmt.Sprintf("%s:%d", host, config.Port)
+		host = net.JoinHostPort(host, strconv.Itoa(config.Port))
+	}
+
+	path := strings.Trim(config.Path, "/")
+	if path == "" {
+		path = "/message"
 	} else {
-		u.Host = host
+		path = "/" + path + "/message"
 	}
 
-	path := config.Path
-	if path != "" && !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-	path = strings.TrimSuffix(path, "/")
-	u.Path = path + "/" + config.Token
-
-	q := u.Query()
-	// Always set priority if it's within valid range, 0 is a valid priority
-	q.Set("priority", strconv.Itoa(config.Priority))
-
-	if config.Title != "" {
-		q.Set("title", config.Title)
-	}
-	if config.DisableTLS {
-		q.Set("disabletls", "yes")
+	endpoint := &url.URL{
+		Scheme: scheme,
+		Host:   host,
+		Path:   path,
 	}
 
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	return endpoint.String(), nil
 }
 
-// SendGotify sends a message via Shoutrrr Gotify using proper service configuration
+// SendGotify sends a message directly through the Gotify HTTP API.
 func SendGotify(ctx context.Context, config models.GotifyConfig, message string) error {
-	shoutrrrURL, err := BuildGotifyURL(config)
-	if err != nil {
-		return errors.WrapIf(err, "failed to build shoutrrr Gotify URL")
+	if message == "" {
+		return errors.New("gotify message is required")
 	}
 
-	sender, err := shoutrrr.CreateSender(shoutrrrURL)
+	endpoint, err := buildGotifyEndpointInternal(config)
 	if err != nil {
-		return errors.WrapIf(err, "failed to create shoutrrr Gotify sender")
+		return errors.WrapIf(err, "failed to build gotify endpoint")
 	}
 
-	params := &shoutrrrTypes.Params{}
+	payload := gotifyMessageRequest{
+		Message:  message,
+		Title:    config.Title,
+		Priority: config.Priority,
+	}
 
-	errs := sender.Send(message, params)
-	for _, err := range errs {
-		if err != nil {
-			return errors.WrapIf(err, "failed to send Gotify message via shoutrrr")
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return errors.WrapIf(err, "failed to marshal gotify message")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return errors.WrapIf(err, "failed to create gotify request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Gotify-Key", config.Token)
+
+	client := &http.Client{
+		CheckRedirect: func(redirectReq *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+
+			originalURL := via[0].URL
+			if redirectReq.URL.Scheme != originalURL.Scheme ||
+				redirectReq.URL.Host != originalURL.Host {
+				return errors.New("refusing Gotify redirect to a different origin")
+			}
+
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.WrapIf(err, "failed to send gotify request")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		responseBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if readErr != nil {
+			return errors.WrapIf(readErr, "failed to read gotify error response")
 		}
+
+		detail := strings.TrimSpace(string(responseBody))
+		if detail == "" {
+			detail = http.StatusText(resp.StatusCode)
+		}
+
+		return fmt.Errorf("gotify returned HTTP %d: %s", resp.StatusCode, detail)
 	}
+
 	return nil
 }

--- a/backend/pkg/utils/notifications/gotify_sender_test.go
+++ b/backend/pkg/utils/notifications/gotify_sender_test.go
@@ -1,6 +1,14 @@
 package notifications
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
@@ -8,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildGotifyURL(t *testing.T) {
+func TestBuildGotifyEndpoint(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   models.GotifyConfig
@@ -16,13 +24,12 @@ func TestBuildGotifyURL(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "basic config (host + token)",
+			name: "basic HTTPS config",
 			config: models.GotifyConfig{
 				Host:  "gotify.example.com",
 				Token: "A12345678901234",
 			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com/A12345678901234?priority=0",
+			expected: "https://gotify.example.com/message",
 		},
 		{
 			name: "config with port",
@@ -31,32 +38,27 @@ func TestBuildGotifyURL(t *testing.T) {
 				Port:  8443,
 				Token: "A12345678901234",
 			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com:8443/A12345678901234?priority=0",
+			expected: "https://gotify.example.com:8443/message",
 		},
 		{
 			name: "config with path",
 			config: models.GotifyConfig{
 				Host:  "gotify.example.com",
-				Path:  "/gotify",
+				Path:  "/gotify/",
 				Token: "A12345678901234",
 			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com/gotify/A12345678901234?priority=0",
+			expected: "https://gotify.example.com/gotify/message",
 		},
 		{
-			name: "config with all options",
+			name: "HTTP when TLS disabled",
 			config: models.GotifyConfig{
 				Host:       "gotify.example.com",
 				Port:       80,
-				Path:       "mysubpath",
-				Token:      "A12345678901234",
-				Priority:   5,
-				Title:      "My Title",
+				Path:       "gotify",
+				Token:      "gtfya.synthetic-regression-token-not-a-secret",
 				DisableTLS: true,
 			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com:80/mysubpath/A12345678901234?disabletls=yes&priority=5&title=My+Title",
+			expected: "http://gotify.example.com:80/gotify/message",
 		},
 		{
 			name: "missing host",
@@ -72,36 +74,126 @@ func TestBuildGotifyURL(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "custom token format",
-			config: models.GotifyConfig{
-				Host:  "gotify.example.com",
-				Token: "custom_token_123",
-			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com/custom_token_123?priority=0",
-		},
-		{
-			name: "negative priority valid",
-			config: models.GotifyConfig{
-				Host:     "gotify.example.com",
-				Token:    "A12345678901234",
-				Priority: -1,
-			},
-			wantErr:  false,
-			expected: "gotify://gotify.example.com/A12345678901234?priority=-1",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, err := BuildGotifyURL(tt.config)
+			endpoint, err := buildGotifyEndpointInternal(tt.config)
 			if tt.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, gotURL)
+				return
 			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, endpoint)
 		})
 	}
+}
+
+func TestSendGotifySupportsGotifyV3Token(t *testing.T) {
+	const token = "gtfya.synthetic-regression-token-not-a-secret"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/gotify/message", r.URL.Path)
+		assert.Equal(t, token, r.Header.Get("X-Gotify-Key"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var payload gotifyMessageRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&payload)) {
+			http.Error(w, "invalid request payload", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "Arcane test notification", payload.Message)
+		assert.Equal(t, "Arcane", payload.Title)
+		assert.Equal(t, 5, payload.Priority)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":1}`))
+	}))
+	defer server.Close()
+
+	config := gotifyConfigForTestServer(t, server.URL)
+	config.Path = "/gotify"
+	config.Token = token
+	config.Title = "Arcane"
+	config.Priority = 5
+
+	err := SendGotify(context.Background(), config, "Arcane test notification")
+	require.NoError(t, err)
+}
+
+func TestSendGotifyRejectsCrossOriginRedirect(t *testing.T) {
+	targetRequests := make(chan string, 1)
+
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests <- r.Header.Get("X-Gotify-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer targetServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer redirectServer.Close()
+
+	config := gotifyConfigForTestServer(t, redirectServer.URL)
+	config.Token = "gtfya.synthetic-regression-token-not-a-secret"
+
+	err := SendGotify(context.Background(), config, "test message")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing Gotify redirect to a different origin")
+
+	select {
+	case token := <-targetRequests:
+		t.Fatalf("cross-origin redirect target received Gotify token %q", token)
+	default:
+	}
+}
+
+func TestSendGotifyReturnsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	config := gotifyConfigForTestServer(t, server.URL)
+	config.Token = "gtfya.invalid"
+
+	err := SendGotify(context.Background(), config, "test message")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gotify returned HTTP 401")
+	assert.Contains(t, err.Error(), "invalid token")
+}
+
+func gotifyConfigForTestServer(t *testing.T, serverURL string) models.GotifyConfig {
+	t.Helper()
+
+	parsed, err := url.Parse(serverURL)
+	require.NoError(t, err)
+
+	host, portString, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+
+	return models.GotifyConfig{
+		Host:       host,
+		Port:       port,
+		Token:      fmt.Sprintf("test-token-%d", port),
+		DisableTLS: true,
+	}
+}
+
+func TestSendGotifyRejectsEmptyMessage(t *testing.T) {
+	err := SendGotify(context.Background(), models.GotifyConfig{
+		Host:  "gotify.example.com",
+		Token: "gtfya.synthetic-regression-token-not-a-secret",
+	}, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gotify message is required")
 }


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes Gotify notifications failing with Gotify v3 application tokens.

Arcane previously routed Gotify delivery through Shoutrrr, which rejects the newer `gtfya...` token format before sending any request. This change sends notifications directly to Gotify’s native HTTP API and passes the application token through unchanged.

Fixes #3318

## Changes Made

- Replaced the Shoutrrr Gotify send path with a direct `POST /message` request.
- Added `X-Gotify-Key` authentication for application tokens.
- Preserved existing host, port, path, TLS, title, and priority settings.
- Used the caller context for outbound requests.
- Added bounded error-response handling for non-2xx responses.
- Added regression tests for Gotify v3 tokens, payload fields, endpoint paths, empty messages, and server errors.

## Testing Done

- `go test ./pkg/utils/notifications -count=1`
- Go formatting check
- Frontend production build for backend embed assets
- `golangci-lint run -c ../.github/.golangci.yml ./...`
- Result: `0 issues`

## AI Tool Used (if applicable)

ChatGPT was used to help investigate the failure path, review the implementation, and draft tests. All changes were manually reviewed and validated locally.

## Additional Context

The underlying issue is caused by Shoutrrr v0.16.1 enforcing the legacy 15-character Gotify token format. Sending directly through Gotify’s HTTP API avoids that obsolete validation while keeping the change isolated to the Gotify provider.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces Shoutrrr-based Gotify delivery with Gotify's native HTTP API.
- Builds the configured HTTP or HTTPS `/message` endpoint.
- Sends JSON message, title, and priority fields using `X-Gotify-Key` authentication.
- Propagates caller cancellation and returns bounded details for non-success responses.
- Adds endpoint, v3 token, payload, empty-message, and server-error regression tests.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The cross-origin redirect credential leak should be fixed before merging; the helper naming issue is non-blocking.

The direct sender attaches the Gotify application token to a request handled by a client that follows redirects without preventing the custom authentication header from reaching another origin.

**Files Needing Attention:** backend/pkg/utils/notifications/gotify_sender.go
</details>

<details open><summary><h3>Security Review</h3></summary>

The new default HTTP client can forward `X-Gotify-Key` to a cross-origin redirect target; redirect handling should reject origin changes or strip the token before following them.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fgotify-v3-token%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgotify-v3-token%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgotify_sender.go%3A92%0A**Cross-origin%20redirects%20expose%20tokens**%0A%0AWhen%20the%20configured%20Gotify%20endpoint%20redirects%20to%20another%20origin%2C%20the%20default%20HTTP%20client%20follows%20the%20redirect%20with%20the%20custom%20%60X-Gotify-Key%60%20header%20intact%2C%20causing%20the%20application%20token%20to%20be%20disclosed%20to%20the%20redirect%20target.%20Reject%20cross-origin%20redirects%20or%20remove%20the%20authentication%20header%20before%20following%20them.%0A%0A**How%20this%20was%20verified%3A**%20The%20token%20is%20attached%20at%20line%2090%20and%20the%20request%20is%20sent%20through%20the%20default%20redirect-following%20client%20at%20line%2092%20without%20a%20redirect%20policy.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgotify_sender.go%3A22%0A**Private%20helper%20lacks%20Internal%20suffix**%0A%0A%60buildGotifyEndpoint%60%20is%20unexported%20but%20does%20not%20use%20the%20backend's%20required%20%60Internal%60%20suffix%2C%20making%20private%20API%20identification%20inconsistent.%20Rename%20it%20to%20%60buildGotifyEndpointInternal%60%20and%20update%20its%20callers.%0A%0A&repo=getarcaneapp%2Farcane&pr=3391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgotify_sender.go%3A92%0A**Cross-origin%20redirects%20expose%20tokens**%0A%0AWhen%20the%20configured%20Gotify%20endpoint%20redirects%20to%20another%20origin%2C%20the%20default%20HTTP%20client%20follows%20the%20redirect%20with%20the%20custom%20%60X-Gotify-Key%60%20header%20intact%2C%20causing%20the%20application%20token%20to%20be%20disclosed%20to%20the%20redirect%20target.%20Reject%20cross-origin%20redirects%20or%20remove%20the%20authentication%20header%20before%20following%20them.%0A%0A**How%20this%20was%20verified%3A**%20The%20token%20is%20attached%20at%20line%2090%20and%20the%20request%20is%20sent%20through%20the%20default%20redirect-following%20client%20at%20line%2092%20without%20a%20redirect%20policy.%0A%0A%23%23%23%20Issue%202%20of%202%0Abackend%2Fpkg%2Futils%2Fnotifications%2Fgotify_sender.go%3A22%0A**Private%20helper%20lacks%20Internal%20suffix**%0A%0A%60buildGotifyEndpoint%60%20is%20unexported%20but%20does%20not%20use%20the%20backend's%20required%20%60Internal%60%20suffix%2C%20making%20private%20API%20identification%20inconsistent.%20Rename%20it%20to%20%60buildGotifyEndpointInternal%60%20and%20update%20its%20callers.%0A%0A&repo=getarcaneapp%2Farcane&pr=3391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
backend/pkg/utils/notifications/gotify_sender.go:92
**Cross-origin redirects expose tokens**

When the configured Gotify endpoint redirects to another origin, the default HTTP client follows the redirect with the custom `X-Gotify-Key` header intact, causing the application token to be disclosed to the redirect target. Reject cross-origin redirects or remove the authentication header before following them.

**How this was verified:** The token is attached at line 90 and the request is sent through the default redirect-following client at line 92 without a redirect policy.

### Issue 2 of 2
backend/pkg/utils/notifications/gotify_sender.go:22
**Private helper lacks Internal suffix**

`buildGotifyEndpoint` is unexported but does not use the backend's required `Internal` suffix, making private API identification inconsistent. Rename it to `buildGotifyEndpointInternal` and update its callers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Gotify V3 Notification Tokens"](https://github.com/getarcaneapp/arcane/commit/21aaf849e78baba47752df37487d22d642578ec2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47336941)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - What: All unexported functions must have the "Inte... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=306fc233-4d2f-4ac4-bdf7-8059588e8a43))

<!-- /greptile_comment -->

## Greptile Summary

Replaces Shoutrrr-based Gotify delivery with Gotify's native HTTP API.

### Implementation

- Builds the configured HTTP or HTTPS `/message` endpoint via `buildGotifyEndpointInternal`.
- Sends JSON `message`, `title`, and `priority` fields using `X-Gotify-Key` authentication.
- Uses a dedicated `http.Client` with a `CheckRedirect` policy that rejects redirects to a different scheme or host, preventing `X-Gotify-Key` from being forwarded to a cross-origin target.
- Propagates caller cancellation.
- Returns bounded details for non-success responses.

### Test Coverage

Adds regression tests covering:

- Endpoint construction
- Gotify v3 tokens
- Request payload fields
- Empty messages
- Server errors
- Cross-origin redirects

## Confidence Score: 5/5

Both previously flagged issues are resolved:

### Cross-Origin Redirect Protection

A custom `CheckRedirect` compares the redirect target's scheme and host against the original request URL and returns an error on any mismatch. This ensures `X-Gotify-Key` is never forwarded to a different origin.

### Private Helper Naming

`buildGotifyEndpoint` has been renamed to `buildGotifyEndpointInternal`, consistent with the convention for unexported helpers in this package.

## Final Assessment

No remaining blocking issues. The implementation is clean and well-tested.
