### PR TITLE
fix: resolve relative compose paths that escape the projects mount

### DIFF
--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -200,17 +200,24 @@ func LoadComposeProjectFromContent(ctx context.Context, opts projecttypes.Compos
 		Environment: composetypes.Mapping(envMap),
 	}
 
-	project, err = loader.LoadWithContext(ctx, configDetails, func(loaderOpts *loader.Options) {
+	loaderOptions := []func(*loader.Options){func(loaderOpts *loader.Options) {
 		if projectName := strings.TrimSpace(opts.ProjectName); projectName != "" {
 			loaderOpts.SetProjectName(projectName, true)
 		}
 		loader.WithDiscardEnvFiles(loaderOpts)
-	})
+	}}
+
+	project, err = loader.LoadWithContext(ctx, configDetails, loaderOptions...)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to load compose project")
 	}
 
-	return finishLoadedProjectInternal(project, workingDir, opts.PathMapper, false)
+	var rawSources map[string]string
+	if !isNilVolumeSourcePathMapperInternal(opts.PathMapper) {
+		rawSources = harvestRawSourcesInternal(ctx, configDetails, loaderOptions...)
+	}
+
+	return finishLoadedProjectInternal(ctx, project, workingDir, opts.PathMapper, false, rawSources)
 }
 
 // wrapTypeCastMappingLenientInternal prepares the interp type-cast mapping for lenient
@@ -376,7 +383,7 @@ func loadComposeProjectInternal(
 		Environment: composetypes.Mapping(fullEnvMap),
 	}
 
