### PR TITLE
fix: update overridden env keys in place in effective .env instead of appending duplicates

### DIFF
--- a/backend/internal/services/gitops_sync_service_test.go
+++ b/backend/internal/services/gitops_sync_service_test.go
@@ -647,7 +647,7 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGi
 
 	effectiveBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, ".env"))
 	require.NoError(t, err)
-	assert.Equal(t, newGitEnvContent+"FOO=useredit\n", string(effectiveBytes))
+	assert.Equal(t, "FOO=useredit\nBAR=new\n", string(effectiveBytes))
 
 	gitBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, ".env.git"))
 	require.NoError(t, err)

--- a/backend/internal/services/project_service_test.go
+++ b/backend/internal/services/project_service_test.go
@@ -3574,7 +3574,7 @@ func TestProjectService_PersistGitSyncEnvFiles_UsesPreparedState(t *testing.T) {
 
 	effectiveBytes, readErr := os.ReadFile(filepath.Join(projectPath, ".env"))
 	require.NoError(t, readErr)
-	assert.Equal(t, "BASE=git-updated\nTOKEN=git\nREMOTE=1\nTOKEN=local\n", string(effectiveBytes))
+	assert.Equal(t, "BASE=git-updated\nTOKEN=local\nREMOTE=1\n", string(effectiveBytes))
 }
 
 func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.T) {

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,20 +22,17 @@ import (
 )
 
 const (
-	GlobalEnvFileName    = ".env.global"
-	EffectiveEnvFileName = ".env"
-	GitSourceEnvFileName = ".env.git"
-	OverrideEnvFileName  = "project.env"
+	GlobalEnvFileName                     = ".env.global"
+	EffectiveEnvFileName                  = ".env"
+	GitSourceEnvFileName                  = ".env.git"
+	OverrideEnvFileName                   = "project.env"
+	ProjectEnvModeDirect   ProjectEnvMode = "direct"
+	ProjectEnvModeOverride ProjectEnvMode = "override"
 )
 
 type EnvMap = map[string]string
 
 type ProjectEnvMode string
-
-const (
-	ProjectEnvModeDirect   ProjectEnvMode = "direct"
-	ProjectEnvModeOverride ProjectEnvMode = "override"
-)
 
 type ProjectEnvState struct {
 	Mode             ProjectEnvMode
@@ -338,9 +336,11 @@ func WithTransientValidationEnvFile(projectPath string, effectiveEnvContent *str
 }
 
 // BuildEffectiveEnvContent merges git and override env sources into the effective
-// .env content written to disk. Each source is preserved verbatim, with the
-// override appended after the Git content so duplicate keys resolve to the
-// override value when Compose parses the effective file.
+// .env content written to disk. Keys present in both layers are rewritten in place
+// on the Git line, preserving ordering and inline comments; override-only keys are
+// appended after the Git content. When the in-place rewrite cannot be verified to
+// parse identically to plain concatenation (e.g. multiline values), the override
+// is appended verbatim instead so duplicate keys resolve to the override value.
 func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error) {
 	contextEnv := make(EnvMap)
 
@@ -350,7 +350,7 @@ func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error
 	}
 	maps.Copy(contextEnv, gitEnv)
 
-	_, err = ParseProjectEnvContent(overrideContent, contextEnv)
+	overrideEnv, err := ParseProjectEnvContent(overrideContent, contextEnv)
 	if err != nil {
 		return "", errors.WrapIf(err, "parse override env content")
 	}
@@ -360,11 +360,110 @@ func BuildEffectiveEnvContent(gitContent, overrideContent string) (string, error
 		return overrideContent, nil
 	case overrideContent == "":
 		return gitContent, nil
-	case strings.HasSuffix(gitContent, "\n"), strings.HasPrefix(overrideContent, "\n"):
-		return gitContent + overrideContent, nil
-	default:
-		return gitContent + "\n" + overrideContent, nil
 	}
+
+	concatenated := gitContent + "\n" + overrideContent
+	if strings.HasSuffix(gitContent, "\n") || strings.HasPrefix(overrideContent, "\n") {
+		concatenated = gitContent + overrideContent
+	}
+
+	candidate, ok := mergeEnvOverridesInPlaceInternal(gitContent, overrideContent, overrideEnv)
+	if !ok {
+		return concatenated, nil
+	}
+
+	candidateEnv, candidateErr := ParseProjectEnvContent(candidate, make(EnvMap))
+	expectedEnv, expectedErr := ParseProjectEnvContent(concatenated, make(EnvMap))
+	if candidateErr == nil && expectedErr == nil && maps.Equal(candidateEnv, expectedEnv) {
+		return candidate, nil
+	}
+
+	return concatenated, nil
+}
+
+var envKeyLineRegexInternal = regexp.MustCompile(`^(\s*(?:export\s+)?)([A-Za-z_][A-Za-z0-9_.-]*)(\s*=)(.*)$`)
+
+// mergeEnvOverridesInPlaceInternal rewrites the value of every gitContent line
+// whose key has an override — keeping line order and trailing inline comments —
+// then appends the override lines whose keys were not rewritten. ok is false when
+// no git line matched an override and the caller should fall back to plain
+// concatenation.
+func mergeEnvOverridesInPlaceInternal(gitContent, overrideContent string, overrideEnv EnvMap) (merged string, ok bool) {
+	rewritten := make(map[string]struct{})
+	gitLines := strings.Split(gitContent, "\n")
+
+	for i, line := range gitLines {
+		body, hadCR := strings.CutSuffix(line, "\r")
+		match := envKeyLineRegexInternal.FindStringSubmatch(body)
+		if match == nil {
+			continue
+		}
+		overrideValue, exists := overrideEnv[match[2]]
+		if !exists {
+			continue
+		}
+
+		value, comment := splitEnvValueCommentInternal(match[4])
+		separator := value[len(strings.TrimRight(value, " \t")):]
+		if comment != "" && separator == "" {
+			separator = " "
+		}
+
+		body = match[1] + match[2] + match[3] + formatEnvValueInternal(overrideValue) + separator + comment
+		if hadCR {
+			body += "\r"
+		}
+		gitLines[i] = body
+		rewritten[match[2]] = struct{}{}
+	}
+
+	if len(rewritten) == 0 {
+		return "", false
+	}
+
+	remainderLines := make([]string, 0)
+	for line := range strings.SplitSeq(overrideContent, "\n") {
+		if match := envKeyLineRegexInternal.FindStringSubmatch(strings.TrimSuffix(line, "\r")); match != nil {
+			if _, drop := rewritten[match[2]]; drop {
+				continue
+			}
+		}
+		remainderLines = append(remainderLines, line)
+	}
+
+	merged = strings.Join(gitLines, "\n")
+	remainder := strings.Join(remainderLines, "\n")
+	switch {
+	case strings.TrimSpace(remainder) == "":
+		return merged, true
+	case strings.HasSuffix(merged, "\n"), strings.HasPrefix(remainder, "\n"):
+		return merged + remainder, true
+	default:
+		return merged + "\n" + remainder, true
+	}
+}
+
+// splitEnvValueCommentInternal splits a raw single-line env value into the value
+// part and a trailing inline comment. A comment starts at an unquoted '#' that is
+// at the start of the value or preceded by whitespace.
+func splitEnvValueCommentInternal(raw string) (value, comment string) {
+	var quote byte
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			} else if c == '\\' && quote == '"' {
+				i++
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '#' && (i == 0 || raw[i-1] == ' ' || raw[i-1] == '\t'):
+			return raw[:i], raw[i:]
+		}
+	}
+	return raw, ""
 }
 
 // BuildAdditiveOverrideEnvContent derives override content from a pre-git local

