### PR TITLE
fix: synchronize structured log toggle state

### DIFF
--- a/frontend/src/lib/components/logs/log-controls.svelte
+++ b/frontend/src/lib/components/logs/log-controls.svelte
@@ -70,9 +70,10 @@
 		showParsedJson = persistedJsonParsing.current === 'true';
 	});
 
-	$effect(() => {
-		persistedJsonParsing.current = showParsedJson ? 'true' : 'false';
-	});
+	function handleParsedModeChange(checked: boolean): void {
+		showParsedJson = checked;
+		persistedJsonParsing.current = checked ? 'true' : 'false';
+	}
 
 	const selectedLabel = $derived(tailOptions.find((o) => o.value === selectedTail)?.label ?? m.log_tail_100_lines());
 </script>
@@ -161,7 +162,7 @@
 			<DropdownMenu.CheckboxItem
 				checked={showParsedJson}
 				onCheckedChange={(checked) => {
-					showParsedJson = checked === true;
+					handleParsedModeChange(checked === true);
 				}}
 			>
 				<div class="flex flex-col gap-0.5">
@@ -243,7 +244,7 @@
 							checked={showParsedJson}
 							label={showParsedJson ? m.common_parsed() : m.common_raw()}
 							onCheckedChange={(checked) => {
-								showParsedJson = checked;
+								handleParsedModeChange(checked);
 							}}
 						/>
 					{/snippet}

--- a/frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte
@@ -257,7 +257,7 @@
 				bind:autoScroll
 				type="container"
 				{containerId}
-				{showParsedJson}
+				bind:showParsedJson
 				maxLines={500}
 				showTimestamps={true}
 				groupAdjacentLines={true}

--- a/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
+++ b/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
@@ -91,7 +91,7 @@
 			bind:autoScroll
 			{projectId}
 			{tailLines}
-			{showParsedJson}
+			bind:showParsedJson
 			type="project"
 			maxLines={500}
 			showTimestamps={true}

--- a/frontend/src/routes/(app)/swarm/services/components/ServiceLogsPanel.svelte
+++ b/frontend/src/routes/(app)/swarm/services/components/ServiceLogsPanel.svelte
@@ -71,7 +71,7 @@
 				bind:autoScroll
 				type="service"
 				{serviceId}
-				{showParsedJson}
+				bind:showParsedJson
 				maxLines={500}
 				showTimestamps={true}
 				height="calc(100vh - 320px)"

--- a/tests/spec/containers.spec.ts
+++ b/tests/spec/containers.spec.ts
@@ -5,6 +5,118 @@ import { openRowActionsMenu } from '../utils/table-actions.util';
 
 const CONTAINERS_ROUTE = '/containers';
 
