### PR TITLE
fix: bulk remove doing nothing on non-HTTPS deployments

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -866,6 +866,7 @@
   "completed": "Completed",
   "vuln_clean": "Clean",
   "vuln_click_to_scan": "Click scan to check for vulnerabilities",
+  "unexpected_error": "An unexpected error occurred",
   "volumes_subtitle": "Manage your Docker volumes",
   "volumes_stat_total": "Total Volumes",
   "unused_volumes": "Unused Volumes",

--- a/frontend/src/lib/components/confirm-dialog/confirm-dialog.svelte
+++ b/frontend/src/lib/components/confirm-dialog/confirm-dialog.svelte
@@ -6,6 +6,7 @@
 	import { Label } from '#lib/components/ui/label';
 	import Checkbox from '../ui/checkbox/checkbox.svelte';
 	import { m } from '#lib/paraglide/messages';
+	import { toast } from 'svelte-sonner';
 
 	let checkboxStates = $state<Record<string, boolean>>({});
 
@@ -25,7 +26,15 @@
 		const action = $confirmDialogStore.confirm.action;
 		const states = $state.snapshot(checkboxStates);
 		$confirmDialogStore.open = false;
-		action(states);
+		// The dialog is already closed, so a throwing action would otherwise be an
+		// unhandled rejection the user never sees — surface it instead. Invoke
+		// inside the chain so synchronous throws also land in the catch.
+		Promise.resolve()
+			.then(() => action(states))
+			.catch((error) => {
+				console.error('Confirm action failed:', error);
+				toast.error(m.unexpected_error());
+			});
 	}
 </script>
 

