### PR TITLE
fix: forward icon catalog setting over tunnel endpoints

### DIFF
--- a/backend/api/middleware/auth.go
+++ b/backend/api/middleware/auth.go
@@ -200,6 +200,25 @@ func createAgentSudoUserInternal() *models.User {
 	}
 }
 
+// applyProxiedIconCatalogInternal copies the requesting user's icon catalog
+// preference, forwarded by the manager, onto the synthetic user this request
+// authenticates as. Without it the synthetic user has no preferences and every
+// proxied icon resolves against the default catalog.
+//
+// Only called on synthetic-user auth paths (agent token, environment access
+// token), where the header is set by the manager after it strips any
+// client-supplied value. Real-user auth paths never read it.
+func applyProxiedIconCatalogInternal(ctx huma.Context, user *models.User) {
+	if user == nil {
+		return
+	}
+	catalog := strings.TrimSpace(ctx.Header(pkgutils.HeaderIconCatalog))
+	if catalog == "" {
+		return
+	}
+	user.Preferences.IconCatalog = &catalog
+}
+
 func createEnvironmentUserInternal(env *models.Environment) *models.User {
 	return &models.User{
 		BaseModel: models.BaseModel{ID: "environment:" + env.ID},
@@ -236,6 +255,7 @@ func NewAuthBridge(api huma.API, authService *services.AuthService, apiKeyServic
 		}
 
 		if user, env, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(pkgutils.HeaderAgentToken)); ok {
+			applyProxiedIconCatalogInternal(ctx, user)
 			newCtx := setUserInContextInternal(ctx.Context(), user, authz.EnvironmentPermissionSet(env.ID))
 			next(huma.WithContext(ctx, newCtx))
 			return
@@ -263,6 +283,7 @@ func tryAgentAuthCtxInternal(ctx huma.Context, cfg *config.Config) (huma.Context
 	if !ok {
 		return ctx, false
 	}
+	applyProxiedIconCatalogInternal(ctx, user)
 	// The agent token path is infrastructure-level and not per-user, so it
 	// gets a sudo PermissionSet that bypasses every check.
 	return huma.WithContext(ctx, setUserInContextInternal(ctx.Context(), user, authz.SudoPermissionSet())), true
@@ -311,6 +332,7 @@ func handleApiKeyAuthInternal(api huma.API, ctx huma.Context, authService *servi
 				return
 			}
 		}
+		applyProxiedIconCatalogInternal(ctx, user)
 		newCtx := setUserInContextInternal(ctx.Context(), user, authz.EnvironmentPermissionSet(env.ID))
 		next(huma.WithContext(ctx, newCtx))
 		return

--- a/backend/api/middleware/auth_test.go
+++ b/backend/api/middleware/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
+	pkgutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2/auth"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v5"
@@ -478,4 +479,46 @@ func TestNewAuthBridge_VersionMismatchIsRecoverable(t *testing.T) {
 		router.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
+}
+
+func TestNewAuthBridge_AgentAuthAppliesForwardedIconCatalog(t *testing.T) {
+	const agentToken = "agent-token"
+	router := echo.New()
+	apiGroup := router.Group("/api")
+
+	humaConfig := huma.DefaultConfig("test", "1.0.0")
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"ApiKeyAuth": {Type: "apiKey", In: "header", Name: "X-API-Key"},
+	}
+
+	api := humaecho.NewWithGroup(router, apiGroup, humaConfig)
+	api.UseMiddleware(NewAuthBridge(api, &services.AuthService{}, nil, nil, nil, &config.Config{
+		AgentMode:  true,
+		AgentToken: agentToken,
+	}))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "secure-agent-icon-catalog",
+		Method:      http.MethodGet,
+		Path:        "/secure-agent-icon-catalog",
+		Security:    []map[string][]string{{"ApiKeyAuth": {}}},
+	}, func(ctx context.Context, _ *secureInput) (*secureOutput, error) {
+		user, ok := models.CurrentUserFromContext(ctx)
+		require.True(t, ok)
+		require.NotNil(t, user.Preferences.IconCatalog)
+		require.Equal(t, "dashboard-icons", *user.Preferences.IconCatalog)
+
+		resp := &secureOutput{}
+		resp.Body.UserID = user.ID
+		return resp, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/secure-agent-icon-catalog", nil)
+	req.Header.Set(pkgutils.HeaderAgentToken, agentToken)
+	req.Header.Set(pkgutils.HeaderIconCatalog, "dashboard-icons")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
 }

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -117,7 +117,7 @@ func createAuthValidatorInternal(deps api.HandlerDeps) middleware.AuthValidator 
 		}
 		return ps
 	}
