### PR TITLE
fix: stop leaking Arcane's own process environment into compose variable interpolation

### DIFF
--- a/backend/pkg/projects/custom_labels.go
+++ b/backend/pkg/projects/custom_labels.go
@@ -205,7 +205,7 @@ func loadComposeProjectForMetadataFromFileInternal(ctx context.Context, composeF
 }
 
 func loadComposeEnvironment(workdir string) map[string]string {
-	envMap := loadProcessEnv()
+	envMap := allowedProcessEnvInternal()
 	if workdir == "" {
 		return envMap
 	}
@@ -267,16 +267,6 @@ func mergeEnvFromDotEnv(envMap map[string]string, workdir string) map[string]str
 	}
 
 	return merged
-}
-
-func loadProcessEnv() map[string]string {
-	envMap := make(map[string]string)
-	for _, kv := range os.Environ() {
-		if k, v, ok := strings.Cut(kv, "="); ok {
-			envMap[k] = v
-		}
-	}
-	return envMap
 }
 
 func parseIncludePaths(composeFilePath string) ([]string, error) {

--- a/backend/pkg/projects/env.go
+++ b/backend/pkg/projects/env.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"emperror.dev/errors"
@@ -70,8 +69,6 @@ type envFileCacheEntry struct {
 }
 
 var (
-	processEnvOnce      sync.Once
-	processEnvSnapshot  EnvMap
 	globalEnvFileCache  = hot.NewHotCache[string, envFileCacheEntry](hot.LRU, 4096).Build()
 	projectEnvFileCache = hot.NewHotCache[string, envFileCacheEntry](hot.LRU, 4096).Build()
 )
@@ -84,12 +81,33 @@ func NewEnvLoader(projectsDir, workdir string, autoInjectEnv bool) *EnvLoader {
 	}
 }
 
+// processEnvAllowlist is the only part of Arcane's own process environment
+// that flows into compose interpolation of managed projects: timezone and
+// locale, whose container values are safe to share. Everything else is
+// excluded so Arcane's variables never leak into ${VAR} references or
+// pass-through environment entries — its PORT collides with project port
+// mappings, secrets would be readable from any compose file, and vars like
+// HOME or PUID carry container-internal values that are wrong for projects.
+var processEnvAllowlist = []string{"TZ", "LANG", "LANGUAGE", "LC_ALL"}
+
+func allowedProcessEnvInternal() EnvMap {
+	envMap := make(EnvMap)
+	for _, key := range processEnvAllowlist {
+		if val, ok := os.LookupEnv(key); ok {
+			envMap[key] = val
+		}
+	}
+	return envMap
+}
+
 // LoadEnvironment loads and merges environment variables from all sources:
-// 1. Process environment
+// 1. Allowlisted process environment (TZ)
 // 2. Global .env.global file (from projects directory)
 // 3. Project-specific .env file (from workdir)