-	project, err = loader.LoadWithContext(ctx, cfg, func(opts *loader.Options) {
+	loaderOptions := []func(*loader.Options){func(opts *loader.Options) {
 		if projectName != "" {
 			opts.SetProjectName(projectName, false)
 		}
@@ -389,7 +396,9 @@ func loadComposeProjectInternal(
 		if configureLoader != nil {
 			configureLoader(opts)
 		}
-	})
+	}}
+
+	project, err = loader.LoadWithContext(ctx, cfg, loaderOptions...)
 	if err != nil {
 		return nil, errors.WrapIf(err, "load compose project")
 	}
@@ -398,7 +407,12 @@ func loadComposeProjectInternal(
 		project.ComposeFiles = append(project.ComposeFiles, configFile.Filename)
 	}
 
-	project, err = finishLoadedProjectInternal(project, workdir, pathMapper, true)
+	var rawSources map[string]string
+	if !isNilVolumeSourcePathMapperInternal(pathMapper) {
+		rawSources = harvestRawSourcesInternal(ctx, cfg, loaderOptions...)
+	}
+
+	project, err = finishLoadedProjectInternal(ctx, project, workdir, pathMapper, true, rawSources)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +421,7 @@ func loadComposeProjectInternal(
 	return project, nil
 }
 
-func finishLoadedProjectInternal(project *composetypes.Project, workingDir string, pathMapper projecttypes.VolumeSourcePathMapper, translateFileResources bool) (*composetypes.Project, error) {
+func finishLoadedProjectInternal(ctx context.Context, project *composetypes.Project, workingDir string, pathMapper projecttypes.VolumeSourcePathMapper, translateFileResources bool, rawSources map[string]string) (*composetypes.Project, error) {
 	project = project.WithoutUnnecessaryResources()
 	ResolveRelativeProjectPaths(project, workingDir)
 
@@ -415,9 +429,72 @@ func finishLoadedProjectInternal(project *composetypes.Project, workingDir strin
 		if err := pathMapper.TranslateVolumeSources(project, translateFileResources); err != nil {
 			return nil, errors.WrapIf(err, "failed to translate paths for docker host")
 		}
+		RemapEscapedRelativeSources(ctx, pathMapper, project, workingDir, rawSources, translateFileResources)
 	}
 
 	return project, nil
+}
+
+// harvestRawSourcesInternal re-parses the same Compose input with path
+// resolution disabled, so the raw still-relative paths survive for
+// RemapEscapedRelativeSources. The resolved project on its own cannot tell a
+// relative path that escaped the projects mount from an intentionally absolute
+// one, and only the former may be re-resolved against the host directory.
+//
+// Best effort by design: any failure yields a nil map and the caller then
+// behaves exactly as it did before. Environment resolution is skipped because
+// env_file paths are left relative here and would otherwise be read against the
+// process working directory; label_file is read regardless, which is one of the
+// reasons this cannot be fatal.
+func harvestRawSourcesInternal(ctx context.Context, cfg composetypes.ConfigDetails, loaderOptions ...func(*loader.Options)) (rawSources map[string]string) {
+	defer func() {
+		if panicErr := emperror.Recover(recover()); panicErr != nil {
+			slog.DebugContext(ctx, "panic while harvesting raw compose paths", "error", panicErr)
+			rawSources = nil
+		}
+	}()
+
+	options := append(slices.Clone(loaderOptions), func(opts *loader.Options) {
+		opts.ResolvePaths = false
+		opts.SkipResolveEnvironment = true
+		opts.SkipValidation = true
+		opts.SkipConsistencyCheck = true
+	})
+
+	project, err := loader.LoadWithContext(ctx, cfg, options...)
+	if err != nil {
+		slog.DebugContext(ctx, "unable to harvest raw compose paths; relative paths outside the projects mount may resolve incorrectly", "error", err)
+		return nil
+	}
+
+	rawSources = make(map[string]string)
+	for name, service := range project.Services {
+		for _, volume := range service.Volumes {
+			if volume.Type == composetypes.VolumeTypeBind && volume.Source != "" {
+				rawSources[VolumeSourceKey(name, volume.Target)] = volume.Source
+			}
+		}
+	}
+
+	for name, volume := range project.Volumes {
+		if device, ok := bindVolumeDeviceInternal(volume); ok {
+			rawSources["volume_device:"+name] = device
+		}
+	}
+
+	for name, secret := range project.Secrets {
+		if secret.File != "" {
+			rawSources["secret:"+name] = secret.File
+		}
+	}
+
+	for name, config := range project.Configs {
+		if config.File != "" {
+			rawSources["config:"+name] = config.File
+		}
+	}
+
+	return rawSources
 }
 
 func isNilVolumeSourcePathMapperInternal(pathMapper projecttypes.VolumeSourcePathMapper) bool {

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -438,3 +438,44 @@ func TestResolveRelativeProjectPaths(t *testing.T) {
 	require.Len(t, service.Volumes, 1)
 	assert.Equal(t, filepath.Join(dir, "config.conf"), service.Volumes[0].Source)
 }
+
+// Reproduces the reported case where a relative bind path escaping the projects
+// mount resolved against Arcane's container path instead of the host path
+// `docker compose up` would use, while checking that in-mount relative paths and
+// intentionally absolute paths keep their current behavior.
+func TestLoadComposeProject_RemapsRelativeBindEscapingProjectsMount(t *testing.T) {
+	t.Parallel()
+
+	projectsRoot := t.TempDir()
+	projectDir := filepath.Join(projectsRoot, "goclaw")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	composePath := filepath.Join(projectDir, "compose.yaml")
+	require.NoError(t, os.WriteFile(composePath, []byte(`services:
+  goclaw:
+    image: nginx:alpine
+    volumes:
+      - ../../../../goclaw/data:/app/data
+      - ./data:/app/cache
+      - /mnt/nas/media:/media
+`), 0o600))
+
+	pathMapper := NewPathMapper(projectsRoot, "/docker/112/arcane/arcane-data/projects")
+	require.True(t, pathMapper.IsNonMatchingMount())
+
+	project, err := LoadComposeProject(context.Background(), composePath, "goclaw", projectsRoot, false, pathMapper)
+	require.NoError(t, err)
+
+	sources := make(map[string]string)
+	for _, volume := range project.Services["goclaw"].Volumes {
+		sources[volume.Target] = volume.Source
+	}
+
+	// Escapes the mount: must land where `docker compose up` in the host project
+	// directory would put it, not at the container-resolved "/goclaw/data".
+	assert.Equal(t, "/docker/112/goclaw/data", sources["/app/data"])
+	// Stays inside the mount: already correct today, must not change.
+	assert.Equal(t, "/docker/112/arcane/arcane-data/projects/goclaw/data", sources["/app/cache"])
+	// Absolute host path: must be passed through untouched.
+	assert.Equal(t, "/mnt/nas/media", sources["/media"])
+}

--- a/backend/pkg/projects/path_mapper.go
+++ b/backend/pkg/projects/path_mapper.go
@@ -3,11 +3,13 @@ package projects
 import (
 	"context"
 	"log/slog"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"emperror.dev/errors"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	projecttypes "github.com/getarcaneapp/arcane/backend/v2/pkg/projects/types"
 	"github.com/moby/moby/client"
 	"github.com/samber/mo"
 )
@@ -137,19 +139,35 @@ func ResolveHostPath(mounts []HostMount, containerPath string) mo.Option[string]
 
 	host := bestSource
 	if bestRel != "." {
-		// Mirror the separator handling used for Windows hosts: keep backslashes when the
-		// host source is a Windows drive path, otherwise use forward slashes.
-		separator := "/"
-		if IsWindowsDrivePath(host) && strings.Contains(host, "\\") {
-			separator = "\\"
-			bestRel = strings.ReplaceAll(bestRel, "/", "\\")
-		}
-		if !strings.HasSuffix(host, separator) {
-			host += separator
-		}
-		host += bestRel
+		host = joinHostRelativePathInternal(host, bestRel)
 	}
 	return mo.Some(host)
+}
+
+// joinHostRelativePathInternal joins rel onto a host base path and cleans the
+// result. A Windows drive prefix is held aside while cleaning so that ".."
+// segments cannot consume it, and the base's separator style is preserved:
+// backslashes are kept for a Windows drive path written with them, forward
+// slashes otherwise (Docker on Windows accepts forward slashes fine).
+func joinHostRelativePathInternal(base, rel string) string {
+	rel = strings.ReplaceAll(rel, "\\", "/")
+	if rel == "" || rel == "." {
+		return base
+	}
+
+	useBackslash := IsWindowsDrivePath(base) && strings.Contains(base, "\\")
+	normalized := strings.ReplaceAll(base, "\\", "/")
+
+	drive := ""
+	if IsWindowsDrivePath(normalized) {
+		drive, normalized = normalized[:2], normalized[2:]
+	}
+
+	joined := drive + path.Join(normalized, rel)
+	if useBackslash {
+		joined = strings.ReplaceAll(joined, "/", "\\")
+	}
+	return joined
 }
 
 // ContainerToHost translates a container path to host path
@@ -250,19 +268,233 @@ func (pm *PathMapper) TranslateVolumeSources(project *composetypes.Project, tran
 		}
 	}
 
+	// Translate bind-backed named volumes. The Docker daemon, not Arcane, opens
+	// the device path, so it needs the same translation as a bind mount source.
+	for name, volume := range project.Volumes {
+		device, ok := bindVolumeDeviceInternal(volume)
+		// Only absolute devices can be translated. compose-go absolutizes a
+		// relative device only when `o` is exactly "bind", so one that is still
+		// relative here keeps its existing behavior instead of failing the load.
+		if !ok || (!filepath.IsAbs(device) && !IsWindowsDrivePath(device)) {
+			continue
+		}
+
+		hostPath, err := pm.ContainerToHost(device)
+		if err != nil {
+			return errors.WrapIff(err, "failed to translate volume device %q", device)
+		}
+		volume.DriverOpts["device"] = hostPath
+		project.Volumes[name] = volume
+	}
+
 	return nil
+}
+
+// bindVolumeDeviceInternal returns the device path of a bind-backed named volume
+// (local driver with `o: bind`), which compose-go resolves against the working
+// directory just like a bind mount source.
+//
+// The check is deliberately looser than compose-go's: an empty driver counts as
+// local because that is how Docker defaults it, and `o` only has to contain
+// "bind" rather than equal it, since a device is a host path whether or not
+// compose-go chose to resolve it.
+func bindVolumeDeviceInternal(volume composetypes.VolumeConfig) (string, bool) {
+	if volume.Driver != "" && volume.Driver != "local" {
+		return "", false
+	}
+	if !strings.Contains(volume.DriverOpts["o"], "bind") {
+		return "", false
+	}
+
+	device := strings.TrimSpace(volume.DriverOpts["device"])
+	return device, device != ""
 }
 
 func (pm *PathMapper) IsNonMatchingMount() bool {
 	return pm.isNonMatching
 }
 