-	return func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, bool) {
+	return func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, *models.User, bool) {
 		req := c.Request()
 		// Check for API key authentication
 		if apiKey := req.Header.Get("X-Api-Key"); apiKey != "" {
@@ -125,16 +125,16 @@ func createAuthValidatorInternal(deps api.HandlerDeps) middleware.AuthValidator 
 			// permissions; scoped keys are limited to their own grants.
 			if user, key, err := deps.ApiKey.ValidateApiKeyWithID(ctx, apiKey); err == nil && user != nil {
 				if key != nil && key.Kind != models.ApiKeyKindPersonal {
-					return resolveKey(ctx, key.ID), true
+					return resolveKey(ctx, key.ID), user, true
 				}
-				return resolveUser(ctx, user), true
+				return resolveUser(ctx, user), user, true
 			}
 			// Environment bootstrap key (user_id = NULL): used by the proxy when forwarding
 			// requests to a remote env whose apiUrl resolves back to this manager.
 			if envID, err := deps.ApiKey.GetEnvironmentByApiKey(ctx, apiKey); err == nil && envID != nil {
-				return authz.EnvironmentPermissionSet(*envID), true
+				return authz.EnvironmentPermissionSet(*envID), nil, true
 			}
-			return nil, false
+			return nil, nil, false
 		}
 
 		// Check for Bearer token authentication
@@ -146,14 +146,14 @@ func createAuthValidatorInternal(deps api.HandlerDeps) middleware.AuthValidator 
 		}
 
 		if token == "" {
-			return nil, false
+			return nil, nil, false
 		}
 
 		user, _, err := deps.Auth.VerifyToken(ctx, token)
 		if err != nil || user == nil {
-			return nil, false
+			return nil, nil, false
 		}
-		return resolveUser(ctx, user), true
+		return resolveUser(ctx, user), user, true
 	}
 }
 

--- a/backend/internal/middleware/environment_middleware.go
+++ b/backend/internal/middleware/environment_middleware.go
@@ -13,9 +13,11 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
 	wsutil "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/ws"
+	pkgutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	httputils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
 	"github.com/labstack/echo/v5"
 )
@@ -51,8 +53,11 @@ type EnvResolver func(ctx context.Context, id string) (string, *string, bool, er
 // caller's effective permission set. The boolean result reports whether the
 // request is authenticated; the permission set is used to authorize proxied
 // requests against the target environment. Sudo permission sets (internal
-// agent proxies) bypass authorization.
-type AuthValidator func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, bool)
+// agent proxies) bypass authorization. The resolved user is returned so
+// per-user context (e.g. the icon catalog preference) can travel with the
+// proxied request; it is nil for callers that are not a user (environment
+// bootstrap keys).
+type AuthValidator func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, *models.User, bool)
 
 // EnvironmentMiddleware proxies requests for remote environments to their respective agents.
 type EnvironmentMiddleware struct {
@@ -115,16 +120,19 @@ func (m *EnvironmentMiddleware) Handle(c *echo.Context, next echo.HandlerFunc) e
 
 	// SECURITY: Validate authentication BEFORE proxying to remote environments.
 	var perms *authz.PermissionSet
+	var user *models.User
 	if m.authValidator != nil {
-		ps, ok := m.authValidator(c.Request().Context(), c)
+		ps, u, ok := m.authValidator(c.Request().Context(), c)
 		if !ok {
 			return c.JSON(http.StatusUnauthorized, map[string]any{
 				"success": false,
 				"data":    map[string]any{"error": "Authentication required to access remote environments"},
 			})
 		}
-		perms = ps
+		perms, user = ps, u
 	}
+
+	m.setIconCatalogHeaderInternal(c, user)
 
 	apiURL, accessToken, enabled, err := m.resolver(c.Request().Context(), envID)
 	if err != nil || apiURL == "" {
@@ -174,6 +182,21 @@ func (m *EnvironmentMiddleware) Handle(c *echo.Context, next echo.HandlerFunc) e
 		return m.proxyWebSocket(c, target, accessToken, envID)
 	}
 	return m.proxyHTTP(c, target, accessToken)
+}
+
+// setIconCatalogHeaderInternal stamps the authenticated user's icon catalog
+// preference onto the outgoing proxied request. Remote agents authenticate the
+// proxy as a synthetic user with no preferences, so without this every remote
+// environment resolves icons against the default catalog.
+//
+// SECURITY: the header is always cleared first, so a browser-supplied value
+// never rides through; only the server-resolved preference is forwarded.
+func (m *EnvironmentMiddleware) setIconCatalogHeaderInternal(c *echo.Context, user *models.User) {
+	c.Request().Header.Del(pkgutils.HeaderIconCatalog)
+	if user == nil || user.Preferences.IconCatalog == nil || *user.Preferences.IconCatalog == "" {
+		return
+	}
+	c.Request().Header.Set(pkgutils.HeaderIconCatalog, *user.Preferences.IconCatalog)
 }
 
 // proxyPermissionDenied reports whether the caller lacks permission to perform

