### PR TITLE
fix: honor updater opt-out labels during image scans

### DIFF
--- a/backend/internal/services/image_update_service.go
+++ b/backend/internal/services/image_update_service.go
@@ -23,11 +23,13 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	"github.com/getarcaneapp/arcane/types/v2/imageupdate"
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	"github.com/samber/mo"
 	"go.getarcane.app/sys/crypto"
 	"go.getarcane.app/updater/digest"
+	"go.getarcane.app/updater/labels"
 	"go.getarcane.app/updater/refs"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
@@ -616,35 +618,124 @@ func (s *ImageUpdateService) getAllImageRefsInternal(ctx context.Context, limit 
 		return nil, err
 	}
 
-	apiCtx, cancel := s.dockerAPIContextInternal(ctx)
-	defer cancel()
-
-	imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{})
+	imageCtx, cancelImage := s.dockerAPIContextInternal(ctx)
+	imageList, err := dockerClient.ImageList(imageCtx, client.ImageListOptions{})
+	cancelImage()
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to list Docker images")
 	}
 
-	return dedupeImageRefsFromSummariesInternal(imageList.Items, limit), nil
+	containerCtx, cancelContainers := s.dockerAPIContextInternal(ctx)
+	containerList, err := dockerClient.ContainerList(containerCtx, client.ContainerListOptions{All: true})
+	cancelContainers()
+	if err != nil {
+		slog.WarnContext(ctx, "failed to list Docker containers; continuing without updater opt-out filtering", "error", err.Error())
+		return imageRefsFromSummariesInternal(imageList.Items, limit), nil
+	}
+
+	return filterImageSummariesByContainerOptOutInternal(imageList.Items, containerList.Items, limit), nil
 }
 