-// IsWindowsDrivePath returns true if the path looks like a Windows drive path (e.g., "C:/path")
-func IsWindowsDrivePath(path string) bool {
-	if len(path) < 3 {
+// VolumeSourceKey identifies a service bind mount across two loads of the same
+// Compose input. Bind targets are unique per service, so the target is a stable
+// key even though the source is exactly what differs between the loads.
+func VolumeSourceKey(service, target string) string {
+	return "volume:" + service + "\x00" + filepath.Clean(target)
+}
+
+// RemapEscapedRelativeSources rewrites daemon-side paths that compose-go
+// resolved against the container-side project directory but that
+// TranslateVolumeSources could not map, because they escaped every mounted
+// directory.
+//
+// compose-go absolutizes relative paths against ConfigDetails.WorkingDir, which
+// for Arcane is a container path. A source like `../../data` can therefore land
+// outside the projects mount, where prefix translation has nothing to match and
+// leaves the path untouched — so the daemon creates it at the wrong place on the
+// host, unlike `docker compose up` run in the project directory. Relativity is
+// not recoverable from the resolved path (an intentionally absolute source is an
+// identical string by then), so the raw pre-resolution paths are passed in as
+// rawSources, keyed by VolumeSourceKey and by "<kind>:<name>".
+//
+// Anything TranslateVolumeSources already rewrote is left alone, so nested
+// independently-bind-mounted directories keep resolving through the mount table.
+func RemapEscapedRelativeSources(
+	ctx context.Context,
+	pathMapper projecttypes.VolumeSourcePathMapper,
+	project *composetypes.Project,
+	containerWorkingDir string,
+	rawSources map[string]string,
+	includeFileResources bool,
+) {
+	if project == nil || pathMapper == nil || len(rawSources) == 0 || containerWorkingDir == "" {
+		return
+	}
+
+	hostWorkingDir := "" // resolved on first use, so a project with nothing to remap logs nothing
+	for _, target := range remapTargetsInternal(project, includeFileResources) {
+		// A missing key yields "", which is not remappable, so absent raw sources
+		// fall out here along with absolute ones.
+		rawSource := rawSources[target.key]
+		if !isRemappableSourceInternal(rawSource) {
+			continue
+		}
+		if target.current != filepath.Clean(filepath.Join(containerWorkingDir, rawSource)) {
+			continue // already translated through the mount table
+		}
+
+		if hostWorkingDir == "" {
+			resolved, ok := hostWorkingDirInternal(ctx, pathMapper, containerWorkingDir)
+			if !ok {
+				return // without a host project directory nothing can be anchored
+			}
+			hostWorkingDir = resolved
+		}
+
+		hostPath := joinHostRelativePathInternal(hostWorkingDir, rawSource)
+		target.apply(hostPath)
+		slog.WarnContext(ctx,
+			"compose relative path resolves outside the mounted projects directory; remapped so the Docker host resolves it the same way `docker compose up` would",
+			"kind", target.kind, "name", target.name, "spec", rawSource,
+			"container_path", target.current, "host_path", hostPath,
+		)
+	}
+}
+
+// remapTarget is one daemon-side path that may need re-resolving, paired with how
+// to write the new value back into the project.
+type remapTarget struct {
+	kind    string
+	name    string
+	key     string
+	current string
+	apply   func(hostPath string)
+}
+
+// remapTargetsInternal collects every daemon-side path in the project, so that
+// deciding which ones to rewrite stays a single flat pass. File-backed secrets
+// and configs are included only when the Docker host, rather than Arcane itself,
+// reads them — matching TranslateVolumeSources.
+func remapTargetsInternal(project *composetypes.Project, includeFileResources bool) []remapTarget {
+	var targets []remapTarget
+
+	for name, service := range project.Services {
+		for i := range service.Volumes {
+			// Mutating through the pointer is enough: the slice shares its backing
+			// array with the ServiceConfig held in project.Services.
+			volume := &service.Volumes[i]
+			if volume.Type != composetypes.VolumeTypeBind {
+				continue
+			}
+			targets = append(targets, remapTarget{
+				kind:    "service_volume",
+				name:    name,
+				key:     VolumeSourceKey(name, volume.Target),
+				current: volume.Source,
+				apply:   func(hostPath string) { volume.Source = hostPath },
+			})
+		}
+	}
+
+	for name, volume := range project.Volumes {
+		device, ok := bindVolumeDeviceInternal(volume)
+		if !ok {
+			continue
+		}
+		targets = append(targets, remapTarget{
+			kind:    "volume_device",
+			name:    name,
+			key:     "volume_device:" + name,
+			current: device,
+			apply:   func(hostPath string) { volume.DriverOpts["device"] = hostPath },
+		})
+	}
+
+	if !includeFileResources {
+		return targets
+	}
+
+	for name, secret := range project.Secrets {
+		targets = append(targets, remapTarget{
+			kind:    "secret",
+			name:    name,
+			key:     "secret:" + name,
+			current: secret.File,
+			apply:   func(hostPath string) { secret.File = hostPath; project.Secrets[name] = secret },
+		})
+	}
+
+	for name, config := range project.Configs {
+		targets = append(targets, remapTarget{
+			kind:    "config",
+			name:    name,
+			key:     "config:" + name,
+			current: config.File,
+			apply:   func(hostPath string) { config.File = hostPath; project.Configs[name] = config },
+		})
+	}
+
+	return targets
+}
+
+// isRemappableSourceInternal reports whether a raw Compose path can be
+// re-resolved against a different working directory. Absolute paths (including
+// Windows drive and UNC paths, which compose-go also leaves alone) are already
+// meaningful to the Docker host, and `~` expands against the container's home
+// directory, which has no host equivalent — all keep their current behavior.
+func isRemappableSourceInternal(rawSource string) bool {
+	rawSource = strings.TrimSpace(rawSource)
+	if rawSource == "" || strings.HasPrefix(rawSource, "~") || strings.HasPrefix(rawSource, `\\`) {
 		return false
 	}
-	return ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) &&
-		path[1] == ':' &&
-		(path[2] == '/' || path[2] == '\\')
+	return !filepath.IsAbs(rawSource) && !IsWindowsDrivePath(rawSource)
+}
+
+// hostWorkingDirInternal resolves the host-side project directory that relative
+// paths must be re-resolved against. It reports false when the project directory
+// itself is not inside a mounted directory, since there is then no host path to
+// anchor to.
+func hostWorkingDirInternal(ctx context.Context, pathMapper projecttypes.VolumeSourcePathMapper, containerWorkingDir string) (string, bool) {
+	hostWorkingDir, err := pathMapper.ContainerToHost(containerWorkingDir)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve host path for project directory; relative paths outside the projects mount may resolve incorrectly",
+			"working_dir", containerWorkingDir, "error", err)
+		return "", false
+	}
+
+	if hostWorkingDir == "" || filepath.Clean(hostWorkingDir) == filepath.Clean(containerWorkingDir) {
+		slog.WarnContext(ctx, "project directory is not inside a mounted directory; relative paths outside the projects mount may resolve incorrectly",
+			"working_dir", containerWorkingDir)
+		return "", false
+	}
+
+	return hostWorkingDir, true
+}
+
+// IsWindowsDrivePath returns true if the path looks like a Windows drive path (e.g., "C:/path")
+func IsWindowsDrivePath(candidate string) bool {
+	if len(candidate) < 3 {
+		return false
+	}
+	return ((candidate[0] >= 'a' && candidate[0] <= 'z') || (candidate[0] >= 'A' && candidate[0] <= 'Z')) &&
+		candidate[1] == ':' &&
+		(candidate[2] == '/' || candidate[2] == '\\')
 }

