### PR TITLE
fix: skip unreadable directories instead of discarding the project file tree

### DIFF
--- a/backend/pkg/projects/project_files.go
+++ b/backend/pkg/projects/project_files.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -106,6 +107,16 @@ type projectFileTreeWalkerInternal struct {
 
 func (w *projectFileTreeWalkerInternal) visit(rel string, entry fs.DirEntry, walkErr error) error {
 	if walkErr != nil {
+		// fs.WalkDir reports a directory it could not read by invoking the
+		// callback a second time with the ReadDir error. Skipping keeps the
+		// rest of the tree intact instead of discarding every sibling; the
+		// directory itself was already recorded by the first call. A failure
+		// on the project root, or one that is not a permission/disappearance
+		// error, stays fatal so real I/O problems remain observable.
+		if rel != "." && entry != nil && entry.IsDir() && (os.IsPermission(walkErr) || os.IsNotExist(walkErr)) {
+			slog.Debug("Skipping unreadable project subdirectory", "relativePath", rel, "error", walkErr)
+			return fs.SkipDir
+		}
 		return walkErr
 	}
 	if rel == "." {
@@ -137,7 +148,18 @@ func (w *projectFileTreeWalkerInternal) visit(rel string, entry fs.DirEntry, wal
 
 	info, err := entry.Info()
 	if err != nil {
-		return errors.WrapIf(err, "inspect project file")
+		// An entry that vanished mid-walk or that we are not allowed to stat is
+		// skipped rather than failing the whole tree; anything else surfaces.
+		// fs.SkipDir on a non-directory would break out of the parent's sibling
+		// loop, so split on IsDir.
+		if !os.IsPermission(err) && !os.IsNotExist(err) {
+			return err
+		}
+		slog.Debug("Skipping unreadable project entry", "relativePath", rel, "error", err)
+		if entry.IsDir() {
+			return fs.SkipDir
+		}
+		return nil
 	}
 
 	// fs.WalkDir visits entries in deterministic lexical order, so hashing

--- a/backend/pkg/projects/project_files_unix_test.go
+++ b/backend/pkg/projects/project_files_unix_test.go
@@ -1,0 +1,59 @@
+//go:build unix
+
+package projects
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Reproduces issue #3309: a project directory containing a bind-mount data
+// folder Arcane cannot read must still list everything else. Before the fix a
+// single EACCES from fs.WalkDir aborted the walk, so the whole tree (and the
+// revision that gates file edits) came back empty.
+func TestReadProjectFileTree_SkipsUnreadableDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("include: []\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "includes"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "includes", "networks.yaml"), []byte("networks: {}\n"), 0o644))
+
+	workdir := filepath.Join(projectDir, "volumes", "adguard-home", "workdir")
+	require.NoError(t, os.MkdirAll(workdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "data.db"), []byte("opaque"), 0o644))
+	require.NoError(t, os.Chmod(workdir, 0o000))
+	// Restore before t.TempDir's own cleanup runs, or it cannot remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(workdir, 0o755) })
+
+	files, revision, _, err := ReadProjectFileTree(projectDir, 5, "", "compose.yaml", 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, revision, "an empty revision blocks every project file edit")
+
+	relativePaths := make([]string, 0, len(files))
+	for _, file := range files {
+		relativePaths = append(relativePaths, file.RelativePath)
+	}
+
+	// Siblings of the unreadable directory survive, and the directory itself is
+	// still listed - just without children.
+	assert.ElementsMatch(t, []string{
+		"includes",
+		"includes/networks.yaml",
+		"volumes",
+		"volumes/adguard-home",
+		"volumes/adguard-home/workdir",
+	}, relativePaths)
+
+	// The compare walk in ApplyProjectFileChanges skips identically, so the
+	// optimistic-concurrency check does not spuriously conflict.
+	_, again, _, err := ReadProjectFileTree(projectDir, 5, "", "compose.yaml", 0)
+	require.NoError(t, err)
+	assert.Equal(t, revision, again)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3309

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes project file-tree traversal for unreadable subdirectories.
- Skips permission and disappearance errors for non-root directories and entries while preserving unrelated siblings.
- Continues surfacing root failures and unexpected filesystem errors.
- Adds a Unix test covering an unreadable nested directory and stable revision generation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains in the fix for the previously reported filesystem-error suppression issue.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that the before-state log contains the complete focused-test output.
- Validated the toolchain details in the log, confirming Go version 1.26.5, GOEXPERIMENT is unset, and the GOMODCACHE location.
- Noted that no after-capture was possible because execution stopped at the toolchain blocker.

<a href="https://app.greptile.com/trex/runs/15929551/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip unreadable directories instead..."](https://github.com/getarcaneapp/arcane/commit/6654523a72e25b14998c613ca78f98f36dcecb98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47382328)</sub>

<!-- /greptile_comment -->