### PR TITLE
fix: project log timestamps

### DIFF
--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -4144,8 +4144,7 @@ func (s *ProjectService) StreamProjectLogs(ctx context.Context, projectID string
 
 	// Writer goroutine: compose logs -> pipe
 	go func() {
-		// timestamps not currently supported by ComposeLogs helper; follow/tail/since are used.
-		err := projects.ComposeLogs(ctx, projects.NormalizeProjectName(proj.Name), pw, follow, tail, since)
+		err := projects.ComposeLogs(ctx, projects.NormalizeProjectName(proj.Name), pw, follow, tail, since, timestamps)
 		_ = pw.Close()
 		done <- err
 	}()

--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -130,14 +130,14 @@ func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) e
 	return c.svc.Down(downCtx, proj.Name, api.DownOptions{RemoveOrphans: true, Volumes: removeVolumes})
 }
 
-func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow bool, tail, since string) error {
+func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow bool, tail, since string, timestamps bool) error {
 	c, err := NewClient(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = c.Close() }()
 
-	return c.svc.Logs(ctx, projectName, writerConsumer{out: out}, api.LogOptions{Follow: follow, Tail: tail, Since: since})
+	return c.svc.Logs(ctx, projectName, writerConsumer{out: out}, api.LogOptions{Follow: follow, Tail: tail, Since: since, Timestamps: timestamps})
 }
 
 func ListGlobalComposeContainers(ctx context.Context) ([]container.Summary, error) {


### PR DESCRIPTION
## Checklist

* [x] This PR is **not** opened from my fork’s `main` branch
* [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes project log timestamps being replaced with the current time in parsed log view.

The project log WebSocket already requested timestamps and passed the option into `StreamProjectLogs`, but the value was dropped before calling Docker Compose. This caused project logs to arrive without Docker’s timestamp prefix, leaving the parser without the original log timestamp.

Fixes: #3428

## Changes Made

* Added a `timestamps` parameter to `ComposeLogs`
* Forwarded the value into Docker Compose through `api.LogOptions.Timestamps`
* Passed the existing timestamp option from `StreamProjectLogs` into `ComposeLogs`
* Removed the outdated comment stating that timestamps were unsupported

## Testing Done

Ran focused backend tests for the affected packages:

```text
GOEXPERIMENT=jsonv2 go test ./pkg/projects ./internal/services -count=1
```

Results:

```text
ok github.com/getarcaneapp/arcane/backend/v2/pkg/projects
ok github.com/getarcaneapp/arcane/backend/v2/internal/services
```

Also verified:

* `api.LogOptions` supports the `Timestamps` field
* Container and swarm log paths already forward the same timestamp option
* The frontend project log viewer requests `timestamps=true`
* The shared log parser expects Docker’s RFC3339 timestamp prefix

## AI Tool Used: Chat GPT

ChatGPT was used to inspect the affected code path, and speed up debugging. All testing and implementation was manually verified and performed. 

## Additional Context

This is a narrow backend propagation fix. It does not change frontend parsing, timestamp formatting, or structured log behavior.