--- a/backend/pkg/projects/path_mapper_test.go
+++ b/backend/pkg/projects/path_mapper_test.go
@@ -166,3 +166,68 @@ func TestPathMapper_TranslateVolumeSourcesKeepsArcaneReadFiles(t *testing.T) {
 	assert.Equal(t, "/app/data/swarm/sources/0/stack/secret.txt", project.Secrets["secret"].File)
 	assert.Equal(t, "/app/data/swarm/sources/0/stack/config.yaml", project.Configs["config"].File)
 }
+
+// A bind-backed named volume's device is opened by the Docker daemon, so it needs
+// the same container->host translation as a bind mount source.
+func TestPathMapper_TranslateVolumeSourcesDriverOptsDevice(t *testing.T) {
+	pm := NewPathMapper("/app/data/projects", "/host/arcane-data/projects")
+	project := &composetypes.Project{
+		Volumes: composetypes.Volumes{
+			"bind-backed": {
+				Driver:     "local",
+				DriverOpts: composetypes.Options{"type": "none", "o": "bind", "device": "/app/data/projects/myproj/data"},
+			},
+			"nfs-backed": {
+				Driver:     "local",
+				DriverOpts: composetypes.Options{"type": "nfs", "o": "addr=10.0.0.1,rw", "device": ":/exported/path"},
+			},
+			// compose-go only absolutizes a device when `o` is exactly "bind", so this
+			// one stays relative and must be left alone rather than failing the load.
+			"unresolved-bind": {
+				Driver:     "local",
+				DriverOpts: composetypes.Options{"type": "none", "o": "bind,ro", "device": "data"},
+			},
+			"plain": {},
+		},
+	}
+
+	require.NoError(t, pm.TranslateVolumeSources(project, true))
+	assert.Equal(t, "/host/arcane-data/projects/myproj/data", project.Volumes["bind-backed"].DriverOpts["device"])
+	assert.Equal(t, ":/exported/path", project.Volumes["nfs-backed"].DriverOpts["device"])
+	assert.Equal(t, "data", project.Volumes["unresolved-bind"].DriverOpts["device"])
+}
+
+// The mount table must keep winning for relative paths that stay inside a nested
+// independently-bind-mounted directory; only paths it cannot resolve fall back to
+// being re-resolved against the host project directory.
+func TestRemapEscapedRelativeSources_MountTableTakesPrecedence(t *testing.T) {
+	pm := NewPathMapperFromMounts([]HostMount{
+		{Destination: "/app/data", Source: "/docker/112/arcane/arcane-data"},
+		{Destination: "/app/data/projects/goclaw/media", Source: "/mnt/media"},
+	})
+	require.True(t, pm.IsNonMatchingMount())
+
+	containerWorkingDir := "/app/data/projects/goclaw"
+	project := &composetypes.Project{
+		Services: composetypes.Services{
+			"goclaw": {
+				Name: "goclaw",
+				Volumes: []composetypes.ServiceVolumeConfig{
+					{Type: composetypes.VolumeTypeBind, Source: "/app/data/projects/goclaw/media", Target: "/media"},
+					{Type: composetypes.VolumeTypeBind, Source: "/goclaw/data", Target: "/app/data"},
+				},
+			},
+		},
+	}
+	rawSources := map[string]string{
+		VolumeSourceKey("goclaw", "/media"):    "./media",
+		VolumeSourceKey("goclaw", "/app/data"): "../../../../goclaw/data",
+	}
+
+	require.NoError(t, pm.TranslateVolumeSources(project, true))
+	RemapEscapedRelativeSources(context.Background(), pm, project, containerWorkingDir, rawSources, true)
+
+	volumes := project.Services["goclaw"].Volumes
+	assert.Equal(t, "/mnt/media", volumes[0].Source, "nested independent mount must win over the host project directory")
+	assert.Equal(t, "/docker/112/goclaw/data", volumes[1].Source)
+}

