### PR TITLE
fix: only grant default admin role during bootstrap or zero-admin recovery, not to any account named arcane

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -259,7 +259,16 @@ func initializeStartupState(p initializeStartupStateParams) {
 
 	startup.InitializeNonAgentFeatures(appCtx, runtimeCfg,
 		p.Role.EnsureBuiltInRoles,
-		p.User.CreateDefaultAdmin,
+		func(ctx context.Context) error {
+			// Backfill legacy users.roles first so CreateDefaultAdmin's
+			// zero-global-admin recovery gate sees upgraded assignments.
+			// No-op on modern schemas; runRoleStartupTasks repeats it
+			// idempotently for agent-mode and error-retry coverage.
+			if err := p.Role.BackfillLegacyRoleAssignments(ctx); err != nil {
+				slog.WarnContext(ctx, "Failed to backfill legacy role assignments before admin bootstrap", "error", err)
+			}
+			return p.User.CreateDefaultAdmin(ctx)
+		},
 		func(ctx context.Context) error {
 			return p.ApiKey.ReconcileDefaultAdminAPIKey(ctx, runtimeCfg.AdminStaticAPIKey)
 		},

--- a/backend/internal/services/api_key_service.go
+++ b/backend/internal/services/api_key_service.go
@@ -347,6 +347,19 @@ func (s *ApiKeyService) getDefaultAdminUser(ctx context.Context) (*models.User, 
 		return nil, errors.WrapIf(err, "failed to load default admin user")
 	}
 
+	// The username is mutable and not proof of provenance — never mint the
+	// managed full-permission key onto an account that isn't a global admin.
+	if s.roleService != nil {
+		perms, err := s.roleService.ResolvePermissions(ctx, adminUser)
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to resolve default admin permissions")
+		}
+		if !perms.IsGlobalAdmin() {
+			slog.WarnContext(ctx, "User is not a global admin, skipping default admin API key reconciliation", "username", defaultAdminUsername)
+			return nil, nil
+		}
+	}
+
 	return adminUser, nil
 }
 

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -260,16 +260,6 @@ func (s *AuthService) AuthenticateLocalPrimary(ctx context.Context, username, pa
 		return nil, ErrInvalidCredentials
 	}
 