--- a/backend/internal/middleware/environment_middleware_test.go
+++ b/backend/internal/middleware/environment_middleware_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
+	pkgutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,10 +23,10 @@ func newTestEnvironmentMiddleware() *EnvironmentMiddleware {
 			_ = ctx
 			return "edge://oracle-1", nil, true, nil
 		},
-		authValidator: func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, bool) {
+		authValidator: func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, *models.User, bool) {
 			_ = ctx
 			_ = c
-			return authz.SudoPermissionSet(), true
+			return authz.SudoPermissionSet(), nil, true
 		},
 		httpClient: &http.Client{Timeout: proxyTimeout},
 		registry:   edge.NewTunnelRegistry(),
@@ -244,10 +246,10 @@ func TestEnvironmentMiddleware_LocalEnvironmentSkipsProxyPermissionCheck(t *test
 		localID:   "0",
 		paramName: "id",
 		matcher:   matcher,
-		authValidator: func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, bool) {
+		authValidator: func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, *models.User, bool) {
 			_ = ctx
 			_ = c
-			return authz.NewPermissionSet(), true
+			return authz.NewPermissionSet(), nil, true
 		},
 		httpClient: &http.Client{Timeout: proxyTimeout},
 		registry:   edge.NewTunnelRegistry(),
@@ -326,6 +328,62 @@ func TestEnvironmentMiddleware_KeepsNodeAgentDeploymentCreationLocal(t *testing.
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "\"success\":true")
 	assert.True(t, localHandlerHit)
