### PR TITLE
fix: sheet panel animation restarting on hover during open

### DIFF
--- a/frontend/src/lib/components/accent-color/accent-color-picker.svelte
+++ b/frontend/src/lib/components/accent-color/accent-color-picker.svelte
@@ -97,7 +97,7 @@
 				{/if}
 			</div>
 			<div
-				class="absolute top-12 left-1/2 z-[var(--arcane-z-sticky)] max-w-0 -translate-x-1/2 transform overflow-hidden rounded-md border bg-background px-2 py-1 text-xs whitespace-nowrap text-muted-foreground opacity-0 shadow-sm transition-all duration-300 ease-out group-hover/item:max-w-[100px] group-hover/item:text-foreground group-hover/item:opacity-100"
+				class="absolute top-12 left-1/2 z-[var(--arcane-z-sticky)] max-w-0 -translate-x-1/2 transform overflow-hidden rounded-md border bg-background px-2 py-1 text-xs whitespace-nowrap text-muted-foreground opacity-0 shadow-sm transition-[max-width,opacity,color] duration-300 ease-out group-hover/item:max-w-[100px] group-hover/item:text-foreground group-hover/item:opacity-100"
 			>
 				{label}
 			</div>

--- a/frontend/src/lib/components/accent-color/custom-color.svelte
+++ b/frontend/src/lib/components/accent-color/custom-color.svelte
@@ -51,12 +51,12 @@
 				<div>
 					<Label for="custom-color-input" class="text-sm font-medium">{m.color_value()}</Label>
 					<div class="flex items-center gap-2">
-						<div class="w-full transition">
+						<div class="w-full">
 							<Input id="custom-color-input" bind:value={customColorInput} placeholder="#3b82f6" class="mt-1 flex-1" />
 						</div>
 						<div
 							class={{
-								'mt-1 rounded-lg border-1 border-border transition-all duration-200 ease-in-out': true,
+								'mt-1 rounded-lg border-1 border-border transition-[height,width] duration-200 ease-in-out': true,
 								'h-9 w-9': isValidColor(customColorInput),
 								'h-0 w-0': !isValidColor(customColorInput)
 							}}

--- a/frontend/src/lib/components/activity/activity-center.svelte
+++ b/frontend/src/lib/components/activity/activity-center.svelte
@@ -94,7 +94,7 @@
 					disabled={activityStore.isCancelling(activity.id)}
 					title={m.activity_cancel()}
 					aria-label={m.activity_cancel()}
-					class="absolute top-1/2 right-11 z-[var(--arcane-z-raised)] flex size-7 -translate-y-1/2 items-center justify-center rounded-md bg-background/70 text-muted-foreground opacity-0 backdrop-blur-sm transition group-hover/activity:opacity-100 hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-40"
+					class="absolute top-1/2 right-11 z-[var(--arcane-z-raised)] flex size-7 -translate-y-1/2 items-center justify-center rounded-md bg-background/70 text-muted-foreground opacity-0 backdrop-blur-sm transition-[opacity,color,background-color] group-hover/activity:opacity-100 hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-40"
 				>
 					<CloseIcon class="size-4" aria-hidden="true" />
 				</button>

--- a/frontend/src/lib/components/activity/activity-detail-panel.svelte
+++ b/frontend/src/lib/components/activity/activity-detail-panel.svelte
@@ -84,7 +84,7 @@
 							type="button"
 							onclick={() => confirmCancelActivity(liveActivity.id)}
 							disabled={activityStore.isCancelling(liveActivity.id)}
-							class="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:border-destructive/30 hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+							class="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-destructive/30 hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
 						>
 							<CloseIcon class="size-3.5" aria-hidden="true" />
 							{m.activity_cancel()}

