### PR TITLE
fix: enforce configured password policy on all password creation and reset paths

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -365,7 +365,7 @@ func registerHandlersInternal(api huma.API, deps HandlerDeps, handlerAppCtx hand
 	handlers.RegisterFederatedCredentials(api, deps.Federated)
 	handlers.RegisterRoles(api, deps.Role)
 	handlers.RegisterAppImages(api, deps.AppImages)
-	handlers.RegisterUsers(api, deps.User, deps.Auth)
+	handlers.RegisterUsers(api, deps.User, deps.Auth, deps.Settings)
 	handlers.RegisterProjects(api, deps.Project, deps.Activity, handlerAppCtx)
 	handlers.RegisterVersion(api, deps.Version)
 	handlers.RegisterEvents(api, deps.Event)

--- a/backend/api/handlers/auth.go
+++ b/backend/api/handlers/auth.go
@@ -397,6 +397,8 @@ func (h *AuthHandler) ChangePassword(ctx context.Context, input *ChangePasswordI
 		switch {
 		case errors.Is(err, services.ErrInvalidCredentials):
 			return nil, huma.Error401Unauthorized("Current password is incorrect")
+		case errors.Is(err, common.ErrValidation):
+			return nil, huma.Error400BadRequest(err.Error())
 		default:
 			return nil, huma.Error500InternalServerError("Failed to change password")
 		}

--- a/backend/api/handlers/users.go
+++ b/backend/api/handlers/users.go
@@ -19,8 +19,9 @@ import (
 
 // UserHandler handles user management endpoints.
 type UserHandler struct {
-	userService *services.UserService
-	authService *services.AuthService
+	userService     *services.UserService
+	authService     *services.AuthService
+	settingsService *services.SettingsService
 }
 
 // ============================================================================
@@ -88,8 +89,8 @@ type GetUserAvatarOutput struct {
 // ============================================================================
 
 // RegisterUsers registers all user management endpoints.
-func RegisterUsers(api huma.API, userService *services.UserService, authService *services.AuthService) {
-	h := &UserHandler{userService: userService, authService: authService}
+func RegisterUsers(api huma.API, userService *services.UserService, authService *services.AuthService, settingsService *services.SettingsService) {
+	h := &UserHandler{userService: userService, authService: authService, settingsService: settingsService}
 
 	huma.Register(api, huma.Operation{
 		OperationID: "listUsers",
@@ -189,6 +190,10 @@ func (h *UserHandler) CreateUser(ctx context.Context, input *CreateUserInput) (*
 	}
 	input.Body.Email = normalizedEmail
 
+	if err := validation.ValidatePasswordPolicy(input.Body.Password, h.passwordPolicyInternal(ctx)); err != nil {
+		return nil, huma.Error400BadRequest(err.Error())
+	}
+
 	hashedPassword, err := h.userService.HashPassword(input.Body.Password)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to hash password")
@@ -276,32 +281,22 @@ func (h *UserHandler) UpdateUser(ctx context.Context, input *UpdateUserInput) (*
 		userModel.TimeFormat = *input.Body.TimeFormat
 	}
 
+	userModel.UpdatedAt = new(time.Now())
+
+	callerPerms, err := h.checkUpdateUserPrivilegesInternal(ctx, input, userModel.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	if input.Body.Password != nil && *input.Body.Password != "" {
+		if err := validation.ValidatePasswordPolicy(*input.Body.Password, h.passwordPolicyInternal(ctx)); err != nil {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		hashedPassword, err := h.userService.HashPassword(*input.Body.Password)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("Failed to hash password")
 		}
 		userModel.PasswordHash = hashedPassword
-	}
-
-	userModel.UpdatedAt = new(time.Now())
-
-	// Privilege ordering: a non-admin caller may not modify a global admin
-	// target, nor set another user's password. The service re-enforces the
-	// target-admin check.
-	callerPerms, _ := humamw.PermissionsFromContext(ctx)
-	caller, _ := models.CurrentUserFromContext(ctx)
-	if callerPerms != nil && !callerPerms.IsGlobalAdmin() {
-		if input.Body.Password != nil && *input.Body.Password != "" && caller != nil && caller.ID != userModel.ID {
-			return nil, huma.Error403Forbidden(services.ErrInsufficientPrivilege.Error())
-		}
-		targetPerms, err := h.userService.ResolveUserPermissions(ctx, userModel.ID)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("Failed to resolve target permissions")
-		}
-		if targetPerms != nil && targetPerms.IsGlobalAdmin() {
-			return nil, huma.Error403Forbidden(services.ErrInsufficientPrivilege.Error())
-		}
 	}
 
 	updatedUser, err := h.userService.UpdateUser(ctx, userModel, callerPerms)
@@ -416,4 +411,32 @@ func normalizeOptionalEmailInternal(email *string) (*string, error) {
 	}
 
 	return &trimmedEmail, nil
+}
+
+// checkUpdateUserPrivilegesInternal enforces that a non-admin caller may not
+// modify a global admin target, nor set another user's password. The service
+// re-enforces the target-admin check.
+func (h *UserHandler) checkUpdateUserPrivilegesInternal(ctx context.Context, input *UpdateUserInput, targetID string) (*authz.PermissionSet, error) {
+	callerPerms, _ := humamw.PermissionsFromContext(ctx)
+	caller, _ := models.CurrentUserFromContext(ctx)
+	if callerPerms != nil && !callerPerms.IsGlobalAdmin() {
+		if input.Body.Password != nil && *input.Body.Password != "" && caller != nil && caller.ID != targetID {
+			return nil, huma.Error403Forbidden(services.ErrInsufficientPrivilege.Error())
+		}
+		targetPerms, err := h.userService.ResolveUserPermissions(ctx, targetID)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("Failed to resolve target permissions")
+		}
+		if targetPerms != nil && targetPerms.IsGlobalAdmin() {
+			return nil, huma.Error403Forbidden(services.ErrInsufficientPrivilege.Error())
+		}
+	}
+	return callerPerms, nil
+}
+
+func (h *UserHandler) passwordPolicyInternal(ctx context.Context) string {
+	if h.settingsService == nil {
+		return validation.PasswordPolicyStrong
+	}
+	return h.settingsService.GetStringSetting(ctx, "authPasswordPolicy", validation.PasswordPolicyStrong)
 }

--- a/backend/cli/admin/reset_password.go
+++ b/backend/cli/admin/reset_password.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"unicode/utf8"
 
 	"emperror.dev/errors"
 	"github.com/spf13/cobra"
@@ -15,7 +14,9 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
 )
 
 const defaultAdminUsername = "arcane"
@@ -66,12 +67,14 @@ func runResetPasswordCommandInternal(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	password, err := readNewPasswordInternal(cmd.OutOrStdout())
+	policy := passwordPolicyFromDBInternal(cmd.Context(), db)
+
+	password, err := readNewPasswordInternal(cmd.OutOrStdout(), policy)
 	if err != nil {
 		return err
 	}
 
-	if err := resetPasswordInternal(cmd.Context(), db, username, password); err != nil {
+	if err := resetPasswordInternal(cmd.Context(), db, username, password, policy); err != nil {
 		return err
 	}
 
@@ -91,7 +94,7 @@ func ensurePasswordResetEnabledInternal(cfg *config.Config) error {
 	return nil
 }
 
-func readNewPasswordInternal(out io.Writer) (string, error) {
+func readNewPasswordInternal(out io.Writer, policy string) (string, error) {
 	password, err := readPasswordInternal(out, "New password: ")
 	if err != nil {
 		return "", errors.WrapIf(err, "failed to read new password")
@@ -102,7 +105,7 @@ func readNewPasswordInternal(out io.Writer) (string, error) {
 		return "", errors.WrapIf(err, "failed to read password confirmation")
 	}
 
-	if err := validatePasswordPairInternal(password, confirmation); err != nil {
+	if err := validatePasswordPairInternal(password, confirmation, policy); err != nil {
 		return "", err
 	}
 	return password, nil
@@ -122,9 +125,9 @@ func readPasswordInternal(out io.Writer, prompt string) (string, error) {
 	return string(password), nil
 }
 
-func validatePasswordPairInternal(password, confirmation string) error {
-	if utf8.RuneCountInString(password) < 8 {
-		return errors.New("password must be at least 8 characters")
+func validatePasswordPairInternal(password, confirmation, policy string) error {
+	if err := validation.ValidatePasswordPolicy(password, policy); err != nil {
+		return err
 	}
 	if password != confirmation {
 		return errors.New("passwords do not match")
@@ -132,7 +135,16 @@ func validatePasswordPairInternal(password, confirmation string) error {
 	return nil
 }
 
-func resetPasswordInternal(ctx context.Context, db *database.DB, username, password string) error {
+func passwordPolicyFromDBInternal(ctx context.Context, db *database.DB) string {
+	var setting models.SettingVariable
+	err := db.WithContext(ctx).First(&setting, "key = ?", "authPasswordPolicy").Error
+	if err != nil || strings.TrimSpace(setting.Value) == "" {
+		return validation.PasswordPolicyStrong
+	}
+	return setting.Value
+}
+
+func resetPasswordInternal(ctx context.Context, db *database.DB, username, password, policy string) error {
 	if db == nil {
 		return errors.New("database is nil")
 	}
@@ -141,8 +153,8 @@ func resetPasswordInternal(ctx context.Context, db *database.DB, username, passw
 	if username == "" {
 		return errors.New("username cannot be empty")
 	}
-	if utf8.RuneCountInString(password) < 8 {
-		return errors.New("password must be at least 8 characters")
+	if err := validation.ValidatePasswordPolicy(password, policy); err != nil {
+		return err
 	}
 
 	roleService := services.NewRoleService(db)

--- a/backend/cli/admin/reset_password_test.go
+++ b/backend/cli/admin/reset_password_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/services"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
 	"github.com/getarcaneapp/arcane/types/v2/auth"
 )
 
@@ -68,7 +69,7 @@ func TestResetPasswordInternalResetsPasswordAndRevokesSessions(t *testing.T) {
 	secondSession, _, err := sessionService.CreateSession(ctx, adminUser.ID, time.Now().Add(time.Hour), auth.SessionMeta{})
 	require.NoError(t, err)
 
-	require.NoError(t, resetPasswordInternal(ctx, db, "arcane", "new-password"))
+	require.NoError(t, resetPasswordInternal(ctx, db, "arcane", "new-password", validation.PasswordPolicyBasic))
 
 	updatedUser, err := userService.GetUserByID(ctx, adminUser.ID)
 	require.NoError(t, err)
@@ -100,7 +101,7 @@ func TestResetPasswordInternalRollsBackWhenSessionRevocationFails(t *testing.T) 
 		END;
 	`).Error)
 
-	err = resetPasswordInternal(ctx, db, adminUser.Username, "new-password")
+	err = resetPasswordInternal(ctx, db, adminUser.Username, "new-password", validation.PasswordPolicyBasic)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "forced session revocation failure")
 
@@ -127,7 +128,7 @@ func TestResetPasswordInternalRejectsNonAdmin(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = resetPasswordInternal(ctx, db, nonAdmin.Username, "new-password")
+	err = resetPasswordInternal(ctx, db, nonAdmin.Username, "new-password", validation.PasswordPolicyBasic)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "effective global administrator")
 
@@ -143,7 +144,7 @@ func TestEnsurePasswordResetEnabledInternal(t *testing.T) {
 }
 
 func TestValidatePasswordPairInternal(t *testing.T) {
-	require.ErrorContains(t, validatePasswordPairInternal("short", "short"), "at least 8")
-	require.ErrorContains(t, validatePasswordPairInternal("new-password", "different"), "do not match")
-	require.NoError(t, validatePasswordPairInternal("new-password", "new-password"))
+	require.ErrorContains(t, validatePasswordPairInternal("short", "short", validation.PasswordPolicyBasic), "at least 8")
+	require.ErrorContains(t, validatePasswordPairInternal("new-password", "different", validation.PasswordPolicyBasic), "do not match")
+	require.NoError(t, validatePasswordPairInternal("new-password", "new-password", validation.PasswordPolicyBasic))
 }

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/jwtclaims"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
 	"github.com/getarcaneapp/arcane/types/v2/auth"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -833,6 +834,14 @@ func (s *AuthService) ChangePassword(ctx context.Context, userID, currentPasswor
 		if err := s.userService.ValidatePassword(user.PasswordHash, currentPassword); err != nil {
 			return ErrInvalidCredentials
 		}
+	}
+
+	policy := validation.PasswordPolicyStrong
+	if s.settingsService != nil {
+		policy = s.settingsService.GetStringSetting(ctx, "authPasswordPolicy", validation.PasswordPolicyStrong)
+	}
+	if err := validation.ValidatePasswordPolicy(newPassword, policy); err != nil {
+		return common.Classify(common.ErrValidation, err)
 	}
 
 	if _, err = s.userService.SetPasswordAndRevokeSessionsExcept(ctx, user, newPassword, currentSessionID); err != nil {

--- a/backend/internal/services/auth_service_test.go
+++ b/backend/internal/services/auth_service_test.go
@@ -582,7 +582,7 @@ func TestChangePassword_RevokesAllSessions(t *testing.T) {
 	sessionA, _ := createTestSession(t, db, user.ID, time.Now().Add(time.Hour))
 	sessionB, _ := createTestSession(t, db, user.ID, time.Now().Add(time.Hour))
 
-	require.NoError(t, s.ChangePassword(context.Background(), user.ID, "old-password", "new-password", ""))
+	require.NoError(t, s.ChangePassword(context.Background(), user.ID, "old-password", "New-password1!", ""))
 
 	sessionA, err = s.sessionService.GetSessionByID(context.Background(), sessionA.ID)
 	require.NoError(t, err)
@@ -612,7 +612,7 @@ func TestChangePassword_KeepsCurrentSessionAlive(t *testing.T) {
 	current, _ := createTestSession(t, db, user.ID, time.Now().Add(time.Hour))
 	other, _ := createTestSession(t, db, user.ID, time.Now().Add(time.Hour))
 
-	require.NoError(t, s.ChangePassword(context.Background(), user.ID, "old-password", "new-password", current.ID))
+	require.NoError(t, s.ChangePassword(context.Background(), user.ID, "old-password", "New-password1!", current.ID))
 
 	current, err = s.sessionService.GetSessionByID(context.Background(), current.ID)
 	require.NoError(t, err)

--- a/backend/pkg/utils/validation/password.go
+++ b/backend/pkg/utils/validation/password.go
@@ -1,0 +1,49 @@
+package validation
+
+import (
+	"unicode"
+
+	"emperror.dev/errors"
+)
+
+const (
+	PasswordPolicyBasic    = "basic"
+	PasswordPolicyStandard = "standard"
+	PasswordPolicyStrong   = "strong"
+)
+
+// ValidatePasswordPolicy checks a password against the named policy tier.
+// Unknown policy values are treated as strong so a corrupted setting fails closed.
+func ValidatePasswordPolicy(password, policy string) error {
+	var length int
+	var hasUpper, hasLower, hasDigit, hasSymbol bool
+	for _, r := range password {
+		length++
+		switch {
+		case unicode.IsUpper(r):
+			hasUpper = true
+		case unicode.IsLower(r):
+			hasLower = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case unicode.IsPunct(r) || unicode.IsSymbol(r) || unicode.IsSpace(r):
+			hasSymbol = true
+		}
+	}
+
+	switch policy {
+	case PasswordPolicyBasic:
+		if length < 8 {
+			return errors.New("password must be at least 8 characters")
+		}
+	case PasswordPolicyStandard:
+		if length < 10 || !hasUpper || !hasLower || !hasDigit {
+			return errors.New("password must be at least 10 characters and include an uppercase letter, a lowercase letter, and a number")
+		}
+	default:
+		if length < 12 || !hasUpper || !hasLower || !hasDigit || !hasSymbol {
+			return errors.New("password must be at least 12 characters and include an uppercase letter, a lowercase letter, a number, and a symbol")
+		}
+	}
+	return nil
+}

--- a/backend/pkg/utils/validation/password_test.go
+++ b/backend/pkg/utils/validation/password_test.go
@@ -1,0 +1,21 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePasswordPolicy(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidatePasswordPolicy("12345678", PasswordPolicyBasic))
+	require.Error(t, ValidatePasswordPolicy("1234567", PasswordPolicyBasic))
+
+	require.NoError(t, ValidatePasswordPolicy("Abcdefghi1", PasswordPolicyStandard))
+	require.Error(t, ValidatePasswordPolicy("abcdefghij1", PasswordPolicyStandard))
+
+	require.NoError(t, ValidatePasswordPolicy("Abcdefghij1!", PasswordPolicyStrong))
+	require.Error(t, ValidatePasswordPolicy("Abcdefghijk1", PasswordPolicyStrong))
+	require.Error(t, ValidatePasswordPolicy("Abcdefgh1!", "bogus-policy"))
+}

--- a/tests/utils/auth.util.ts
+++ b/tests/utils/auth.util.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 const DEFAULT_PASSWORD = 'arcane-admin';
-const TEST_PASSWORD = 'test-password-123';
+const TEST_PASSWORD = 'Test-password-123';
 
 async function login(page: Page): Promise<string> {
 	await page.goto('/login');


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change centralizes password-policy enforcement for account creation, user updates, self-service password changes, and administrative resets. Verification found that local users with existing bcrypt password hashes can no longer sign in with correct credentials because `backend/internal/services/user_service.go` now accepts only Argon2-formatted hashes.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until compatibility with existing bcrypt password hashes is restored.

A reproduced authentication regression prevents users with legacy local bcrypt credentials from signing in, even when they enter the correct password.

**Files Needing Attention:** backend/internal/services/user_service.go, backend/internal/services/auth_service.go
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the review comment.
- Direct go test was blocked by the documented Go 1.26 encoding/json build constraint; a dependency-minimal runnable alternative exercised the removed bcrypt comparator and the current ValidatePassword parser behavior, capturing command headers and exit codes.
- T-Rex produced a second finding-proof for another posted P1 finding.

<a href="https://app.greptile.com/trex/runs/17187199/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/services/user_service.go`, line 91-95 ([link](https://github.com/getarcaneapp/arcane/blob/4c8125c462d3ed38bfbaf74c5704fa80b229278b/backend/internal/services/user_service.go#L91-L95)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Existing bcrypt passwords cannot authenticate**

   `ValidatePassword` now parses every stored password hash as a six-part Argon2 encoding. Existing `$2a$`, `$2b$`, and `$2y$` bcrypt hashes have four `$`-separated fields, so correct passwords return `invalid hash format`; `AuthenticateLocalPrimary` converts that result to invalid credentials. Upgrades with users created before the Argon2 migration will lock those local users out. Restore bcrypt-prefix handling with `bcrypt.CompareHashAndPassword` before the Argon2 parser and retain regression coverage for each supported bcrypt prefix.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Before reproduction source for the removed bcrypt branch](https://app.greptile.com/trex/artifacts/319f2c4f-326c-480c-9ef2-343de115e1b3)**

   - Authored Go source generates a bcrypt hash and invokes the removed comparator for all deployed bcrypt prefixes, showing the prior compatible behavior.

   **[Before runtime output showing bcrypt hashes accepted](https://app.greptile.com/trex/artifacts/13da69f7-3673-4a4b-a675-a3ab6571ba97)**

   - Captured \`go run\` output shows \`bcrypt.CompareHashAndPassword\` accepted valid \`$2a$\`, \`$2b$\`, and \`$2y$\` hashes with exit code 0, establishing the previous behavior.

   **[After reproduction source for the current ValidatePassword parser](https://app.greptile.com/trex/artifacts/b400a0db-5b40-4005-998f-8dabf6340f18)**

   - Authored Go source generates the same class of bcrypt hash and executes the exact current \`ValidatePassword\` delimiter check before the Argon2 branch.

   **[After runtime output showing bcrypt hashes rejected](https://app.greptile.com/trex/artifacts/c00402de-8a2b-4dc1-9eb4-6fdef285fb92)**

   - Captured \`go run\` output shows every valid bcrypt prefix has four fields and is rejected as \`invalid hash format\` with exit code 0, proving the regression.

   <a href="https://app.greptile.com/trex/runs/17187199/artifacts?artifact=319f2c4f-326c-480c-9ef2-343de115e1b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/services/user_service.go
   Line: 91-95

   Comment:
   **Existing bcrypt passwords cannot authenticate**

   `ValidatePassword` now parses every stored password hash as a six-part Argon2 encoding. Existing `$2a$`, `$2b$`, and `$2y$` bcrypt hashes have four `$`-separated fields, so correct passwords return `invalid hash format`; `AuthenticateLocalPrimary` converts that result to invalid credentials. Upgrades with users created before the Argon2 migration will lock those local users out. Restore bcrypt-prefix handling with `bcrypt.CompareHashAndPassword` before the Argon2 parser and retain regression coverage for each supported bcrypt prefix.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_enforce_configured_password_policy_on_all_password_creation_and_reset_paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_enforce_configured_password_policy_on_all_password_creation_and_reset_paths%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fuser_service.go%0ALine%3A%2091-95%0A%0AComment%3A%0A**Existing%20bcrypt%20passwords%20cannot%20authenticate**%0A%0A%60ValidatePassword%60%20now%20parses%20every%20stored%20password%20hash%20as%20a%20six-part%20Argon2%20encoding.%20Existing%20%60%242a%24%60%2C%20%60%242b%24%60%2C%20and%20%60%242y%24%60%20bcrypt%20hashes%20have%20four%20%60%24%60-separated%20fields%2C%20so%20correct%20passwords%20return%20%60invalid%20hash%20format%60%3B%20%60AuthenticateLocalPrimary%60%20converts%20that%20result%20to%20invalid%20credentials.%20Upgrades%20with%20users%20created%20before%20the%20Argon2%20migration%20will%20lock%20those%20local%20users%20out.%20Restore%20bcrypt-prefix%20handling%20with%20%60bcrypt.CompareHashAndPassword%60%20before%20the%20Argon2%20parser%20and%20retain%20regression%20coverage%20for%20each%20supported%20bcrypt%20prefix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fservices%2Fuser_service.go%0ALine%3A%2091-95%0A%0AComment%3A%0A**Existing%20bcrypt%20passwords%20cannot%20authenticate**%0A%0A%60ValidatePassword%60%20now%20parses%20every%20stored%20password%20hash%20as%20a%20six-part%20Argon2%20encoding.%20Existing%20%60%242a%24%60%2C%20%60%242b%24%60%2C%20and%20%60%242y%24%60%20bcrypt%20hashes%20have%20four%20%60%24%60-separated%20fields%2C%20so%20correct%20passwords%20return%20%60invalid%20hash%20format%60%3B%20%60AuthenticateLocalPrimary%60%20converts%20that%20result%20to%20invalid%20credentials.%20Upgrades%20with%20users%20created%20before%20the%20Argon2%20migration%20will%20lock%20those%20local%20users%20out.%20Restore%20bcrypt-prefix%20handling%20with%20%60bcrypt.CompareHashAndPassword%60%20before%20the%20Argon2%20parser%20and%20retain%20regression%20coverage%20for%20each%20supported%20bcrypt%20prefix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Local login no longer supports existing bcrypt password hashes**

   - **Bug**
     - A correct password for deployed `$2a$`, `$2b$`, or `$2y$` bcrypt hashes now returns `invalid hash format`. Local authentication therefore returns `ErrInvalidCredentials` instead of authenticating the user.
   - **Cause**
     - The change removed bcrypt-prefix detection and `bcrypt.CompareHashAndPassword`, leaving `ValidatePassword` to parse every hash exclusively as six-part Argon2id encoding.
   - **Fix**
     - Restore bcrypt prefix detection for `$2a$`, `$2b$`, and `$2y$` and validate those values with `bcrypt.CompareHashAndPassword`; retain the Argon2id parser for all other hashes. Add regression coverage for all three prefixes and for the `AuthenticateLocalPrimary` path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_enforce_configured_password_policy_on_all_password_creation_and_reset_paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_enforce_configured_password_policy_on_all_password_creation_and_reset_paths%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fservices%2Fuser_service.go%3A91-95%0A**Existing%20bcrypt%20passwords%20cannot%20authenticate**%0A%0A%60ValidatePassword%60%20now%20parses%20every%20stored%20password%20hash%20as%20a%20six-part%20Argon2%20encoding.%20Existing%20%60%242a%24%60%2C%20%60%242b%24%60%2C%20and%20%60%242y%24%60%20bcrypt%20hashes%20have%20four%20%60%24%60-separated%20fields%2C%20so%20correct%20passwords%20return%20%60invalid%20hash%20format%60%3B%20%60AuthenticateLocalPrimary%60%20converts%20that%20result%20to%20invalid%20credentials.%20Upgrades%20with%20users%20created%20before%20the%20Argon2%20migration%20will%20lock%20those%20local%20users%20out.%20Restore%20bcrypt-prefix%20handling%20with%20%60bcrypt.CompareHashAndPassword%60%20before%20the%20Argon2%20parser%20and%20retain%20regression%20coverage%20for%20each%20supported%20bcrypt%20prefix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fservices%2Fuser_service.go%3A91-95%0A**Existing%20bcrypt%20passwords%20cannot%20authenticate**%0A%0A%60ValidatePassword%60%20now%20parses%20every%20stored%20password%20hash%20as%20a%20six-part%20Argon2%20encoding.%20Existing%20%60%242a%24%60%2C%20%60%242b%24%60%2C%20and%20%60%242y%24%60%20bcrypt%20hashes%20have%20four%20%60%24%60-separated%20fields%2C%20so%20correct%20passwords%20return%20%60invalid%20hash%20format%60%3B%20%60AuthenticateLocalPrimary%60%20converts%20that%20result%20to%20invalid%20credentials.%20Upgrades%20with%20users%20created%20before%20the%20Argon2%20migration%20will%20lock%20those%20local%20users%20out.%20Restore%20bcrypt-prefix%20handling%20with%20%60bcrypt.CompareHashAndPassword%60%20before%20the%20Argon2%20parser%20and%20retain%20regression%20coverage%20for%20each%20supported%20bcrypt%20prefix.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/services/user_service.go:91-95
**Existing bcrypt passwords cannot authenticate**

`ValidatePassword` now parses every stored password hash as a six-part Argon2 encoding. Existing `$2a$`, `$2b$`, and `$2y$` bcrypt hashes have four `$`-separated fields, so correct passwords return `invalid hash format`; `AuthenticateLocalPrimary` converts that result to invalid credentials. Upgrades with users created before the Argon2 migration will lock those local users out. Restore bcrypt-prefix handling with `bcrypt.CompareHashAndPassword` before the Argon2 parser and retain regression coverage for each supported bcrypt prefix.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: enforce configured password policy ..."](https://github.com/getarcaneapp/arcane/commit/4c8125c462d3ed38bfbaf74c5704fa80b229278b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49921417)</sub>

<!-- /greptile_comment -->