+}
+
+func TestEnvironmentMiddleware_ForwardsResolvedIconCatalogHeaderOnly(t *testing.T) {
+	tests := []struct {
+		name           string
+		catalog        *string
+		clientSupplied string
+		wantHeader     string
+	}{
+		{name: "forwards the caller's preference", catalog: new("dashboard-icons"), wantHeader: "dashboard-icons"},
+		{name: "strips a client-supplied header when the caller has no preference", clientSupplied: "dashboard-icons", wantHeader: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var forwarded string
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwarded = r.Header.Get(pkgutils.HeaderIconCatalog)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			mw := &EnvironmentMiddleware{
+				localID:   "0",
+				paramName: "id",
+				resolver: func(ctx context.Context, id string) (string, *string, bool, error) {
+					_, _ = ctx, id
+					return backend.URL, nil, true, nil
+				},
+				authValidator: func(ctx context.Context, c *echo.Context) (*authz.PermissionSet, *models.User, bool) {
+					_, _ = ctx, c
+					u := &models.User{}
+					u.Preferences.IconCatalog = tt.catalog
+					return authz.SudoPermissionSet(), u, true
+				},
+				httpClient: &http.Client{Timeout: proxyTimeout},
+				registry:   edge.NewTunnelRegistry(),
+			}
+
+			router := echo.New()
+			api := attachMiddleware(router, mw)
+			api.GET("/environments/:id/containers", func(c *echo.Context) error {
+				return c.JSON(http.StatusOK, map[string]any{"success": true})
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/api/environments/env-remote/containers", nil)
+			if tt.clientSupplied != "" {
+				req.Header.Set(pkgutils.HeaderIconCatalog, tt.clientSupplied)
+			}
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			assert.Equal(t, tt.wantHeader, forwarded)
+		})
+	}
 }
 
 func TestIsCentralSwarmManagementPathInternal_IsMethodAware(t *testing.T) {

--- a/backend/internal/services/project_service.go
+++ b/backend/internal/services/project_service.go
@@ -4922,8 +4922,9 @@ func (s *ProjectService) getProjectMetadataForProject(ctx context.Context, p mod
 }
 
 // iconCatalogForContextInternal resolves the icon catalog of the requesting
-// user. Background jobs and agent-proxied calls have no user attached and fall
-// back to the default catalog.
+// user. On agent-proxied calls the caller is a synthetic user whose preference
+// is populated from the X-Arcane-Icon-Catalog header the manager forwards.
+// Background jobs have no user attached and fall back to the default catalog.
 func iconCatalogForContextInternal(ctx context.Context) string {
 	if u, ok := models.CurrentUserFromContext(ctx); ok && u != nil && u.Preferences.IconCatalog != nil && *u.Preferences.IconCatalog != "" {
 		return *u.Preferences.IconCatalog

--- a/backend/pkg/utils/auth.go
+++ b/backend/pkg/utils/auth.go
@@ -8,5 +8,10 @@ const (
 	HeaderAgentToken      = "X-Arcane-Agent-Token" // #nosec G101: header name, not a credential
 	HeaderApiKey          = "X-Api-Key"            // #nosec G101: header name, not a credential
 	HeaderActivityBatchID = "X-Arcane-Batch-Id"
-	AgentPairingPrefix    = "/api/environments/0/agent/pair"
+	// HeaderIconCatalog carries the requesting user's icon catalog preference to
+	// remote environments. Agents authenticate proxied calls as a synthetic user
+	// with no preferences, so without it every remote environment would resolve
+	// container/project icons against the default catalog.
+	HeaderIconCatalog  = "X-Arcane-Icon-Catalog"
+	AgentPairingPrefix = "/api/environments/0/agent/pair"
 )


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3478

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change introduces passkey sign-in, passkey MFA, recovery codes, step-up authentication, and an administrator MFA reset command. It also updates local, OIDC, device, and auto-login behavior to require the configured second factor before issuing a session, and forwards the resolved icon catalog preference to proxied environment users.

The reviewed MFA session paths did not expose a route that grants an MFA-enabled account an authenticated session before a passkey assertion or recovery code is verified.

### T-Rex validation blocked

The focused Go test could not start because the required Go 1.26.5 toolchain panics during `cmd/go/internal/fips140.Init` before package loading. The unavailable item is a working Go 1.26.5 toolchain; no credentials, application service, or secret was required.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline state confirmed: the pre-feature parent predates PasskeyMFAEnabled and has no comparable MFA-account flow.
- Validated the focused passkey MFA login gate harness against the changed source; all seven checks passed, including local login, browser OIDC challenge before session issuance, OIDC device exchange, MFA bypass refusal, and verification of passkey and recovery flows.
- Tried the narrow Go service test but the Go toolchain panicked during FIPS initialization before packages could load; a Python-based fallback harness was uploaded for future runs.
- Post-change evidence compares before and after: the before log shows no PasskeyMFAEnabled, the after record shows all focused path gates passed and no unauthenticated completion path; the Go runtime blocker log documents the panic, and the Python harness is available for future validation.

<a href="https://app.greptile.com/trex/runs/16992312/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: forward icon catalog setting over t..."](https://github.com/getarcaneapp/arcane/commit/f1c7d0e81314e5308d83d29538cf6b59fb805901) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49534965)</sub>

<!-- /greptile_comment -->