--- a/frontend/src/lib/components/form/mobile-floating-form-actions.svelte
+++ b/frontend/src/lib/components/form/mobile-floating-form-actions.svelte
@@ -92,7 +92,7 @@
 
 {#if isMobile.current || isTablet.current}
 	<div
-		class="fixed right-4 z-[var(--arcane-z-app-chrome)] flex flex-col gap-3 transition-all duration-300 ease-out sm:hidden"
+		class="fixed right-4 z-[var(--arcane-z-app-chrome)] flex flex-col gap-3 transition-[bottom] duration-300 ease-out sm:hidden"
 		style="bottom: {scrollToHideEnabled && !mobileNavVisible
 			? '1rem'
 			: 'calc(var(--mobile-' +

--- a/frontend/src/lib/components/mobile-nav/mobile-nav.svelte
+++ b/frontend/src/lib/components/mobile-nav/mobile-nav.svelte
@@ -163,7 +163,7 @@
 				? 'fixed left-1/2 z-[var(--arcane-z-app-chrome)] -translate-x-1/2 transform'
 				: 'fixed right-0 bottom-0 left-0 z-[var(--arcane-z-app-chrome)] gap-2',
 			'border-border/30 bg-background/60 backdrop-blur-xl',
-			'shadow-sm transition-all duration-300 ease-out select-none',
+			'shadow-sm transition-[translate,scale,opacity] duration-300 ease-out select-none',
 			'flex items-center',
 			mode === 'floating'
 				? cn(

--- a/frontend/src/lib/components/sidebar/sidebar-logo.svelte
+++ b/frontend/src/lib/components/sidebar/sidebar-logo.svelte
@@ -12,17 +12,15 @@
 
 <div
 	class={cn(
-		'flex border-b border-border/30 transition-all duration-300',
+		'flex border-b border-border/30 transition-[height,padding] duration-300',
 		isCollapsed ? 'h-16 items-center justify-center px-2' : 'h-14 items-center justify-center px-4'
 	)}
 >
-	<div
-		class={cn('relative flex shrink-0 items-center justify-center transition-all duration-300', isCollapsed ? '' : 'flex-col')}
-	>
+	<div class={cn('relative flex shrink-0 items-center justify-center', isCollapsed ? '' : 'flex-col')}>
 		<img
 			src={logoUrl}
 			alt={m.layout_title()}
-			class={cn('drop-shadow-sm transition-all duration-300', isCollapsed ? 'h-6 w-6' : 'h-9 w-auto max-w-[160px]')}
+			class={cn('drop-shadow-sm transition-[height,width] duration-300', isCollapsed ? 'h-6 w-6' : 'h-9 w-auto max-w-[160px]')}
 			width={isCollapsed ? '24' : '160'}
 			height={isCollapsed ? '24' : '72'}
 		/>

--- a/frontend/src/lib/components/ui/accordion/accordion-content.svelte
+++ b/frontend/src/lib/components/ui/accordion/accordion-content.svelte
@@ -13,7 +13,7 @@
 <AccordionPrimitive.Content
 	bind:ref
 	class={cn(
-		'overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
+		'overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
 		className
 	)}
 	{...restProps}

--- a/frontend/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/frontend/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -19,7 +19,7 @@
 		bind:ref
 		data-slot="alert-dialog-content"
 		class={cn(
-			'fixed top-[50%] left-[50%] z-[var(--arcane-z-surface)] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:fill-mode-forwards data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+			'fixed top-[50%] left-[50%] z-[var(--arcane-z-surface)] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg animation-duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:fill-mode-forwards data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
 			className
 		)}
 		{...restProps}

--- a/frontend/src/lib/components/ui/collapsible/collapsible-content.svelte
+++ b/frontend/src/lib/components/ui/collapsible/collapsible-content.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { Collapsible as CollapsiblePrimitive } from 'bits-ui';
+	import { cn } from '#lib/utils.js';
 
-	let { ref = $bindable(null), ...restProps }: CollapsiblePrimitive.ContentProps = $props();
+	let { ref = $bindable(null), class: className, ...restProps }: CollapsiblePrimitive.ContentProps = $props();
 </script>
 
-<CollapsiblePrimitive.Content bind:ref data-slot="collapsible-content" {...restProps} />
+<CollapsiblePrimitive.Content
+	bind:ref
+	data-slot="collapsible-content"
+	class={cn('overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down', className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/frontend/src/lib/components/ui/copy-button/copy-button.svelte
@@ -40,7 +40,11 @@
 </script>
 
 {#snippet idleIcon()}
-	<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+	<div
+		class="col-start-1 row-start-1"
+		in:scale={{ duration: animationDuration, start: 0.85 }}
+		out:scale={{ duration: animationDuration, start: 0.85 }}
+	>
 		{#if icon}
 			{@render icon()}
 		{:else}
@@ -66,19 +70,29 @@
 			onCopy?.(status);
 		}}
 	>
-		{#if clipboard.status === 'success'}
-			<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-				<CheckIcon tabindex={-1} />
-				<span class="sr-only">{m.common_copied()}</span>
-			</div>
-		{:else if clipboard.status === 'failure'}
-			<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-				<CloseIcon tabindex={-1} />
-				<span class="sr-only">{m.common_copy_failed()}</span>
-			</div>
-		{:else}
-			{@render idleIcon()}
-		{/if}
+		<span class="grid place-items-center">
+			{#if clipboard.status === 'success'}
+				<div
+					class="col-start-1 row-start-1"
+					in:scale={{ duration: animationDuration, start: 0.85 }}
+					out:scale={{ duration: animationDuration, start: 0.85 }}
+				>
+					<CheckIcon tabindex={-1} />
+					<span class="sr-only">{m.common_copied()}</span>
+				</div>
+			{:else if clipboard.status === 'failure'}
+				<div
+					class="col-start-1 row-start-1"
+					in:scale={{ duration: animationDuration, start: 0.85 }}
+					out:scale={{ duration: animationDuration, start: 0.85 }}
+				>
+					<CloseIcon tabindex={-1} />
+					<span class="sr-only">{m.common_copy_failed()}</span>
+				</div>
+			{:else}
+				{@render idleIcon()}
+			{/if}
+		</span>
 		{@render children?.()}
 	</ArcaneButton>
 {:else}
@@ -95,7 +109,9 @@
 				name="copy"
 				disabled
 			>
-				{@render idleIcon()}
+				<span class="grid place-items-center">
+					{@render idleIcon()}
+				</span>
 				{@render children?.()}
 			</ArcaneButton>
 		</Tooltip.Trigger>

--- a/frontend/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/frontend/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'fixed top-[50%] left-[50%] z-[var(--arcane-z-surface)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-border/30 bg-white p-6 text-foreground shadow-lg backdrop-blur-md duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:fill-mode-forwards data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-2xl dark:border-border/80 dark:bg-surface/10',
+			'fixed top-[50%] left-[50%] z-[var(--arcane-z-surface)] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-border/30 bg-white p-6 text-foreground shadow-lg backdrop-blur-md animation-duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:fill-mode-forwards data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-2xl dark:border-border/80 dark:bg-surface/10',
 			className
 		)}
 		{...restProps}

--- a/frontend/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/frontend/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 	export const sheetVariants = tv({
-		base: 'text-foreground bg-white dark:bg-surface/10 backdrop-blur-md border border-border/70 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards fixed z-[var(--arcane-z-surface)] flex flex-col gap-4 transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+		base: 'text-foreground bg-white dark:bg-surface/10 backdrop-blur-md border border-border/70 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards fixed z-[var(--arcane-z-surface)] flex flex-col gap-4 ease-in-out data-[state=closed]:animation-duration-300 data-[state=open]:animation-duration-500',
 		variants: {
 			side: {
 				top: 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto rounded-b-2xl',

--- a/frontend/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/frontend/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -27,7 +27,7 @@
 	}}
 	title={sidebar.isTablet ? '' : 'Toggle Sidebar'}
 	class={cn(
-		'absolute inset-y-0 z-[var(--arcane-z-sticky)] hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+		'absolute inset-y-0 z-[var(--arcane-z-sticky)] hidden w-4 -translate-x-1/2 transition-transform ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
 		// Only show hover and cursor effects when not in tablet mode
 		!sidebar.isTablet && [
 			'hover:after:bg-sidebar-border',

--- a/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/frontend/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -27,7 +27,7 @@
 		{sideOffset}
 		{side}
 		class={cn(
-			'z-[var(--arcane-z-surface)] w-fit origin-(--bits-tooltip-content-transform-origin) animate-in rounded-xl border border-border/40 bg-popover/90 px-3 py-1.5 text-xs text-balance text-popover-foreground shadow-lg backdrop-blur-md backdrop-saturate-150 fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 dark:bg-popover/20',
+			'z-[var(--arcane-z-surface)] w-fit origin-(--bits-tooltip-content-transform-origin) rounded-xl border border-border/40 bg-popover/90 px-3 py-1.5 text-xs text-balance text-popover-foreground shadow-lg backdrop-blur-md backdrop-saturate-150 fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:animate-in data-[state=instant-open]:animate-in dark:bg-popover/20',
 			className
 		)}
 		{...restProps}

--- a/frontend/src/lib/layouts/tabbed-page-layout.svelte
+++ b/frontend/src/lib/layouts/tabbed-page-layout.svelte
@@ -52,7 +52,7 @@
 <div class={cn('flex h-full min-h-0 flex-col bg-background', className)}>
 	<Tabs.Root value={selectedTab} class="flex min-h-0 w-full flex-1 flex-col">
 		<div
-			class="sticky top-0 border-b transition-all duration-300"
+			class="sticky top-0 border-b transition-opacity duration-300"
 			style="opacity: {showFloatingHeader ? 0 : 1}; pointer-events: {showFloatingHeader ? 'none' : 'auto'};"
 		>
 			<div class="max-w-full px-4 py-3">
@@ -84,9 +84,7 @@
 		</div>
 
 		{#if showFloatingHeader}
-			<div
-				class="fixed top-4 left-1/2 z-[var(--arcane-z-page-floating)] -translate-x-1/2 transition-all duration-300 ease-in-out"
-			>
+			<div class="fixed top-4 left-1/2 z-[var(--arcane-z-page-floating)] -translate-x-1/2">
 				<div
 					class="bubble-shadow-lg rounded-lg border border-border/50 bg-popover/90 px-4 py-3 backdrop-blur-md supports-backdrop-filter:bg-popover/80"
 				>

--- a/frontend/src/routes/(app)/images/builds/components/build-workspace-panel.svelte
+++ b/frontend/src/routes/(app)/images/builds/components/build-workspace-panel.svelte
@@ -111,7 +111,7 @@
 							value={remoteContext}
 							oninput={(event) => onRemoteContextChange?.((event.currentTarget as HTMLInputElement).value)}
 							placeholder={m.build_remote_git_context_placeholder()}
-							class="w-full rounded-xl border border-border bg-background/80 px-4 py-3 text-sm transition outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							class="w-full rounded-xl border border-border bg-background/80 px-4 py-3 text-sm transition-shadow outline-none focus-visible:ring-2 focus-visible:ring-ring"
 							spellcheck="false"
 							autocomplete="off"
 						/>

--- a/frontend/src/routes/(app)/settings/+layout.svelte
+++ b/frontend/src/routes/(app)/settings/+layout.svelte
@@ -78,7 +78,7 @@
 		{#if isSubPage}
 			<div
 				class={cn(
-					'sticky top-4 z-[var(--arcane-z-sticky)] mx-4 mb-6 rounded-lg border shadow-lg transition-all duration-200 md:hidden',
+					'sticky top-4 z-[var(--arcane-z-sticky)] mx-4 mb-6 rounded-lg border shadow-lg md:hidden',
 					'bg-background/95 backdrop-blur-md'
 				)}
 			>

--- a/frontend/src/routes/layout.css
+++ b/frontend/src/routes/layout.css
@@ -132,6 +132,18 @@ html.reduce-effects *::after {
 	transition-delay: 0ms !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.001ms !important;
+		animation-delay: 0ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+		transition-delay: 0ms !important;
+	}
+}
+
 @theme inline {
 	--radius-sm: calc(var(--radius) * 0.6);
 	--radius-md: calc(var(--radius) * 0.8);
@@ -222,7 +234,17 @@ html.reduce-effects *::after {
 		scrollbar-color: transparent transparent;
 	}
 
-	*:hover {
+	:where(
+		html,
+		body,
+		.overflow-auto,
+		.overflow-y-auto,
+		.overflow-x-auto,
+		.overflow-scroll,
+		.overflow-y-scroll,
+		.overflow-x-scroll,
+		.arcane-code-editor .cm-scroller
+	):hover {
 		scrollbar-color: var(--muted-foreground) transparent;
 	}
 
@@ -244,7 +266,17 @@ html.reduce-effects *::after {
 		transition: background 0.2s ease;
 	}
 
-	*:hover::-webkit-scrollbar-thumb {
+	:where(
+			html,
+			body,
+			.overflow-auto,
+			.overflow-y-auto,
+			.overflow-x-auto,
+			.overflow-scroll,
+			.overflow-y-scroll,
+			.overflow-x-scroll,
+			.arcane-code-editor .cm-scroller
+		):hover::-webkit-scrollbar-thumb {
 		background: var(--muted-foreground);
 		border: 2px solid transparent;
 		background-clip: content-box;


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3500

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change prevents hover-driven transitions from restarting overlay animations, uses animation-specific timing for dialogs and sheets, adds system reduced-motion handling, and limits scrollbar reveal styling to intended scroll containers.

Rendered Chromium checks confirmed that sheets retained a running 500ms entry animation, dialogs retained 200ms, instant-open tooltips retained 150ms, and CopyButton copying preserved its layout while updating its accessible status. Hovering both native overflow containers and CodeMirror-style scrollers revealed their scrollbars as intended. No defects were found.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

Browser validation confirmed the targeted animation timing, CopyButton interaction and accessibility feedback, stable button layout, and intended scrollbar visibility.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Rendered a focused component harness in Chromium against both the parent commit and the PR head, exercising the sheet, dialog, and tooltip animations, the CopyButton clipboard interaction, accessible status text, icon transition, and the native and CodeMirror-style scrollers; observed that the targeted UI behaviors operate as intended.
- Executed the validation sources and harness, confirming that every requested interaction was exercised against Chromium and that the before/after outputs align with the baseline expectations.

<a href="https://app.greptile.com/trex/runs/17168025/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: sheet panel animation restarting on..."](https://github.com/getarcaneapp/arcane/commit/df50e03c1c6b83490949fca0781fe931281109e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49893442)</sub>

<!-- /greptile_comment -->