+const structuredContainerLog = {
+	level: 'stdout',
+	message: JSON.stringify({
+		level: 'info',
+		message: 'structured container log marker',
+		request_id: 'request-3415'
+	}),
+	timestamp: '2026-07-27T23:08:37.000Z'
+};
+
+async function mockContainerLogsWebSocket(page: Page) {
+	await page.addInitScript((logEntry) => {
+		localStorage.setItem('arcane_log_json_parsing_v3', 'false');
+		localStorage.setItem('arcane_log_auto_start', 'false');
+
+		const browserWindow = globalThis as typeof globalThis & {
+			WebSocket: any;
+			EventTarget: any;
+			Event: any;
+			MessageEvent: any;
+			CloseEvent: any;
+		};
+
+		const NativeWebSocket = browserWindow.WebSocket;
+		const containerLogsPathPattern =
+			/\/api\/environments\/[^/]+\/ws\/containers\/[^/]+\/logs(?:\?.*)?$/;
+
+		class MockContainerLogsWebSocket extends browserWindow.EventTarget {
+			static CONNECTING = 0;
+			static OPEN = 1;
+			static CLOSING = 2;
+			static CLOSED = 3;
+
+			url: string;
+			readyState = MockContainerLogsWebSocket.CONNECTING;
+			bufferedAmount = 0;
+			extensions = '';
+			protocol = '';
+			binaryType = 'blob';
+			onopen: ((event: unknown) => void) | null = null;
+			onmessage: ((event: unknown) => void) | null = null;
+			onerror: ((event: unknown) => void) | null = null;
+			onclose: ((event: unknown) => void) | null = null;
+
+			constructor(url: string | URL) {
+				super();
+				this.url = String(url);
+
+				queueMicrotask(() => {
+					if (this.readyState !== MockContainerLogsWebSocket.CONNECTING) return;
+
+					this.readyState = MockContainerLogsWebSocket.OPEN;
+
+					const openEvent = new browserWindow.Event('open');
+					this.dispatchEvent(openEvent);
+					this.onopen?.(openEvent);
+
+					const messageEvent = new browserWindow.MessageEvent('message', {
+						data: JSON.stringify(logEntry)
+					});
+
+					this.dispatchEvent(messageEvent);
+					this.onmessage?.(messageEvent);
+				});
+			}
+
+			send(_data?: string | ArrayBufferLike | Blob | ArrayBufferView) {}
+
+			close(code = 1000, reason = '') {
+				if (this.readyState === MockContainerLogsWebSocket.CLOSED) return;
+
+				this.readyState = MockContainerLogsWebSocket.CLOSED;
+
+				const closeEvent = new browserWindow.CloseEvent('close', {
+					code,
+					reason,
+					wasClean: true
+				});
+
+				this.dispatchEvent(closeEvent);
+				this.onclose?.(closeEvent);
+			}
+		}
+
+		const PatchedWebSocket = function (
+			this: unknown,
+			url: string | URL,
+			protocols?: string | string[]
+		) {
+			const urlString = String(url);
+
+			if (containerLogsPathPattern.test(urlString)) {
+				return new MockContainerLogsWebSocket(urlString);
+			}
+
+			return protocols === undefined
+				? new NativeWebSocket(url)
+				: new NativeWebSocket(url, protocols);
+		} as unknown as typeof WebSocket;
+
+		Object.defineProperties(PatchedWebSocket, {
+			CONNECTING: { value: NativeWebSocket.CONNECTING },
+			OPEN: { value: NativeWebSocket.OPEN },
+			CLOSING: { value: NativeWebSocket.CLOSING },
+			CLOSED: { value: NativeWebSocket.CLOSED }
+		});
+
+		PatchedWebSocket.prototype = NativeWebSocket.prototype;
+		browserWindow.WebSocket = PatchedWebSocket;
+	}, structuredContainerLog);
+}
+
 async function navigateToContainers(page: Page) {
 	await page.goto(CONTAINERS_ROUTE);
 	await page.waitForLoadState('load');
@@ -77,6 +189,31 @@ test.describe('Containers Page', () => {
 		await expect(page.getByTestId('container-log-memory-monitor')).toBeVisible();
 		await expect(page.getByTestId('container-log-cpu-monitor')).not.toContainText('N/A');
 		await expect(page.getByTestId('container-log-memory-monitor')).not.toContainText('N/A');
+	});
+
+	test('keeps the parsed log toggle synchronized when structured logs are detected', async ({
+		page
+	}) => {
+		const running = containersData.data.find((container) => container.state === 'running');
+		test.skip(!running, 'No running container available');
+
+		await mockContainerLogsWebSocket(page);
+		await page.goto(`/containers/${running!.id}`);
+		await page.waitForLoadState('load');
+		await page.getByRole('tab', { name: 'Logs' }).click();
+
+		const parsedModeToggle = page.locator('#parsed-log-mode-toggle:visible');
+		await expect(parsedModeToggle).toHaveAttribute('aria-checked', 'false');
+
+		await page.getByRole('button', { name: 'Start', exact: true }).first().click();
+
+		await expect(
+			page.getByText('structured container log marker', { exact: true }).filter({ visible: true })
+		).toBeVisible();
+		await expect(parsedModeToggle).toHaveAttribute('aria-checked', 'true');
+		await expect
+			.poll(() => page.evaluate(() => localStorage.getItem('arcane_log_json_parsing_v3')))
+			.toBe('false');
 	});
 
 	test('should show non-live fallback monitors on the logs tab for stopped containers', async ({


### PR DESCRIPTION
## Checklist

* [x] This PR is **not** opened from my fork’s `main` branch
* [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes the structured log viewer state mismatch where structured logs were automatically rendered in parsed mode while the visible control still indicated Raw.

Restores two-way binding between `LogViewer` and `LogControls` so automatic structured-log detection updates the toggle state consistently across container, project, and Swarm service logs.

Fixes #3415

## Changes Made

* Restored `bind:showParsedJson` in the container log panel.
* Restored `bind:showParsedJson` in the project log panel.
* Restored `bind:showParsedJson` in the Swarm service log panel.
* Added a Playwright regression test that sends a structured log over a mocked container log WebSocket and verifies that the parsed-mode toggle updates when structured view is automatically enabled.

## Testing Done

* `pnpm -C frontend format:check`
* `pnpm -C frontend check`
* `pnpm -C tests format:check`
* `pnpm -C tests check`
* Targeted Chromium regression test:

  * 3 passed
* Full Chromium container spec:

  * 11 passed
  * 1 skipped
* `git diff --check`

The regression test failed before the binding fix because the log viewer rendered parsed output while the toggle remained in Raw mode. It passes after the fix.

## AI Tool Used (if applicable)

AI Tool: ChatGPT

Assistance Level: Moderate

ChatGPT assisted with tracing the state flow between `LogViewer`, `LogControls`, and the three parent log panels, identifying the missing two-way bindings, developing and reviewing the Playwright regression test, and reviewing the final diff for correctness and scope.


All code was personally reviewed and implemented, AI provided speed.

## Additional Context

Automatic structured-view activation is existing behavior. This change does not alter when parsed mode is enabled. It only restores synchronization between the viewer state and the visible toggle.

No user-facing strings were added.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Restores two-way parsed-log state synchronization and adds a container-log regression test.
- Binds LogViewer parsed-mode state back to the controls in container, project, and Swarm service panels.
- Adds a mocked container-log WebSocket test covering automatic structured-log detection.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The persisted-preference side effect should be fixed before merging because merely viewing a structured log can permanently replace the user's Raw-mode selection.

The restored bindings correctly synchronize the display, but they also route LogViewer's automatic assignment through LogControls, whose reactive persistence writes it to localStorage across all three log panels.

**Files Needing Attention:** frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte, frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte, frontend/src/routes/(app)/swarm/services/components/ServiceLogsPanel.svelte
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Flog-viewer-parsed-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Flog-viewer-parsed-state%22.%0A%0A%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2Fcomponents%2FContainerLogsPanel.svelte%3A260%0A**Automatic%20detection%20overwrites%20preference**%0A%0AWhen%20a%20user%20has%20Raw%20mode%20persisted%20and%20a%20structured%20log%20arrives%2C%20this%20binding%20propagates%20%60LogViewer%60%E2%80%99s%20automatic%20parsed-mode%20assignment%20through%20%60LogControls%60%2C%20which%20stores%20it%20in%20%60arcane_log_json_parsing_v3%60%3B%20later%20log%20viewers%20and%20future%20sessions%20therefore%20start%20in%20Parsed%20mode%20despite%20the%20user%E2%80%99s%20Raw%20selection.%20The%20same%20state%20flow%20is%20introduced%20in%20the%20project%20and%20Swarm%20service%20log%20panels.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fcontainers%2Fcomponents%2FContainerLogsPanel.svelte%3A260%0A**Automatic%20detection%20overwrites%20preference**%0A%0AWhen%20a%20user%20has%20Raw%20mode%20persisted%20and%20a%20structured%20log%20arrives%2C%20this%20binding%20propagates%20%60LogViewer%60%E2%80%99s%20automatic%20parsed-mode%20assignment%20through%20%60LogControls%60%2C%20which%20stores%20it%20in%20%60arcane_log_json_parsing_v3%60%3B%20later%20log%20viewers%20and%20future%20sessions%20therefore%20start%20in%20Parsed%20mode%20despite%20the%20user%E2%80%99s%20Raw%20selection.%20The%20same%20state%20flow%20is%20introduced%20in%20the%20project%20and%20Swarm%20service%20log%20panels.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
frontend/src/routes/(app)/containers/components/ContainerLogsPanel.svelte:260
**Automatic detection overwrites preference**

When a user has Raw mode persisted and a structured log arrives, this binding propagates `LogViewer`’s automatic parsed-mode assignment through `LogControls`, which stores it in `arcane_log_json_parsing_v3`; later log viewers and future sessions therefore start in Parsed mode despite the user’s Raw selection. The same state flow is introduced in the project and Swarm service log panels.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Structured Log Toggle Synchronizatio..."](https://github.com/getarcaneapp/arcane/commit/bb879c15d596ae1f0e10407f49c5baee38300d05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47813486)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Frontend application (SvelteKit)](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/frontend-app.md)

<!-- /greptile_comment -->
<img width="741" height="394" alt="image" src="https://github.com/user-attachments/assets/6f9a1d7c-e26d-48bb-91c3-3cce1df0d708" />