--- a/backend/pkg/projects/types/compose_content.go
+++ b/backend/pkg/projects/types/compose_content.go
@@ -7,6 +7,11 @@ import (
 // VolumeSourcePathMapper translates Compose volume sources for the Docker host.
 type VolumeSourcePathMapper interface {
 	TranslateVolumeSources(project *composetypes.Project, translateFileResources bool) error
+	// ContainerToHost translates a single container-side path to its host-side
+	// equivalent, returning the path unchanged when it is outside every mounted
+	// directory. Needed to re-resolve relative Compose paths that escape the
+	// projects mount, where prefix translation has nothing to match.
+	ContainerToHost(containerPath string) (string, error)
 }
 
 // ComposeContentOptions configures loading a Compose project from in-memory content.

--- a/go.work.sum
+++ b/go.work.sum
@@ -378,6 +378,7 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
+github.com/ClickHouse/ch-go v0.73.0 h1:jsHiGRbQ3sz+gekvDFJF29LWDo5dzbJm5s1h8TWVP2M=
 github.com/ClickHouse/ch-go v0.73.0/go.mod h1:wkFIxrqlXeRJ9cn3r5Fz5Qen9jl5aTMPuGZeuJpANNY=
 github.com/ClickHouse/clickhouse-go v1.4.3 h1:iAFMa2UrQdR5bHJ2/yaSLffZkxpcOYQMCUuKeNXGdqc=
 github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
@@ -385,6 +386,7 @@ github.com/ClickHouse/clickhouse-go/v2 v2.45.0 h1:iHt15nA4iYhfde5bDQAcLAat9BAh7B
 github.com/ClickHouse/clickhouse-go/v2 v2.45.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0 h1:s3eRy+hYmu5uzotB6ZhDofgHu8kDgGN/fpmjxRkqSpk=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
+github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4SVRLC77BR7Z5Q=
 github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
@@ -471,6 +473,7 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -775,6 +778,7 @@ github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcK
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
@@ -940,6 +944,7 @@ github.com/eggsampler/acme/v3 v3.6.2 h1:gvyZbQ92wNQLDASVftGpHEdFwPSfg0+17P0lLt09
 github.com/eggsampler/acme/v3 v3.6.2/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK53r226Fhuo=
 github.com/elastic/go-sysinfo v1.15.4 h1:A3zQcunCxik14MgXu39cXFXcIw2sFXZ0zL886eyiv1Q=
 github.com/elastic/go-sysinfo v1.15.4/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
+github.com/elastic/go-sysinfo v1.15.5 h1:fCVUDmjHgljLUQCygherMnsRRJ9AkuAQIywTL7dEH28=
 github.com/elastic/go-sysinfo v1.15.5/go.mod h1:ZBVXmqS368dOn/jvijV/zHLfakWTYHBZPk3G244lHrU=
 github.com/elastic/go-windows v1.0.2 h1:yoLLsAsV5cfg9FLhZ9EXZ2n2sQFKeDYrHenkcivY4vI=
 github.com/elastic/go-windows v1.0.2/go.mod h1:bGcDpBzXgYSqM0Gx3DM4+UxFj300SZLixie9u9ixLM8=
@@ -1724,6 +1729,7 @@ github.com/pierrec/lz4/v4 v4.1.16 h1:kQPfno+wyx6C5572ABwV+Uo3pDFzQ7yhyGchSyRda0c
 github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk=
 github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
@@ -1948,6 +1954,7 @@ github.com/transparency-dev/tessera v1.0.2 h1:PNfGPFfJHpCFVswlrsQvRghxqYz2xy/OtP
 github.com/transparency-dev/tessera v1.0.2/go.mod h1:WD/EMM6RXWRyImk9yyJ2hrs8xdknN/lpwUrFR2GemfU=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc h1:lzi/5fg2EfinRlh3v//YyIhnc4tY7BTqazQGwb1ar+0=
 github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60 h1:TfQEwhr0Q9t+Bgs0TNk2eHZ9EGD107Mimic0kcoGS1M=
 github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
@@ -1994,6 +2001,7 @@ github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7r
 github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/vertica/vertica-sql-go v1.3.6 h1:uDJPdBivsI5EwfX3NMDWZaQlVs9zTnVyxE/nYhr3bY0=
 github.com/vertica/vertica-sql-go v1.3.6/go.mod h1:jnn2GFuv+O2Jcjktb7zyc4Utlbu9YVqpHH/lx63+1M4=
+github.com/vertica/vertica-sql-go v1.3.8 h1:FomjkM3cam9yE6zSic31flNWPLdsZbYGK9ihlLtbF1Y=
 github.com/vertica/vertica-sql-go v1.3.8/go.mod h1:c4OZ8lq1Ztc18w8a0nG+dzQh69BzJRcKN2LZOnYbERI=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
@@ -2043,6 +2051,7 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.135.0 h1:8c/M2B5W5xJd968DCedPv7DvQHuKzz
 github.com/ydb-platform/ydb-go-sdk/v3 v3.135.0/go.mod h1:VYUUkRJkKuQPkIpgtZJj6+58Fa2g8ccAqdmaaK6HP5k=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.141.1 h1:PrYjW94P31ue55DKsHdAZRaHY7owKBOSr31p5qISoZM=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.141.1/go.mod h1:b9NEO6mgaiqsnOMkS003uS82XsKh6GL+ZTFfPqXWz+c=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.144.6 h1:XWx3dStuZHEvEHAFzvNIbFYJUw7EayHnNUUx+YKAKxw=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.144.6/go.mod h1:b9NEO6mgaiqsnOMkS003uS82XsKh6GL+ZTFfPqXWz+c=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
@@ -2274,6 +2283,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1wZsLRnSNimn2Sp/NPsCrsv8ak=
+golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
 golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
@@ -2461,6 +2471,7 @@ golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 h1:FjUup8XrRy7lv+XHONi
 golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 h1:nwGZBCt+FnXUrGsj5vjzAsEmkcaFvd82BbOjECiFYZc=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
+golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 h1:RJhm5l6Fo4rmEIcndxDllNhhf/fAx8qIm4t6A7vpm2A=
 golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3372

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes host resolution for relative Compose paths that escape the projects mount.
- Re-parses Compose input without path resolution to retain raw relative sources.
- Remaps escaped bind mounts, bind-backed named volumes, secrets, and configs against the host project directory.
- Extends path-mapper behavior and adds regression coverage for escaped and nested-mounted paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Remapping is limited to sources proven relative by the second Compose load, preserves paths already translated through the mount table, and falls back to the previous behavior if raw-source harvesting fails.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reviewed the general contract validation proof for the escaped-compose-path scenario to understand the expected run captures.
- I inspected the before log and confirmed it captures the normal focused command and the build-constraint failure (exit 1).
- I inspected the after log and confirmed it captures the Go version/environment and the GOEXPERIMENT=jsonv2 FIPS panic (exit 2).
- I checked the combined log and confirmed it contains both complete attempts as requested.

<a href="https://app.greptile.com/trex/runs/15954587/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve relative compose paths that..."](https://github.com/getarcaneapp/arcane/commit/ebe791592fbca307c9ece3c0228f4c5ab8ca1cff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47435429)</sub>

<!-- /greptile_comment -->