### PR TITLE
fix(cli): align commands with backend API contract

### DIFF
--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -238,19 +237,6 @@ type APIResponse[T any] struct {
 	Success bool   `json:"success"`
 	Data    T      `json:"data"`
 	Error   string `json:"error,omitempty"`
-}
-
-// PaginatedResponse wraps paginated API responses.
-// It includes the list of items for the current page along with pagination
-// metadata including current page, page size, total items, and total pages.
-type PaginatedResponse[T any] struct {
-	Items      []T `json:"items"`
-	Pagination struct {
-		CurrentPage int   `json:"currentPage"`
-		PageSize    int   `json:"pageSize"`
-		TotalItems  int64 `json:"totalItems"`
-		TotalPages  int   `json:"totalPages"`
-	} `json:"pagination"`
 }
 
 // Request makes an HTTP request to the API with JSON body serialization.
@@ -573,11 +559,11 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 	return c.Request(ctx, http.MethodDelete, path, nil)
 }
 
-// EnvPath returns a path prefixed with the environment.
-// It constructs an environment-scoped API path in the format:
-// /api/environments/{envID}{path}
-func (c *Client) EnvPath(path string) string {
-	return fmt.Sprintf("/api/environments/%s%s", c.envID, path)
+// DeleteWithBody makes a DELETE request to the specified path with a JSON body.
+// A handful of Arcane delete endpoints — project destroy, for one — take options
+// in the request body rather than as query parameters.
+func (c *Client) DeleteWithBody(ctx context.Context, path string, body any) (*http.Response, error) {
+	return c.Request(ctx, http.MethodDelete, path, body)
 }
 
 // DoJSON performs a request and decodes a standard API envelope into out.
@@ -600,11 +586,6 @@ func (c *Client) DoJSON(ctx context.Context, method, path string, body any, out 
 		return errors.WrapIf(err, "failed to decode response")
 	}
 	return nil
-}
-
-// DoPaginated performs a request and decodes a paginated API envelope into out.
-func (c *Client) DoPaginated(ctx context.Context, method, path string, body any, out any) error {
-	return c.DoJSON(ctx, method, path, body, out)
 }
 
 // DoRaw performs a request and returns the response payload when status is 2xx.
@@ -660,36 +641,6 @@ func DecodeResponseStrict[T any](resp *http.Response) (*APIResponse[T], error) {
 			return &result, errors.Errorf("API error: %s", result.Error)
 		}
 		return &result, errors.New("API error: request was not successful")
-	}
-
-	return &result, nil
-}
-
-// DecodePaginatedResponse decodes a paginated API response.
-// It reads the response body and unmarshals it into a PaginatedResponse
-// containing the items array and pagination metadata.
-// Note: This function closes the response body.
-func DecodePaginatedResponse[T any](resp *http.Response) (*PaginatedResponse[T], error) {
-	return DecodePaginatedResponseStrict[T](resp)
-}
-
-// DecodePaginatedResponseStrict decodes a paginated envelope and enforces HTTP and API success.
-func DecodePaginatedResponseStrict[T any](resp *http.Response) (*PaginatedResponse[T], error) {
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
-		return nil, errors.Errorf("request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to read response body")
-	}
-
-	var result PaginatedResponse[T]
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, errors.WrapIff(err, "failed to decode response (body: %s)", string(body))
 	}
 
 	return &result, nil

