### PR TITLE
fix: put arcane binary on $PATH in container images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,6 +98,8 @@ WORKDIR /app
 
 # The container starts as "root", but arcane drops to the requetsed PUID and PGID after the runtime is initialized 
 USER 0:0
+
+ENV PATH="/app:$PATH"
 COPY --from=backend-builder --chown=65532:65532 /build/rootfs/app/ /app/
 COPY --from=backend-builder --chown=65532:65532 /build/rootfs/builds/ /builds/
 COPY --from=backend-builder --chown=65532:65532 /build/arcane .

--- a/docker/Dockerfile-static
+++ b/docker/Dockerfile-static
@@ -13,6 +13,8 @@ ENV PORT=3552
 
 # The container starts as "root", but arcane drops to the requetsed PUID and PGID after the runtime is initialized 
 USER 0:0
+
+ENV PATH="/app:$PATH"
 EXPOSE 3552
 VOLUME ["/app/data"]
 


### PR DESCRIPTION
## Summary
- `docker exec` with a bare command name resolves against `$PATH`, which did not include `/app`. The docs instruct `docker exec -it arcane arcane admin reset-password`, so the OCI runtime failed with `executable file not found in $PATH` on every deployment. `WORKDIR=/app` only helps `./arcane`.
- Add `ENV PATH="/app:$PATH"` to the runner stage of `docker/Dockerfile` and `docker/Dockerfile-static`.

Fixes #3545

#### Test plan
- [x] Reproduced original error on `ghcr.io/getarcaneapp/manager:latest` (v2.7.0): bare `arcane admin reset-password` → `executable file not found in $PATH` (exit 127)
- [x] Layered `ENV PATH="/app:$PATH"` onto the same image and re-ran end-to-end with a pty: `Password reset successfully for global administrator "arcane"` (exit 0)