### PR TITLE
fix: serialize bulk deletes and refresh image data

### DIFF
--- a/frontend/src/routes/(app)/images/+page.svelte
+++ b/frontend/src/routes/(app)/images/+page.svelte
@@ -14,14 +14,16 @@
 	import { hasPermission } from '#lib/utils/auth';
 	import { queryKeys } from '#lib/query/query-keys';
 	import type { ImageUsageCounts } from '#lib/types/docker';
+	import type { SearchPaginationSortRequest } from '#lib/types/shared';
 	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '#lib/layouts/index.js';
 	import { CloseIcon, VolumesIcon, LocalFolderComputerIcon, SearchIcon } from '#lib/icons';
-	import { createMutation, createQuery } from '@tanstack/svelte-query';
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import PruneModeCard from '#lib/components/prune/prune-mode-card.svelte';
 	import { activityToastOptions, extractActivityId } from '#lib/utils/activity-toast';
 
 	let { data } = $props();
+	const queryClient = useQueryClient();
 
 	let images = $state(untrack(() => data.images));
 	let requestOptions = $state(untrack(() => data.imageRequestOptions));
@@ -36,6 +38,7 @@
 	let imagePruneUntil = $state('');
 	const envId = $derived(environmentStore.selected?.id || '0');
 	let previousEnvId = untrack(() => envId);
+	let latestImageRequestId = 0;
 	const imageUsageFallback: ImageUsageCounts = {
 		imagesInuse: 0,
 		imagesUnused: 0,
@@ -185,11 +188,34 @@
 		{ value: 'olderThan', label: m.prune_mode_older_than() }
 	];
 