--- a/cli/internal/cmdutil/limit.go
+++ b/cli/internal/cmdutil/limit.go
@@ -12,10 +12,12 @@ import (
 
 // EffectiveLimit resolves the final list limit with precedence:
 // explicit flag > per-resource config > global config > fallback default.
+// A limit of ShowAllLimit is passed straight through so that `--limit -1`
+// reaches the server as the documented "return everything" sentinel.
 func EffectiveLimit(cmd *cobra.Command, resource, flagName string, flagValue, fallbackDefault int) int {
 	if cmd != nil {
 		if flag := cmd.Flags().Lookup(flagName); flag != nil && flag.Changed {
-			if flagValue > 0 {
+			if flagValue > 0 || flagValue == ShowAllLimit {
 				return flagValue
 			}
 			return 0
@@ -25,12 +27,12 @@ func EffectiveLimit(cmd *cobra.Command, resource, flagName string, flagValue, fa
 	resource = clitypes.NormalizePaginatedResource(resource)
 	if app, ok := runtimectx.From(cmd.Context()); ok {
 		if cfg := app.Config(); cfg != nil {
-			if v := cfg.LimitFor(resource); v > 0 {
+			if v := cfg.LimitFor(resource); v != 0 {
 				return v
 			}
 		}
 	} else if cfg, err := config.Load(); err == nil && cfg != nil {
-		if v := cfg.LimitFor(resource); v > 0 {
+		if v := cfg.LimitFor(resource); v != 0 {
 			return v
 		}
 	}

--- a/cli/internal/cmdutil/pagination.go
+++ b/cli/internal/cmdutil/pagination.go
@@ -8,31 +8,79 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ShowAllLimit is the sentinel the Arcane API uses for "return everything".
+// The backend honours it on every list path: DB-backed lists short-circuit to
+// paginateDBAll (bypassing the 100-item clamp), in-memory Docker lists return
+// the full slice, and the handlers that coerce a zero limit to 20 test for
+// exactly 0 so they leave it alone.
+const ShowAllLimit = -1
+
+// AllFlagUsage is the shared help text for the --all flag on list commands.
+const AllFlagUsage = "Return every item, ignoring pagination"
+
+// StartFlagUsage is the shared help text for the --start flag on list commands.
+// Database-backed resources (projects, repos, gitops-syncs, environments,
+// registries, users, events, api-keys, roles) derive a page number from
+// start/limit, so an offset that is not a multiple of --limit is rounded down.
+const StartFlagUsage = "Offset for pagination (rounded down to a multiple of --limit on database-backed resources)"
+
+// AppendQuery merges extra query parameters into a path, preserving any that
+// are already present.
+func AppendQuery(path string, extra url.Values) string {
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return path
+	}
+	query := parsed.Query()
+	for key, values := range extra {
+		for _, value := range values {
+			query.Set(key, value)
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+// ListParams describes how a list command wants its results paginated.
+type ListParams struct {
+	// Resource is the canonical resource name used to look up a configured
+	// per-resource limit. See clitypes.KnownPaginatedResources.
+	Resource string
+	// Limit is the value of the command's --limit flag.
+	Limit int
+	// FallbackDefault applies when neither the flag nor config supplies a limit.
+	FallbackDefault int
+	// Start is the value of the command's --start flag.
+	Start int
+	// All requests every item, ignoring pagination entirely.
+	All bool
+}
+
 // ApplyPaginationParams appends limit and start query params to a list path.
 // It preserves any existing query parameters on the path.
-func ApplyPaginationParams(
-	cmd *cobra.Command,
-	path string,
-	resource string,
-	limitFlagName string,
-	limitFlagValue int,
-	fallbackDefault int,
-	startFlagName string,
-	start int,
-) (string, error) {
+func ApplyPaginationParams(cmd *cobra.Command, path string, p ListParams) (string, error) {
 	parsed, err := url.Parse(path)
 	if err != nil {
 		return "", errors.WrapIf(err, "failed to parse path")
 	}
 
 	query := parsed.Query()
-	effectiveLimit := EffectiveLimit(cmd, resource, limitFlagName, limitFlagValue, fallbackDefault)
-	if effectiveLimit > 0 {
+
+	if p.All {
+		if cmd != nil && (cmd.Flags().Changed("limit") || cmd.Flags().Changed("start")) {
+			return "", errors.New("--all cannot be combined with --limit or --start")
+		}
+		query.Set("limit", strconv.Itoa(ShowAllLimit))
+		parsed.RawQuery = query.Encode()
+		return parsed.String(), nil
+	}
+
+	if effectiveLimit := EffectiveLimit(cmd, p.Resource, "limit", p.Limit, p.FallbackDefault); effectiveLimit != 0 {
 		query.Set("limit", strconv.Itoa(effectiveLimit))
 	}
 	if cmd != nil {
-		if flag := cmd.Flags().Lookup(startFlagName); flag != nil && flag.Changed {
-			query.Set("start", strconv.Itoa(start))
+		if flag := cmd.Flags().Lookup("start"); flag != nil && flag.Changed {
+			query.Set("start", strconv.Itoa(p.Start))
 		}
 	}
 

--- a/cli/internal/cmdutil/response.go
+++ b/cli/internal/cmdutil/response.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -52,6 +53,34 @@ func DecodeJSON[T any](resp *http.Response, out *T) error {
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return errors.WrapIf(err, "failed to parse response")
 	}
+	return nil
+}
+
+// ReadJSONBody enforces a successful HTTP status and returns the raw response body.
+// Use it when a command needs both to decode a response and to echo it verbatim,
+// so that fields the CLI does not model — such as the counts and groups objects
+// on the container, volume, network and gitops-sync list endpoints — survive
+// --json output instead of being dropped by a re-marshal.
+func ReadJSONBody(resp *http.Response) ([]byte, error) {
+	if err := EnsureSuccessStatus(resp); err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to read response")
+	}
+	return body, nil
+}
+
+// PrintRawJSON pretty-prints a raw JSON document, falling back to the bytes as-is.
+func PrintRawJSON(body []byte) error {
+	var buf bytes.Buffer
+	if json.Indent(&buf, body, "", "  ") == nil {
+		fmt.Println(buf.String())
+		return nil
+	}
+	// Not valid JSON: echo the server's bytes verbatim rather than swallow them.
+	fmt.Println(string(body))
 	return nil
 }
 

--- a/cli/internal/integrationtest/pagination_test.go
+++ b/cli/internal/integrationtest/pagination_test.go
@@ -129,7 +129,11 @@ func TestContainersListTextShowsShowingSummary(t *testing.T) {
 	}
 }
 
-func TestContainersListAllSkipsPaginationParams(t *testing.T) {
+// TestContainersListAllRequestsEveryItem pins the wire form of --all. The API
+// has no "all" query parameter — it silently ignores unknown ones — so sending
+// all=true without a limit left Huma applying its default of 20. limit=-1 is the
+// documented "return everything" sentinel.
+func TestContainersListAllRequestsEveryItem(t *testing.T) {
 	var (
 		mu       sync.Mutex
 		gotPath  string
@@ -166,8 +170,48 @@ func TestContainersListAllSkipsPaginationParams(t *testing.T) {
 	if gotPath != "/api/environments/0/containers" {
 		t.Fatalf("path = %q, want %q", gotPath, "/api/environments/0/containers")
 	}
-	if gotQuery != "all=true" {
-		t.Fatalf("query = %q, want %q", gotQuery, "all=true")
+	if gotQuery != "limit=-1" {
+		t.Fatalf("query = %q, want %q", gotQuery, "limit=-1")
+	}
+}
+
+// TestProjectsListAllIncludesArchived covers the one resource where "everything"
+// takes a second parameter: the projects list filters archived rows out by
+// default, so --all has to opt back into them.
+func TestProjectsListAllIncludesArchived(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		gotQuery string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotQuery = r.URL.RawQuery
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": [],
+			"pagination": {"totalPages":1,"totalItems":0,"currentPage":1,"itemsPerPage":0}
+		}`))
+	}))
+	defer srv.Close()
+
+	configPath := writeCLIIntegrationConfigInternal(t, srv.URL)
+	_, errOut, err := executeCLIIntegrationCommandInternal(
+		t,
+		[]string{"--config", configPath, "projects", "list", "--json", "--all"},
+	)
+	if err != nil {
+		t.Fatalf("execute: %v (%s)", err, errOut)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if gotQuery != "archived=all&limit=-1" {
+		t.Fatalf("query = %q, want %q", gotQuery, "archived=all&limit=-1")
 	}
 }
 

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -79,6 +79,9 @@ var (
 
 var ansiRegexp = regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
 
+// ansiReset closes a styled run re-applied after truncation.
+const ansiReset = "\x1b[0m"
+
 var tableWhitespaceReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ")
 
 var colorEnabled = true
@@ -372,11 +375,20 @@ func truncateVisible(value string, maxWidth int) string {
 	}
 
 	plain := ansiRegexp.ReplaceAllString(value, "")
-	if maxWidth == 1 {
-		return "…"
+	truncated := "…"
+	if maxWidth > 1 {
+		truncated = runewidth.Truncate(plain, maxWidth, "…")
 	}
 
-	return runewidth.Truncate(plain, maxWidth, "…")
+	// Re-apply the cell's styling. Colour is written as a single leading escape
+	// sequence plus a trailing reset, so measuring against the stripped text and
+	// then returning it bare would leave truncated cells uncoloured while their
+	// untruncated neighbours in the same column stay tinted.
+	codes := ansiRegexp.FindAllString(value, -1)
+	if len(codes) == 0 || !strings.HasPrefix(value, codes[0]) {
+		return truncated
+	}
+	return codes[0] + truncated + ansiReset
 }
 
 func tableNonContentWidth(columnCount int) int {

--- a/cli/internal/output/tui.go
+++ b/cli/internal/output/tui.go
@@ -156,6 +156,17 @@ func safeCapacity(value int64) bytes.Capacity {
 	return bytes.Capacity(uint64(value))
 }
 
+// Bytes renders a signed byte count in human-readable form. Negative values,
+// which bytes.Capacity would otherwise wrap into the exabyte range, render as 0.
+func Bytes(value int64) string {
+	return safeCapacity(value).String()
+}
+
+// UnsignedBytes renders an unsigned byte count in human-readable form.
+func UnsignedBytes(value uint64) string {
+	return bytes.Capacity(value).String()
+}
+
 // Progress renders a Bubble Tea progress bar inline.
 type Progress struct {
 	program *tea.Program

--- a/cli/internal/types/config.go
+++ b/cli/internal/types/config.go
@@ -34,6 +34,7 @@ var KnownPaginatedResources = []string{
 	"repos",
 	"gitops-syncs",
 	"users",
+	"roles",
 	"events",
 	"apikeys",
 }
@@ -69,6 +70,8 @@ func NormalizePaginatedResource(resource string) string {
 		return "gitops-syncs"
 	case "user":
 		return "users"
+	case "role":
+		return "roles"
 	case "event":
 		return "events"
 	default:

--- a/cli/internal/types/endpoints.go
+++ b/cli/internal/types/endpoints.go
@@ -9,7 +9,8 @@ import (
 // Endpoint paths may contain format specifiers (e.g., %s) for environment IDs or resource IDs.
 type ArcaneApiEndpoints struct {
 	// Version
-	VersionEndpoint string
+	VersionEndpoint    string
+	AppVersionEndpoint string
 
 	// Authentication
 	AuthLogoutEndpoint    string
@@ -127,7 +128,6 @@ type ArcaneApiEndpoints struct {
 	// Container Registries
 	ContainerRegistriesEndpoint   string
 	ContainerRegistryEndpoint     string
-	ContainerRegistrySyncEndpoint string
 	ContainerRegistryTestEndpoint string
 
 	// Events
@@ -142,6 +142,7 @@ type ArcaneApiEndpoints struct {
 	TemplatesDefaultEndpoint    string
 	TemplatesRegistriesEndpoint string
 	TemplateRegistryEndpoint    string
+	VariableEndpoint            string
 	TemplatesVariablesEndpoint  string
 	TemplateContentEndpoint     string
 	TemplateDownloadEndpoint    string
@@ -173,13 +174,13 @@ type ArcaneApiEndpoints struct {
 	GitRepositoryTestEndpoint     string
 	GitRepositoryBranchesEndpoint string
 	GitRepositoryFilesEndpoint    string
-	GitRepositoriesSyncEndpoint   string
 }
 
 // Endpoints contains the defined API endpoints
 var Endpoints = ArcaneApiEndpoints{ //nolint:gosec // static endpoint paths; auth-related names are not credentials
 	// Version
-	VersionEndpoint: "/api/version",
+	VersionEndpoint:    "/api/version",
+	AppVersionEndpoint: "/api/app-version",
 
 	// Authentication
 	AuthLogoutEndpoint:    "/api/auth/logout",
@@ -297,7 +298,6 @@ var Endpoints = ArcaneApiEndpoints{ //nolint:gosec // static endpoint paths; aut
 	// Container Registries
 	ContainerRegistriesEndpoint:   "/api/container-registries",
 	ContainerRegistryEndpoint:     "/api/container-registries/%s",
-	ContainerRegistrySyncEndpoint: "/api/container-registries/sync",
 	ContainerRegistryTestEndpoint: "/api/container-registries/%s/test",
 
 	// Events
@@ -312,7 +312,8 @@ var Endpoints = ArcaneApiEndpoints{ //nolint:gosec // static endpoint paths; aut
 	TemplatesDefaultEndpoint:    "/api/templates/default",
 	TemplatesRegistriesEndpoint: "/api/templates/registries",
 	TemplateRegistryEndpoint:    "/api/templates/registries/%s",
-	TemplatesVariablesEndpoint:  "/api/templates/variables",
+	TemplatesVariablesEndpoint:  "/api/variables",
+	VariableEndpoint:            "/api/variables/%s",
 	TemplateContentEndpoint:     "/api/templates/%s/content",
 	TemplateDownloadEndpoint:    "/api/templates/%s/download",
 	TemplateFetchEndpoint:       "/api/templates/fetch",
@@ -343,7 +344,6 @@ var Endpoints = ArcaneApiEndpoints{ //nolint:gosec // static endpoint paths; aut
 	GitRepositoryTestEndpoint:     "/api/customize/git-repositories/%s/test",
 	GitRepositoryBranchesEndpoint: "/api/customize/git-repositories/%s/branches",
 	GitRepositoryFilesEndpoint:    "/api/customize/git-repositories/%s/files",
-	GitRepositoriesSyncEndpoint:   "/api/git-repositories/sync",
 }
 
 // Auth endpoints
@@ -653,7 +653,6 @@ func (e ArcaneApiEndpoints) ContainerRegistries() string { return e.ContainerReg
 func (e ArcaneApiEndpoints) ContainerRegistry(id string) string {
 	return fmt.Sprintf(e.ContainerRegistryEndpoint, id)
 }
-func (e ArcaneApiEndpoints) ContainerRegistrySync() string { return e.ContainerRegistrySyncEndpoint }
 func (e ArcaneApiEndpoints) ContainerRegistryTest(id string) string {
 	return fmt.Sprintf(e.ContainerRegistryTestEndpoint, id)
 }
@@ -677,6 +676,11 @@ func (e ArcaneApiEndpoints) TemplateRegistry(id string) string {
 	return fmt.Sprintf(e.TemplateRegistryEndpoint, id)
 }
 func (e ArcaneApiEndpoints) TemplatesVariables() string { return e.TemplatesVariablesEndpoint }
+
+// Variable returns the path for a single global variable.
+func (e ArcaneApiEndpoints) Variable(id string) string {
+	return fmt.Sprintf(e.VariableEndpoint, id)
+}
 func (e ArcaneApiEndpoints) TemplateContent(id string) string {
 	return fmt.Sprintf(e.TemplateContentEndpoint, id)
 }
@@ -727,4 +731,3 @@ func (e ArcaneApiEndpoints) GitRepositoryBranches(id string) string {
 func (e ArcaneApiEndpoints) GitRepositoryFiles(id string) string {
 	return fmt.Sprintf(e.GitRepositoryFilesEndpoint, id)
 }
-func (e ArcaneApiEndpoints) GitRepositoriesSync() string { return e.GitRepositoriesSyncEndpoint }

--- a/cli/pkg/admin/apikeys/cmd.go
+++ b/cli/pkg/admin/apikeys/cmd.go
@@ -19,6 +19,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -38,6 +39,17 @@ var (
 // grant list. Each token is either `resource:action` (global grant) or
 // `resource:action:envId` (env-scoped grant). Anything else is an error so the
 // user catches typos before the server rejects them.
+// apiKeyUpdateBody mirrors apikey.UpdateApiKey but holds Permissions behind a
+// pointer. The shared type tags that field omitempty, so encoding/json drops an
+// empty slice — turning `--permission ""` (clear every grant) into a silent
+// no-op even though the server treats a non-nil empty list as "clear".
+type apiKeyUpdateBody struct {
+	Name        *string                   `json:"name,omitempty"`
+	Description *string                   `json:"description,omitempty"`
+	ExpiresAt   *time.Time                `json:"expiresAt,omitempty"`
+	Permissions *[]apikey.PermissionGrant `json:"permissions,omitempty"`
+}
+
 func parsePermissionGrantsInternal(tokens []string) ([]apikey.PermissionGrant, error) {
 	out := make([]apikey.PermissionGrant, 0, len(tokens))
 	for _, raw := range tokens {
@@ -84,7 +96,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.ApiKeys()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "apikeys", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "apikeys", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -304,7 +316,7 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		var req apikey.UpdateApiKey
+		var req apiKeyUpdateBody
 		if cmd.Flags().Changed("name") {
 			req.Name = &apikeyUpdateName
 		}
@@ -325,7 +337,7 @@ var updateCmd = &cobra.Command{
 			}
 			// Allow `--permission ""` once to clear all grants. Otherwise
 			// the parsed slice replaces the key's permission set entirely.
-			req.Permissions = grants
+			req.Permissions = &grants
 		}
 
 		resp, err := c.Put(cmd.Context(), types.Endpoints.ApiKey(args[0]), req)
@@ -359,7 +371,8 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of API keys to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Create command flags

--- a/cli/pkg/admin/events/cmd.go
+++ b/cli/pkg/admin/events/cmd.go
@@ -17,6 +17,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -40,7 +41,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.Events()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "events", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "events", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -52,8 +53,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[event.Event]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -102,7 +103,7 @@ var listEnvCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.EventsEnvironment(c.EnvID())
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "events", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "events", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -114,8 +115,8 @@ var listEnvCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[event.Event]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -196,11 +197,13 @@ func init() {
 	EventsCmd.AddCommand(deleteCmd)
 
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of events to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	listEnvCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of events to show")
-	listEnvCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listEnvCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listEnvCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listEnvCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	deleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force deletion without confirmation")

--- a/cli/pkg/admin/notifications/cmd.go
+++ b/cli/pkg/admin/notifications/cmd.go
@@ -49,8 +49,8 @@ var settingsGetCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result []notification.Response
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {

--- a/cli/pkg/admin/oidcmappings/cmd.go
+++ b/cli/pkg/admin/oidcmappings/cmd.go
@@ -215,21 +215,29 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
+// fetchMappingInternal looks a mapping up by ID. The API registers only PUT and
+// DELETE on /oidc/role-mappings/{id} — a GET there is a 405 — so this filters
+// the list instead.
 func fetchMappingInternal(cmd *cobra.Command, id string) (*roletypes.OidcRoleMapping, error) {
 	c, err := cmdutil.ClientFromCommand(cmd)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Get(cmd.Context(), types.Endpoints.OidcRoleMapping(id))
+	resp, err := c.Get(cmd.Context(), types.Endpoints.OidcRoleMappings())
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to load current mapping")
 	}
 	defer func() { _ = resp.Body.Close() }()
-	var result base.ApiResponse[roletypes.OidcRoleMapping]
+	var result base.ApiResponse[[]roletypes.OidcRoleMapping]
 	if err := cmdutil.DecodeJSON(resp, &result); err != nil {
 		return nil, errors.WrapIf(err, "failed to load current mapping")
 	}
-	return &result.Data, nil
+	for i := range result.Data {
+		if result.Data[i].ID == id {
+			return &result.Data[i], nil
+		}
+	}
+	return nil, errors.Errorf("OIDC mapping %q not found", id)
 }
 
 func init() {

--- a/cli/pkg/admin/roles/cmd.go
+++ b/cli/pkg/admin/roles/cmd.go
@@ -23,6 +23,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -66,7 +67,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.Roles()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "roles", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "roles", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -454,7 +455,8 @@ func init() {
 	RolesCmd.AddCommand(assignCmd)
 
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of roles to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	getCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")

--- a/cli/pkg/admin/users/cmd.go
+++ b/cli/pkg/admin/users/cmd.go
@@ -20,6 +20,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -102,7 +103,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.Users()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "users", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "users", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -114,8 +115,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[user.User]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -197,8 +198,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[user.User]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -236,8 +237,8 @@ var getCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[user.User]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -366,7 +367,8 @@ func init() {
 	UsersCmd.AddCommand(deleteCmd)
 
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of users to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	createCmd.Flags().StringVar(&userCreateUsername, "username", "", "Username")

--- a/cli/pkg/auth/cmd.go
+++ b/cli/pkg/auth/cmd.go
@@ -236,8 +236,8 @@ var meCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[any]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if cmdutil.JSONOutputEnabled(cmd) || jsonOutput {
@@ -368,8 +368,8 @@ var refreshCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[auth.TokenRefreshResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if cmdutil.JSONOutputEnabled(cmd) || jsonOutput {
@@ -426,8 +426,8 @@ var oidcStatusCmd = &cobra.Command{
 			EnvConfigured bool `json:"envConfigured"`
 			MergeAccounts bool `json:"mergeAccounts"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if cmdutil.JSONOutputEnabled(cmd) || jsonOutput {

--- a/cli/pkg/containers/cmd.go
+++ b/cli/pkg/containers/cmd.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,16 +21,20 @@ import (
 	"github.com/getarcaneapp/arcane/cli/v2/internal/types"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	"github.com/getarcaneapp/arcane/types/v2/container"
+	"github.com/getarcaneapp/arcane/types/v2/updater"
 	"github.com/spf13/cobra"
 )
 
 var (
-	containersLimit         int
-	containersStart         int
-	containersAll           bool
-	containersUpdatesFilter string
-	forceFlag               bool
-	jsonOutput              bool
+	containersLimit           int
+	containersStart           int
+	containersAll             bool
+	containersUpdatesFilter   string
+	containersStandalone      string
+	containersIncludeInternal bool
+	containersDeleteVolumes   bool
+	forceFlag                 bool
+	jsonOutput                bool
 
 	containerCreateFile       string
 	containerCreateName       string
@@ -94,18 +99,18 @@ func runContainersList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	var result base.Paginated[container.Summary]
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return errors.WrapIf(err, "failed to parse response")
+	body, err := cmdutil.ReadJSONBody(resp)
+	if err != nil {
+		return errors.WrapIf(err, "failed to list containers")
 	}
 
 	if jsonOutput {
-		resultBytes, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return errors.WrapIf(err, "failed to marshal JSON")
-		}
-		fmt.Println(string(resultBytes))
-		return nil
+		return cmdutil.PrintRawJSON(body)
+	}
+
+	var result base.Paginated[container.Summary]
+	if err := json.Unmarshal(body, &result); err != nil {
+		return errors.WrapIf(err, "failed to parse response")
 	}
 
 	effectiveUpdatesFilter := strings.TrimSpace(containersUpdatesFilter)
@@ -149,17 +154,15 @@ func runContainersList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 }
 
 func buildContainersListPath(cmd *cobra.Command, c *client.Client, forceHasUpdateFilter bool) (string, error) {
-	path := types.Endpoints.Containers(c.EnvID())
-	if containersAll {
-		if cmd != nil && (cmd.Flags().Changed("limit") || cmd.Flags().Changed("start")) {
-			return "", errors.New("--all cannot be combined with explicit pagination flags")
-		}
-	} else {
-		var err error
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "containers", "limit", containersLimit, 20, "start", containersStart)
-		if err != nil {
-			return "", errors.WrapIf(err, "failed to build pagination query")
-		}
+	path, err := cmdutil.ApplyPaginationParams(cmd, types.Endpoints.Containers(c.EnvID()), cmdutil.ListParams{
+		Resource:        "containers",
+		Limit:           containersLimit,
+		FallbackDefault: 20,
+		Start:           containersStart,
+		All:             containersAll,
+	})
+	if err != nil {
+		return "", errors.WrapIf(err, "failed to build pagination query")
 	}
 
 	parsed, err := url.Parse(path)
@@ -168,8 +171,11 @@ func buildContainersListPath(cmd *cobra.Command, c *client.Client, forceHasUpdat
 	}
 
 	query := parsed.Query()
-	if containersAll {
-		query.Set("all", "true")
+	if containersStandalone != "" {
+		query.Set("standalone", containersStandalone)
+	}
+	if containersIncludeInternal {
+		query.Set("includeInternal", "true")
 	}
 	updatesFilter := strings.TrimSpace(containersUpdatesFilter)
 	if forceHasUpdateFilter {
@@ -235,8 +241,8 @@ var containersGetCmd = &cobra.Command{
 			defer func() { _ = resp.Body.Close() }()
 
 			var result base.ApiResponse[container.Details]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resolved = &result.Data
 		}
@@ -308,7 +314,9 @@ var containersUpdateCmd = &cobra.Command{
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runContainerPostAction[container.ActionResult](cmd, args[0], containerPostActionConfig[container.ActionResult]{
+		// This route is served by the updater handler, so it answers with an
+		// updater.Result rather than a container.ActionResult.
+		return runContainerPostAction[updater.Result](cmd, args[0], containerPostActionConfig[updater.Result]{
 			endpoint:       types.Endpoints.ContainerUpdate,
 			failureMessage: "failed to update container",
 			successVerb:    "updated",
@@ -366,8 +374,8 @@ func runContainerPostAction[T any](cmd *cobra.Command, containerRef string, cfg 
 	}
 
 	var result base.ApiResponse[T]
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return errors.WrapIf(err, "failed to parse response")
+	if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+		return err
 	}
 
 	if jsonOutput {
@@ -413,7 +421,10 @@ var containersDeleteCmd = &cobra.Command{
 			}
 		}
 
-		path := types.Endpoints.Container(c.EnvID(), resolved.ID) + "?force=true"
+		query := url.Values{}
+		query.Set("force", strconv.FormatBool(forceFlag))
+		query.Set("volumes", strconv.FormatBool(containersDeleteVolumes))
+		path := types.Endpoints.Container(c.EnvID(), resolved.ID) + "?" + query.Encode()
 		resp, err := c.Delete(cmd.Context(), path)
 		if err != nil {
 			return errors.WrapIf(err, "failed to delete container")
@@ -421,8 +432,8 @@ var containersDeleteCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[base.MessageResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to delete container")
 		}
 
 		if !result.Success {
@@ -465,8 +476,8 @@ var containersCountsCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[container.StatusCounts]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -593,8 +604,8 @@ var containersCreateCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[container.Created]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -650,16 +661,20 @@ func init() {
 
 	// List command flags
 	containersListCmd.Flags().IntVarP(&containersLimit, "limit", "n", 20, "Number of containers to show")
-	containersListCmd.Flags().IntVar(&containersStart, "start", 0, "Offset for pagination")
-	containersListCmd.Flags().BoolVarP(&containersAll, "all", "a", false, "Show all containers (including stopped)")
+	containersListCmd.Flags().IntVar(&containersStart, "start", 0, cmdutil.StartFlagUsage)
+	containersListCmd.Flags().BoolVarP(&containersAll, "all", "a", false, cmdutil.AllFlagUsage)
 	containersListCmd.Flags().StringVar(&containersUpdatesFilter, "updates", "", "Filter by update status (has_update, up_to_date, error, unknown)")
+	containersListCmd.Flags().StringVar(&containersStandalone, "standalone", "", "Filter standalone containers only (true/false)")
+	containersListCmd.Flags().BoolVar(&containersIncludeInternal, "include-internal", false, "Include Arcane-internal containers")
 	containersListCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	containersUpdatesCmd.Flags().IntVarP(&containersLimit, "limit", "n", 20, "Number of containers to show")
-	containersUpdatesCmd.Flags().IntVar(&containersStart, "start", 0, "Offset for pagination")
+	containersUpdatesCmd.Flags().IntVar(&containersStart, "start", 0, cmdutil.StartFlagUsage)
+	containersUpdatesCmd.Flags().BoolVarP(&containersAll, "all", "a", false, cmdutil.AllFlagUsage)
 	containersUpdatesCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Delete command flags
-	containersDeleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force deletion without confirmation")
+	containersDeleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force removal of a running container and skip the confirmation prompt")
+	containersDeleteCmd.Flags().BoolVar(&containersDeleteVolumes, "volumes", false, "Remove anonymous volumes associated with the container")
 
 	// Global JSON output flags
 	containersGetCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
@@ -761,7 +776,7 @@ func fetchContainerByIdentifier(ctx context.Context, c *client.Client, identifie
 }
 
 func searchContainerMatches(ctx context.Context, c *client.Client, identifier string) ([]container.Summary, error) {
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Containers(c.EnvID()), url.QueryEscape(identifier), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Containers(c.EnvID()), url.QueryEscape(identifier), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to search containers")
@@ -831,7 +846,7 @@ func containerDetailsFromSummary(summary container.Summary) *container.Details {
 }
 
 func fallbackContainerByIDPrefix(ctx context.Context, c *client.Client, identifierLower string) (*container.Details, bool, error) {
-	fallbackPath := fmt.Sprintf("%s?limit=%d", types.Endpoints.Containers(c.EnvID()), 200)
+	fallbackPath := fmt.Sprintf("%s?limit=%d", types.Endpoints.Containers(c.EnvID()), cmdutil.ShowAllLimit)
 	fallbackResp, err := c.Get(ctx, fallbackPath)
 	if err != nil {
 		return nil, false, errors.WrapIf(err, "failed to search containers")

--- a/cli/pkg/environments/cmd.go
+++ b/cli/pkg/environments/cmd.go
@@ -18,12 +18,14 @@ import (
 	"github.com/getarcaneapp/arcane/cli/v2/internal/types"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	"github.com/getarcaneapp/arcane/types/v2/environment"
+	"github.com/getarcaneapp/arcane/types/v2/version"
 	"github.com/spf13/cobra"
 )
 
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -61,7 +63,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.Environments()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "environments", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "environments", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -73,8 +75,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[environment.Environment]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -163,8 +165,8 @@ var getCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[environment.Environment]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -241,7 +243,7 @@ var switchCmd = &cobra.Command{
 			return err
 		}
 
-		path := fmt.Sprintf("%s?limit=%d", types.Endpoints.Environments(), 200)
+		path := fmt.Sprintf("%s?limit=%d", types.Endpoints.Environments(), cmdutil.ShowAllLimit)
 		resp, err := c.Get(cmd.Context(), path)
 		if err != nil {
 			return errors.WrapIf(err, "failed to list environments")
@@ -249,8 +251,8 @@ var switchCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[environment.Environment]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if len(result.Data) == 0 {
@@ -372,8 +374,8 @@ var updateCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[environment.Environment]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -414,22 +416,13 @@ var versionCmd = &cobra.Command{
 			return errors.WrapIf(err, "failed to get environment version")
 		}
 
-		var result struct {
-			CurrentVersion  string `json:"currentVersion"`
-			CurrentTag      string `json:"currentTag"`
-			Revision        string `json:"revision"`
-			ShortRevision   string `json:"shortRevision"`
-			GoVersion       string `json:"goVersion"`
-			BuildTime       string `json:"buildTime"`
-			DisplayVersion  string `json:"displayVersion"`
-			UpdateAvailable bool   `json:"updateAvailable"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		var result base.ApiResponse[version.Info]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result, "", "  ")
+			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
 			if err != nil {
 				return errors.WrapIf(err, "failed to marshal JSON")
 			}
@@ -438,13 +431,13 @@ var versionCmd = &cobra.Command{
 		}
 
 		output.Header("Environment Version")
-		output.KeyValue("Version", result.DisplayVersion)
-		output.KeyValue("Full Version", result.CurrentVersion)
-		output.KeyValue("Tag", result.CurrentTag)
-		output.KeyValue("Revision", result.ShortRevision)
-		output.KeyValue("Go Version", result.GoVersion)
-		output.KeyValue("Build Time", result.BuildTime)
-		output.KeyValue("Update Available", strconv.FormatBool(result.UpdateAvailable))
+		output.KeyValue("Version", result.Data.DisplayVersion)
+		output.KeyValue("Full Version", result.Data.CurrentVersion)
+		output.KeyValue("Tag", result.Data.CurrentTag)
+		output.KeyValue("Revision", result.Data.ShortRevision)
+		output.KeyValue("Go Version", result.Data.GoVersion)
+		output.KeyValue("Build Time", result.Data.BuildTime)
+		output.KeyValue("Update Available", strconv.FormatBool(result.Data.UpdateAvailable))
 		return nil
 	},
 }
@@ -488,7 +481,8 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of environments to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Get command flags

--- a/cli/pkg/gitops/cmd.go
+++ b/cli/pkg/gitops/cmd.go
@@ -22,10 +22,12 @@ import (
 )
 
 var (
-	limitFlag  int
-	startFlag  int
-	forceFlag  bool
-	jsonOutput bool
+	limitFlag       int
+	startFlag       int
+	allFlag         bool
+	forceFlag       bool
+	jsonOutput      bool
+	gitopsFilesPath string
 )
 
 var (
@@ -59,7 +61,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.GitOpsSyncs(c.EnvID())
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "gitops-syncs", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "gitops-syncs", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -71,8 +73,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[gitops.GitOpsSync]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -156,8 +158,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[gitops.GitOpsSync]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -199,8 +201,8 @@ var getCmd = &cobra.Command{
 			defer func() { _ = resp.Body.Close() }()
 
 			var result base.ApiResponse[gitops.GitOpsSync]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resolved = &result.Data
 		}
@@ -358,8 +360,8 @@ var statusCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[gitops.SyncStatus]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -416,8 +418,8 @@ var syncCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[gitops.SyncResult]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -458,15 +460,20 @@ var filesCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Get(cmd.Context(), types.Endpoints.GitOpsSyncFiles(c.EnvID(), resolved.ID))
+		filesPath := types.Endpoints.GitOpsSyncFiles(c.EnvID(), resolved.ID)
+		if gitopsFilesPath != "" {
+			filesPath = cmdutil.AppendQuery(filesPath, url.Values{"path": []string{gitopsFilesPath}})
+		}
+
+		resp, err := c.Get(cmd.Context(), filesPath)
 		if err != nil {
 			return errors.WrapIf(err, "failed to get gitops sync files")
 		}
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[gitops.BrowseResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		files := result.Data.Files
@@ -513,7 +520,9 @@ var importCmd = &cobra.Command{
 			SyncInterval:      interval,
 		}
 
-		resp, err := c.Post(cmd.Context(), types.Endpoints.GitOpsSyncsImport(c.EnvID()), req)
+		// The endpoint accepts a batch, so a single sync still has to be wrapped
+		// in an array.
+		resp, err := c.Post(cmd.Context(), types.Endpoints.GitOpsSyncsImport(c.EnvID()), []gitops.ImportGitOpsSyncRequest{req})
 		if err != nil {
 			return errors.WrapIf(err, "failed to import gitops sync")
 		}
@@ -524,8 +533,8 @@ var importCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[gitops.ImportGitOpsSyncResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -561,7 +570,8 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of syncs to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Create command flags
@@ -602,6 +612,7 @@ func init() {
 	syncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Files command flags
+	filesCmd.Flags().StringVar(&gitopsFilesPath, "path", "", "Path within the repository to browse")
 	filesCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Import command flags
@@ -649,7 +660,7 @@ func resolveGitOpsSync(ctx context.Context, c *client.Client, identifier string,
 
 	identifierLower := strings.ToLower(trimmed)
 
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.GitOpsSyncs(c.EnvID()), url.QueryEscape(trimmed), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.GitOpsSyncs(c.EnvID()), url.QueryEscape(trimmed), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return nil, false, errors.WrapIf(err, "failed to search gitops syncs")
@@ -730,7 +741,7 @@ func flattenFileTree(nodes []gitops.FileTreeNode, depth int) [][]string {
 		prefix := strings.Repeat("  ", depth)
 		size := "-"
 		if node.Type == gitops.FileTreeNodeTypeFile {
-			size = formatSize(node.Size)
+			size = output.Bytes(node.Size)
 		}
 		rows = append(rows, []string{
 			prefix + node.Name,
@@ -743,20 +754,4 @@ func flattenFileTree(nodes []gitops.FileTreeNode, depth int) [][]string {
 		}
 	}
 	return rows
-}
-
-func formatSize(bytes int64) string {
-	if bytes == 0 {
-		return "0 B"
-	}
-	const unit = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := int64(unit), 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }

--- a/cli/pkg/images/cmd.go
+++ b/cli/pkg/images/cmd.go
@@ -54,9 +54,9 @@ import (
 	"github.com/getarcaneapp/arcane/cli/v2/internal/prompt"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/types"
 	"github.com/getarcaneapp/arcane/cli/v2/pkg/images/updates"
+	"github.com/getarcaneapp/arcane/types/v2/base"
 	"github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/spf13/cobra"
-	"go.getarcane.app/sys/bytes"
 )
 
 var (
@@ -67,6 +67,9 @@ var (
 	imagesSearch     string
 	imagesInUseOnly  bool
 	imagesUnusedOnly bool
+	imagesAll        bool
+
+	imagesUpdatesFilter string
 )
 
 const maxPromptOptions = 20
@@ -111,9 +114,26 @@ var imagesListCmd = &cobra.Command{
 		if imagesSearch != "" {
 			q.Set("search", imagesSearch)
 		}
+		// Filter server-side so that pagination and the reported totals apply to
+		// the matching set rather than to whichever page happened to be fetched.
+		if imagesInUseOnly {
+			q.Set("inUse", "true")
+		}
+		if imagesUnusedOnly {
+			q.Set("inUse", "false")
+		}
+		if imagesUpdatesFilter != "" {
+			q.Set("updates", imagesUpdatesFilter)
+		}
 
 		u.RawQuery = q.Encode()
-		path, err = cmdutil.ApplyPaginationParams(cmd, u.String(), "images", "limit", imagesLimit, 0, "start", imagesStart)
+		path, err = cmdutil.ApplyPaginationParams(cmd, u.String(), cmdutil.ListParams{
+			Resource:        "images",
+			Limit:           imagesLimit,
+			FallbackDefault: 0,
+			Start:           imagesStart,
+			All:             imagesAll,
+		})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -126,39 +146,20 @@ var imagesListCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := cmdutil.ReadJSONBody(resp)
 		if err != nil {
-			return errors.WrapIf(err, "failed to read response")
+			return errors.WrapIf(err, "failed to list images")
 		}
 
 		log.Debugf("Response body: %s", string(body))
 
-		if cmdutil.JSONOutputEnabled(cmd) && !imagesInUseOnly && !imagesUnusedOnly {
-			fmt.Println(string(body))
-			return nil
+		if cmdutil.JSONOutputEnabled(cmd) {
+			return cmdutil.PrintRawJSON(body)
 		}
 
-		var result struct {
-			Success    bool            `json:"success"`
-			Data       []image.Summary `json:"data"`
-			Pagination struct {
-				TotalItems int64 `json:"totalItems"`
-			} `json:"pagination"`
-		}
-
+		var result base.Paginated[image.Summary]
 		if err := json.Unmarshal(body, &result); err != nil {
 			return errors.WrapIf(err, "failed to parse response")
-		}
-		result.Data = filterImagesByUsage(result.Data, imagesInUseOnly, imagesUnusedOnly)
-		result.Pagination.TotalItems = int64(len(result.Data))
-
-		if cmdutil.JSONOutputEnabled(cmd) {
-			resultBytes, err := json.MarshalIndent(result, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
 		}
 
 		headers := []string{"ID", "REPOSITORY:TAG", "SIZE", "IN USE"}
@@ -174,7 +175,7 @@ var imagesListCmd = &cobra.Command{
 				inUse = color.New(color.FgGreen).Sprint("Yes")
 			}
 			id := color.New(color.FgHiWhite, color.Bold).Sprint(img.ID)
-			rows = append(rows, []string{id, tag, bytes.Capacity(img.Size).String(), inUse})
+			rows = append(rows, []string{id, tag, output.Bytes(img.Size), inUse})
 		}
 
 		output.Table(headers, rows)
@@ -239,7 +240,7 @@ var imagesGetCmd = &cobra.Command{
 		if len(result.Data.RepoTags) > 0 {
 			output.KeyValue("Tags", strings.Join(result.Data.RepoTags, ", "))
 		}
-		output.KeyValue("Size", bytes.Capacity(result.Data.Size).String())
+		output.KeyValue("Size", output.Bytes(result.Data.Size))
 		output.KeyValue("Architecture", result.Data.Architecture)
 		output.KeyValue("OS", result.Data.Os)
 		if result.Data.Created != "" {
@@ -404,6 +405,7 @@ var imagesPullCmd = &cobra.Command{
 
 		for {
 			var event struct {
+				Type           string `json:"type"`
 				Status         string `json:"status"`
 				Error          string `json:"error"`
 				ID             string `json:"id"`
@@ -418,6 +420,12 @@ var imagesPullCmd = &cobra.Command{
 					break
 				}
 				return errors.WrapIf(err, "failed to decode stream")
+			}
+
+			// The stream opens with an activity frame that carries no Docker
+			// status; printing it would emit a blank line per pull.
+			if event.Type != "" && event.Status == "" && event.Error == "" {
+				continue
 			}
 
 			if event.Error != "" {
@@ -537,7 +545,7 @@ var imagesPruneCmd = &cobra.Command{
 			return errors.WrapIf(err, "failed to parse response")
 		}
 
-		output.Success("Pruned %d images, reclaimed %s", len(result.Data.ImagesDeleted), bytes.Capacity(result.Data.SpaceReclaimed).String())
+		output.Success("Pruned %d images, reclaimed %s", len(result.Data.ImagesDeleted), output.Bytes(result.Data.SpaceReclaimed))
 
 		return nil
 	},
@@ -589,7 +597,7 @@ var imagesCountsCmd = &cobra.Command{
 		output.KeyValue("In Use", result.Data.Inuse)
 		output.KeyValue("Unused", result.Data.Unused)
 		output.KeyValue("Total", result.Data.Total)
-		output.KeyValue("Total Size", bytes.Capacity(result.Data.TotalSize).String())
+		output.KeyValue("Total Size", output.Bytes(result.Data.TotalSize))
 
 		return nil
 	},
@@ -708,7 +716,9 @@ var imagesUploadCmd = &cobra.Command{
 func init() {
 	ImagesCmd.AddCommand(imagesListCmd)
 	imagesListCmd.Flags().IntVarP(&imagesLimit, "limit", "n", 0, "Number of images to show (server default 20)")
-	imagesListCmd.Flags().IntVar(&imagesStart, "start", 0, "Offset for pagination")
+	imagesListCmd.Flags().IntVar(&imagesStart, "start", 0, cmdutil.StartFlagUsage)
+	imagesListCmd.Flags().BoolVarP(&imagesAll, "all", "a", false, cmdutil.AllFlagUsage)
+	imagesListCmd.Flags().StringVar(&imagesUpdatesFilter, "updates", "", "Filter by update status (has_update, up_to_date, error, unknown)")
 	imagesListCmd.Flags().StringVar(&imagesSort, "sort", "", "Field to sort by")
 	imagesListCmd.Flags().StringVar(&imagesOrder, "order", "", "Sort order (asc/desc)")
 	imagesListCmd.Flags().StringVar(&imagesSearch, "search", "", "Search query")
@@ -825,7 +835,7 @@ func buildImageSearchTerms(trimmed string) []string {
 }
 
 func searchImageMatches(ctx context.Context, c *client.Client, term, trimmed string) ([]image.Summary, error) {
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Images(c.EnvID()), url.QueryEscape(term), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Images(c.EnvID()), url.QueryEscape(term), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to search images")
@@ -933,21 +943,4 @@ func formatImageMatchOption(match image.Summary) string {
 		label = match.Repo + ":" + match.Tag
 	}
 	return fmt.Sprintf("%s (%s)", label, match.ID)
-}
-
-func filterImagesByUsage(items []image.Summary, inUseOnly, unusedOnly bool) []image.Summary {
-	if !inUseOnly && !unusedOnly {
-		return items
-	}
-	filtered := make([]image.Summary, 0, len(items))
-	for _, item := range items {
-		if inUseOnly && !item.InUse {
-			continue
-		}
-		if unusedOnly && item.InUse {
-			continue
-		}
-		filtered = append(filtered, item)
-	}
-	return filtered
 }

--- a/cli/pkg/images/updates/cmd.go
+++ b/cli/pkg/images/updates/cmd.go
@@ -75,7 +75,8 @@ var checkAllCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Post(cmd.Context(), types.Endpoints.ImageUpdatesCheckAll(c.EnvID()), nil)
+		// The handler declares a non-pointer Body, so an empty body is a 400.
+		resp, err := c.Post(cmd.Context(), types.Endpoints.ImageUpdatesCheckAll(c.EnvID()), imageupdate.CheckAllImagesRequest{})
 		if err != nil {
 			return errors.WrapIf(err, "failed to check all updates")
 		}

--- a/cli/pkg/jobs/cmd.go
+++ b/cli/pkg/jobs/cmd.go
@@ -44,8 +44,8 @@ var getCmd = &cobra.Command{
 		}
 
 		var cfg jobschedule.Config
-		if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &cfg); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -103,8 +103,8 @@ var updateCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[jobschedule.Config]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {

--- a/cli/pkg/networks/cmd.go
+++ b/cli/pkg/networks/cmd.go
@@ -24,6 +24,7 @@ import (
 var (
 	limitFlag      int
 	startFlag      int
+	allFlag        bool
 	forceFlag      bool
 	jsonOutput     bool
 	inUseOnlyFlag  bool
@@ -53,10 +54,24 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		path := types.Endpoints.Networks(c.EnvID())
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "networks", "limit", limitFlag, 20, "start", startFlag)
+		path, err := cmdutil.ApplyPaginationParams(cmd, types.Endpoints.Networks(c.EnvID()), cmdutil.ListParams{
+			Resource:        "networks",
+			Limit:           limitFlag,
+			FallbackDefault: 20,
+			Start:           startFlag,
+			All:             allFlag,
+		})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
+		}
+
+		// Filter server-side so that pagination and the reported totals apply to
+		// the matching set rather than to whichever page happened to be fetched.
+		if inUseOnlyFlag {
+			path = cmdutil.AppendQuery(path, url.Values{"inUse": []string{"true"}})
+		}
+		if unusedOnlyFlag {
+			path = cmdutil.AppendQuery(path, url.Values{"inUse": []string{"false"}})
 		}
 
 		resp, err := c.Get(cmd.Context(), path)
@@ -65,20 +80,18 @@ var listCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.Paginated[network.Summary]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		body, err := cmdutil.ReadJSONBody(resp)
+		if err != nil {
+			return errors.WrapIf(err, "failed to list networks")
 		}
-		result.Data = filterNetworksByUsage(result.Data, inUseOnlyFlag, unusedOnlyFlag)
-		result.Pagination.TotalItems = int64(len(result.Data))
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintRawJSON(body)
+		}
+
+		var result base.Paginated[network.Summary]
+		if err := json.Unmarshal(body, &result); err != nil {
+			return errors.WrapIf(err, "failed to parse response")
 		}
 
 		headers := []string{"ID", "NAME", "DRIVER", "SCOPE", "CREATED", "IN USE"}
@@ -128,8 +141,8 @@ var getCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[network.Inspect]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -204,8 +217,8 @@ var deleteCmd = &cobra.Command{
 
 		if jsonOutput {
 			var result base.ApiResponse[any]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
 			if err != nil {
@@ -237,8 +250,8 @@ var countsCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[network.UsageCounts]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -289,8 +302,8 @@ var pruneCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[network.PruneReport]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -304,6 +317,7 @@ var pruneCmd = &cobra.Command{
 
 		output.Success("Networks pruned successfully")
 		output.KeyValue("Deleted networks", len(result.Data.NetworksDeleted))
+		output.KeyValue("Space Reclaimed", output.UnsignedBytes(result.Data.SpaceReclaimed))
 		return nil
 	},
 }
@@ -317,7 +331,8 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of networks to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	listCmd.Flags().BoolVar(&inUseOnlyFlag, "inuse", false, "Only show networks currently in use")
 	listCmd.Flags().BoolVar(&unusedOnlyFlag, "unused", false, "Only show networks not in use")
@@ -373,7 +388,7 @@ func resolveNetworkID(ctx context.Context, c *client.Client, identifier string, 
 		return "", "", errors.Errorf("failed to resolve network %q (status %d): %s", trimmed, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Networks(c.EnvID()), url.QueryEscape(trimmed), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Networks(c.EnvID()), url.QueryEscape(trimmed), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return "", "", errors.WrapIf(err, "failed to search networks")
@@ -440,21 +455,4 @@ func networkMatches(item network.Summary, identifierLower, original string) bool
 		return true
 	}
 	return strings.EqualFold(item.Name, original)
-}
-
-func filterNetworksByUsage(items []network.Summary, inUseOnly, unusedOnly bool) []network.Summary {
-	if !inUseOnly && !unusedOnly {
-		return items
-	}
-	filtered := make([]network.Summary, 0, len(items))
-	for _, item := range items {
-		if inUseOnly && !item.InUse {
-			continue
-		}
-		if unusedOnly && item.InUse {
-			continue
-		}
-		filtered = append(filtered, item)
-	}
-	return filtered
 }

--- a/cli/pkg/projects/cmd.go
+++ b/cli/pkg/projects/cmd.go
@@ -27,11 +27,16 @@ import (
 )
 
 var (
-	limitFlag             int
-	startFlag             int
-	projectsUpdatesFilter string
-	forceFlag             bool
-	jsonOutput            bool
+	limitFlag              int
+	startFlag              int
+	allFlag                bool
+	projectsUpdatesFilter  string
+	projectsStatusFilter   string
+	projectsArchivedFilter string
+	forceFlag              bool
+	jsonOutput             bool
+	destroyRemoveFiles     bool
+	destroyRemoveVolumes   bool
 
 	createName    string
 	createFile    string
@@ -86,18 +91,18 @@ func runProjectsList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	var result base.Paginated[project.Details]
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return errors.WrapIf(err, "failed to parse response")
+	body, err := cmdutil.ReadJSONBody(resp)
+	if err != nil {
+		return errors.WrapIf(err, "failed to list projects")
 	}
 
 	if jsonOutput {
-		resultBytes, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return errors.WrapIf(err, "failed to marshal JSON")
-		}
-		fmt.Println(string(resultBytes))
-		return nil
+		return cmdutil.PrintRawJSON(body)
+	}
+
+	var result base.Paginated[project.Details]
+	if err := json.Unmarshal(body, &result); err != nil {
+		return errors.WrapIf(err, "failed to parse response")
 	}
 
 	effectiveUpdatesFilter := strings.TrimSpace(projectsUpdatesFilter)
@@ -148,9 +153,13 @@ func runProjectsList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 }
 
 func buildProjectsListPath(cmd *cobra.Command, c *client.Client, forceHasUpdateFilter bool) (string, error) {
-	path := types.Endpoints.Projects(c.EnvID())
-	var err error
-	path, err = cmdutil.ApplyPaginationParams(cmd, path, "projects", "limit", limitFlag, 20, "start", startFlag)
+	path, err := cmdutil.ApplyPaginationParams(cmd, types.Endpoints.Projects(c.EnvID()), cmdutil.ListParams{
+		Resource:        "projects",
+		Limit:           limitFlag,
+		FallbackDefault: 20,
+		Start:           startFlag,
+		All:             allFlag,
+	})
 	if err != nil {
 		return "", errors.WrapIf(err, "failed to build pagination query")
 	}
@@ -167,6 +176,17 @@ func buildProjectsListPath(cmd *cobra.Command, c *client.Client, forceHasUpdateF
 	}
 	if updatesFilter != "" {
 		query.Set("updates", updatesFilter)
+	}
+	if projectsStatusFilter != "" {
+		query.Set("status", projectsStatusFilter)
+	}
+	// The server excludes archived projects unless asked, so --all has to opt
+	// into them explicitly to actually mean "everything".
+	switch {
+	case projectsArchivedFilter != "":
+		query.Set("archived", projectsArchivedFilter)
+	case allFlag:
+		query.Set("archived", "all")
 	}
 
 	parsed.RawQuery = query.Encode()
@@ -212,7 +232,10 @@ var destroyCmd = &cobra.Command{
 			}
 		}
 
-		resp, err := c.Delete(cmd.Context(), types.Endpoints.ProjectDestroy(c.EnvID(), resolved.ID))
+		resp, err := c.DeleteWithBody(cmd.Context(), types.Endpoints.ProjectDestroy(c.EnvID(), resolved.ID), project.Destroy{
+			RemoveFiles:   &destroyRemoveFiles,
+			RemoveVolumes: destroyRemoveVolumes,
+		})
 		if err != nil {
 			return errors.WrapIf(err, "failed to destroy project")
 		}
@@ -251,8 +274,8 @@ var getCmd = &cobra.Command{
 			defer func() { _ = resp.Body.Close() }()
 
 			var result base.ApiResponse[project.Details]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resolved = &result.Data
 		}
@@ -473,8 +496,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[project.CreateReponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -545,8 +568,8 @@ var updateCmd = &cobra.Command{
 
 		if jsonOutput {
 			var result base.ApiResponse[project.Details]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
 			if err != nil {
@@ -598,8 +621,8 @@ var updateIncludesCmd = &cobra.Command{
 
 		if jsonOutput {
 			var result base.ApiResponse[project.Details]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
 			if err != nil {
@@ -631,8 +654,8 @@ var countsCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[map[string]any]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -669,11 +692,15 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of projects to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage+", including archived projects")
 	listCmd.Flags().StringVar(&projectsUpdatesFilter, "updates", "", "Filter by update status (has_update, up_to_date, error, unknown)")
+	listCmd.Flags().StringVar(&projectsStatusFilter, "status", "", "Filter by status (comma-separated: running, stopped, partially running)")
+	listCmd.Flags().StringVar(&projectsArchivedFilter, "archived", "", "Archived filter: 'true' for archived only, 'all' to include archived")
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	updatesCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of projects to show")
-	updatesCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	updatesCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	updatesCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	updatesCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Get command flags
@@ -684,6 +711,8 @@ func init() {
 
 	// Destroy command flags
 	destroyCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force destroy without confirmation")
+	destroyCmd.Flags().BoolVar(&destroyRemoveFiles, "remove-files", true, "Remove the project's files from disk")
+	destroyCmd.Flags().BoolVar(&destroyRemoveVolumes, "remove-volumes", false, "Remove the project's volumes")
 	destroyCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Create command flags
@@ -737,7 +766,7 @@ func resolveProject(ctx context.Context, c *client.Client, identifier string, al
 
 	identifierLower := strings.ToLower(trimmed)
 
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Projects(c.EnvID()), url.QueryEscape(trimmed), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Projects(c.EnvID()), url.QueryEscape(trimmed), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return nil, false, errors.WrapIf(err, "failed to search projects")

--- a/cli/pkg/registries/cmd.go
+++ b/cli/pkg/registries/cmd.go
@@ -18,6 +18,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 
@@ -57,7 +58,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.ContainerRegistries()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "registries", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "registries", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -69,8 +70,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[containerregistry.ContainerRegistry]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -104,40 +105,6 @@ var listCmd = &cobra.Command{
 
 		output.Table(headers, rows)
 		output.Showing(len(result.Data), result.Pagination.TotalItems, "registries")
-		return nil
-	},
-}
-
-var syncCmd = &cobra.Command{
-	Use:          "sync",
-	Short:        "Sync container registries",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := client.NewFromConfig()
-		if err != nil {
-			return err
-		}
-
-		resp, err := c.Post(cmd.Context(), types.Endpoints.ContainerRegistrySync(), nil)
-		if err != nil {
-			return errors.WrapIf(err, "failed to sync registries")
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if err := cmdutil.EnsureSuccessStatus(resp); err != nil {
-			return errors.WrapIf(err, "failed to sync registries")
-		}
-
-		if jsonOutput {
-			var result base.ApiResponse[any]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
-				if resultBytes, err := json.MarshalIndent(result.Data, "", "  "); err == nil {
-					fmt.Println(string(resultBytes))
-				}
-			}
-			return nil
-		}
-
-		output.Success("Registries synced successfully")
 		return nil
 	},
 }
@@ -195,8 +162,8 @@ var getCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[containerregistry.ContainerRegistry]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -231,19 +198,20 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
+		// No field on CreateContainerRegistryRequest carries omitempty, so Huma
+		// marks all of them required — every key has to be present, including
+		// description.
 		req := map[string]any{
 			"url":                registryCreateURL,
 			"registryType":       registryCreateType,
 			"username":           registryCreateUsername,
 			"token":              registryCreateToken,
+			"description":        registryCreateDescription,
 			"insecure":           registryCreateInsecure,
 			"enabled":            !registryCreateDisabled,
 			"awsAccessKeyId":     registryCreateAWSKeyID,
 			"awsSecretAccessKey": registryCreateAWSSecret,
 			"awsRegion":          registryCreateAWSRegion,
-		}
-		if registryCreateDescription != "" {
-			req["description"] = registryCreateDescription
 		}
 
 		resp, err := c.Post(cmd.Context(), types.Endpoints.ContainerRegistries(), req)
@@ -256,8 +224,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[containerregistry.ContainerRegistry]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -292,27 +260,48 @@ var updateCmd = &cobra.Command{
 			return err
 		}
 
-		req := make(map[string]any)
 		if cmd.Flags().Changed("enabled") && cmd.Flags().Changed("disabled") {
 			return errors.New("--enabled and --disabled are mutually exclusive")
 		}
-		if cmd.Flags().Changed("url") {
-			req["url"] = registryUpdateURL
-		}
-		if cmd.Flags().Changed("username") {
-			req["username"] = registryUpdateUsername
-		}
-		if cmd.Flags().Changed("password") {
-			req["token"] = registryUpdatePassword
-		}
-		if cmd.Flags().Changed("enabled") {
-			req["enabled"] = registryUpdateEnabled
-		}
-		if cmd.Flags().Changed("disabled") {
-			req["enabled"] = !registryUpdateDisabled
+
+		// Every field on UpdateContainerRegistryRequest lacks omitempty, so Huma
+		// requires all of them. They are all pointers though, so an explicit null
+		// is valid and the service leaves those fields untouched.
+		req := map[string]any{
+			"url":                nil,
+			"username":           nil,
+			"token":              nil,
+			"description":        nil,
+			"insecure":           nil,
+			"enabled":            nil,
+			"registryType":       nil,
+			"awsAccessKeyId":     nil,
+			"awsSecretAccessKey": nil,
+			"awsRegion":          nil,
 		}
 
-		if len(req) == 0 {
+		changed := false
+		setField := func(key string, value any) {
+			req[key] = value
+			changed = true
+		}
+		if cmd.Flags().Changed("url") {
+			setField("url", registryUpdateURL)
+		}
+		if cmd.Flags().Changed("username") {
+			setField("username", registryUpdateUsername)
+		}
+		if cmd.Flags().Changed("password") {
+			setField("token", registryUpdatePassword)
+		}
+		if cmd.Flags().Changed("enabled") {
+			setField("enabled", registryUpdateEnabled)
+		}
+		if cmd.Flags().Changed("disabled") {
+			setField("enabled", !registryUpdateDisabled)
+		}
+
+		if !changed {
 			return errors.New("no updates provided; use --url, --username, --password, --enabled, or --disabled")
 		}
 
@@ -381,18 +370,17 @@ func init() {
 	RegistriesCmd.AddCommand(listCmd)
 	RegistriesCmd.AddCommand(getCmd)
 	RegistriesCmd.AddCommand(createCmd)
-	RegistriesCmd.AddCommand(syncCmd)
 	RegistriesCmd.AddCommand(testCmd)
 	RegistriesCmd.AddCommand(updateCmd)
 	RegistriesCmd.AddCommand(deleteCmd)
 
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of registries to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	getCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
-	syncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	testCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	createCmd.Flags().StringVar(&registryCreateURL, "url", "", "Registry URL (e.g. ghcr.io, docker.io, registry.example.com)")

--- a/cli/pkg/repos/cmd.go
+++ b/cli/pkg/repos/cmd.go
@@ -26,6 +26,7 @@ import (
 var (
 	limitFlag  int
 	startFlag  int
+	allFlag    bool
 	forceFlag  bool
 	jsonOutput bool
 )
@@ -83,7 +84,7 @@ var listCmd = &cobra.Command{
 		}
 
 		path := types.Endpoints.GitRepositories()
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "repos", "limit", limitFlag, 20, "start", startFlag)
+		path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "repos", Limit: limitFlag, FallbackDefault: 20, Start: startFlag, All: allFlag})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
 		}
@@ -95,8 +96,8 @@ var listCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.Paginated[gitops.GitRepository]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -180,8 +181,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[gitops.GitRepository]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -441,8 +442,8 @@ var branchesCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[gitops.BranchesResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -508,8 +509,8 @@ var filesCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[gitops.BrowseResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		files := result.Data.Files
@@ -543,40 +544,6 @@ var filesCmd = &cobra.Command{
 	},
 }
 
-var syncCmd = &cobra.Command{
-	Use:          "sync",
-	Short:        "Sync all git repositories",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := client.NewFromConfig()
-		if err != nil {
-			return err
-		}
-
-		resp, err := c.Post(cmd.Context(), types.Endpoints.GitRepositoriesSync(), nil)
-		if err != nil {
-			return errors.WrapIf(err, "failed to sync repositories")
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if err := cmdutil.EnsureSuccessStatus(resp); err != nil {
-			return errors.WrapIf(err, "failed to sync repositories")
-		}
-
-		if jsonOutput {
-			var result base.ApiResponse[any]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
-				if resultBytes, err := json.MarshalIndent(result.Data, "", "  "); err == nil {
-					fmt.Println(string(resultBytes))
-				}
-			}
-			return nil
-		}
-
-		output.Success("Repositories synced successfully")
-		return nil
-	},
-}
-
 // resolveGitRepository attempts to resolve a repository by ID or name.
 // It first tries a direct GET by ID. If that returns 404, it falls back to
 // searching the list endpoint by name or ID prefix.
@@ -601,7 +568,7 @@ func resolveGitRepository(ctx context.Context, c *client.Client, identifier stri
 	}
 
 	// Fallback: search via list endpoint.
-	listPath := types.Endpoints.GitRepositories() + "?limit=200"
+	listPath := cmdutil.AppendQuery(types.Endpoints.GitRepositories(), url.Values{"limit": []string{strconv.Itoa(cmdutil.ShowAllLimit)}})
 	listResp, err := c.Get(ctx, listPath)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to search repositories")
@@ -609,8 +576,8 @@ func resolveGitRepository(ctx context.Context, c *client.Client, identifier stri
 	defer func() { _ = listResp.Body.Close() }()
 
 	var listResult base.Paginated[gitops.GitRepository]
-	if err := json.NewDecoder(listResp.Body).Decode(&listResult); err != nil {
-		return nil, errors.WrapIf(err, "failed to parse repository list")
+	if err := cmdutil.DecodeJSON(listResp, &listResult); err != nil {
+		return nil, errors.WrapIf(err, "failed to search repositories")
 	}
 
 	lowerIdentifier := strings.ToLower(trimmed)
@@ -655,11 +622,11 @@ func init() {
 	ReposCmd.AddCommand(testCmd)
 	ReposCmd.AddCommand(branchesCmd)
 	ReposCmd.AddCommand(filesCmd)
-	ReposCmd.AddCommand(syncCmd)
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of repositories to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Create command flags
@@ -703,10 +670,10 @@ func init() {
 	branchesCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Files command flags
-	filesCmd.Flags().StringVar(&filesBranch, "branch", "", "Branch to browse")
+	filesCmd.Flags().StringVar(&filesBranch, "branch", "", "Branch to browse (required)")
+	_ = filesCmd.MarkFlagRequired("branch")
 	filesCmd.Flags().StringVar(&filesPath, "path", "", "Path within repository")
 	filesCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Sync command flags
-	syncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 }

--- a/cli/pkg/settings/cmd.go
+++ b/cli/pkg/settings/cmd.go
@@ -115,8 +115,8 @@ func runSettingsList(cmd *cobra.Command, cfg settingsListConfig) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	var result []settings.PublicSetting
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return errors.WrapIf(err, "failed to parse response")
+	if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+		return err
 	}
 
 	if jsonOutput {

--- a/cli/pkg/system/cmd.go
+++ b/cli/pkg/system/cmd.go
@@ -52,8 +52,8 @@ var pruneCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[system.PruneAllResult]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -66,7 +66,7 @@ var pruneCmd = &cobra.Command{
 		}
 
 		output.Header("System Prune Results")
-		output.KeyValue("Space Reclaimed", result.Data.SpaceReclaimed)
+		output.KeyValue("Space Reclaimed", output.UnsignedBytes(result.Data.SpaceReclaimed))
 		return nil
 	},
 }
@@ -87,25 +87,22 @@ var dockerInfoCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[dockerinfo.Info]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		// This endpoint returns dockerinfo.Info directly, not wrapped in an
+		// ApiResponse envelope.
+		var result dockerinfo.Info
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to get docker info")
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result)
 		}
 
 		output.Header("Docker Info")
-		output.KeyValue("API Version", result.Data.APIVersion)
-		output.KeyValue("OS", result.Data.Os)
-		output.KeyValue("Architecture", result.Data.Arch)
-		output.KeyValue("Go Version", result.Data.GoVersion)
+		output.KeyValue("API Version", result.APIVersion)
+		output.KeyValue("OS", result.Os)
+		output.KeyValue("Architecture", result.Arch)
+		output.KeyValue("Go Version", result.GoVersion)
 		return nil
 	},
 }
@@ -221,8 +218,8 @@ var convertCmd = &cobra.Command{
 			EnvVars       string `json:"envVars"`
 			ServiceName   string `json:"serviceName"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -327,8 +324,8 @@ var upgradeCheckCmd = &cobra.Command{
 			Error      bool   `json:"error"`
 			Message    string `json:"message"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {

--- a/cli/pkg/templates/cmd.go
+++ b/cli/pkg/templates/cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -46,7 +47,12 @@ var (
 	templateDownloadOutput    string
 	templateDefaultsSaveFile  string
 	templateDefaultsEnvFile   string
-	templateVarsUpdateFile    string
+	templateFetchURL          string
+	templateVarsUpdateKey     string
+	templateVarsUpdateValue   string
+	templateVarsUpdateSecret  bool
+	templateVarsUpdateAllEnvs bool
+	templateVarsUpdateEnvIDs  []string
 	templateRegUpdateName     string
 	templateRegUpdateURL      string
 	templateRegUpdateDesc     string
@@ -91,8 +97,8 @@ var listCmd = &cobra.Command{
 			defer func() { _ = resp.Body.Close() }()
 
 			var result base.ApiResponse[[]template.Template]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 
 			templates = result.Data
@@ -100,7 +106,7 @@ var listCmd = &cobra.Command{
 			jsonPayload = result.Data
 		} else {
 			path = types.Endpoints.Templates()
-			path, err = cmdutil.ApplyPaginationParams(cmd, path, "templates", "limit", limitFlag, 20, "start", startFlag)
+			path, err = cmdutil.ApplyPaginationParams(cmd, path, cmdutil.ListParams{Resource: "templates", Limit: limitFlag, FallbackDefault: 20, Start: startFlag})
 			if err != nil {
 				return errors.WrapIf(err, "failed to build pagination query")
 			}
@@ -112,8 +118,8 @@ var listCmd = &cobra.Command{
 			defer func() { _ = resp.Body.Close() }()
 
 			var result base.Paginated[template.Template]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 
 			templates = result.Data
@@ -172,8 +178,8 @@ var defaultCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[template.DefaultTemplatesResponse]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -210,8 +216,8 @@ var contentCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[template.TemplateContent]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -256,8 +262,8 @@ var registriesCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[[]template.TemplateRegistry]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -293,7 +299,7 @@ var registriesCmd = &cobra.Command{
 var variablesCmd = &cobra.Command{
 	Use:          "variables",
 	Aliases:      []string{"vars"},
-	Short:        "List template variables",
+	Short:        "List global variables",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client.NewFromConfig()
@@ -307,26 +313,28 @@ var variablesCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[[]env.Variable]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		var result base.ApiResponse[[]env.GlobalVariable]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to list variables")
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
-		headers := []string{"KEY", "VALUE"}
+		headers := []string{"ID", "KEY", "VALUE", "SECRET", "SCOPE"}
 		rows := make([][]string, len(result.Data))
 		for i, v := range result.Data {
+			scope := "all environments"
+			if !v.AllEnvironments {
+				scope = strings.Join(v.EnvironmentIDs, ", ")
+			}
 			rows[i] = []string{
+				v.ID,
 				v.Key,
 				v.Value,
+				strconv.FormatBool(v.IsSecret),
+				scope,
 			}
 		}
 
@@ -853,8 +861,8 @@ var createCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[template.Template]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -879,9 +887,32 @@ var updateCmd = &cobra.Command{
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := client.NewFromConfig()
+		if err != nil {
+			return err
+		}
+
+		// UpdateRequest has no omitempty fields and the handler replaces the whole
+		// record, so an unset --file would otherwise wipe the compose content.
+		// Start from the stored template and overlay only what was passed.
+		current, err := fetchTemplateInternal(cmd, c, args[0])
+		if err != nil {
+			return err
+		}
+
 		req := template.UpdateRequest{
-			Name:        templateUpdateName,
-			Description: templateUpdateDescription,
+			Name:        current.Name,
+			Description: current.Description,
+			Content:     current.Content,
+		}
+		if current.EnvContent != nil {
+			req.EnvContent = *current.EnvContent
+		}
+		if cmd.Flags().Changed("name") {
+			req.Name = templateUpdateName
+		}
+		if cmd.Flags().Changed("description") {
+			req.Description = templateUpdateDescription
 		}
 
 		if templateUpdateFile != "" {
@@ -900,11 +931,6 @@ var updateCmd = &cobra.Command{
 			req.EnvContent = string(envContent)
 		}
 
-		c, err := client.NewFromConfig()
-		if err != nil {
-			return err
-		}
-
 		resp, err := c.Put(cmd.Context(), types.Endpoints.Template(args[0]), req)
 		if err != nil {
 			return errors.WrapIf(err, "failed to update template")
@@ -912,17 +938,12 @@ var updateCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[template.Template]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to update template")
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
 		output.Success("Template updated successfully")
@@ -952,9 +973,9 @@ var downloadCmd = &cobra.Command{
 			return errors.WrapIf(err, "failed to download template")
 		}
 
-		var result base.ApiResponse[template.TemplateContent]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		var result base.ApiResponse[template.Template]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if templateDownloadOutput != "" {
@@ -1011,16 +1032,11 @@ var defaultsSaveCmd = &cobra.Command{
 		}
 
 		if jsonOutput {
-			var result base.ApiResponse[template.DefaultTemplatesResponse]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			var result base.ApiResponse[base.MessageResponse]
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
 		output.Success("Default templates saved successfully")
@@ -1029,19 +1045,32 @@ var defaultsSaveCmd = &cobra.Command{
 }
 
 var variablesUpdateCmd = &cobra.Command{
-	Use:          "variables-update",
+	Use:          "variables-update <variable-id>",
 	Aliases:      []string{"vars-update"},
-	Short:        "Update template variables",
+	Short:        "Update a global variable",
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		content, err := os.ReadFile(templateVarsUpdateFile)
-		if err != nil {
-			return errors.WrapIff(err, "failed to read file %s", templateVarsUpdateFile)
+		// Only the flags that were set are sent; every field on the request is a
+		// pointer, and the server keeps the current value for the ones omitted.
+		var req env.UpdateGlobalVariableRequest
+		if cmd.Flags().Changed("key") {
+			req.Key = &templateVarsUpdateKey
 		}
-
-		var variables []env.Variable
-		if err := json.Unmarshal(content, &variables); err != nil {
-			return errors.WrapIf(err, "failed to parse variables JSON")
+		if cmd.Flags().Changed("value") {
+			req.Value = &templateVarsUpdateValue
+		}
+		if cmd.Flags().Changed("secret") {
+			req.IsSecret = &templateVarsUpdateSecret
+		}
+		if cmd.Flags().Changed("all-environments") {
+			req.AllEnvironments = &templateVarsUpdateAllEnvs
+		}
+		if cmd.Flags().Changed("environment") {
+			req.EnvironmentIDs = &templateVarsUpdateEnvIDs
+		}
+		if req.Key == nil && req.Value == nil && req.IsSecret == nil && req.AllEnvironments == nil && req.EnvironmentIDs == nil {
+			return errors.New("no changes requested; pass at least one of --key, --value, --secret, --all-environments or --environment")
 		}
 
 		c, err := client.NewFromConfig()
@@ -1049,29 +1078,22 @@ var variablesUpdateCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Put(cmd.Context(), types.Endpoints.TemplatesVariables(), variables)
+		resp, err := c.Put(cmd.Context(), types.Endpoints.Variable(args[0]), req)
 		if err != nil {
-			return errors.WrapIf(err, "failed to update variables")
+			return errors.WrapIf(err, "failed to update variable")
 		}
 		defer func() { _ = resp.Body.Close() }()
-		if err := cmdutil.EnsureSuccessStatus(resp); err != nil {
-			return errors.WrapIf(err, "failed to update variables")
+
+		var result base.ApiResponse[env.GlobalVariableMutationResponse]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to update variable")
 		}
 
 		if jsonOutput {
-			var result base.ApiResponse[[]env.Variable]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
-			}
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
-		output.Success("Template variables updated successfully")
+		output.Success("Variable updated successfully")
 		return nil
 	},
 }
@@ -1082,16 +1104,43 @@ var registriesUpdateCmd = &cobra.Command{
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		req := template.UpdateRegistryRequest{
-			Name:        templateRegUpdateName,
-			URL:         templateRegUpdateURL,
-			Description: templateRegUpdateDesc,
-			Enabled:     templateRegUpdateEnabled && !templateRegUpdateDisabled,
+		if templateRegUpdateEnabled && templateRegUpdateDisabled {
+			return errors.New("--enabled and --disabled cannot be used together")
 		}
 
 		c, err := client.NewFromConfig()
 		if err != nil {
 			return err
+		}
+
+		// Every field on UpdateRegistryRequest is required and the handler does a
+		// full replace, so start from the current registry and overlay only the
+		// flags that were actually passed.
+		current, err := fetchTemplateRegistryInternal(cmd, c, args[0])
+		if err != nil {
+			return err
+		}
+
+		req := template.UpdateRegistryRequest{
+			Name:        current.Name,
+			URL:         current.URL,
+			Description: current.Description,
+			Enabled:     current.Enabled,
+		}
+		if cmd.Flags().Changed("name") {
+			req.Name = templateRegUpdateName
+		}
+		if cmd.Flags().Changed("url") {
+			req.URL = templateRegUpdateURL
+		}
+		if cmd.Flags().Changed("description") {
+			req.Description = templateRegUpdateDesc
+		}
+		if templateRegUpdateEnabled {
+			req.Enabled = true
+		}
+		if templateRegUpdateDisabled {
+			req.Enabled = false
 		}
 
 		resp, err := c.Put(cmd.Context(), types.Endpoints.TemplateRegistry(args[0]), req)
@@ -1100,25 +1149,58 @@ var registriesUpdateCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[template.TemplateRegistry]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		// The handler answers with a plain message, not the updated registry.
+		var result base.ApiResponse[base.MessageResponse]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to update registry")
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
 		output.Success("Template registry updated successfully")
-		output.KeyValue("ID", result.Data.ID)
-		output.KeyValue("Name", result.Data.Name)
+		output.KeyValue("ID", current.ID)
+		output.KeyValue("Name", req.Name)
 		return nil
 	},
+}
+
+// fetchTemplateInternal loads a single template, including its content.
+func fetchTemplateInternal(cmd *cobra.Command, c *client.Client, id string) (template.Template, error) {
+	resp, err := c.Get(cmd.Context(), types.Endpoints.Template(id))
+	if err != nil {
+		return template.Template{}, errors.WrapIf(err, "failed to load template")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result base.ApiResponse[template.Template]
+	if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+		return template.Template{}, errors.WrapIf(err, "failed to load template")
+	}
+	return result.Data, nil
+}
+
+// fetchTemplateRegistryInternal looks a registry up by ID. The API exposes no
+// get-by-id route for template registries, so this filters the list.
+func fetchTemplateRegistryInternal(cmd *cobra.Command, c *client.Client, id string) (template.TemplateRegistry, error) {
+	resp, err := c.Get(cmd.Context(), types.Endpoints.TemplatesRegistries())
+	if err != nil {
+		return template.TemplateRegistry{}, errors.WrapIf(err, "failed to load registry")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var listed base.ApiResponse[[]template.TemplateRegistry]
+	if err := cmdutil.DecodeJSON(resp, &listed); err != nil {
+		return template.TemplateRegistry{}, errors.WrapIf(err, "failed to load registry")
+	}
+
+	for _, registry := range listed.Data {
+		if registry.ID == id {
+			return registry, nil
+		}
+	}
+	return template.TemplateRegistry{}, errors.Errorf("template registry %q not found", id)
 }
 
 var fetchCmd = &cobra.Command{
@@ -1131,7 +1213,8 @@ var fetchCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Get(cmd.Context(), types.Endpoints.TemplateFetch())
+		path := cmdutil.AppendQuery(types.Endpoints.TemplateFetch(), url.Values{"url": []string{templateFetchURL}})
+		resp, err := c.Get(cmd.Context(), path)
 		if err != nil {
 			return errors.WrapIf(err, "failed to fetch templates")
 		}
@@ -1142,8 +1225,8 @@ var fetchCmd = &cobra.Command{
 
 		if jsonOutput {
 			var result base.ApiResponse[any]
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return errors.WrapIf(err, "failed to parse response")
+			if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+				return err
 			}
 			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
 			if err != nil {
@@ -1220,7 +1303,11 @@ func init() {
 	_ = defaultsSaveCmd.MarkFlagRequired("file")
 
 	// variables-update command flags
-	variablesUpdateCmd.Flags().StringVar(&templateVarsUpdateFile, "file", "", "Path to variables JSON file")
+	variablesUpdateCmd.Flags().StringVar(&templateVarsUpdateKey, "key", "", "New variable key")
+	variablesUpdateCmd.Flags().StringVar(&templateVarsUpdateValue, "value", "", "New variable value")
+	variablesUpdateCmd.Flags().BoolVar(&templateVarsUpdateSecret, "secret", false, "Mark the variable as a secret")
+	variablesUpdateCmd.Flags().BoolVar(&templateVarsUpdateAllEnvs, "all-environments", false, "Scope the variable to all environments")
+	variablesUpdateCmd.Flags().StringSliceVar(&templateVarsUpdateEnvIDs, "environment", nil, "Environment IDs to scope the variable to (repeatable)")
 	variablesUpdateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	_ = variablesUpdateCmd.MarkFlagRequired("file")
 
@@ -1233,5 +1320,7 @@ func init() {
 	registriesUpdateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// fetch command flags
+	fetchCmd.Flags().StringVar(&templateFetchURL, "url", "", "Registry URL to fetch templates from (required)")
+	_ = fetchCmd.MarkFlagRequired("url")
 	fetchCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 }

--- a/cli/pkg/updater/cmd.go
+++ b/cli/pkg/updater/cmd.go
@@ -3,11 +3,13 @@ package updater
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
 	"emperror.dev/errors"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/client"
+	"github.com/getarcaneapp/arcane/cli/v2/internal/cmdutil"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/output"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/types"
 	"github.com/getarcaneapp/arcane/types/v2/base"
@@ -15,7 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var jsonOutput bool
+var (
+	jsonOutput   bool
+	historyLimit int
+)
 
 // UpdaterCmd is the parent command for updater operations
 var UpdaterCmd = &cobra.Command{
@@ -41,8 +46,8 @@ var statusCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[updater.Status]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -81,8 +86,8 @@ var runCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[updater.Result]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -104,6 +109,23 @@ var runCmd = &cobra.Command{
 	},
 }
 
+// autoUpdateRecord mirrors the backend's models.AutoUpdateRecord, which is not
+// exported through the shared types module.
+type autoUpdateRecord struct {
+	ID              string            `json:"id"`
+	ResourceID      string            `json:"resourceId"`
+	ResourceType    string            `json:"resourceType"`
+	ResourceName    string            `json:"resourceName"`
+	Status          string            `json:"status"`
+	StartTime       time.Time         `json:"startTime"`
+	EndTime         *time.Time        `json:"endTime,omitempty"`
+	UpdateAvailable bool              `json:"updateAvailable"`
+	UpdateApplied   bool              `json:"updateApplied"`
+	Error           *string           `json:"error,omitempty"`
+	OldImages       map[string]string `json:"oldImageVersions,omitempty"`
+	NewImages       map[string]string `json:"newImageVersions,omitempty"`
+}
+
 var historyCmd = &cobra.Command{
 	Use:          "history",
 	Short:        "Get updater history",
@@ -114,34 +136,39 @@ var historyCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := c.Get(cmd.Context(), types.Endpoints.UpdaterHistory(c.EnvID()))
+		path := types.Endpoints.UpdaterHistory(c.EnvID())
+		if cmd.Flags().Changed("limit") {
+			path = cmdutil.AppendQuery(path, url.Values{"limit": []string{strconv.Itoa(historyLimit)}})
+		}
+
+		resp, err := c.Get(cmd.Context(), path)
 		if err != nil {
 			return errors.WrapIf(err, "failed to get updater history")
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.ApiResponse[[]updater.Result]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		var result base.ApiResponse[[]autoUpdateRecord]
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return errors.WrapIf(err, "failed to get updater history")
 		}
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintJSON(result.Data)
 		}
 
-		headers := []string{"CHECKED", "UPDATED", "FAILED", "DURATION"}
+		headers := []string{"RESOURCE", "TYPE", "STATUS", "APPLIED", "STARTED"}
 		rows := make([][]string, len(result.Data))
 		for i, h := range result.Data {
+			name := h.ResourceName
+			if name == "" {
+				name = h.ResourceID
+			}
 			rows[i] = []string{
-				strconv.Itoa(h.Checked),
-				strconv.Itoa(h.Updated),
-				strconv.Itoa(h.Failed),
-				h.Duration,
+				name,
+				h.ResourceType,
+				h.Status,
+				strconv.FormatBool(h.UpdateApplied),
+				h.StartTime.Format("2006-01-02 15:04"),
 			}
 		}
 
@@ -159,4 +186,5 @@ func init() {
 	statusCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	runCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	historyCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	historyCmd.Flags().IntVarP(&historyLimit, "limit", "n", 50, "Number of history entries to show")
 }

--- a/cli/pkg/version/cmd.go
+++ b/cli/pkg/version/cmd.go
@@ -3,7 +3,6 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 
 	"emperror.dev/errors"
 	"github.com/getarcaneapp/arcane/cli/v2/internal/client"
@@ -28,8 +27,11 @@ var VersionCmd = &cobra.Command{
 			return err
 		}
 
-		logger.GetLogger().Debug("Sending request", "endpoint", clitypes.Endpoints.VersionEndpoint)
-		resp, err := c.Get(cmd.Context(), clitypes.Endpoints.VersionEndpoint)
+		// /api/version returns the trimmed version.Check payload, which carries
+		// neither displayVersion nor revision. /api/app-version returns the full
+		// version.Info, including the update-check fields printed below.
+		logger.GetLogger().Debug("Sending request", "endpoint", clitypes.Endpoints.AppVersionEndpoint)
+		resp, err := c.Get(cmd.Context(), clitypes.Endpoints.AppVersionEndpoint)
 		if err != nil {
 			return errors.WrapIf(err, "failed to get version")
 		}
@@ -37,9 +39,9 @@ var VersionCmd = &cobra.Command{
 
 		logger.GetLogger().Debug("Response received", "status", resp.Status)
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := cmdutil.ReadJSONBody(resp)
 		if err != nil {
-			return errors.WrapIf(err, "failed to read response")
+			return errors.WrapIf(err, "failed to get version")
 		}
 
 		logger.GetLogger().Debug("Raw response", "body", string(body))

--- a/cli/pkg/volumes/cmd.go
+++ b/cli/pkg/volumes/cmd.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"emperror.dev/errors"
@@ -22,12 +23,14 @@ import (
 )
 
 var (
-	limitFlag      int
-	startFlag      int
-	forceFlag      bool
-	jsonOutput     bool
-	inUseOnlyFlag  bool
-	unusedOnlyFlag bool
+	limitFlag           int
+	startFlag           int
+	allFlag             bool
+	forceFlag           bool
+	jsonOutput          bool
+	inUseOnlyFlag       bool
+	unusedOnlyFlag      bool
+	includeInternalFlag bool
 )
 
 var (
@@ -60,10 +63,31 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		path := types.Endpoints.Volumes(c.EnvID())
-		path, err = cmdutil.ApplyPaginationParams(cmd, path, "volumes", "limit", limitFlag, 20, "start", startFlag)
+		path, err := cmdutil.ApplyPaginationParams(cmd, types.Endpoints.Volumes(c.EnvID()), cmdutil.ListParams{
+			Resource:        "volumes",
+			Limit:           limitFlag,
+			FallbackDefault: 20,
+			Start:           startFlag,
+			All:             allFlag,
+		})
 		if err != nil {
 			return errors.WrapIf(err, "failed to build pagination query")
+		}
+
+		// Filter server-side so that pagination and the reported totals apply to
+		// the matching set rather than to whichever page happened to be fetched.
+		query := url.Values{}
+		if inUseOnlyFlag {
+			query.Set("inUse", "true")
+		}
+		if unusedOnlyFlag {
+			query.Set("inUse", "false")
+		}
+		if includeInternalFlag {
+			query.Set("includeInternal", "true")
+		}
+		if len(query) > 0 {
+			path = cmdutil.AppendQuery(path, query)
 		}
 
 		resp, err := c.Get(cmd.Context(), path)
@@ -72,20 +96,18 @@ var listCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		var result base.Paginated[volume.Volume]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		body, err := cmdutil.ReadJSONBody(resp)
+		if err != nil {
+			return errors.WrapIf(err, "failed to list volumes")
 		}
-		result.Data = filterVolumesByUsage(result.Data, inUseOnlyFlag, unusedOnlyFlag)
-		result.Pagination.TotalItems = int64(len(result.Data))
 
 		if jsonOutput {
-			resultBytes, err := json.MarshalIndent(result, "", "  ")
-			if err != nil {
-				return errors.WrapIf(err, "failed to marshal JSON")
-			}
-			fmt.Println(string(resultBytes))
-			return nil
+			return cmdutil.PrintRawJSON(body)
+		}
+
+		var result base.Paginated[volume.Volume]
+		if err := json.Unmarshal(body, &result); err != nil {
+			return errors.WrapIf(err, "failed to parse response")
 		}
 
 		headers := []string{"NAME", "DRIVER", "MOUNTPOINT", "CREATED", "IN USE"}
@@ -144,7 +166,7 @@ var getCmd = &cobra.Command{
 		output.KeyValue("Created", resolved.CreatedAt)
 		output.KeyValue("In Use", resolved.InUse)
 		if resolved.Size > 0 {
-			output.KeyValue("Size (bytes)", resolved.Size)
+			output.KeyValue("Size", output.Bytes(resolved.Size))
 		}
 		return nil
 	},
@@ -179,7 +201,11 @@ var deleteCmd = &cobra.Command{
 			}
 		}
 
-		resp, err := c.Delete(cmd.Context(), types.Endpoints.Volume(c.EnvID(), resolved.Name))
+		deletePath := cmdutil.AppendQuery(
+			types.Endpoints.Volume(c.EnvID(), resolved.Name),
+			url.Values{"force": []string{strconv.FormatBool(forceFlag)}},
+		)
+		resp, err := c.Delete(cmd.Context(), deletePath)
 		if err != nil {
 			return errors.WrapIf(err, "failed to delete volume")
 		}
@@ -238,8 +264,8 @@ var pruneCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[any]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -290,8 +316,8 @@ func runVolumeDataCommand(cmd *cobra.Command, cfg volumeDataCommandConfig) error
 	defer func() { _ = resp.Body.Close() }()
 
 	var result base.ApiResponse[any]
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return errors.WrapIf(err, "failed to parse response")
+	if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+		return err
 	}
 
 	resultBytes, err := json.MarshalIndent(result.Data, "", "  ")
@@ -336,8 +362,8 @@ var usageCmd = &cobra.Command{
 		defer func() { _ = resp.Body.Close() }()
 
 		var result base.ApiResponse[any]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -405,8 +431,8 @@ var createCmd = &cobra.Command{
 		}
 
 		var result base.ApiResponse[volume.Volume]
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return errors.WrapIf(err, "failed to parse response")
+		if err := cmdutil.DecodeJSON(resp, &result); err != nil {
+			return err
 		}
 
 		if jsonOutput {
@@ -438,16 +464,18 @@ func init() {
 
 	// List command flags
 	listCmd.Flags().IntVarP(&limitFlag, "limit", "n", 20, "Number of volumes to show")
-	listCmd.Flags().IntVar(&startFlag, "start", 0, "Offset for pagination")
+	listCmd.Flags().IntVar(&startFlag, "start", 0, cmdutil.StartFlagUsage)
+	listCmd.Flags().BoolVarP(&allFlag, "all", "a", false, cmdutil.AllFlagUsage)
 	listCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	listCmd.Flags().BoolVar(&inUseOnlyFlag, "inuse", false, "Only show volumes currently in use")
 	listCmd.Flags().BoolVar(&unusedOnlyFlag, "unused", false, "Only show volumes not in use")
+	listCmd.Flags().BoolVar(&includeInternalFlag, "include-internal", false, "Include Arcane-internal volumes")
 
 	// Get command flags
 	getCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Delete command flags
-	deleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force deletion without confirmation")
+	deleteCmd.Flags().BoolVarP(&forceFlag, "force", "f", false, "Force removal of a volume that is in use and skip the confirmation prompt")
 	deleteCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 
 	// Prune command flags
@@ -497,7 +525,7 @@ func resolveVolume(ctx context.Context, c *client.Client, identifier string, all
 		return nil, errors.Errorf("failed to resolve volume %q (status %d): %s", trimmed, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Volumes(c.EnvID()), url.QueryEscape(trimmed), 200)
+	searchPath := fmt.Sprintf("%s?search=%s&limit=%d", types.Endpoints.Volumes(c.EnvID()), url.QueryEscape(trimmed), cmdutil.ShowAllLimit)
 	searchResp, err := c.Get(ctx, searchPath)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to search volumes")
@@ -568,21 +596,4 @@ func volumeMatches(item volume.Volume, identifierLower, original string) bool {
 		return true
 	}
 	return false
-}
-
-func filterVolumesByUsage(items []volume.Volume, inUseOnly, unusedOnly bool) []volume.Volume {
-	if !inUseOnly && !unusedOnly {
-		return items
-	}
-	filtered := make([]volume.Volume, 0, len(items))
-	for _, item := range items {
-		if inUseOnly && !item.InUse {
-			continue
-		}
-		if unusedOnly && item.InUse {
-			continue
-		}
-		filtered = append(filtered, item)
-	}
-	return filtered
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -378,12 +378,14 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
+github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
 github.com/ClickHouse/clickhouse-go v1.4.3 h1:iAFMa2UrQdR5bHJ2/yaSLffZkxpcOYQMCUuKeNXGdqc=
 github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/ClickHouse/clickhouse-go/v2 v2.45.0 h1:iHt15nA4iYhfde5bDQAcLAat9BAh7B5ksPRNRa4UI7s=
 github.com/ClickHouse/clickhouse-go/v2 v2.45.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0 h1:s3eRy+hYmu5uzotB6ZhDofgHu8kDgGN/fpmjxRkqSpk=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 h1:2afWGsMzkIcN8Qm4mgPJKZWyroE5QBszMiDMYEBrnfw=
@@ -469,6 +471,7 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9 h1:goHVqTbFX3AIo0tzGr14pgfAW2ZfPChKO21Z9MGf/gk=
@@ -772,6 +775,7 @@ github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcK
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/compose-spec/compose-go/v2 v2.9.1/go.mod h1:Oky9AZGTRB4E+0VbTPZTUu4Kp+oEMMuwZXZtPPVT1iE=
@@ -936,6 +940,7 @@ github.com/eggsampler/acme/v3 v3.6.2 h1:gvyZbQ92wNQLDASVftGpHEdFwPSfg0+17P0lLt09
 github.com/eggsampler/acme/v3 v3.6.2/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/elastic/go-sysinfo v1.15.4 h1:A3zQcunCxik14MgXu39cXFXcIw2sFXZ0zL886eyiv1Q=
 github.com/elastic/go-sysinfo v1.15.4/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
+github.com/elastic/go-sysinfo v1.15.5/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
 github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
@@ -1719,6 +1724,7 @@ github.com/pierrec/lz4/v4 v4.1.16 h1:kQPfno+wyx6C5572ABwV+Uo3pDFzQ7yhyGchSyRda0c
 github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
@@ -1942,6 +1948,7 @@ github.com/transparency-dev/tessera v1.0.2 h1:PNfGPFfJHpCFVswlrsQvRghxqYz2xy/OtP
 github.com/transparency-dev/tessera v1.0.2/go.mod h1:WD/EMM6RXWRyImk9yyJ2hrs8xdknN/lpwUrFR2GemfU=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc h1:lzi/5fg2EfinRlh3v//YyIhnc4tY7BTqazQGwb1ar+0=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
@@ -1987,6 +1994,7 @@ github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7r
 github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/vertica/vertica-sql-go v1.3.6 h1:uDJPdBivsI5EwfX3NMDWZaQlVs9zTnVyxE/nYhr3bY0=
 github.com/vertica/vertica-sql-go v1.3.6/go.mod h1:jnn2GFuv+O2Jcjktb7zyc4Utlbu9YVqpHH/lx63+1M4=
+github.com/vertica/vertica-sql-go v1.3.8/go.mod h1:c4OZ8lq1Ztc18w8a0nG+dzQh69BzJRcKN2LZOnYbERI=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
@@ -2035,6 +2043,7 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.135.0 h1:8c/M2B5W5xJd968DCedPv7DvQHuKzz
 github.com/ydb-platform/ydb-go-sdk/v3 v3.135.0/go.mod h1:VYUUkRJkKuQPkIpgtZJj6+58Fa2g8ccAqdmaaK6HP5k=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.141.1 h1:PrYjW94P31ue55DKsHdAZRaHY7owKBOSr31p5qISoZM=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.141.1/go.mod h1:b9NEO6mgaiqsnOMkS003uS82XsKh6GL+ZTFfPqXWz+c=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.144.6/go.mod h1:b9NEO6mgaiqsnOMkS003uS82XsKh6GL+ZTFfPqXWz+c=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/ysmood/fetchup v0.2.3 h1:ulX+SonA0Vma5zUFXtv52Kzip/xe7aj4vqT5AJwQ+ZQ=
@@ -2452,6 +2461,7 @@ golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 h1:FjUup8XrRy7lv+XHONi
 golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 h1:nwGZBCt+FnXUrGsj5vjzAsEmkcaFvd82BbOjECiFYZc=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
+golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns CLI commands with current backend API contracts.
- Centralizes pagination, including `--all` support through `limit=-1`, and adds server-side list filters.
- Corrects endpoint paths, request bodies, response decoding, and JSON output preservation across CLI resources.
- Adds missing command options for container deletion, project destruction, GitOps browsing, and related operations.
- Improves byte-size formatting and terminal table truncation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The reviewed endpoint, pagination, destructive-operation, and response-decoding changes match the corresponding backend contracts, and no reachable regression remained after examining their handlers and service semantics.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof and confirmed that the two CLI-pagination runs captured the exact experiment command, working directory, exit code, and full panic stack.
- Compared the before and after logs and confirmed that neither run reached an application test, HTTP request, or assertion.
- Noted a compile/setup blocker reported in the before-run log that prevented advancing to the application tests.

<a href="https://app.greptile.com/trex/runs/15937348/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): align commands with backend AP..."](https://github.com/getarcaneapp/arcane/commit/98fe064cb657a22ec7fe4dbf0776eafa263b9416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47399050)</sub>

<!-- /greptile_comment -->