--- a/backend/pkg/projects/env_test.go
+++ b/backend/pkg/projects/env_test.go
@@ -161,15 +161,29 @@ func TestBuildEffectiveEnvContent(t *testing.T) {
 			wantEnv:    EnvMap{"Z_LAST": "last", "A_FIRST": "first"},
 		},
 		{
-			name:            "adds a separator without changing either layer",
+			name:            "rewrites shared keys in place and appends override-only keys",
 			gitContent:      "BASE_URL=https://example.com\nSHARED=git",
 			overrideContent: "# local values\nAPI_TOKEN=secret\nSHARED=override\n",
-			want:            "BASE_URL=https://example.com\nSHARED=git\n# local values\nAPI_TOKEN=secret\nSHARED=override\n",
+			want:            "BASE_URL=https://example.com\nSHARED=override\n# local values\nAPI_TOKEN=secret\n",
 			wantEnv: EnvMap{
 				"BASE_URL":  "https://example.com",
 				"API_TOKEN": "secret",
 				"SHARED":    "override",
 			},
+		},
+		{
+			name:            "updates overridden value in place preserving inline comment",
+			gitContent:      "PORT=3001 # Port to run the server on\n",
+			overrideContent: "PORT=3011\n",
+			want:            "PORT=3011 # Port to run the server on\n",
+			wantEnv:         EnvMap{"PORT": "3011"},
+		},
+		{
+			name:            "falls back to appending when the git line cannot be rewritten safely",
+			gitContent:      "MULTI=\"line1\nline2\"\nOTHER=1\n",
+			overrideContent: "MULTI=replaced\n",
+			want:            "MULTI=\"line1\nline2\"\nOTHER=1\nMULTI=replaced\n",
+			wantEnv:         EnvMap{"MULTI": "replaced", "OTHER": "1"},
 		},
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3460

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change updates generated project `.env` files so local values replace matching Git-managed keys at their original positions, while local-only keys remain appended. A focused comparison against the previous concatenation behavior exercised interpolation, quoting, inline comments, duplicate keys, CRLF input, multiline values, `export` syntax, and escaped-dollar values. All parsed environment maps matched the previous behavior, and the complete `backend/pkg/projects` test suite passed. No defects were found; the change is safe to merge.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The revised merge behavior preserves the parsed dotenv values produced by the previous concatenation approach for the exercised syntax cases.

No defects remain after comparing the effective environment values with the prior implementation and running the package test suite.

**Files Needing Attention:** No files require follow-up.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an authored Go validation comparing BuildEffectiveEnvContent between the parent revision and this change for nine dotenv syntax cases, producing identical parsed environment maps across interpolation ordering, quoted values, hash comments, duplicate Git keys, CRLF, multiline values, export syntax, and escaped dollars.
- Executed the backend/pkg/projects Go test suite with Go 1.26.5 and GOEXPERIMENT=jsonv2 to verify end-to-end behavior, and the tests passed.
- Compared the before/after results and confirmed that nine parsed effective maps exactly match the legacy concatenation, with the rewrite enabled only where verified.
- Aggregated the validation and test evidence into artifacts that support semantic preservation of dotenv processing for the exercised cases.

<a href="https://app.greptile.com/trex/runs/16995052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update overridden env keys in place..."](https://github.com/getarcaneapp/arcane/commit/5cbfc4a4377f60df8e0bcd02ca75d7425eb8ab9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49540135)</sub>

<!-- /greptile_comment -->