### PR TITLE
feat: apply swarm container updates to the owning service

### DIFF
--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -142,10 +142,11 @@ type updaterServiceParams struct {
 	Notification  *services.NotificationService
 	SystemUpgrade *services.SystemUpgradeService
 	Activity      *services.ActivityService
+	Swarm         *services.SwarmService
 }
 
 func provideUpdaterServiceInternal(p updaterServiceParams) (*services.UpdaterService, error) {
-	return services.NewUpdaterService(p.DB, p.Settings, p.Docker, p.Project, p.ImageUpdate, p.Registry, p.Event, p.Image, p.Notification, p.SystemUpgrade, p.Activity)
+	return services.NewUpdaterService(p.DB, p.Settings, p.Docker, p.Project, p.ImageUpdate, p.Registry, p.Event, p.Image, p.Notification, p.SystemUpgrade, p.Activity, p.Swarm)
 }
 
 func provideUserServiceInternal(db *database.DB, role *services.RoleService) *services.UserService {

--- a/backend/internal/services/swarm_service.go
+++ b/backend/internal/services/swarm_service.go
@@ -430,6 +430,78 @@ func (s *SwarmService) UpdateService(ctx context.Context, serviceID string, req 
 	}, nil
 }
 
+// UpdateServiceImage applies an image update to a swarm service while
+// preserving the rest of its spec. It implements the updater module's
+// SwarmServiceUpdater port: serviceID and serviceName come from a task
+// container's com.docker.swarm.service.* labels, so name lookup is the
+// fallback for externally deployed stacks whose service ID is stale.
+func (s *SwarmService) UpdateServiceImage(ctx context.Context, serviceID, serviceName, imageRef string) error {
+	if err := s.ensureSwarmManagerInternal(ctx); err != nil {
+		return err
+	}
+
+	dockerClient, err := s.dockerService.GetClient(ctx)
+	if err != nil {
+		return errors.WrapIf(err, "failed to connect to Docker")
+	}
+
+	serviceID = strings.TrimSpace(serviceID)
+	serviceName = strings.TrimSpace(serviceName)
+	ref := serviceID
+	if ref == "" {
+		ref = serviceName
+	}
+	serviceResult, err := dockerClient.ServiceInspect(ctx, ref, dockerclient.ServiceInspectOptions{})
+	if err != nil && serviceName != "" && ref != serviceName {
+		serviceResult, err = dockerClient.ServiceInspect(ctx, serviceName, dockerclient.ServiceInspectOptions{})
+	}
+	if err != nil {
+		return errors.WrapIf(err, "failed to inspect swarm service")
+	}
+	service := serviceResult.Service
+
+	if service.Spec.TaskTemplate.ContainerSpec == nil {
+		service.Spec.TaskTemplate.ContainerSpec = &swarm.ContainerSpec{}
+	}
+	service.Spec.TaskTemplate.ContainerSpec.Image = imageRef
+	// Unlike stack deploys (which pin ForceUpdate to avoid no-op rescheduling),
+	// an updater-triggered image change must reschedule tasks even when the ref
+	// string is unchanged (mutable tags), like docker service update --force.
+	service.Spec.TaskTemplate.ForceUpdate++
+	sanitizeServiceSpecInternal(&service.Spec)
+
+	encodedRegistryAuth, err := s.registryService.GetRegistryAuthForImage(ctx, imageRef)
+	if err != nil {
+		return errors.WrapIff(err, "failed to resolve registry auth for image %s", imageRef)
+	}
+
+	opts := dockerclient.ServiceUpdateOptions{
+		Version:       service.Version,
+		Spec:          service.Spec,
+		QueryRegistry: true,
+	}
+	if encodedRegistryAuth != "" {
+		opts.EncodedRegistryAuth = encodedRegistryAuth
+		opts.RegistryAuthFrom = swarm.RegistryAuthFromSpec
+	} else {
+		opts.RegistryAuthFrom = swarm.RegistryAuthFromPreviousSpec
+	}
+
+	if _, err := dockerClient.ServiceUpdate(ctx, service.ID, opts); err != nil {
+		// Services that were never updated have no previous spec to read auth
+		// from; retry without a registry auth source.
+		if strings.Contains(err.Error(), "service does not have a previous spec") {
+			opts.RegistryAuthFrom = ""
+			if _, retryErr := dockerClient.ServiceUpdate(ctx, service.ID, opts); retryErr != nil {
+				return errors.WrapIff(retryErr, "failed to update swarm service %s", service.Spec.Name)
+			}
+			return nil
+		}
+		return errors.WrapIff(err, "failed to update swarm service %s", service.Spec.Name)
+	}
+	return nil
+}
+
 func (s *SwarmService) RemoveService(ctx context.Context, serviceID string) error {
 	if err := s.ensureSwarmManagerInternal(ctx); err != nil {
 		return err

--- a/backend/internal/services/updater_service.go
+++ b/backend/internal/services/updater_service.go
@@ -51,6 +51,7 @@ type updaterDependenciesInternal struct {
 	Notifications          *NotificationService
 	SelfUpgrade            selfUpgradeServiceInternal
 	Activity               *ActivityService
+	Swarm                  *SwarmService
 	SystemUser             models.User
 	Logger                 *slog.Logger
 }
@@ -74,6 +75,7 @@ func NewUpdaterService(
 	notifications *NotificationService,
 	upgrade selfUpgradeServiceInternal,
 	activityService *ActivityService,
+	swarm *SwarmService,
 ) (*UpdaterService, error) {
 	service := &UpdaterService{
 		deps: updaterDependenciesInternal{
@@ -88,6 +90,7 @@ func NewUpdaterService(
 			Notifications:          notifications,
 			SelfUpgrade:            upgrade,
 			Activity:               activityService,
+			Swarm:                  swarm,
 			SystemUser:             systemUser,
 		},
 	}
@@ -108,6 +111,7 @@ func (s *UpdaterService) configInternal() updater.Config {
 		Settings:               s,
 		RegistryDigestResolver: s.registryDigestResolverInternal(),
 		ProjectUpdater:         s,
+		SwarmServiceUpdater:    s.swarmServiceUpdaterInternal(),
 		SelfUpdater:            s,
 		Notifier:               s,
 		EventRecorder:          s,
@@ -145,6 +149,16 @@ func (s *UpdaterService) registryDigestResolverInternal() updater.RegistryDigest
 		return nil
 	}
 	return s.deps.RegistryDigestResolver
+}
+
+// swarmServiceUpdaterInternal keeps the engine's SwarmServiceUpdater port a
+// true nil interface when no SwarmService is wired, so the engine falls back
+// to skipping swarm tasks instead of calling through a typed-nil pointer.
+func (s *UpdaterService) swarmServiceUpdaterInternal() updater.SwarmServiceUpdater {
+	if s == nil || s.deps.Swarm == nil {
+		return nil
+	}
+	return s.deps.Swarm
 }
 
 // ApplyPending executes pending image updates. When the options carry
@@ -245,34 +259,21 @@ func (s *UpdaterService) applyScopedUpdatesInternal(ctx context.Context, options
 	}
 
 	engineOpts := updater.Options{Force: options.ForceUpdate, DryRun: options.DryRun}
-	var engineErrs []error
-	for _, containerID := range containerIDs {
-		moduleResult, engineErr := s.engineInternal().UpdateContainer(ctx, containerID, engineOpts)
-		if moduleResult != nil {
-			partial := resultFromModuleInternal(moduleResult)
-			out.Checked += partial.Checked
-			out.Updated += partial.Updated
-			out.Restarted += partial.Restarted
-			out.Skipped += partial.Skipped
-			out.Failed += partial.Failed
-			out.Items = append(out.Items, partial.Items...)
-		}
-		if engineErr != nil {
-			out.Failed++
-			out.Items = append(out.Items, arcaneupdater.ResourceResult{
-				ResourceID:   containerID,
-				ResourceType: "container",
-				Status:       arcaneupdater.StatusFailed,
-				Error:        engineErr.Error(),
-			})
-			engineErrs = append(engineErrs, errors.WrapIff(engineErr, "%s", containerID))
-		}
+	// The engine's batch path folds per-container errors into failed items and
+	// deduplicates swarm task replicas down to one service update each.
+	moduleResult, engineErr := s.engineInternal().UpdateContainers(ctx, containerIDs, engineOpts)
+	if moduleResult != nil {
+		partial := resultFromModuleInternal(moduleResult)
+		out.Checked += partial.Checked
+		out.Updated += partial.Updated
+		out.Restarted += partial.Restarted
+		out.Skipped += partial.Skipped
+		out.Failed += partial.Failed
+		out.Items = append(out.Items, partial.Items...)
 	}
 	s.logResultItemsInternal(ctx, out)
 	out.Success = out.Failed == 0
-	// Engine errors propagate like the unscoped path's engine error does —
-	// the remaining containers were still attempted and recorded above.
-	return stderrors.Join(engineErrs...)
+	return engineErr
 }
 
 // resolveScopedContainerIDsInternal maps a scoped options payload to the

--- a/backend/internal/services/updater_service_test.go
+++ b/backend/internal/services/updater_service_test.go
@@ -195,7 +195,7 @@ func (m *mockSystemUpgradeServiceInternal) TriggerUpgradeViaCLI(_ context.Contex
 func TestUpdaterService_ApplyPendingNoRecordsInternal(t *testing.T) {
 	ctx := context.Background()
 	db := setupProjectTestDB(t)
-	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	result, err := svc.ApplyPending(ctx, arcaneupdater.Options{DryRun: true})
@@ -251,7 +251,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 
 	t.Run("server label triggers upgrade with system user", func(t *testing.T) {
 		mockUpgrade := &mockSystemUpgradeServiceInternal{}
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.TriggerSelfUpdateViaCLI(ctx, "test", "container-1", "arcane", map[string]string{
@@ -270,7 +270,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 
 	t.Run("agent label triggers upgrade", func(t *testing.T) {
 		mockUpgrade := &mockSystemUpgradeServiceInternal{}
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.TriggerSelfUpdateViaCLI(ctx, "test", "container-1", "arcane-agent", map[string]string{
@@ -283,7 +283,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 
 	t.Run("non Arcane labels fail without triggering upgrade", func(t *testing.T) {
 		mockUpgrade := &mockSystemUpgradeServiceInternal{}
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.TriggerSelfUpdateViaCLI(ctx, "test", "container-1", "demo", map[string]string{
@@ -296,7 +296,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 	})
 
 	t.Run("missing upgrade service reports required hook", func(t *testing.T) {
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.TriggerSelfUpdateViaCLI(ctx, "test", "container-1", "arcane", map[string]string{
@@ -309,7 +309,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 
 	t.Run("upgrade errors are wrapped", func(t *testing.T) {
 		mockUpgrade := &mockSystemUpgradeServiceInternal{triggerError: errors.New("upgrade failed")}
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.TriggerSelfUpdateViaCLI(ctx, "test", "container-1", "arcane", map[string]string{
@@ -322,7 +322,7 @@ func TestUpdaterService_TriggerSelfUpdateViaCLIInternal(t *testing.T) {
 }
 
 func TestUpdaterService_StatusTrackingInternal(t *testing.T) {
-	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	stopContainer := svc.BeginContainerUpdate("container-1")
@@ -348,7 +348,7 @@ func TestUpdaterService_DockerClientAdapterInternal(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("missing docker service returns unavailable error", func(t *testing.T) {
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 
 		cli, err := svc.DockerClient(ctx)
@@ -362,7 +362,7 @@ func TestUpdaterService_DockerClientAdapterInternal(t *testing.T) {
 		server := newProjectImagePullServer(t, nil)
 		wantClient := newTestDockerClient(t, server)
 		dockerSvc := &DockerClientService{client: wantClient}
-		svc, svcErr := NewUpdaterService(nil, nil, dockerSvc, nil, nil, nil, nil, nil, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, dockerSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 
 		gotClient, err := svc.DockerClient(ctx)
@@ -376,7 +376,7 @@ func TestUpdaterService_PullImageAdapterInternal(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("missing image service returns unavailable error", func(t *testing.T) {
-		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 
 		err := svc.PullImage(ctx, "registry.example.com/app:1.2.3", nil)
@@ -390,7 +390,7 @@ func TestUpdaterService_PullImageAdapterInternal(t *testing.T) {
 		server := newProjectImagePullServer(t, nil)
 		dockerSvc := &DockerClientService{client: newTestDockerClient(t, server)}
 		imageSvc := NewImageService(db, dockerSvc, nil, nil, nil, NewEventService(db, nil, nil))
-		svc, svcErr := NewUpdaterService(db, nil, dockerSvc, nil, nil, nil, nil, imageSvc, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(db, nil, dockerSvc, nil, nil, nil, nil, imageSvc, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 		var progress bytes.Buffer
 
@@ -422,7 +422,7 @@ func TestUpdaterService_PullImageAdapterInternal(t *testing.T) {
 		envSvc := NewEnvironmentService(db, nil, nil, nil, nil, nil)
 		projectSvc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, nil).
 			WithRegistryCredentialsProvider(envSvc.GetEnabledRegistryCredentials)
-		svc, svcErr := NewUpdaterService(db, nil, dockerSvc, projectSvc, nil, nil, nil, imageSvc, nil, nil, nil)
+		svc, svcErr := NewUpdaterService(db, nil, dockerSvc, projectSvc, nil, nil, nil, imageSvc, nil, nil, nil, nil)
 		require.NoError(t, svcErr)
 		var progress bytes.Buffer
 
@@ -466,7 +466,7 @@ func TestUpdaterService_PendingImageUpdatesAdapterInternal(t *testing.T) {
 		UpdateType: models.UpdateTypeDigest,
 		CheckTime:  checkTime,
 	}).Error)
-	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	records, err := svc.PendingImageUpdates(ctx)
@@ -512,7 +512,7 @@ func TestUpdaterService_PendingImageUpdatesFlushesPendingNotificationsInternal(t
 
 	notif := NewNotificationService(db, nil, nil, nil)
 	imageUpdates := NewImageUpdateService(db, nil, nil, nil, nil, notif, nil)
-	svc, svcErr := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
@@ -543,7 +543,7 @@ func TestUpdaterService_PendingImageUpdatesNoProvidersLeavesUnnotifiedInternal(t
 
 	notif := NewNotificationService(db, nil, nil, nil)
 	imageUpdates := NewImageUpdateService(db, nil, nil, nil, nil, notif, nil)
-	svc, svcErr := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, imageUpdates, nil, nil, nil, notif, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
@@ -567,7 +567,7 @@ func TestUpdaterService_RecordUpdateRunAdapterInternal(t *testing.T) {
 	ctx := context.Background()
 	db := setupProjectTestDB(t)
 	require.NoError(t, db.AutoMigrate(&models.AutoUpdateRecord{}))
-	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, svcErr)
 
 	err := svc.RecordUpdateRun(ctx, updater.ResourceResult{
@@ -692,7 +692,7 @@ func TestUpdaterService_ApplyPending_ProjectFailureDoesNotBlockOtherProjectsInte
 		},
 	}
 
-	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, svcErr)
 	engine, engineErr := updater.New(updater.Config{
 		DockerClientProvider: dockerProvider,
@@ -823,7 +823,7 @@ func TestUpdaterService_ApplyPending_RoutesLegacyArcaneServerThroughSelfUpgradeI
 	}
 	mockUpgrade := &mockSystemUpgradeServiceInternal{}
 
-	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil)
+	svc, svcErr := NewUpdaterService(nil, nil, nil, nil, nil, nil, nil, nil, nil, mockUpgrade, nil, nil)
 	require.NoError(t, svcErr)
 	engine, engineErr := updater.New(updater.Config{
 		DockerClientProvider: dockerProvider,

--- a/frontend/src/routes/(app)/updates/container-updates-table.svelte
+++ b/frontend/src/routes/(app)/updates/container-updates-table.svelte
@@ -24,8 +24,9 @@
 	import { hasPermission } from '#lib/utils/auth';
 	import { confirmAndUpdateContainer } from '#lib/utils/container-actions';
 	import { isAutoUpdateIgnored, isAutoUpdateLabelDisabled } from '#lib/utils/container-auto-update';
-	import { bulkConfirmAndRun } from '#lib/utils/bulk-actions';
-	import { throwOnUpdateFailure } from '#lib/utils/update-actions';
+	import { confirmAndRun } from '#lib/utils/bulk-actions';
+	import { summarizeUpdateResult } from '#lib/utils/update-actions';
+	import { imageService } from '#lib/services/image-service';
 	import { formatImageUpdateCheckedAt, formatImageUpdateValue } from '#lib/utils/image-updates';
 	import { toast } from 'svelte-sonner';
 
@@ -139,21 +140,22 @@
 		}
 	}
 
+	// One scoped updater run for the whole selection: the backend deduplicates
+	// swarm task replicas down to a single service update per owning service and
+	// reports the merged tally back.
 	function handleBulkUpdate(ids: string[]) {
-		bulkConfirmAndRun({
-			ids,
+		confirmAndRun({
 			title: m.updates_bulk_update_confirm_title({ count: ids.length }),
 			message: m.updates_bulk_update_confirm_message({ count: ids.length }),
 			confirmLabel: m.common_update(),
-			run: (id) => containerService.updateContainer(id).then(throwOnUpdateFailure),
-			messages: {
-				success: (count) => m.updates_bulk_update_success({ count }),
-				partial: (success, total, failed) => m.updates_bulk_update_partial({ success, total, failed }),
-				failure: () => m.updates_bulk_update_failed()
-			},
 			setLoading: (loading) => (bulkUpdating = loading),
-			onComplete: refreshRows,
-			clearSelection: () => (selectedIds = [])
+			run: () => imageService.runAutoUpdate({ type: 'container', resourceIds: ids }),
+			failureMessage: m.updates_bulk_update_failed(),
+			onSuccess: async (result) => {
+				summarizeUpdateResult(result);
+				selectedIds = [];
+				await refreshRows();
+			}
 		});
 	}
 

--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	./backend
 	./cli
 	./types
+	../go-modules/updater
 )


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: 

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change routes Swarm task-container updates through their owning service, uses a batch path for scoped container updates, and updates the update table to submit one scoped bulk request. It also adds an external updater module to the Go workspace. A standalone checkout containing only Arcane cannot load that workspace because the referenced sibling module is absent, preventing normal Go dependency and build commands from starting. This should be corrected before merge.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until standalone Arcane checkouts can resolve the Go workspace without an unprovisioned sibling directory.

The workspace failure was reproduced in an isolated checkout made from tracked repository files, and the same module command succeeded when the workspace was disabled.

**Files Needing Attention:** go.work needs to stop requiring ../go-modules/updater for normal repository-only build environments, or the repository's checkout/bootstrap process must provide that module.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment proof for a posted P1 finding and documented the related review comment.
- T-Rex produced a second finding-comment proof for the P1 finding.
- T-Rex performed a general-contract-validation-proof showing the affected location go.work:7, the reproduction script source, and the failure capture and after-state logs.
- T-Rex attached key artifacts to proofs 0 and 2 to aid reviewer inspection of the findings and validation.

<a href="https://app.greptile.com/trex/runs/17962900/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Repository-only checkout cannot load the Go workspace**

   - **Bug**
     - In an isolated copy made only from tracked repository files, automatic workspace discovery from `backend` fails because the workspace requires a sibling module that is not part of the checkout.
   - **Cause**
     - `go.work:7` declares `../go-modules/updater`, whose resolved `go.mod` is unavailable in a standalone clone.
   - **Fix**
     - Remove or replace the external workspace member for repository-contained workflows, or provide a checkout/bootstrap mechanism that guarantees the sibling module exists before Go commands run.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat_apply_swarm_container_updates_to_the_owning_service%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat_apply_swarm_container_updates_to_the_owning_service%22.%0A%0A%23%23%23%20Issue%201%0Ago.work%3A7%0A**External%20workspace%20module%20breaks%20standalone%20builds**%0A%0AA%20checkout%20containing%20only%20this%20repository%20cannot%20run%20Go%20commands%20with%20normal%20workspace%20discovery%3A%20%60..%2Fgo-modules%2Fupdater%60%20is%20not%20part%20of%20the%20repository%2C%20so%20Go%20fails%20before%20it%20can%20download%20dependencies%20or%20compile%20Arcane.%20Remove%20this%20external%20workspace%20member%20or%20ensure%20the%20sibling%20module%20is%20provisioned%20by%20every%20build%20environment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3513&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ago.work%3A7%0A**External%20workspace%20module%20breaks%20standalone%20builds**%0A%0AA%20checkout%20containing%20only%20this%20repository%20cannot%20run%20Go%20commands%20with%20normal%20workspace%20discovery%3A%20%60..%2Fgo-modules%2Fupdater%60%20is%20not%20part%20of%20the%20repository%2C%20so%20Go%20fails%20before%20it%20can%20download%20dependencies%20or%20compile%20Arcane.%20Remove%20this%20external%20workspace%20member%20or%20ensure%20the%20sibling%20module%20is%20provisioned%20by%20every%20build%20environment.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3513&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
go.work:7
**External workspace module breaks standalone builds**

A checkout containing only this repository cannot run Go commands with normal workspace discovery: `../go-modules/updater` is not part of the repository, so Go fails before it can download dependencies or compile Arcane. Remove this external workspace member or ensure the sibling module is provisioned by every build environment.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: apply swarm container updates to t..."](https://github.com/getarcaneapp/arcane/commit/72d0095d71b083ba4d31256be3789d639f8fa45f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51504965)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->