-func dedupeImageRefsFromSummariesInternal(images []image.Summary, limit int) []string {
+func imageRefsFromSummariesInternal(images []image.Summary, limit int) []string {
 	seen := make(map[string]struct{})
-	var imageRefs []string
-	for _, img := range images {
-		for _, tag := range img.RepoTags {
-			if tag != "<none>:<none>" {
-				if _, exists := seen[tag]; exists {
-					continue
-				}
-				seen[tag] = struct{}{}
-				imageRefs = append(imageRefs, tag)
+	imageRefs := make([]string, 0)
+
+	for _, summary := range images {
+		for _, imageRef := range summary.RepoTags {
+			if imageRef == "<none>:<none>" {
+				continue
 			}
+			if _, exists := seen[imageRef]; exists {
+				continue
+			}
+
+			seen[imageRef] = struct{}{}
+			imageRefs = append(imageRefs, imageRef)
 			if limit > 0 && len(imageRefs) >= limit {
-				return imageRefs[:limit]
+				return imageRefs
 			}
 		}
 	}
+
 	return imageRefs
+}
+
+type imageContainerUsageInternal struct {
+	optedOut bool
+	eligible bool
+}
+
+func filterImageSummariesByContainerOptOutInternal(images []image.Summary, containers []container.Summary, limit int) []string {
+	usageByImageID := make(map[string]imageContainerUsageInternal)
+	usageByRef := make(map[string]imageContainerUsageInternal)
+
+	for _, summary := range containers {
+		disabled := labels.IsUpdateDisabled(summary.Labels)
+		usage := imageContainerUsageInternal{
+			optedOut: disabled,
+			eligible: !disabled,
+		}
+
+		if imageID := strings.TrimSpace(summary.ImageID); imageID != "" {
+			usageByImageID[imageID] = mergeImageContainerUsageInternal(usageByImageID[imageID], usage)
+		}
+
+		imageRef := strings.TrimSpace(summary.Image)
+		if imageRef == "" || refs.IsImageIDLikeReference(imageRef) {
+			continue
+		}
+
+		normalizedRef := refs.NormalizeImageUpdateRef(imageRef)
+		if normalizedRef == "" {
+			continue
+		}
+
+		usageByRef[normalizedRef] = mergeImageContainerUsageInternal(usageByRef[normalizedRef], usage)
+	}
+
+	seen := make(map[string]struct{})
+	filtered := make([]string, 0)
+
+	for _, summary := range images {
+		imageUsage, hasImageUsage := usageByImageID[strings.TrimSpace(summary.ID)]
+
+		for _, imageRef := range summary.RepoTags {
+			if imageRef == "<none>:<none>" {
+				continue
+			}
+			if _, exists := seen[imageRef]; exists {
+				continue
+			}
+
+			usage := imageUsage
+			hasUsage := hasImageUsage
+
+			normalizedRef := refs.NormalizeImageUpdateRef(imageRef)
+			if refUsage, hasRefUsage := usageByRef[normalizedRef]; hasRefUsage {
+				usage = mergeImageContainerUsageInternal(usage, refUsage)
+				hasUsage = true
+			}
+
+			if hasUsage && usage.optedOut && !usage.eligible {
+				continue
+			}
+
+			seen[imageRef] = struct{}{}
+			filtered = append(filtered, imageRef)
+			if limit > 0 && len(filtered) >= limit {
+				return filtered
+			}
+		}
+	}
+
+	return filtered
+}
+
+func mergeImageContainerUsageInternal(current, next imageContainerUsageInternal) imageContainerUsageInternal {
+	return imageContainerUsageInternal{
+		optedOut: current.optedOut || next.optedOut,
+		eligible: current.eligible || next.eligible,
+	}
 }
 
 func (s *ImageUpdateService) inspectLocalImageSnapshotInternal(ctx context.Context, imageRef string, composeBuildRefs map[string]struct{}) (*localImageSnapshot, error) {

--- a/backend/internal/services/image_update_service_test.go
+++ b/backend/internal/services/image_update_service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.getarcane.app/updater/labels"
 	"gorm.io/gorm"
 )
 
@@ -1729,20 +1730,6 @@ func TestImageUpdateService_ParseAndGroupImages_DedupesNormalizedRefs(t *testing
 			containsAll(firstRefSet, "redis:7", "docker.io/library/redis:7")))
 }
 
-func TestDedupeImageRefsFromSummaries_WithLimit(t *testing.T) {
-	summaries := []dockertypesimage.Summary{
-		{RepoTags: []string{"nginx:latest", "nginx:latest", "<none>:<none>"}},
-		{RepoTags: []string{"redis:7", "docker.io/library/nginx:latest"}},
-		{RepoTags: []string{"postgres:16"}},
-	}
-
-	refsNoLimit := dedupeImageRefsFromSummariesInternal(summaries, 0)
-	assert.Equal(t, []string{"nginx:latest", "redis:7", "docker.io/library/nginx:latest", "postgres:16"}, refsNoLimit)
-
-	refsLimited := dedupeImageRefsFromSummariesInternal(summaries, 2)
-	assert.Equal(t, []string{"nginx:latest", "redis:7"}, refsLimited)
-}
-
 func newImageUpdateTestSettingsServiceInternal(registryTimeout, dockerAPITimeout string) *SettingsService {
 	settingsService := &SettingsService{}
 	cfg := DefaultSettingsConfig()
@@ -1773,4 +1760,345 @@ func containsAll(set map[string]struct{}, refs ...string) bool {
 		}
 	}
 	return true
+}
+
+func newImageUpdateDiscoveryServerInternal(
+	t *testing.T,
+	images []dockertypesimage.Summary,
+	containers []dockertypescontainer.Summary,
+) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/images/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(images))
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(containers))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestImageUpdateService_GetAllImageRefsHonorsExclusiveContainerOptOutInternal(t *testing.T) {
+	const (
+		disabledRef = "local/disabled:latest"
+		enabledRef  = "local/enabled:latest"
+		sharedRef   = "local/shared:latest"
+		unusedRef   = "local/unused:latest"
+	)
+
+	images := []dockertypesimage.Summary{
+		{ID: "sha256:disabled", RepoTags: []string{disabledRef}},
+		{ID: "sha256:enabled", RepoTags: []string{enabledRef}},
+		{ID: "sha256:shared", RepoTags: []string{sharedRef}},
+		{ID: "sha256:unused", RepoTags: []string{unusedRef}},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:     "disabled-container",
+			Image:  disabledRef,
+			Labels: map[string]string{labels.LabelUpdater: "false"},
+		},
+		{
+			ID:    "enabled-container",
+			Image: enabledRef,
+		},
+		{
+			ID:     "shared-disabled-container",
+			Image:  sharedRef,
+			Labels: map[string]string{labels.LabelUpdater: "off"},
+		},
+		{
+			ID:    "shared-enabled-container",
+			Image: sharedRef,
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.NotContains(t, got, disabledRef)
+	assert.Contains(t, got, enabledRef)
+	assert.Contains(t, got, sharedRef)
+	assert.Contains(t, got, unusedRef)
+}
+
+func TestImageUpdateService_GetAllImageRefsAppliesLimitAfterOptOutFilteringInternal(t *testing.T) {
+	const (
+		disabledRef = "local/disabled:latest"
+		enabledRef  = "local/enabled:latest"
+		unusedRef   = "local/unused:latest"
+	)
+
+	images := []dockertypesimage.Summary{
+		{ID: "sha256:disabled", RepoTags: []string{disabledRef}},
+		{ID: "sha256:enabled", RepoTags: []string{enabledRef}},
+		{ID: "sha256:unused", RepoTags: []string{unusedRef}},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:     "disabled-container",
+			Image:  disabledRef,
+			Labels: map[string]string{labels.LabelUpdater: "0"},
+		},
+		{
+			ID:    "enabled-container",
+			Image: enabledRef,
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{enabledRef, unusedRef}, got)
+}
+
+func TestImageUpdateService_GetAllImageRefsExcludesAliasesOfOptedOutImageInternal(t *testing.T) {
+	const (
+		imageID    = "sha256:local-build"
+		primaryRef = "local/caddy:latest"
+		aliasRef   = "local/caddy:dev"
+		enabledRef = "local/enabled:latest"
+	)
+
+	images := []dockertypesimage.Summary{
+		{
+			ID:       imageID,
+			RepoTags: []string{primaryRef, aliasRef},
+		},
+		{
+			ID:       "sha256:enabled",
+			RepoTags: []string{enabledRef},
+		},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:      "disabled-container",
+			ImageID: imageID,
+			Image:   primaryRef,
+			Labels:  map[string]string{labels.LabelUpdater: "false"},
+		},
+		{
+			ID:      "enabled-container",
+			ImageID: "sha256:enabled",
+			Image:   enabledRef,
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.NotContains(t, got, primaryRef)
+	assert.NotContains(t, got, aliasRef)
+	assert.Contains(t, got, enabledRef)
+}
+
+func TestImageUpdateService_GetAllImageRefsKeepsImageSharedByEligibleContainerInternal(t *testing.T) {
+	const (
+		imageID  = "sha256:shared-image"
+		imageRef = "local/shared:latest"
+		aliasRef = "local/shared:dev"
+	)
+
+	images := []dockertypesimage.Summary{
+		{
+			ID:       imageID,
+			RepoTags: []string{imageRef, aliasRef},
+		},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:      "disabled-container",
+			ImageID: imageID,
+			Image:   imageRef,
+			Labels:  map[string]string{labels.LabelUpdater: "false"},
+		},
+		{
+			ID:      "enabled-container",
+			ImageID: imageID,
+			Image:   imageRef,
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.Contains(t, got, imageRef)
+	assert.Contains(t, got, aliasRef)
+}
+
+func TestImageUpdateService_GetAllImageRefsFallsBackToRefWhenImageIDsDifferInternal(t *testing.T) {
+	const imageRef = "local/caddy:latest"
+
+	images := []dockertypesimage.Summary{
+		{
+			ID:       "sha256:image-list-id",
+			RepoTags: []string{imageRef},
+		},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:      "disabled-container",
+			ImageID: "sha256:container-list-id",
+			Image:   imageRef,
+			Labels:  map[string]string{labels.LabelUpdater: "false"},
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.NotContains(t, got, imageRef)
+}
+
+func TestImageUpdateService_GetAllImageRefsMergesIDAndReferenceEligibilityInternal(t *testing.T) {
+	const (
+		imageRef = "local/shared:latest"
+		imageID  = "sha256:image-summary-id"
+	)
+
+	images := []dockertypesimage.Summary{
+		{
+			ID:       imageID,
+			RepoTags: []string{imageRef},
+		},
+	}
+	containers := []dockertypescontainer.Summary{
+		{
+			ID:      "disabled-container",
+			ImageID: imageID,
+			Image:   imageRef,
+			Labels:  map[string]string{labels.LabelUpdater: "false"},
+		},
+		{
+			ID:      "eligible-container",
+			ImageID: "sha256:different-container-id",
+			Image:   imageRef,
+		},
+	}
+
+	server := newImageUpdateDiscoveryServerInternal(t, images, containers)
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.Contains(t, got, imageRef)
+}
+
+func TestImageUpdateService_GetAllImageRefsFallsBackWhenContainerDiscoveryFailsInternal(t *testing.T) {
+	const (
+		firstRef  = "local/first:latest"
+		secondRef = "local/second:latest"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/images/json"):
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode([]dockertypesimage.Summary{
+				{ID: "sha256:first", RepoTags: []string{firstRef}},
+				{ID: "sha256:second", RepoTags: []string{secondRef}},
+			}))
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			http.Error(w, "container listing denied", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	svc := NewImageUpdateService(
+		nil,
+		nil,
+		nil,
+		&DockerClientService{client: newTestDockerClient(t, server)},
+		nil,
+		nil,
+		nil,
+	)
+
+	got, err := svc.getAllImageRefsInternal(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{firstRef, secondRef}, got)
 }


### PR DESCRIPTION
## Checklist

* [x] This PR is **not** opened from my fork’s `main` branch
* [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes Arcane image update scans ignoring the `com.getarcaneapp.arcane.updater=false` container label.

`CheckAllImages` previously enumerated all tagged Docker images without considering whether those images were used only by containers that had opted out of updater participation. This caused locally built images, such as `local/caddy:latest`, to be checked against a registry and produce avoidable 401/403 errors.

Fixes #3302

## Changes Made

* Added container-aware filtering to `CheckAllImages`.
* Excludes images used exclusively by containers with updater participation disabled.
* Preserves images shared by both opted-out and eligible containers.
* Excludes all repository tag aliases belonging to an exclusively opted-out Docker image.
* Falls back to normalized image-reference matching when Docker image IDs are unavailable or do not align.
* Keeps unused tagged images eligible for image update checks.
* Applies the image limit after opt-out filtering.
* Gives image and container discovery independent Docker API timeout contexts.
* Leaves explicit single-image and selected-image update checks unchanged.
* Replaced the superseded image-reference deduplication helper with coverage for the new filtering behavior.

## Testing Done

* Added regression coverage for:

  * images used exclusively by opted-out containers
  * enabled containers
  * images shared by opted-out and enabled containers
  * unused tagged images
  * limits applied after filtering
  * repository tag aliases of opted-out images
  * shared image aliases
  * normalized-reference fallback when Docker image IDs differ
* Ran focused image discovery tests:

  * `GOEXPERIMENT=jsonv2 go test ./internal/services -run 'TestImageUpdateService_GetAllImageRefs' -count=1`
* Ran the full service test package:

  * `GOEXPERIMENT=jsonv2 go test ./internal/services -count=1`
* Ran GolangCI-Lint:

  * `golangci-lint run -c ../.github/.golangci.yml ./internal/services/...`
  * Result: `0 issues`
* Ran `git diff --check`.
* Repository pre-commit formatting checks passed.

## AI Tool Used (if applicable)

ChatGPT was used to help trace the image update scan path, identify edge cases, design regression tests, and review the final implementation. All changes were manually validated with focused tests, the full service test package, repository formatting checks, and GolangCI-Lint.

## Additional Context

The updater execution path already honored the opt-out label. The defect was isolated to the image discovery path used by scheduled and manual “check all images” operations.

Explicit checks for a single image or a selected set of images still run when directly requested.


## Summary Update

This PR makes check-all image discovery container-aware by filtering images used exclusively by updater-disabled containers, while preserving shared and unused images.

Both critical issues from the original review are now resolved:

- ID-based and normalized-reference usage are merged before eligibility is decided, so an opted-out container cannot hide an image still used by an eligible container.
- Container-discovery failures now log a warning and fall back to discovered image references instead of aborting check-all scans.

The implementation uses a merge-based usage model, degrades gracefully when container listing fails, and is covered by eight focused regression tests.

**Revised Confidence Score: 4/5**

The logic is sound, the fallback is safe and properly logged, and the key scenarios are covered comprehensively. The remaining confidence gap is limited to external `refs.NormalizeImageUpdateRef` and `refs.IsImageIDLikeReference` behavior that could not be fully verified from the diff alone.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes check-all image discovery honor container updater opt-out labels.
- Filters images used exclusively by opted-out containers while retaining shared and unused images.
- Merges image-ID and normalized-reference usage before determining eligibility.
- Falls back to the previously discovered image references when container discovery fails.
- Applies scan limits after opt-out filtering and adds focused regression coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

Both previously reported failures are fixed: ID-based and reference-based eligibility are merged before filtering, and container-list errors retain discovered image references instead of aborting the scan; no blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Image Scan Updater Opt-Out"](https://github.com/getarcaneapp/arcane/commit/086bb556bf48b49155183ae71b0dd2184520005b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47465982)</sub>

**Context used:**

- Knowledge Base — [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)

<!-- /greptile_comment -->