+// The rest of the Arcane process environment is intentionally excluded so its
+// own variables never leak into compose interpolation of managed projects.
 func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injectionVars EnvMap, err error) {
-	envMap = cloneEnvMapInternal(loadProcessEnvSnapshotInternal())
+	envMap = allowedProcessEnvInternal()
 	injectionVars = make(EnvMap)
 
 	if strings.TrimSpace(l.projectsDir) != "" {
@@ -111,18 +129,6 @@ func (l *EnvLoader) LoadEnvironment(ctx context.Context) (envMap EnvMap, injecti
 	return envMap, injectionVars, nil
 }
 
-func loadProcessEnvSnapshotInternal() EnvMap {
-	processEnvOnce.Do(func() {
-		processEnvSnapshot = make(EnvMap)
-		for _, kv := range os.Environ() {
-			if k, v, ok := strings.Cut(kv, "="); ok {
-				processEnvSnapshot[k] = v
-			}
-		}
-	})
-	return processEnvSnapshot
-}
-
 func (l *EnvLoader) loadAndMergeGlobalEnv(ctx context.Context, path string, envMap, injectionVars EnvMap) error {
 	entry, err := loadCachedEnvFileInternal(ctx, globalEnvFileCache, path, path, envMap)
 	if err != nil {
@@ -133,9 +139,7 @@ func (l *EnvLoader) loadAndMergeGlobalEnv(ctx context.Context, path string, envM
 	}
 
 	for k, v := range entry.values {
-		if _, exists := envMap[k]; !exists {
-			envMap[k] = v
-		}
+		envMap[k] = v
 		injectionVars[k] = v
 	}
 
@@ -234,12 +238,6 @@ func validEnvFileCacheEntryInternal(entry envFileCacheEntry) bool {
 	return entry.exists && info.ModTime().Equal(entry.mtime)
 }
 
-func cloneEnvMapInternal(src EnvMap) EnvMap {
-	dst := make(EnvMap, len(src))
-	maps.Copy(dst, src)
-	return dst
-}
-
 func parseProjectEnvFileExistingInternal(path string, contextEnv EnvMap) (EnvMap, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -259,14 +257,13 @@ func ParseProjectEnvFile(path string, contextEnv EnvMap) (EnvMap, error) {
 }
 
 // ParseProjectEnvContent parses project .env content from a string using
-// compose-go's dotenv parser with variable expansion. Lookups check contextEnv
-// first (previously loaded vars), then the process environment.
+// compose-go's dotenv parser with variable expansion. Lookups resolve from
+// contextEnv (previously loaded vars) only; the Arcane process environment is
+// intentionally never consulted so its variables don't leak into project env.
 func ParseProjectEnvContent(content string, contextEnv EnvMap) (EnvMap, error) {
 	lookupFn := func(key string) (string, bool) {
-		if val, ok := contextEnv[key]; ok {
-			return val, true
-		}
-		return os.LookupEnv(key)
+		val, ok := contextEnv[key]
+		return val, ok
 	}
 
 	envMap, err := dotenv.ParseWithLookup(strings.NewReader(content), lookupFn)

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -162,10 +162,7 @@ func LoadComposeProjectFromContent(ctx context.Context, opts projecttypes.Compos
 		}
 	}
 
-	envMap := maps.Clone(loadProcessEnvSnapshotInternal())
-	if envMap == nil {
-		envMap = make(EnvMap)
-	}
+	envMap := allowedProcessEnvInternal()
 	if strings.TrimSpace(opts.EnvContent) != "" {
 		parsedEnv, parseErr := ParseProjectEnvContent(opts.EnvContent, envMap)
 		if parseErr != nil {

--- a/backend/pkg/projects/load_test.go
+++ b/backend/pkg/projects/load_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -159,6 +160,53 @@ func TestLoadComposeProject_MergesComposeOverrideFile(t *testing.T) {
 	assert.Contains(t, app.Environment, "FROM_BASE")
 	assert.Contains(t, app.Environment, "FROM_OVERRIDE")
 	assert.Equal(t, []string{basePath, overridePath}, project.ComposeFiles)
+}
+
+func TestLoadComposeProject_ArcaneProcessEnvInterpolation(t *testing.T) {
+	// Arcane's own env (e.g. PORT) must not leak into compose interpolation of
+	// managed projects: ${PORT:-8191} falls back to its default (issue #3499).
+	// Allowlisted vars like TZ still flow through.
+	t.Setenv("PORT", "3552")
+	t.Setenv("TZ", "America/Chicago")
+
+	testCases := []struct {
+		name    string
+		compose string
+		check   func(t *testing.T, app composetypes.ServiceConfig)
+	}{
+		{
+			name:    "blocked var falls back to compose default",
+			compose: "services:\n  app:\n    image: nginx:alpine\n    ports:\n      - \"${PORT:-8191}:8191\"\n",
+			check: func(t *testing.T, app composetypes.ServiceConfig) {
+				t.Helper()
+				require.Len(t, app.Ports, 1)
+				assert.Equal(t, "8191", app.Ports[0].Published)
+			},
+		},
+		{
+			name:    "allowlisted var flows through",
+			compose: "services:\n  app:\n    image: nginx:alpine\n    environment:\n      TZ: ${TZ:-UTC}\n",
+			check: func(t *testing.T, app composetypes.ServiceConfig) {
+				t.Helper()
+				require.NotNil(t, app.Environment["TZ"])
+				assert.Equal(t, "America/Chicago", *app.Environment["TZ"])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			basePath := filepath.Join(dir, "compose.yaml")
+			require.NoError(t, os.WriteFile(basePath, []byte(tc.compose), 0o600))
+
+			project, err := LoadComposeProject(context.Background(), basePath, "demo", dir, false, nil, nil, nil, false)
+			require.NoError(t, err)
+			require.NotNil(t, project)
+
+			tc.check(t, project.Services["app"])
+		})
+	}
 }
 
 func TestLoadComposeProject_DoesNotMergeOverrideForCustomBaseName(t *testing.T) {


### PR DESCRIPTION
> [!IMPORTANT]
> **Project variable resolution now matches the Docker Compose CLI**
>
> Previously, environment variables set on Arcane's own container (such as `PORT`) could be picked up when resolving `${VARIABLE}` references in your projects' compose files. This could cause surprising results — for example, a project using `${PORT:-8191}` could end up binding to Arcane's own port instead of its default (#3499).
>
> Starting with this release, variable references in a project's compose file resolve only from:
>
> - your global **Variables** (`.env.global`)
> - the project's own `.env` file
> - defaults in the compose file itself (`${VAR:-default}`)
> - timezone and locale from Arcane's environment (`TZ`, `LANG`, `LANGUAGE`, `LC_ALL`)
>
> This means a project deployed through Arcane now resolves its variables the same way as running `docker compose up` in the project directory, and projects can no longer accidentally pick up Arcane's own configuration.
>
> **If a project referenced a variable that was only defined on Arcane's container**, add it under **Customization → Variables** to share it with all projects, or to that project's `.env` file. No other action is needed.


## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3499

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change prevents Arcane’s runtime environment from affecting managed Compose projects except for the intended timezone and locale variables. A real Compose-loading check exercised arbitrary process values, all four allowlisted variables, `.env.global`, and project `.env` precedence. It confirmed that `PORT` and an arbitrary secret no longer interpolate, while `TZ`, `LANG`, `LANGUAGE`, and `LC_ALL` remain available; configured environment files override allowlisted process values, with project values taking precedence over global values.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The exercised Compose-loading path confirmed process-environment isolation, the intended locale/timezone allowlist, and correct global and project environment-file precedence.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored Go regression test that loads real Compose projects with process, global, and project environment values.
- Compared the current PR against the parent revision, where PORT=3552 previously interpolated and the process TZ override affected .env.global.
- Re-ran the test on this revision with Go 1.26.5 and GOEXPERIMENT=jsonv2; all process-blocking, allowlist, global override, and project override cases passed.
- Validated environment-interpolation boundaries by examining before and after results; the after state passed all boundary and precedence cases, and the authored executable test source was uploaded.

<a href="https://app.greptile.com/trex/runs/17265324/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stop leaking Arcane&#39;s own process e..."](https://github.com/getarcaneapp/arcane/commit/9d0e61643cfe1d4d76267d7963a2befd5c88c16f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50103220)</sub>

<!-- /greptile_comment -->