--- a/frontend/src/lib/components/confirm-dialog/store.ts
+++ b/frontend/src/lib/components/confirm-dialog/store.ts
@@ -11,7 +11,7 @@ interface ConfirmDialogStore {
 		destructive?: boolean;
 		/** ArcaneButton action variant for the confirm button; overrides the destructive/remove default. */
 		button?: Action;
-		action: (checkboxStates: Record<string, boolean>) => void;
+		action: (checkboxStates: Record<string, boolean>) => void | Promise<void>;
 	};
 	checkboxes?: Array<{
 		id: string;
@@ -43,7 +43,7 @@ export function openConfirmDialog({
 		label?: string;
 		destructive?: boolean;
 		button?: Action;
-		action: (checkboxStates: Record<string, boolean>) => void;
+		action: (checkboxStates: Record<string, boolean>) => void | Promise<void>;
 	};
 	checkboxes?: Array<{
 		id: string;

--- a/frontend/src/lib/services/image-service.ts
+++ b/frontend/src/lib/services/image-service.ts
@@ -1,5 +1,5 @@
 import BaseAPIService from './api-service';
-import { environmentStore } from '#lib/stores/environment.store.svelte';
+import { environmentStore, LOCAL_DOCKER_ENVIRONMENT_ID } from '#lib/stores/environment.store.svelte';
 import type {
 	ImageSummaryDto,
 	ImageUsageCounts,
@@ -145,7 +145,11 @@ class ImageService extends BaseAPIService {
 	}
 
 	async deleteImage(imageId: string, options?: { force?: boolean; noprune?: boolean }): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+		// Resolve the env id synchronously when possible so bulk deletes start
+		// their request inside the runWithActivityBatchId scope (see api-service).
+		const envId = environmentStore.isInitialized()
+			? (environmentStore.selected?.id ?? LOCAL_DOCKER_ENVIRONMENT_ID)
+			: await environmentStore.getCurrentEnvironmentId();
 		return this.handleResponse(this.api.delete(`/environments/${envId}/images/${imageId}`, { params: options }));
 	}
 

--- a/frontend/src/lib/services/volume-service.ts
+++ b/frontend/src/lib/services/volume-service.ts
@@ -1,5 +1,5 @@
 import BaseAPIService from './api-service';
-import { environmentStore } from '#lib/stores/environment.store.svelte';
+import { environmentStore, LOCAL_DOCKER_ENVIRONMENT_ID } from '#lib/stores/environment.store.svelte';
 import type {
 	VolumeSummaryDto,
 	VolumeDetailDto,
@@ -63,7 +63,11 @@ class VolumeService extends BaseAPIService {
 	}
 
 	async deleteVolume(volumeName: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+		// Resolve the env id synchronously when possible so bulk deletes start
+		// their request inside the runWithActivityBatchId scope (see api-service).
+		const envId = environmentStore.isInitialized()
+			? (environmentStore.selected?.id ?? LOCAL_DOCKER_ENVIRONMENT_ID)
+			: await environmentStore.getCurrentEnvironmentId();
 		return this.handleResponse(this.api.delete(`/environments/${envId}/volumes/${volumeName}`));
 	}
 }

--- a/frontend/src/lib/utils/bulk-actions.ts
+++ b/frontend/src/lib/utils/bulk-actions.ts
@@ -1,5 +1,6 @@
 import { toast } from 'svelte-sonner';
 import { openConfirmDialog } from '#lib/components/confirm-dialog';
+import { streamCacheBuster } from '#lib/utils/streaming';
 import { markActivityToastShown } from '#lib/components/activity/activity-completion-toasts';
 import { runWithActivityBatchId } from '#lib/services/api-service';
 import { handleApiResultWithCallbacks, tryCatch, type Result } from '#lib/utils/api';
@@ -84,7 +85,10 @@ async function runBulkOperation<T>({
 		// Multi-item runs share a batch id so the Activity Center renders one
 		// batch row. Each request is STARTED inside the synchronous batch scope
 		// (awaited outside it), so concurrent unrelated actions never inherit it.
-		const batchId = total > 1 ? crypto.randomUUID() : null;
+		// streamCacheBuster instead of bare crypto.randomUUID: the latter is
+		// secure-context-only (throws on plain-HTTP deployments), and the fallback
+		// format matches the backend batch-id pattern ^[A-Za-z0-9_-]{1,64}$.
+		const batchId = total > 1 ? streamCacheBuster() : null;
 		const startRun = (id: string) => (batchId ? runWithActivityBatchId(batchId, () => tryCatch(run(id))) : tryCatch(run(id)));
 		if (sequential) {
 			for (const id of ids) {

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -27,6 +27,7 @@
 	import { isLikelyStaleFailedSummary, isVulnerabilityScanInProgress } from '#lib/utils/docker';
 	import { environmentStore } from '#lib/stores/environment.store.svelte';
 	import { hasPermission } from '#lib/utils/auth';
+	import userStore from '#lib/stores/user-store';
 	import { activityToastOptions, extractActivityId } from '#lib/utils/activity-toast';
 	import { bulkConfirmAndRun } from '#lib/utils/bulk-actions';
 	import InUseStatus from '#lib/components/arcane-table/cells/in-use-status.svelte';
@@ -67,11 +68,28 @@
 	});
 
 	const currentEnvId = $derived(environmentStore.selected?.id || '0');
-	const canDeleteImage = $derived(hasPermission('images:delete', currentEnvId));
-	const canPullImage = $derived(hasPermission('images:pull', currentEnvId));
-	const canScanImage = $derived(hasPermission('vulnerabilities:scan', currentEnvId));
-	const canTagImage = $derived(hasPermission('images:tag', currentEnvId));
-	const canReadImage = $derived(hasPermission('images:read', currentEnvId));
+	// Track the user store: hasPermission reads it non-reactively, so without
+	// this the deriveds would cache pre-hydration falses forever.
+	const canDeleteImage = $derived.by(() => {
+		$userStore;
+		return hasPermission('images:delete', currentEnvId);
+	});
+	const canPullImage = $derived.by(() => {
+		$userStore;
+		return hasPermission('images:pull', currentEnvId);
+	});
+	const canScanImage = $derived.by(() => {
+		$userStore;
+		return hasPermission('vulnerabilities:scan', currentEnvId);
+	});
+	const canTagImage = $derived.by(() => {
+		$userStore;
+		return hasPermission('images:tag', currentEnvId);
+	});
+	const canReadImage = $derived.by(() => {
+		$userStore;
+		return hasPermission('images:read', currentEnvId);
+	});
 
 	let isPullingInline = $state<Record<string, boolean>>({});
 	let isScanningInline = $state<Record<string, boolean>>({});

--- a/frontend/src/routes/(app)/volumes/volume-table.svelte
+++ b/frontend/src/routes/(app)/volumes/volume-table.svelte
@@ -25,6 +25,7 @@
 	import type { ColumnVisibilityState } from '@tanstack/table-core';
 	import { environmentStore } from '#lib/stores/environment.store.svelte';
 	import { hasPermission } from '#lib/utils/auth';
+	import userStore from '#lib/stores/user-store';
 	import { activityToastOptions, extractActivityId } from '#lib/utils/activity-toast';
 	import { bulkConfirmAndRun } from '#lib/utils/bulk-actions';
 
@@ -45,7 +46,12 @@
 	});
 
 	const currentEnvId = $derived(environmentStore.selected?.id || '0');
-	const canDeleteVolume = $derived(hasPermission('volumes:delete', currentEnvId));
+	// Track the user store: hasPermission reads it non-reactively, so without
+	// this the derived would cache a pre-hydration false forever.
+	const canDeleteVolume = $derived.by(() => {
+		$userStore;
+		return hasPermission('volumes:delete', currentEnvId);
+	});
 	let customSettings = $state<Record<string, unknown>>({});
 	let showInternal = $derived.by(() => {
 		return (customSettings['showInternalVolumes'] as boolean) ?? false;
@@ -155,8 +161,10 @@
 	}
 
 	function handleDeleteSelected(ids: string[]) {
-		const idToName = new Map(volumes.data.map((v) => [v.id, v.name] as const));
-		const idsToDelete = ids.filter((id) => !isBackupVolumeName(idToName.get(id)));
+		// A volume's id IS its name (backend sets ID: v.Name), so ids can be
+		// passed to the delete endpoint directly — no per-page name lookup, which
+		// would break for selections carried across pages.
+		const idsToDelete = ids.filter((id) => !isBackupVolumeName(id));
 
 		bulkConfirmAndRun({
 			ids: idsToDelete,
@@ -164,7 +172,7 @@
 			message: m.volumes_remove_selected_message({ count: idsToDelete.length }),
 			confirmLabel: m.common_remove(),
 			destructive: true,
-			run: (id) => volumeService.deleteVolume(idToName.get(id)?.trim() || m.common_unknown()),
+			run: (id) => volumeService.deleteVolume(id),
 			messages: {
 				success: (count) => m.common_bulk_remove_success({ count, resource: m.resource_volumes_cap() }),
 				partial: (success, total, failed) =>
@@ -196,10 +204,8 @@
 		{ id: 'driver', label: m.common_driver(), defaultVisible: true }
 	];
 
-	const deletableSelectedIds = $derived.by(() => {
-		const idToName = new Map(volumes.data.map((v) => [v.id, v.name] as const));
-		return (selectedIds ?? []).filter((id) => !isBackupVolumeName(idToName.get(id)));
-	});
+	// Volume id === name, so the backup-volume filter works on the id directly.
+	const deletableSelectedIds = $derived((selectedIds ?? []).filter((id) => !isBackupVolumeName(id)));
 
 	const bulkActions = $derived.by<BulkAction[]>(() => [
 		{


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3368

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change restores multi-item image and volume removal for plain-HTTP deployments, keeps delete requests bound to the selected environment after hydration, preserves volume identifiers across paginated selections, and reports confirmation-action failures to users.

The following failure predictions were disproved by an executed delete-flow check: missing `crypto.randomUUID` prevented bulk deletion; hydrated delete requests fell back from the selected environment; and persisted volume selections were converted to `Unknown`. The check observed a valid shared fallback batch ID, DELETE requests to `remote-42` with activity batch headers, and the original persisted volume identifiers. No defects remain.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The exercised plain-HTTP bulk deletion, selected-environment routing, and persisted volume-selection flows all behaved as intended.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the head-6cb285f4-delete-flow-validation.mjs script in a Vite SSR harness with crypto.randomUUID unavailable.
- Observed that both image DELETE requests received the same fallback batch ID 1785722535822-31vbszpmsfd, which matches the backend-accepted character pattern.
- Verified that image and volume DELETE requests retained the hydrated environment remote-42 and carried batch headers for their multi-item operations.
- Confirmed persisted volume selections were sent as persisted-volume and persisted-volume-two, with no Unknown fallback.
- Reviewed the second validation run and documented that three hypotheses were disproved: the batch ID behavior, the hydrated environment retention for multi-item flows, and the persisted-volume payloads, as shown in the validation logs.

<a href="https://app.greptile.com/trex/runs/17000194/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bulk remove doing nothing on non-HT..."](https://github.com/getarcaneapp/arcane/commit/6cb285f4bbb59a404639390fb624130e3d608cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49546930)</sub>

<!-- /greptile_comment -->