-	if s.userService.NeedsPasswordUpgrade(user.PasswordHash) {
-		s.runInBackground(ctx, "upgrade_password_hash", func(ctx context.Context) error {
-			if err := s.userService.UpgradePasswordHash(ctx, user.ID, password); err != nil {
-				return errors.WrapIff(err, "failed to upgrade password hash for user %s", user.ID)
-			}
-			slog.InfoContext(ctx, "Successfully upgraded password hash from bcrypt to Argon2", "user", user.Username)
-			return nil
-		})
-	}
-
 	user.LastLogin = new(time.Now())
 	userCopy := new(*user)
 	s.runInBackground(ctx, "update_last_login", func(ctx context.Context) error {

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -569,7 +569,7 @@ func TestChangePassword_RevokesAllSessions(t *testing.T) {
 	s.userService = userSvc
 	s.sessionService = NewSessionService(db)
 
-	passwordHash, err := userSvc.hashPassword("old-password")
+	passwordHash, err := userSvc.HashPassword("old-password")
 	require.NoError(t, err)
 	user := &models.User{
 		BaseModel:    models.BaseModel{ID: "u-password"},
@@ -599,7 +599,7 @@ func TestChangePassword_KeepsCurrentSessionAlive(t *testing.T) {
 	s.userService = userSvc
 	s.sessionService = NewSessionService(db)
 
-	passwordHash, err := userSvc.hashPassword("old-password")
+	passwordHash, err := userSvc.HashPassword("old-password")
 	require.NoError(t, err)
 	user := &models.User{
 		BaseModel:    models.BaseModel{ID: "u-keep"},

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -12,7 +12,6 @@ import (
 	"emperror.dev/errors"
 
 	"golang.org/x/crypto/argon2"
-	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -72,7 +71,7 @@ func (s *UserService) WithRoleService(roleService *RoleService) *UserService {
 	return s
 }
 
-func (s *UserService) hashPassword(password string) (string, error) {
+func (s *UserService) HashPassword(password string) (string, error) {
 	salt := make([]byte, s.argon2Params.saltLength)
 	_, err := rand.Read(salt)
 	if err != nil {
@@ -90,20 +89,6 @@ func (s *UserService) hashPassword(password string) (string, error) {
 }
 
 func (s *UserService) ValidatePassword(encodedHash, password string) error {
-	// Check if it's a bcrypt hash (starts with $2a$, $2b$, or $2y$)
-	if strings.HasPrefix(encodedHash, "$2a$") || strings.HasPrefix(encodedHash, "$2b$") || strings.HasPrefix(encodedHash, "$2y$") {
-		return s.validateBcryptPassword(encodedHash, password)
-	}
-
-	// Otherwise, assume it's Argon2
-	return s.validateArgon2Password(encodedHash, password)
-}
-
-func (s *UserService) validateBcryptPassword(hash, password string) error {
-	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-}
-
-func (s *UserService) validateArgon2Password(encodedHash, password string) error {
 	parts := strings.Split(encodedHash, "$")
 	if len(parts) != 6 {
 		return errors.New("invalid hash format")
@@ -284,7 +269,7 @@ func (s *UserService) SetPassword(ctx context.Context, user *models.User, passwo
 		return nil, errors.New("user is nil")
 	}
 
-	hashedPassword, err := s.hashPassword(password)
+	hashedPassword, err := s.HashPassword(password)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to hash password")
 	}
@@ -306,7 +291,7 @@ func (s *UserService) SetPasswordAndRevokeSessionsExcept(ctx context.Context, us
 		return nil, ErrUserNotFound
 	}
 
-	hashedPassword, err := s.hashPassword(password)
+	hashedPassword, err := s.HashPassword(password)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to hash password")
 	}
@@ -388,24 +373,42 @@ func (s *UserService) AttachOidcSubjectTransactional(ctx context.Context, userID
 }
 
 func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
-	// Hash password outside transaction to minimize lock time
-	hashedPassword, err := s.hashPassword("arcane-admin")
-	if err != nil {
-		return errors.WrapIf(err, "failed to hash default admin password")
+	// If users already exist and at least one effective global admin remains,
+	// there is nothing to bootstrap or recover — bail before touching the
+	// `arcane` username at all. The username is mutable, so treating it as a
+	// provenance marker would let anyone with users:create/users:update rename
+	// an account to `arcane` and get promoted on the next restart.
+	if s.roleService != nil {
+		var count int64
+		if err := s.db.WithContext(ctx).Model(&models.User{}).Count(&count).Error; err != nil {
+			return errors.WrapIf(err, "failed to count users")
+		}
+		if count > 0 {
+			admins, err := s.roleService.CountGlobalAdminsExcludingUser(ctx, "")
+			if err != nil {
+				return errors.WrapIf(err, "failed to count global admins")
+			}
+			if admins > 0 {
+				return nil
+			}
+		}
 	}
 
 	// Step 1: ensure the default admin user row exists. If the users table is
-	// empty we create it; otherwise we find the existing `arcane` user (if any).
-	// Either way the role assignment is reconciled below — idempotently — so
-	// upgrades from older builds that didn't grant the role get patched up.
+	// empty we create it; otherwise (zero global admins — a broken/ancient
+	// upgrade) we find the existing `arcane` user to recover, if any.
 	var adminUserID string
-	err = dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
+	err := dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
 		var count int64
 		if err := tx.Model(&models.User{}).Count(&count).Error; err != nil {
 			return errors.WrapIf(err, "failed to count users")
 		}
 
 		if count == 0 {
+			hashedPassword, err := s.HashPassword("arcane-admin")
+			if err != nil {
+				return errors.WrapIf(err, "failed to hash default admin password")
+			}
 			email := "admin@localhost"
 			displayName := "Arcane Admin"
 			userModel := &models.User{
@@ -426,8 +429,9 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 			return nil
 		}
 
-		// Users already exist — see if `arcane` is one of them. If not,
-		// someone removed the default admin on purpose and we leave it alone.
+		// Users exist but no global admin does (recovery only — the early
+		// return above skips this path on healthy installs). See if `arcane`
+		// is present; if not, leave the install alone.
 		var existing models.User
 		err := tx.Where("username = ?", "arcane").First(&existing).Error
 		if err != nil {
@@ -446,12 +450,15 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 	if adminUserID == "" || s.roleService == nil {
 		return nil
 	}
+	return s.grantDefaultAdminRoleInternal(ctx, adminUserID)
+}
 
-	// Step 2: ensure the default admin holds the global Admin role assignment.
-	// Idempotent — if the assignment already exists, SetUserAssignments is a
-	// no-op write (it dedupes via the unique index). This recovers users that
-	// were created by older builds before the role-grant on bootstrap was
-	// wired up.
+// grantDefaultAdminRoleInternal grants the global Admin role to the bootstrap
+// user. Reached only on fresh bootstrap or zero-admin recovery.
+// SetUserAssignments replaces manual-source rows, so carry forward only the
+// existing manual assignments — copying OIDC-sourced rows here would duplicate
+// them as manual and pin them forever.
+func (s *UserService) grantDefaultAdminRoleInternal(ctx context.Context, adminUserID string) error {
 	assignments, err := s.roleService.ListUserAssignments(ctx, adminUserID)
 	if err != nil {
 		return errors.WrapIf(err, "failed to list default admin assignments")
@@ -461,16 +468,16 @@ func (s *UserService) CreateDefaultAdmin(ctx context.Context) error {
 			return nil // already has it
 		}
 	}
-	desired := append([]models.UserRoleAssignment{}, assignments...)
-	desired = append(desired, models.UserRoleAssignment{
+	manual := make([]models.UserRoleAssignment, 0, len(assignments)+1)
+	for _, a := range assignments {
+		if a.Source == models.RoleAssignmentSourceManual {
+			manual = append(manual, models.UserRoleAssignment{RoleID: a.RoleID, EnvironmentID: a.EnvironmentID})
+		}
+	}
+	manual = append(manual, models.UserRoleAssignment{
 		RoleID:        authz.BuiltInRoleAdmin,
 		EnvironmentID: nil,
 	})
-	// Strip the source field so SetUserAssignments classifies everything as manual.
-	manual := make([]models.UserRoleAssignment, 0, len(desired))
-	for _, a := range desired {
-		manual = append(manual, models.UserRoleAssignment{RoleID: a.RoleID, EnvironmentID: a.EnvironmentID})
-	}
 	if err := s.roleService.SetUserAssignments(ctx, adminUserID, manual); err != nil {
 		return errors.WrapIf(err, "failed to grant default admin global role")
 	}
@@ -508,30 +515,6 @@ func (s *UserService) DeleteUser(ctx context.Context, id string, actorPerms *aut
 
 		if err := tx.Delete(&models.User{}, "id = ?", id).Error; err != nil {
 			return errors.WrapIf(err, "failed to delete user")
-		}
-		return nil
-	})
-}
-
-func (s *UserService) HashPassword(password string) (string, error) {
-	return s.hashPassword(password)
-}
-
-func (s *UserService) NeedsPasswordUpgrade(hash string) bool {
-	return strings.HasPrefix(hash, "$2a$") || strings.HasPrefix(hash, "$2b$") || strings.HasPrefix(hash, "$2y$")
-}
-
-func (s *UserService) UpgradePasswordHash(ctx context.Context, userID, password string) error {
-	newHash, err := s.hashPassword(password)
-	if err != nil {
-		return errors.WrapIf(err, "failed to create new hash")
-	}
-
-	return dbutil.WithTx(ctx, s.db.DB, func(tx *gorm.DB) error {
-		if err := tx.Model(&models.User{}).
-			Where("id = ?", userID).
-			Update("password_hash", newHash).Error; err != nil {
-			return errors.WrapIf(err, "failed to update password hash")
 		}
 		return nil
 	})

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -352,3 +352,33 @@ func TestDeleteUserAllowsGlobalAdminActorDeletingAdmin(t *testing.T) {
 	actorCtx := context.WithValue(ctx, models.CurrentUserContextKey{}, other)
 	require.NoError(t, userSvc.DeleteUser(actorCtx, admin.ID, otherPerms))
 }
+
+func TestCreateDefaultAdminDoesNotPromoteRenamedArcaneUser(t *testing.T) {
+	userSvc, roleSvc := setupUserAndRoleServices(t)
+	ctx := context.Background()
+
+	admin := createTestUser(t, userSvc, "admin-1", "boss")
+	grantGlobalAdmin(t, roleSvc, admin.ID)
+	imposter := createTestUser(t, userSvc, "user-2", "arcane")
+
+	require.NoError(t, userSvc.CreateDefaultAdmin(ctx))
+
+	assignments, err := roleSvc.ListUserAssignments(ctx, imposter.ID)
+	require.NoError(t, err)
+	require.Empty(t, assignments)
+}
+
+func TestCreateDefaultAdminRecoversArcaneUserWhenNoGlobalAdminExists(t *testing.T) {
+	userSvc, roleSvc := setupUserAndRoleServices(t)
+	ctx := context.Background()
+
+	orphan := createTestUser(t, userSvc, "user-1", "arcane")
+
+	require.NoError(t, userSvc.CreateDefaultAdmin(ctx))
+
+	assignments, err := roleSvc.ListUserAssignments(ctx, orphan.ID)
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.Equal(t, authz.BuiltInRoleAdmin, assignments[0].RoleID)
+	require.Nil(t, assignments[0].EnvironmentID)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change narrows default-admin recovery, protects managed API-key reconciliation from non-admin ownership, and removes legacy bcrypt password validation and login-time migration.

Existing local accounts that still store bcrypt password hashes will be unable to authenticate with their correct passwords after this change.

## T-Rex validation blocked

A focused local-authentication reproduction could not run because the configured Go 1.26.5 toolchain crashes in `cmd/go/internal/fips140.Init` before compilation when `GOEXPERIMENT=jsonv2` is enabled. The affected tool is the Go toolchain; no application authentication result was produced.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>




</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused temporary test was prepared to persist bcrypt- and Argon2-hashed users and authenticate both through AuthenticateLocalPrimary.
- The Go toolchain crashed in cmd/go/internal/fips140.Init before compilation, so neither authentication path executed.
- As a result, the local-authentication check could not run and remains blocked until the toolchain is repaired.
- The final status is blocked / inconclusive, with no executed authentication result available.
- The review highlights the Argon2 parsing path in backend/internal/services/user\_service.go:91-104 and its failure surfacing in backend/internal/services/auth\_service.go:252-261.

<a href="https://app.greptile.com/trex/runs/17176114/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/services/user_service.go`, line 91-104 ([link](https://github.com/getarcaneapp/arcane/blob/0bf3524aa8a3762fb2c8119617a58fa06c2d4daf/backend/internal/services/user_service.go#L91-L104)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy bcrypt logins are rejected**

   If an existing local account still has a bcrypt password hash from before the Argon2 transition, `ValidatePassword` parses it exclusively as Argon2 and returns an invalid-format error, which `AuthenticateLocalPrimary` reports as invalid credentials and locks the user out despite a correct password.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/user_service.go
   Line: 91-104

   Comment:
   **Legacy bcrypt logins are rejected**

   If an existing local account still has a bcrypt password hash from before the Argon2 transition, `ValidatePassword` parses it exclusively as Argon2 and returns an invalid-format error, which `AuthenticateLocalPrimary` reports as invalid credentials and locks the user out despite a correct password.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_only_grant_default_admin_role_during_bootstrap_or_zero-admin_recovery_not_to_any_account_named_arcane%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_only_grant_default_admin_role_during_bootstrap_or_zero-admin_recovery_not_to_any_account_named_arcane%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fuser_service.go%0ALine%3A%2091-104%0A%0AComment%3A%0A**Legacy%20bcrypt%20logins%20are%20rejected**%0A%0AIf%20an%20existing%20local%20account%20still%20has%20a%20bcrypt%20password%20hash%20from%20before%20the%20Argon2%20transition%2C%20%60ValidatePassword%60%20parses%20it%20exclusively%20as%20Argon2%20and%20returns%20an%20invalid-format%20error%2C%20which%20%60AuthenticateLocalPrimary%60%20reports%20as%20invalid%20credentials%20and%20locks%20the%20user%20out%20despite%20a%20correct%20password.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fuser_service.go%0ALine%3A%2091-104%0A%0AComment%3A%0A**Legacy%20bcrypt%20logins%20are%20rejected**%0A%0AIf%20an%20existing%20local%20account%20still%20has%20a%20bcrypt%20password%20hash%20from%20before%20the%20Argon2%20transition%2C%20%60ValidatePassword%60%20parses%20it%20exclusively%20as%20Argon2%20and%20returns%20an%20invalid-format%20error%2C%20which%20%60AuthenticateLocalPrimary%60%20reports%20as%20invalid%20credentials%20and%20locks%20the%20user%20out%20despite%20a%20correct%20password.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_only_grant_default_admin_role_during_bootstrap_or_zero-admin_recovery_not_to_any_account_named_arcane%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_only_grant_default_admin_role_during_bootstrap_or_zero-admin_recovery_not_to_any_account_named_arcane%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fservices%2Fuser_service.go%3A91-104%0A**Legacy%20bcrypt%20logins%20are%20rejected**%0A%0AIf%20an%20existing%20local%20account%20still%20has%20a%20bcrypt%20password%20hash%20from%20before%20the%20Argon2%20transition%2C%20%60ValidatePassword%60%20parses%20it%20exclusively%20as%20Argon2%20and%20returns%20an%20invalid-format%20error%2C%20which%20%60AuthenticateLocalPrimary%60%20reports%20as%20invalid%20credentials%20and%20locks%20the%20user%20out%20despite%20a%20correct%20password.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fservices%2Fuser_service.go%3A91-104%0A**Legacy%20bcrypt%20logins%20are%20rejected**%0A%0AIf%20an%20existing%20local%20account%20still%20has%20a%20bcrypt%20password%20hash%20from%20before%20the%20Argon2%20transition%2C%20%60ValidatePassword%60%20parses%20it%20exclusively%20as%20Argon2%20and%20returns%20an%20invalid-format%20error%2C%20which%20%60AuthenticateLocalPrimary%60%20reports%20as%20invalid%20credentials%20and%20locks%20the%20user%20out%20despite%20a%20correct%20password.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/services/user_service.go:91-104
**Legacy bcrypt logins are rejected**

If an existing local account still has a bcrypt password hash from before the Argon2 transition, `ValidatePassword` parses it exclusively as Argon2 and returns an invalid-format error, which `AuthenticateLocalPrimary` reports as invalid credentials and locks the user out despite a correct password.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: only grant default admin role durin..."](https://github.com/getarcaneapp/arcane/commit/0bf3524aa8a3762fb2c8119617a58fa06c2d4daf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49908984)</sub>

<!-- /greptile_comment -->