+	async function loadImages(options: SearchPaginationSortRequest = requestOptions, requestedEnvId: string = envId) {
+		const requestId = ++latestImageRequestId;
+		requestOptions = options;
+		const [nextImages] = await Promise.all([
+			queryClient.fetchQuery({
+				queryKey: queryKeys.images.list(requestedEnvId, options),
+				queryFn: () => imageService.getImagesForEnvironment(requestedEnvId, options)
+			}),
+			queryClient.fetchQuery({
+				queryKey: queryKeys.images.usageCounts(requestedEnvId),
+				queryFn: () => imageService.getImageUsageCountsForEnvironment(requestedEnvId)
+			})
+		]);
+
+		if (requestedEnvId !== envId) {
+			selectedIds = [];
+			return;
+		}
+		if (requestId !== latestImageRequestId) return;
+
+		images = nextImages;
+	}
+
 	async function refresh() {
 		const requestedEnvId = envId;
 		isRefreshing = true;
 		try {
-			await Promise.all([imagesQuery.refetch(), imageUsageCountsQuery.refetch()]);
+			await loadImages(requestOptions, requestedEnvId);
 		} finally {
 			if (requestedEnvId === envId) {
 				isRefreshing = false;
@@ -287,12 +313,7 @@
 				bind:requestOptions
 				loading={imagesQuery.isLoading}
 				onRefreshData={async (options) => {
-					const requestedEnvId = envId;
-					requestOptions = options;
-					await imageUsageCountsQuery.refetch();
-					if (requestedEnvId !== envId) {
-						selectedIds = [];
-					}
+					await loadImages(options, envId);
 				}}
 				onImageUpdated={async () => {
 					await imagesQuery.refetch();

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -109,7 +109,8 @@
 			onComplete: async (result) => {
 				if (result.success > 0) await refreshImages();
 			},
-			clearSelection: () => (selectedIds = [])
+			clearSelection: () => (selectedIds = []),
+			sequential: true
 		});
 	}
 

--- a/tests/spec/images.spec.ts
+++ b/tests/spec/images.spec.ts
@@ -13,6 +13,76 @@ async function navigateToImages(page: Page) {
 	await page.waitForLoadState('load');
 }
 
+function getImageRows(page: Page) {
+	return page
+		.getByRole('row')
+		.filter({ has: page.getByRole('checkbox', { name: 'Select row', exact: true }) });
+}
+
+async function mockImageDeleteFlow(page: Page, failFirst = false) {
+	const state = {
+		deleteRequestCount: 0,
+		imageListRequestCount: 0,
+		usageCountRequestCount: 0,
+		inFlight: 0,
+		maxInFlight: 0,
+		deletedIds: new Set<string>()
+	};
+
+	await page.route('**/api/environments/0/images**', async (route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+
+		if (request.method() === 'DELETE' && url.pathname.startsWith(`${ROUTES.apiImages}/`)) {
+			state.deleteRequestCount += 1;
+			state.inFlight += 1;
+			state.maxInFlight = Math.max(state.maxInFlight, state.inFlight);
+			const imageId = decodeURIComponent(url.pathname.slice(`${ROUTES.apiImages}/`.length));
+			const shouldFail = failFirst && state.deleteRequestCount === 1;
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			state.inFlight -= 1;
+			if (!shouldFail) state.deletedIds.add(imageId);
+
+			await route.fulfill({
+				status: shouldFail ? 500 : 200,
+				contentType: 'application/json',
+				body: JSON.stringify(
+					shouldFail
+						? { success: false, message: 'mock delete failure' }
+						: { success: true, data: { message: 'Image removed successfully' } }
+				)
+			});
+			return;
+		}
+
+		if (request.method() === 'GET' && url.pathname === ROUTES.apiImages) {
+			state.imageListRequestCount += 1;
+			const response = await route.fetch();
+			const body = await response.json();
+			if (Array.isArray(body?.data)) {
+				body.data = body.data.filter((image: { id: string }) => !state.deletedIds.has(image.id));
+				if (body.pagination?.totalItems !== undefined) {
+					body.pagination.totalItems = Math.max(
+						0,
+						Number(body.pagination.totalItems) - state.deletedIds.size
+					);
+				}
+			}
+			await route.fulfill({ response, body: JSON.stringify(body) });
+			return;
+		}
+
+		if (request.method() === 'GET' && url.pathname === `${ROUTES.apiImages}/counts`) {
+			state.usageCountRequestCount += 1;
+		}
+
+		await route.continue();
+	});
+
+	return state;
+}
+
 async function fetchAllImagesForUsage(page: Page): Promise<any[]> {
 	const limit = 200;
 	let start = 0;
@@ -202,12 +272,89 @@ test.describe('Images Page', () => {
 
 		const dialog = page.getByRole('dialog', { name: 'Remove image', exact: true });
 		await expect(dialog).toBeVisible();
+		const refreshedImageList = page.waitForRequest((request) => {
+			return request.method() === 'GET' && new URL(request.url()).pathname === ROUTES.apiImages;
+		});
+		const refreshedUsageCounts = page.waitForRequest((request) => {
+			return (
+				request.method() === 'GET' &&
+				new URL(request.url()).pathname === `${ROUTES.apiImages}/counts`
+			);
+		});
 		await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
 		await expect.poll(() => removeRequestCount).toBe(1);
+		await Promise.all([refreshedImageList, refreshedUsageCounts]);
 
 		await expect(
 			page.getByRole('region', { name: 'Notifications alt+T', exact: true }).getByRole('listitem')
 		).toBeVisible();
+	});
+
+	test('should remove selected images sequentially and refresh the list and usage counts', async ({
+		page
+	}) => {
+		test.skip(realImages.length < 2, 'At least two images are required for bulk remove test');
+		await navigateToImages(page);
+
+		const rows = getImageRows(page);
+		await expect(rows.nth(1)).toBeVisible();
+		const initialRowCount = await rows.count();
+		const mock = await mockImageDeleteFlow(page);
+
+		await rows.nth(0).getByRole('checkbox', { name: 'Select row', exact: true }).check();
+		await rows.nth(1).getByRole('checkbox', { name: 'Select row', exact: true }).check();
+		await expect(
+			page.getByRole('button', { name: 'Remove Selected (2)', exact: true })
+		).toBeVisible();
+		await page.getByRole('button', { name: 'Remove Selected (2)', exact: true }).click();
+
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
+
+		await expect.poll(() => mock.deleteRequestCount).toBe(2);
+		expect(mock.maxInFlight).toBe(1);
+		await expect(
+			page
+				.getByRole('region', { name: 'Notifications alt+T', exact: true })
+				.getByRole('listitem')
+				.filter({ hasText: '2 images removed successfully' })
+		).toBeVisible();
+		await expect.poll(() => mock.imageListRequestCount).toBeGreaterThan(0);
+		await expect.poll(() => mock.usageCountRequestCount).toBeGreaterThan(0);
+		await expect.poll(() => getImageRows(page).count()).toBe(initialRowCount - 2);
+		await expect(page.getByRole('button', { name: /^Remove Selected/ })).toHaveCount(0);
+	});
+
+	test('should continue bulk removal after a failed image and refresh successful results', async ({
+		page
+	}) => {
+		test.skip(realImages.length < 2, 'At least two images are required for bulk remove test');
+		await navigateToImages(page);
+
+		const rows = getImageRows(page);
+		await expect(rows.nth(1)).toBeVisible();
+		const initialRowCount = await rows.count();
+		const mock = await mockImageDeleteFlow(page, true);
+
+		await rows.nth(0).getByRole('checkbox', { name: 'Select row', exact: true }).check();
+		await rows.nth(1).getByRole('checkbox', { name: 'Select row', exact: true }).check();
+		await page.getByRole('button', { name: 'Remove Selected (2)', exact: true }).click();
+
+		const dialog = page.getByRole('dialog');
+		await dialog.getByRole('button', { name: 'Remove', exact: true }).click();
+
+		await expect.poll(() => mock.deleteRequestCount).toBe(2);
+		expect(mock.maxInFlight).toBe(1);
+		await expect(
+			page
+				.getByRole('region', { name: 'Notifications alt+T', exact: true })
+				.getByRole('listitem')
+				.filter({ hasText: 'Removed 1 of 2' })
+		).toBeVisible();
+		await expect.poll(() => mock.imageListRequestCount).toBeGreaterThan(0);
+		await expect.poll(() => mock.usageCountRequestCount).toBeGreaterThan(0);
+		await expect.poll(() => getImageRows(page).count()).toBe(initialRowCount - 1);
+		await expect(page.getByRole('button', { name: /^Remove Selected/ })).toHaveCount(0);
 	});
 
 	test('should call prune API on prune click and confirmation', async ({ page }) => {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: [https://github.com/getarcaneapp/arcane/issues/3465](https://github.com/getarcaneapp/arcane/issues/3465)

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change prevents stale image-list responses from replacing newer results and serializes bulk image deletion requests. Focused runtime validation confirmed that a newer table refresh remains displayed when an older manual refresh completes later, the manual refresh indicator clears, and three bulk deletions run with only one request in flight before image data is refreshed. Frontend Svelte checks and test TypeScript checks completed without errors.

### T-Rex validation blocked

A full authenticated Images-page end-to-end run could not start because the Docker service is unavailable. The suite requires Docker Compose and the `arcane:playwright-tests` image.

[Configure VMs](https://app.greptile.com/-/settings/trex#environments)
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to start the authenticated Images-page end-to-end suite, but validation blocked because Docker is unavailable.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: serialize bulk deletes and refresh ..."](https://github.com/getarcaneapp/arcane/commit/795a78e1443afb25c15b412705844974e996568b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48948683)</sub>

<!-- /greptile_comment -->