### PR TITLE
fix: derive project status from live Docker state instead of stale DB columns

### DIFF
--- a/backend/internal/dashboard/service_test.go
+++ b/backend/internal/dashboard/service_test.go
@@ -179,7 +179,6 @@ func TestDashboardService_GetSnapshot_ReturnsDashboardSnapshot(t *testing.T) {
 		Name:      "project-with-update",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 	projectSvc := project.NewProjectService(db, settingsSvc, nil, image.NewImageService(db, nil, nil, nil, nil, nil), nil, nil, nil, nil, config.Load())
 	svc := NewDashboardService(db, dockerSvc, nil, projectSvc, nil, settingsSvc, nil, nil, nil, volume.NewVolumeService(db, nil, nil, nil, nil, nil))

--- a/backend/internal/environment/service_test.go
+++ b/backend/internal/environment/service_test.go
@@ -208,7 +208,6 @@ func TestEnvironmentService_DeleteEnvironment_CascadesGitOpsSyncs(t *testing.T) 
 		BaseModel:       models.BaseModel{ID: "project-managed-by-deleted-env"},
 		Name:            "demo",
 		Path:            "/tmp/demo",
-		Status:          models.ProjectStatusStopped,
 		GitOpsManagedBy: &syncID,
 	}).Error)
 

--- a/backend/internal/gitops/gitops_sync.go
+++ b/backend/internal/gitops/gitops_sync.go
@@ -2075,10 +2075,8 @@ func (s *GitOpsSyncService) createRecoveredProjectFromDirectoryInternal(ctx cont
 		Name:            sync.ProjectName,
 		DirName:         new(filepath.Base(projectPath)),
 		Path:            projectPath,
-		Status:          models.ProjectStatusUnknown,
 		StatusReason:    new("Project recovered from existing GitOps-managed directory"),
 		ServiceCount:    0,
-		RunningCount:    0,
 		GitOpsManagedBy: &sync.ID,
 	}
 
@@ -2214,9 +2212,7 @@ func (s *GitOpsSyncService) createDirectorySyncProjectInternal(ctx context.Conte
 		Name:         sync.ProjectName,
 		DirName:      new(folderName),
 		Path:         projectPath,
-		Status:       models.ProjectStatusStopped,
 		ServiceCount: stage.serviceCount,
-		RunningCount: 0,
 	}
 
 	if err := s.projectService.CreateGitOpsManagedProject(ctx, sync, project, actor); err != nil {

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -204,7 +204,6 @@ func TestGitOpsSyncService_CleanupOrphanedSyncsOnStartup_DeletesOnlyOrphans(t *t
 		BaseModel:       models.BaseModel{ID: "project-orphan"},
 		Name:            "orphan",
 		Path:            "/tmp/orphan",
-		Status:          models.ProjectStatusStopped,
 		GitOpsManagedBy: &orphanSyncID,
 	}).Error)
 
@@ -564,7 +563,6 @@ services:
 		Name:      "demo-project",
 		DirName:   new("demo-project"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -654,7 +652,6 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGi
 		Name:      "demo-project",
 		DirName:   new("demo-project"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -745,7 +742,6 @@ func TestGitOpsSyncService_SyncProjectDirectory_MigratesLegacyTrackedEnvOnFirstS
 		Name:      "demo-project",
 		DirName:   new("demo-project"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -954,7 +950,6 @@ func TestGitOpsSyncService_DirectorySync_OverwritesExistingDirectoryAtFilePath(t
 		Name:      "traefik-project",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1104,7 +1099,6 @@ func TestGitOpsSyncService_GetDirectorySyncProjectInternal_RelinksManagedProject
 		Name:            "Radarr",
 		DirName:         &dirName,
 		Path:            projectPath,
-		Status:          models.ProjectStatusStopped,
 		GitOpsManagedBy: &sync.ID,
 	}
 	require.NoError(t, db.Create(project).Error)

--- a/backend/internal/gitops/service_unix_test.go
+++ b/backend/internal/gitops/service_unix_test.go
@@ -48,7 +48,6 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesUnreadableBindMountData
 		Name:      "demo-project",
 		DirName:   new("demo-project"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 

--- a/backend/internal/models/project.go
+++ b/backend/internal/models/project.go
@@ -17,19 +17,17 @@ const (
 type Project struct {
 	BaseModel
 
-	Name               string        `json:"name" sortable:"true" gorm:"index:idx_projects_name"`
-	DirName            *string       `json:"dir_name"`
-	Path               string        `json:"path" sortable:"true" gorm:"uniqueIndex"`
-	Status             ProjectStatus `json:"status" sortable:"true"`
-	StatusReason       *string       `json:"status_reason"`
-	ServiceCount       int           `json:"service_count" sortable:"true"`
-	RunningCount       int           `json:"running_count" sortable:"true"`
-	GitOpsManagedBy    *string       `json:"gitops_managed_by,omitempty" gorm:"column:gitops_managed_by"`
-	ComposeProjectName *string       `json:"compose_project_name,omitempty" gorm:"column:compose_project_name"`
-	ImageRefsJSON      string        `json:"image_refs_json,omitempty" gorm:"column:image_refs_json"`
-	BuildImageRefsJSON *string       `json:"-" gorm:"column:build_image_refs_json"`
-	IsArchived         bool          `json:"is_archived" gorm:"column:is_archived;default:false;index"`
-	ArchivedAt         *time.Time    `json:"archived_at,omitempty" gorm:"column:archived_at"`
+	Name               string     `json:"name" sortable:"true" gorm:"index:idx_projects_name"`
+	DirName            *string    `json:"dir_name"`
+	Path               string     `json:"path" sortable:"true" gorm:"uniqueIndex"`
+	StatusReason       *string    `json:"status_reason"`
+	ServiceCount       int        `json:"service_count" sortable:"true"`
+	GitOpsManagedBy    *string    `json:"gitops_managed_by,omitempty" gorm:"column:gitops_managed_by"`
+	ComposeProjectName *string    `json:"compose_project_name,omitempty" gorm:"column:compose_project_name"`
+	ImageRefsJSON      string     `json:"image_refs_json,omitempty" gorm:"column:image_refs_json"`
+	BuildImageRefsJSON *string    `json:"-" gorm:"column:build_image_refs_json"`
+	IsArchived         bool       `json:"is_archived" gorm:"column:is_archived;default:false;index"`
+	ArchivedAt         *time.Time `json:"archived_at,omitempty" gorm:"column:archived_at"`
 }
 
 func (Project) TableName() string {

--- a/backend/internal/project/handler.go
+++ b/backend/internal/project/handler.go
@@ -652,7 +652,7 @@ func (h *ProjectHandler) CreateProject(ctx context.Context, input *CreateProject
 	if err := mapper.MapStruct(proj, &response); err != nil {
 		return nil, huma.Error500InternalServerError("failed to map response")
 	}
-	response.Status = string(proj.Status)
+	response.Status = string(models.ProjectStatusStopped)
 	response.StatusReason = proj.StatusReason
 	response.CreatedAt = proj.CreatedAt.Format(time.RFC3339)
 	response.UpdatedAt = proj.UpdatedAt.Format(time.RFC3339)

--- a/backend/internal/project/project_details.go
+++ b/backend/internal/project/project_details.go
@@ -51,36 +51,19 @@ func getServiceCounts(services []ProjectServiceInfo) (total int, running int) {
 	return total, running
 }
 
-func (s *ProjectService) updateProjectStatusandCountsInternal(ctx context.Context, projectID string, status models.ProjectStatus) error {
+func (s *ProjectService) refreshProjectServiceCountInternal(ctx context.Context, projectID string) error {
 	services, err := s.GetProjectServices(ctx, projectID)
 	if err != nil {
-		slog.Error("GetProjectServices failed during status update", "projectID", projectID, "error", err)
-		return s.updateProjectStatusInternal(ctx, projectID, status)
+		return errors.WrapIf(err, "failed to get project services for service count refresh")
 	}
 
-	serviceCount, runningCount := getServiceCounts(services)
+	serviceCount, _ := getServiceCounts(services)
 
 	if err := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", projectID).Updates(map[string]any{
-		"status":        status,
 		"service_count": serviceCount,
-		"running_count": runningCount,
 		"updated_at":    time.Now(),
 	}).Error; err != nil {
-		return errors.WrapIf(err, "failed to update project status and counts")
-	}
-
-	return nil
-}
-
-func (s *ProjectService) updateProjectStatusInternal(ctx context.Context, id string, status models.ProjectStatus) error {
-	now := time.Now()
-	res := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", id).Updates(map[string]any{
-		"status":     status,
-		"updated_at": now,
-	})
-
-	if res.Error != nil {
-		return errors.WrapIf(res.Error, "failed to update project status")
+		return errors.WrapIf(err, "failed to update project service count")
 	}
 
 	return nil
@@ -221,10 +204,9 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 	applyResolvedProjectIconInternal(&resp, iconcatalog.Resolve(IconCatalogForContext(ctx), meta.ProjectIcon))
 	resp.URLs = meta.ProjectURLS
 
-	// Default counts/status from DB (will be overridden if runtime check succeeds)
+	// Default counts/status (overridden if the runtime check succeeds)
 	resp.ServiceCount = proj.ServiceCount
-	resp.RunningCount = proj.RunningCount
-	resp.Status = string(proj.Status)
+	resp.Status = string(models.ProjectStatusUnknown)
 
 	if opts.IncludeComposeContent {
 		composeContent, _, overrideContent, _ := s.GetProjectContent(ctx, projectID)

--- a/backend/internal/project/project_lifecycle.go
+++ b/backend/internal/project/project_lifecycle.go
@@ -113,7 +113,6 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 	if err != nil {
 		return err
 	}
-	previousStatus := projectFromDb.Status
 
 	// 1. Load project
 	compProj, _, err := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
@@ -121,41 +120,29 @@ func (s *ProjectService) UpdateProjectServices(ctx context.Context, projectID st
 		return errors.WrapIf(err, "failed to load compose project")
 	}
 
-	// 2. Set status to deploying/restarting
-	if err := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusDeploying); err != nil {
-		return err
-	}
-
 	credentials, err := s.ResolveRegistryCredentials(ctx)
 	if err != nil {
-		if statusErr := s.updateProjectStatusInternal(ctx, projectID, previousStatus); statusErr != nil {
-			slog.ErrorContext(ctx, "UpdateProjectServices: failed to restore project status after credential lookup failure", "projectID", projectID, "error", statusErr)
-		}
 		return errors.WrapIf(err, "resolve registry credentials")
 	}
 
-	// 3. Pull images for specific services
+	// 2. Pull images for specific services
 	if err := s.composePullSelectedServicesInternal(ctx, compProj, servicesToUpdate, user, credentials); err != nil {
-		if statusErr := s.updateProjectStatusInternal(ctx, projectID, previousStatus); statusErr != nil {
-			slog.ErrorContext(ctx, "UpdateProjectServices: failed to restore project status after compose pull failure", "projectID", projectID, "error", statusErr)
-		}
 		return errors.WrapIf(err, "pull updated service images")
 	}
 
-	// 4. Stop specific services
+	// 3. Stop specific services
 	if err := composeStopProjectServicesInternal(ctx, compProj, servicesToUpdate); err != nil {
 		slog.WarnContext(ctx, "compose stop failed, continuing", "error", err)
 	}
 
-	// 5. Up specific services
+	// 4. Up specific services
 	if err := composeUpProjectServicesInternal(ctx, compProj, servicesToUpdate, false, true, false, s.composeRegistryAuthConfigsInternal(ctx), s.deployWaitTimeoutInternal()); err != nil {
-		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return errors.WrapIf(err, "failed to up services")
 	}
 
-	// 6. Finalize status
-	if err := s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusRunning); err != nil {
-		return err
+	// 5. Refresh service count
+	if err := s.refreshProjectServiceCountInternal(ctx, projectID); err != nil {
+		slog.WarnContext(ctx, "failed to refresh project service count after service update", "projectID", projectID, "error", err)
 	}
 
 	metadata := models.JSON{
@@ -176,23 +163,6 @@ func ensureProjectMutableInternal(proj *models.Project) error {
 	return nil
 }
 
-func isProjectArchiveBlockedInternal(proj *models.Project) bool {
-	if proj == nil {
-		return false
-	}
-	if proj.RunningCount > 0 {
-		return true
-	}
-	switch proj.Status {
-	case models.ProjectStatusRunning, models.ProjectStatusPartiallyRunning, models.ProjectStatusDeploying, models.ProjectStatusRestarting:
-		return true
-	case models.ProjectStatusStopped, models.ProjectStatusUnknown, models.ProjectStatusStopping:
-		return false
-	default:
-		return false
-	}
-}
-
 func (s *ProjectService) ArchiveProject(ctx context.Context, projectID string, user models.User) error {
 	proj, err := s.GetProjectFromDatabaseByID(ctx, projectID)
 	if err != nil {
@@ -201,7 +171,13 @@ func (s *ProjectService) ArchiveProject(ctx context.Context, projectID string, u
 	if proj.IsArchived {
 		return nil
 	}
-	if isProjectArchiveBlockedInternal(proj) {
+
+	// A project without a compose file cannot have running services, so it may be archived.
+	services, err := s.GetProjectServices(ctx, projectID)
+	if err != nil && !errors.Is(err, common.ErrProjectComposeFileNotFound) {
+		return errors.WrapIf(err, "cannot verify project is stopped before archiving")
+	}
+	if _, running := getServiceCounts(services); running > 0 {
 		return common.Classify(common.ErrProjectMustBeStopped, errors.New("project must be stopped before archiving"))
 	}
 
@@ -278,36 +254,28 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		resolvedPullPolicy = "missing"
 	}
 
-	if err := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusDeploying); err != nil {
-		return errors.WrapIf(err, "failed to update project status to deploying")
-	}
-
 	// Run any configured pre-deploy lifecycle hook before loading the compose
 	// project so hooks can produce files that compose then consumes (e.g.
 	// `sops -d secrets.enc.env > .env.runtime` for an `env_file: .env.runtime`
 	// service). A failed hook aborts the deploy.
 	if s.lifecycleService != nil {
 		if lerr := s.lifecycleService.RunPreDeploy(ctx, projectFromDb, user); lerr != nil {
-			s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 			return errors.WrapIf(lerr, "pre-deploy lifecycle hook failed")
 		}
 	}
 
 	projectModel, _, derr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if derr != nil {
-		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return errors.WrapIff(derr, "failed to load compose project in %s", projectFromDb.Path)
 	}
 
 	credentials, cerr := s.ResolveRegistryCredentials(ctx)
 	if cerr != nil {
-		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return errors.WrapIf(cerr, "resolve registry credentials")
 	}
 
 	progressWriter, _ := ctx.Value(dockerutil.ProgressWriterKey{}).(io.Writer)
 	if perr := s.prepareProjectImagesForDeploy(ctx, projectID, projectModel, progressWriter, credentials, &user, resolvedPullPolicy); perr != nil {
-		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 		return errors.WrapIf(perr, "failed to prepare project images for deploy")
 	}
 
@@ -321,7 +289,6 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 		if containers, psErr := s.GetProjectServices(ctx, projectID); psErr == nil {
 			slog.Info("containers after failed deploy", "projectID", projectID, "containers", containers)
 		}
-		s.restoreProjectStatusAfterFailedDeployInternal(ctx, projectID)
 
 		// Provide more helpful error messages
 		errMsg := err.Error()
@@ -335,11 +302,10 @@ func (s *ProjectService) DeployProject(ctx context.Context, projectID string, us
 	metadata := models.JSON{"action": "deploy", "projectID": projectID, "projectName": projectModel.Name}
 	s.logProjectEventInternal(ctx, models.EventTypeProjectDeploy, projectID, projectModel.Name, user, metadata, "could not log project deployment action")
 
-	err = s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusRunning)
-	if err != nil {
-		slog.Error("failed to update project status and counts after deploy", "projectID", projectID, "error", err)
+	if err := s.refreshProjectServiceCountInternal(ctx, projectID); err != nil {
+		slog.Warn("failed to refresh project service count after deploy", "projectID", projectID, "error", err)
 	}
-	return err
+	return nil
 }
 
 func (s *ProjectService) DownProject(ctx context.Context, projectID string, user models.User) error {
@@ -350,16 +316,10 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 
 	proj, _, lerr := s.loadComposeProjectForProjectInternal(ctx, projectFromDb, nil)
 	if lerr != nil {
-		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return errors.WrapIf(lerr, "failed to load compose project")
 	}
 
-	if err := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusStopped); err != nil {
-		return errors.WrapIf(err, "failed to update project status to stopping")
-	}
-
 	if err := projects.ComposeDown(ctx, proj, false); err != nil {
-		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return errors.WrapIf(err, "failed to bring down project")
 	}
 
@@ -370,7 +330,10 @@ func (s *ProjectService) DownProject(ctx context.Context, projectID string, user
 	}
 	s.logProjectEventInternal(ctx, models.EventTypeProjectStop, projectID, projectFromDb.Name, user, metadata, "could not log project down action")
 
-	return s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusStopped)
+	if err := s.refreshProjectServiceCountInternal(ctx, projectID); err != nil {
+		slog.WarnContext(ctx, "failed to refresh project service count after down", "projectID", projectID, "error", err)
+	}
+	return nil
 }
 
 // CreateProject creates a project's directory, files, and DB row. When
@@ -414,9 +377,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, name, composeContent
 		Name:         name,
 		DirName:      &folderName,
 		Path:         projectPath,
-		Status:       models.ProjectStatusStopped,
 		ServiceCount: 0,
-		RunningCount: 0,
 	}
 
 	if err := projects.ApplyProjectWorkspaceChanges(projectPath, manifest.FileChanges, uploads, projects.ProjectWorkspaceApplyOptions{
@@ -899,30 +860,6 @@ func (s *ProjectService) prepareServiceBuildRequest(
 	return buildReq, updatedSvc, updated, nil
 }
 
-func (s *ProjectService) restoreProjectStatusAfterFailedDeployInternal(ctx context.Context, projectID string) {
-	services, err := s.GetProjectServices(ctx, projectID)
-	if err == nil {
-		serviceCount, runningCount := getServiceCounts(services)
-		status := calculateProjectStatus(services)
-		updateErr := s.db.WithContext(ctx).Model(&models.Project{}).Where("id = ?", projectID).Updates(map[string]any{
-			"status":        status,
-			"service_count": serviceCount,
-			"running_count": runningCount,
-			"updated_at":    time.Now(),
-		}).Error
-		if updateErr == nil {
-			return
-		}
-		slog.WarnContext(ctx, "failed to restore project status after deploy failure", "projectID", projectID, "error", updateErr)
-	} else {
-		slog.WarnContext(ctx, "failed to inspect project services after deploy failure", "projectID", projectID, "error", err)
-	}
-
-	if updateErr := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusStopped); updateErr != nil {
-		slog.WarnContext(ctx, "failed to set stopped status after deploy failure", "projectID", projectID, "error", updateErr)
-	}
-}
-
 func (s *ProjectService) buildProjectServicesInternal(ctx context.Context, projectID string, project *composetypes.Project, options ProjectBuildOptions, progressWriter io.Writer, user *models.User) error {
 	if s.buildService == nil {
 		return nil
@@ -969,10 +906,6 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, s
 		return err
 	}
 
-	if err := s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRestarting); err != nil {
-		return errors.WrapIf(err, "failed to update project status to restarting")
-	}
-
 	// Get configured projects directory from settings
 	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
 	projectsDirectory := getProjectsDirectoryOrDefaultInternal(ctx, cfg)
@@ -990,12 +923,10 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, s
 
 	compProj, _, lerr := projects.LoadComposeProjectFromDir(ctx, proj.Path, projects.NormalizeProjectName(proj.Name), projectsDirectory, utils.BoolOrDefault(cfg.AutoInjectEnv.Value, false), pathMapper)
 	if lerr != nil {
-		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return errors.WrapIf(lerr, "failed to load compose project")
 	}
 
 	if err := projects.ComposeRestart(ctx, compProj, services); err != nil {
-		_ = s.updateProjectStatusInternal(ctx, projectID, models.ProjectStatusRunning)
 		return errors.WrapIf(err, "failed to restart project")
 	}
 
@@ -1009,5 +940,8 @@ func (s *ProjectService) RestartProject(ctx context.Context, projectID string, s
 	}
 	s.logProjectEventInternal(ctx, models.EventTypeProjectStart, projectID, proj.Name, user, metadata, "could not log project restart action")
 
-	return s.updateProjectStatusandCountsInternal(ctx, projectID, models.ProjectStatusRunning)
+	if err := s.refreshProjectServiceCountInternal(ctx, projectID); err != nil {
+		slog.WarnContext(ctx, "failed to refresh project service count after restart", "projectID", projectID, "error", err)
+	}
+	return nil
 }

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -122,12 +122,9 @@ func (s *ProjectService) GetProjectStatusCounts(ctx context.Context) (folderCoun
 	// 1. Fetch all compose containers
 	containers, err := projects.ListGlobalComposeContainers(ctx)
 	if err != nil {
+		// Degrade the counts rather than failing the load; live state is unknowable.
 		slog.ErrorContext(ctx, "Failed to list global compose containers for counts", "error", err)
-		// Fallback to DB status
-		for _, p := range activeProjects {
-			incrementStatusCounts(p.Status, &runningProjects, &stoppedProjects)
-		}
-		return folderCount, runningProjects, stoppedProjects, totalProjects, archivedProjects, nil
+		return folderCount, 0, 0, totalProjects, archivedProjects, nil
 	}
 
 	// 2. Group by project
@@ -169,19 +166,19 @@ func (s *ProjectService) ListProjects(ctx context.Context, params pagination.Que
 		archivedFilter = strings.TrimSpace(params.Filters["archived"])
 	}
 	query = applyProjectArchivedDBFilterInternal(query, archivedFilter)
-	if statusFilter != "" || updatesFilter != "" {
+	// Status filtering and sorting operate on live-computed status, so they go
+	// through the derived (in-memory) path.
+	if statusFilter != "" || updatesFilter != "" || strings.EqualFold(strings.TrimSpace(params.Sort), "status") {
 		return s.listProjectsWithDerivedFiltersInternal(ctx, params, query)
 	}
 
 	if term := strings.TrimSpace(params.Search); term != "" {
 		searchPattern := "%" + term + "%"
 		query = query.Where(
-			"name LIKE ? OR path LIKE ? OR status LIKE ? OR COALESCE(dir_name, '') LIKE ?",
-			searchPattern, searchPattern, searchPattern, searchPattern,
+			"name LIKE ? OR path LIKE ? OR COALESCE(dir_name, '') LIKE ?",
+			searchPattern, searchPattern, searchPattern,
 		)
 	}
-
-	query = pagination.ApplyFilter(query, "status", params.Filters["status"])
 
 	var projectsArray []models.Project
 	paginationResp, err := pagination.PaginateAndSortDB(params, query, &projectsArray)
@@ -247,8 +244,8 @@ func (s *ProjectService) filterProjectsWithDerivedFiltersInternal(
 	if term := strings.TrimSpace(params.Search); term != "" {
 		searchPattern := "%" + term + "%"
 		query = query.Where(
-			"name LIKE ? OR path LIKE ? OR status LIKE ? OR COALESCE(dir_name, '') LIKE ?",
-			searchPattern, searchPattern, searchPattern, searchPattern,
+			"name LIKE ? OR path LIKE ? OR COALESCE(dir_name, '') LIKE ?",
+			searchPattern, searchPattern, searchPattern,
 		)
 	}
 	if err := query.Find(&projectsArray).Error; err != nil {

--- a/backend/internal/project/project_sync.go
+++ b/backend/internal/project/project_sync.go
@@ -189,18 +189,16 @@ func (s *ProjectService) upsertProjectForDir(ctx context.Context, dirName, dirPa
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create a minimal project entry
-		reason := "Project discovered from filesystem, status pending Docker service query"
+		reason := "Project discovered from filesystem"
 		proj := &models.Project{
 			Name:               composeMetadata.resolvedProjectName,
 			DirName:            new(dirName),
 			Path:               dirPath,
-			Status:             models.ProjectStatusUnknown,
 			StatusReason:       new(reason),
 			ServiceCount:       composeMetadata.serviceCount,
-			RunningCount:       0,
 			ComposeProjectName: composeMetadata.composeProjectName,
 		}
-		slog.InfoContext(ctx, "Discovered new project with unknown status",
+		slog.InfoContext(ctx, "Discovered new project",
 			"project", dirName,
 			"path", dirPath,
 			"reason", reason)

--- a/backend/internal/project/project_update.go
+++ b/backend/internal/project/project_update.go
@@ -229,7 +229,7 @@ func (s *ProjectService) refreshProjectAfterContentUpdateInternal(ctx context.Co
 
 	s.refreshComposeProjectNameInternal(ctx, proj)
 	s.refreshProjectImageRefsInternal(ctx, proj)
-	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
+	if err := s.refreshProjectServiceCountInternal(ctx, proj.ID); err != nil {
 		slog.WarnContext(ctx, "failed to update service counts after compose edit", "projectID", proj.ID, "error", err)
 	}
 }
@@ -267,8 +267,8 @@ func (s *ProjectService) ApplyGitSyncProjectFiles(ctx context.Context, projectID
 	s.refreshComposeProjectNameInternal(ctx, &proj)
 	s.refreshProjectImageRefsInternal(ctx, &proj)
 
-	// Recalculate service counts and status after compose file sync
-	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
+	// Recalculate service counts after compose file sync
+	if err := s.refreshProjectServiceCountInternal(ctx, proj.ID); err != nil {
 		slog.WarnContext(ctx, "failed to update service counts after git sync", "projectID", proj.ID, "error", err)
 	}
 
@@ -374,7 +374,7 @@ func projectRenameVolumeMigrationComposeNamesInternal(s *ProjectService, proj *m
 	}
 
 	newProjectName := strings.TrimSpace(*name)
-	if newProjectName == "" || proj.Name == newProjectName || proj.Status != models.ProjectStatusStopped {
+	if newProjectName == "" || proj.Name == newProjectName {
 		return "", "", false
 	}
 
@@ -592,14 +592,11 @@ func (s *ProjectService) ensureProjectStoppedForRenameInternal(ctx context.Conte
 	if !isProjectRenameRequestedInternal(proj, name) {
 		return nil
 	}
-	if proj.Status != models.ProjectStatusStopped && proj.Status != models.ProjectStatusUnknown {
-		return errors.Errorf("project must be stopped before renaming (current status: %s)", proj.Status)
-	}
 
 	services, err := s.GetProjectServices(ctx, proj.ID)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to resolve project status before rename", "projectID", proj.ID, "error", err)
-		return errors.WrapIff(err, "project must be stopped before renaming (current status: %s): failed to verify live status", proj.Status)
+		return errors.WrapIf(err, "failed to verify project is stopped before renaming")
 	}
 
 	status := calculateProjectStatus(services)
@@ -607,11 +604,8 @@ func (s *ProjectService) ensureProjectStoppedForRenameInternal(ctx context.Conte
 		return errors.Errorf("project must be stopped before renaming (current status: %s)", status)
 	}
 
-	serviceCount, runningCount := getServiceCounts(services)
-	proj.Status = models.ProjectStatusStopped
-	proj.StatusReason = nil
+	serviceCount, _ := getServiceCounts(services)
 	proj.ServiceCount = serviceCount
-	proj.RunningCount = runningCount
 	return nil
 }
 
@@ -623,10 +617,6 @@ func (s *ProjectService) applyProjectRenameIfNeeded(ctx context.Context, proj *m
 	newName := strings.TrimSpace(*name)
 	if newName == "" || proj.Name == newName {
 		return nil
-	}
-
-	if proj.Status != models.ProjectStatusStopped {
-		return errors.Errorf("project must be stopped before renaming (current status: %s)", proj.Status)
 	}
 
 	newDirName := projects.SanitizeProjectName(newName)

--- a/backend/internal/project/service_test.go
+++ b/backend/internal/project/service_test.go
@@ -298,7 +298,6 @@ func TestProjectService_DestroyProject_RemovesFilesWhenRequested(t *testing.T) {
 		Name:      "demo-remove",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -323,7 +322,6 @@ func TestProjectService_DestroyProject_PreservesFilesWhenRequested(t *testing.T)
 		Name:      "demo-preserve",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -453,32 +451,6 @@ func TestProjectService_CalculateProjectStatus(t *testing.T) {
 			got := calculateProjectStatus(tt.services)
 			assert.Equal(t, tt.want, got)
 		})
-	}
-}
-
-func TestProjectService_UpdateProjectStatusInternal(t *testing.T) {
-	db := setupProjectTestDB(t)
-	ctx := context.Background()
-	svc := NewProjectService(db, nil, nil, nil, nil, nil, nil, nil, config.Load())
-
-	proj := &models.Project{
-		BaseModel: models.BaseModel{
-			ID: "p1",
-		},
-		Status: models.ProjectStatusUnknown,
-	}
-	require.NoError(t, db.Create(proj).Error)
-
-	err := svc.updateProjectStatusInternal(ctx, "p1", models.ProjectStatusRunning)
-	require.NoError(t, err)
-
-	var updated models.Project
-	require.NoError(t, db.First(&updated, "id = ?", "p1").Error)
-	assert.Equal(t, models.ProjectStatusRunning, updated.Status)
-	if updated.UpdatedAt != nil {
-		assert.WithinDuration(t, time.Now(), *updated.UpdatedAt, time.Second)
-	} else {
-		assert.Fail(t, "UpdatedAt should not be nil")
 	}
 }
 
@@ -661,7 +633,6 @@ func TestProjectService_PullProjectImages_UpdatesCurrentImageRecordAfterPull(t *
 		Name:      "compose-pull",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
@@ -1031,7 +1002,6 @@ func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *t
 		Name:      "compose-update-pull-fail",
 		DirName:   ptr("compose-update-pull-fail"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusRunning,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 	require.NoError(t, db.Create(&models.ImageUpdateRecord{
@@ -1059,10 +1029,6 @@ func TestProjectService_UpdateProjectServicesHardFailsWhenPullFailsInternal(t *t
 	require.Error(t, err)
 	require.ErrorContains(t, err, "pull updated service images")
 	assert.False(t, upCalled, "compose up must not run after a pull failure")
-
-	var persistedProject models.Project
-	require.NoError(t, db.WithContext(ctx).Where("id = ?", projectRecord.ID).First(&persistedProject).Error)
-	assert.Equal(t, models.ProjectStatusRunning, persistedProject.Status)
 
 	var persistedRecord models.ImageUpdateRecord
 	require.NoError(t, db.WithContext(ctx).Where("id = ?", "sha256:selected-old").First(&persistedRecord).Error)
@@ -1104,7 +1070,6 @@ func TestProjectService_UpdateProjectServicesForcesRecreateInternal(t *testing.T
 		Name:      "compose-update-force",
 		DirName:   ptr("compose-update-force"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusRunning,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
@@ -1214,7 +1179,6 @@ func TestProjectService_UpdateProject_RenameFailsWhenVolumeMigrationPreparationF
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1257,7 +1221,6 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_AppliesVolumeMigrati
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1332,7 +1295,6 @@ func TestProjectService_PrepareProjectRenameVolumeMigrationForUpdate_UsesCompose
 		Name:      "nginx",
 		DirName:   ptr("nginx"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 
 	t.Run("skips volume made explicit in pending compose", func(t *testing.T) {
@@ -1429,7 +1391,6 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_RollsBackVolumeMigra
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1474,7 +1435,6 @@ func TestProjectService_ApplyProjectUpdateWithRenameJournal_SucceedsCommittedRen
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1521,7 +1481,6 @@ func TestProjectService_UpdateProject_ClearsJournalForNonRenameWhenRecoveryDocke
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1587,7 +1546,6 @@ func TestProjectService_UpdateProject_AllowsRenameAfterJournalRecoveryDockerUnav
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1650,7 +1608,6 @@ func TestProjectService_UpdateProject_RenamesDirectoryWhenNameChanges(t *testing
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1702,7 +1659,6 @@ func TestProjectService_UpdateProject_RenameFailsWhenTargetDirectoryExists(t *te
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1724,7 +1680,7 @@ func TestProjectService_UpdateProject_RenameFailsWhenTargetDirectoryExists(t *te
 	assert.Equal(t, "Foo", *fromDB.DirName)
 }
 
-func TestProjectService_UpdateProject_RenameFailsWhenProjectRunning(t *testing.T) {
+func TestProjectService_UpdateProject_RenameFailsWhenComposeUnloadable(t *testing.T) {
 	db := setupProjectTestDB(t)
 	ctx := context.Background()
 
@@ -1746,7 +1702,6 @@ func TestProjectService_UpdateProject_RenameFailsWhenProjectRunning(t *testing.T
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusRunning,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1756,7 +1711,7 @@ func TestProjectService_UpdateProject_RenameFailsWhenProjectRunning(t *testing.T
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "project must be stopped before renaming (current status: running)")
+	assert.Contains(t, err.Error(), "failed to verify project is stopped before renaming")
 	assert.DirExists(t, originalPath)
 	assert.NoDirExists(t, filepath.Join(projectsDir, "bar"))
 
@@ -1805,7 +1760,6 @@ func TestProjectService_UpdateProject_RenameRejectsStaleStoppedWhenRuntimeIsRunn
 		Name:      "Foo",
 		DirName:   &originalDirName,
 		Path:      originalPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -1823,7 +1777,6 @@ func TestProjectService_UpdateProject_RenameRejectsStaleStoppedWhenRuntimeIsRunn
 	require.NoError(t, db.First(&fromDB, "id = ?", project.ID).Error)
 	assert.Equal(t, "Foo", fromDB.Name)
 	assert.Equal(t, originalPath, fromDB.Path)
-	assert.Equal(t, models.ProjectStatusStopped, fromDB.Status)
 }
 
 func TestProjectService_UpdateProject_RenameResolvesUnknownStoppedStatusBeforeVolumeMigration(t *testing.T) {
@@ -1852,7 +1805,6 @@ func TestProjectService_UpdateProject_RenameResolvesUnknownStoppedStatusBeforeVo
 		Name:         "Foo",
 		DirName:      &originalDirName,
 		Path:         originalPath,
-		Status:       models.ProjectStatusUnknown,
 		StatusReason: &statusReason,
 	}
 	require.NoError(t, db.Create(project).Error)
@@ -1867,10 +1819,7 @@ func TestProjectService_UpdateProject_RenameResolvesUnknownStoppedStatusBeforeVo
 	expectedPath := filepath.Join(projectsDir, "bar")
 	assert.Equal(t, "bar", updated.Name)
 	assert.Equal(t, expectedPath, updated.Path)
-	assert.Equal(t, models.ProjectStatusStopped, updated.Status)
-	assert.Nil(t, updated.StatusReason)
 	assert.Equal(t, 1, updated.ServiceCount)
-	assert.Equal(t, 0, updated.RunningCount)
 	assert.NoDirExists(t, originalPath)
 	assert.DirExists(t, expectedPath)
 
@@ -1878,10 +1827,7 @@ func TestProjectService_UpdateProject_RenameResolvesUnknownStoppedStatusBeforeVo
 	require.NoError(t, db.First(&fromDB, "id = ?", project.ID).Error)
 	assert.Equal(t, "bar", fromDB.Name)
 	assert.Equal(t, expectedPath, fromDB.Path)
-	assert.Equal(t, models.ProjectStatusStopped, fromDB.Status)
-	assert.Nil(t, fromDB.StatusReason)
 	assert.Equal(t, 1, fromDB.ServiceCount)
-	assert.Equal(t, 0, fromDB.RunningCount)
 }
 
 func TestProjectService_UpdateProject_RenameRejectsUnknownWhenRuntimeIsRunning(t *testing.T) {
@@ -1924,7 +1870,6 @@ func TestProjectService_UpdateProject_RenameRejectsUnknownWhenRuntimeIsRunning(t
 		Name:         "Foo",
 		DirName:      &originalDirName,
 		Path:         originalPath,
-		Status:       models.ProjectStatusUnknown,
 		StatusReason: &statusReason,
 	}
 	require.NoError(t, db.Create(project).Error)
@@ -1943,7 +1888,6 @@ func TestProjectService_UpdateProject_RenameRejectsUnknownWhenRuntimeIsRunning(t
 	require.NoError(t, db.First(&fromDB, "id = ?", project.ID).Error)
 	assert.Equal(t, "Foo", fromDB.Name)
 	assert.Equal(t, originalPath, fromDB.Path)
-	assert.Equal(t, models.ProjectStatusUnknown, fromDB.Status)
 	require.NotNil(t, fromDB.StatusReason)
 	assert.Equal(t, statusReason, *fromDB.StatusReason)
 }
@@ -1970,7 +1914,6 @@ func TestProjectService_UpdateProject_ValidatesComposeUsingExistingProjectName(t
 		Name:      "demo",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2013,7 +1956,6 @@ func TestProjectService_UpdateProject_AllowsMissingEnvFileDuringComposeValidatio
 		Name:      "env-required",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2058,7 +2000,6 @@ func TestProjectService_UpdateProject_AllowsMissingLocalIncludeDuringComposeVali
 		Name:      "include-new",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2084,7 +2025,6 @@ services:
 	require.NoError(t, err)
 	require.Len(t, details.IncludeFiles, 1)
 	assert.Equal(t, "metadata.yaml", details.IncludeFiles[0].RelativePath)
-
 }
 
 func TestProjectService_CreateProject_AllowsExternalInclude(t *testing.T) {
@@ -2141,7 +2081,6 @@ func TestProjectService_UpdateProject_AllowsExternalInclude(t *testing.T) {
 		Name:      "external-include",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2251,7 +2190,6 @@ func TestProjectService_UpdateProject_UsesExistingEnvFileDuringComposeValidation
 		Name:      "env-existing",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2300,7 +2238,6 @@ func newProjectServiceForOverrideTestInternal(t *testing.T, dirName, baseCompose
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2411,7 +2348,6 @@ func TestProjectService_UpdateProject_UsesProvidedEnvContentDuringComposeValidat
 		Name:      "env-updated",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2458,7 +2394,6 @@ func TestProjectService_UpdateProject_ReturnsEnvParseErrorDuringComposeValidatio
 		Name:      "env-invalid",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2504,7 +2439,6 @@ func TestProjectService_UpdateProject_UsesGlobalEnvDuringComposeValidation(t *te
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2553,7 +2487,6 @@ func TestProjectService_UpdateProject_DoesNotResolveHostEnvThroughGlobalEnvDurin
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2599,7 +2532,6 @@ func TestProjectService_UpdateProject_DerivesProjectOverrideEnvWhenGitSourceExis
 		Name:      "override-edit",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2651,7 +2583,6 @@ func TestProjectService_UpdateProject_UnchangedGitEnvLeavesFilesUntouched(t *tes
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2744,7 +2675,6 @@ func TestProjectService_UpdateProject_DeletingGitBackedKeyFallsBackToGit(t *test
 		Name:      "override-delete",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2792,7 +2722,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_MigratesDirectEnvIntoProjectOve
 		Name:      "git-sync-migrate",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2842,7 +2771,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_PreservesGitEnvSyntax(t *testin
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2906,7 +2834,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_NormalizesStaleCopiedGitOverrid
 		Name:      "git-sync-normalize",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -2954,7 +2881,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_RemovesLegacyDeletedGitMasks(t 
 		Name:      "git-sync-delete-mask",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3002,7 +2928,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_RemovesGitEnvSource(t *testing.
 		Name:      "git-sync-remove",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3044,7 +2969,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_WritesAndRemovesComposeOverride
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3095,7 +3019,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_UsesGlobalEnvDuringComposeValid
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3155,7 +3078,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_TolerantOfUndefinedComposeVar(t
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3235,7 +3157,6 @@ func TestProjectService_GetProjectDetails_ReturnsEffectiveEnvContent(t *testing.
 		Name:      "details-override",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -3357,7 +3278,6 @@ func TestProjectService_GetProjectDetails_IncludesUpdateInfo(t *testing.T) {
 		Name:      "updates-demo",
 		DirName:   ptr("updates-demo"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
@@ -3440,9 +3360,7 @@ func TestProjectService_GetProjectDetails_RefreshesRuntimeStatusWithoutRuntimeSe
 		Name:         "projectA",
 		DirName:      ptr("projectA"),
 		Path:         projectPath,
-		Status:       models.ProjectStatusStopped,
 		ServiceCount: 2,
-		RunningCount: 0,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
@@ -3492,9 +3410,7 @@ func TestProjectService_GetProjectDetails_PopulatesRuntimeServicesFromComposePs(
 		Name:         "projectA",
 		DirName:      ptr("projectA"),
 		Path:         projectPath,
-		Status:       models.ProjectStatusStopped,
 		ServiceCount: 1,
-		RunningCount: 0,
 	}
 	require.NoError(t, db.Create(projectRecord).Error)
 
@@ -3538,28 +3454,24 @@ func TestProjectService_ListProjects_FiltersByUpdateStatus(t *testing.T) {
 		Name:      "updated-demo",
 		DirName:   ptr("updated-demo"),
 		Path:      updatedPath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 	require.NoError(t, db.Create(&models.Project{
 		BaseModel: models.BaseModel{ID: "project-current"},
 		Name:      "current-demo",
 		DirName:   ptr("current-demo"),
 		Path:      upToDatePath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 	require.NoError(t, db.Create(&models.Project{
 		BaseModel: models.BaseModel{ID: "project-error"},
 		Name:      "error-demo",
 		DirName:   ptr("error-demo"),
 		Path:      errorPath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 	require.NoError(t, db.Create(&models.Project{
 		BaseModel: models.BaseModel{ID: "project-unknown"},
 		Name:      "unknown-demo",
 		DirName:   ptr("unknown-demo"),
 		Path:      unknownPath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 
 	now := time.Now().UTC()
@@ -3741,14 +3653,12 @@ func TestProjectService_ListProjects_FiltersArchivedProjects(t *testing.T) {
 		Name:      "active-demo",
 		DirName:   ptr("active-demo"),
 		Path:      activePath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 	require.NoError(t, db.Create(&models.Project{
 		BaseModel:  models.BaseModel{ID: "project-archived"},
 		Name:       "archived-demo",
 		DirName:    ptr("archived-demo"),
 		Path:       archivedPath,
-		Status:     models.ProjectStatusStopped,
 		IsArchived: true,
 		ArchivedAt: new(time.Now().UTC()),
 	}).Error)
@@ -3791,18 +3701,35 @@ func TestProjectService_ArchiveProject_RequiresStoppedProject(t *testing.T) {
 	ctx := context.Background()
 
 	projectsRoot := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsRoot)
 	settingsService, err := newSettingsServiceForTestInternal(t, ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
 
 	projectPath := createComposeProjectDir(t, projectsRoot, "running-demo")
+
+	server := newProjectRuntimeDockerServerInternal(t, []container.Summary{
+		{
+			ID:     "app-container",
+			Names:  []string{"/running-demo-app-1"},
+			Image:  "nginx:alpine",
+			State:  container.StateRunning,
+			Status: "Up 30 seconds",
+			Labels: map[string]string{
+				composeapi.ProjectLabel:    "running-demo",
+				composeapi.ServiceLabel:    "app",
+				composeapi.ConfigHashLabel: "app-hash",
+				composeapi.WorkingDirLabel: projectPath,
+			},
+		},
+	})
+	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, server.URL))
+
 	require.NoError(t, db.Create(&models.Project{
-		BaseModel:    models.BaseModel{ID: "project-running"},
-		Name:         "running-demo",
-		DirName:      ptr("running-demo"),
-		Path:         projectPath,
-		Status:       models.ProjectStatusRunning,
-		RunningCount: 1,
+		BaseModel: models.BaseModel{ID: "project-running"},
+		Name:      "running-demo",
+		DirName:   ptr("running-demo"),
+		Path:      projectPath,
 	}).Error)
 
 	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
@@ -3821,9 +3748,13 @@ func TestProjectService_ArchiveProject_TogglesArchiveFlag(t *testing.T) {
 	ctx := context.Background()
 
 	projectsRoot := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsRoot)
 	settingsService, err := newSettingsServiceForTestInternal(t, ctx, db)
 	require.NoError(t, err)
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	server := newProjectRuntimeDockerServerInternal(t, nil)
+	t.Setenv("DOCKER_HOST", dockerHostFromProjectRuntimeServerURLInternal(t, server.URL))
 
 	projectPath := createComposeProjectDir(t, projectsRoot, "stopped-demo")
 	require.NoError(t, db.Create(&models.Project{
@@ -3831,7 +3762,6 @@ func TestProjectService_ArchiveProject_TogglesArchiveFlag(t *testing.T) {
 		Name:      "stopped-demo",
 		DirName:   ptr("stopped-demo"),
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 
 	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
@@ -3848,6 +3778,62 @@ func TestProjectService_ArchiveProject_TogglesArchiveFlag(t *testing.T) {
 	require.NoError(t, db.First(&unarchived, "id = ?", "project-stopped").Error)
 	assert.False(t, unarchived.IsArchived)
 	assert.Nil(t, unarchived.ArchivedAt)
+}
+
+func TestProjectService_ArchiveProject_DockerUnreachableFails(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsRoot := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsRoot)
+	settingsService, err := newSettingsServiceForTestInternal(t, ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:1")
+
+	projectPath := createComposeProjectDir(t, projectsRoot, "unverifiable-demo")
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel: models.BaseModel{ID: "project-unverifiable"},
+		Name:      "unverifiable-demo",
+		DirName:   ptr("unverifiable-demo"),
+		Path:      projectPath,
+	}).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
+	err = svc.ArchiveProject(ctx, "project-unverifiable", models.User{BaseModel: models.BaseModel{ID: "user-1"}, Username: "tester"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot verify project is stopped before archiving")
+
+	var stored models.Project
+	require.NoError(t, db.First(&stored, "id = ?", "project-unverifiable").Error)
+	assert.False(t, stored.IsArchived)
+}
+
+func TestProjectService_ArchiveProject_MissingComposeFileAllowsArchive(t *testing.T) {
+	db := setupProjectTestDB(t)
+	ctx := context.Background()
+
+	projectsRoot := t.TempDir()
+	t.Setenv("PROJECTS_DIRECTORY", projectsRoot)
+	settingsService, err := newSettingsServiceForTestInternal(t, ctx, db)
+	require.NoError(t, err)
+	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
+
+	projectPath := filepath.Join(projectsRoot, "composeless-demo")
+	require.NoError(t, os.MkdirAll(projectPath, 0o755))
+	require.NoError(t, db.Create(&models.Project{
+		BaseModel: models.BaseModel{ID: "project-composeless"},
+		Name:      "composeless-demo",
+		DirName:   ptr("composeless-demo"),
+		Path:      projectPath,
+	}).Error)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
+	require.NoError(t, svc.ArchiveProject(ctx, "project-composeless", models.User{BaseModel: models.BaseModel{ID: "user-1"}, Username: "tester"}))
+
+	var stored models.Project
+	require.NoError(t, db.First(&stored, "id = ?", "project-composeless").Error)
+	assert.True(t, stored.IsArchived)
 }
 
 func TestProjectService_MapProjectToDto_SetsRedeployDisabledFromRuntimeServices(t *testing.T) {
@@ -3971,7 +3957,6 @@ func TestProjectService_ListProjects_WithDerivedStatusFilter_AllowsAllPageSizeSe
 			Name:      fmt.Sprintf("stopped-%02d", i),
 			DirName:   ptr(fmt.Sprintf("stopped-%02d", i)),
 			Path:      projectPath,
-			Status:    models.ProjectStatusStopped,
 		}).Error)
 	}
 
@@ -4208,7 +4193,6 @@ func TestProjectService_DeployProject_StopsOnBuildPreparationError(t *testing.T)
 		BaseModel: models.BaseModel{ID: "p1"},
 		Name:      "demo",
 		Path:      projectDir,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(proj).Error)
 
@@ -4219,10 +4203,6 @@ func TestProjectService_DeployProject_StopsOnBuildPreparationError(t *testing.T)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to prepare project images for deploy")
 	assert.Contains(t, err.Error(), "boom build")
-
-	var updated models.Project
-	require.NoError(t, db.First(&updated, "id = ?", "p1").Error)
-	assert.Equal(t, models.ProjectStatusStopped, updated.Status)
 }
 
 func TestProjectService_DeployProject_BuildsGeneratedImageWithoutPull(t *testing.T) {
@@ -4250,7 +4230,6 @@ func TestProjectService_DeployProject_BuildsGeneratedImageWithoutPull(t *testing
 		BaseModel: models.BaseModel{ID: "p-generated"},
 		Name:      "build-test",
 		Path:      projectDir,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(proj).Error)
 
@@ -4577,9 +4556,8 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesProjectsWhenDirector
 	const seeded = 3
 	for i := range seeded {
 		require.NoError(t, db.WithContext(ctx).Create(&models.Project{
-			Name:   fmt.Sprintf("project-%d", i),
-			Path:   filepath.Join(projectsRoot, fmt.Sprintf("project-%d", i)),
-			Status: models.ProjectStatusStopped,
+			Name: fmt.Sprintf("project-%d", i),
+			Path: filepath.Join(projectsRoot, fmt.Sprintf("project-%d", i)),
 		}).Error)
 	}
 
@@ -4745,7 +4723,6 @@ func TestProjectService_SyncProjectsFromFileSystem_DiscoversReadableProjectsDesp
 		Name:      "stranded-project",
 		DirName:   &strandedDirName,
 		Path:      filepath.Join(unreadableDir, "stranded-project"),
-		Status:    models.ProjectStatusStopped,
 	}).Error)
 
 	require.NoError(t, settingsService.SetStringSetting(ctx, "projectsDirectory", projectsRoot))
@@ -4939,7 +4916,6 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesValidCustomNameWitho
 		Name:      "custom-name",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -4986,7 +4962,6 @@ func TestProjectService_SyncProjectsFromFileSystem_PreservesGitOpsProjectWithCus
 		Name:            "Radarr",
 		DirName:         ptr("Radarr-3"),
 		Path:            projectDir,
-		Status:          models.ProjectStatusStopped,
 		GitOpsManagedBy: &syncID,
 	}
 	require.NoError(t, db.Create(project).Error)
@@ -5037,7 +5012,6 @@ func TestProjectService_GetProjectDetails_UsesGitOpsCustomComposeFilename(t *tes
 		Name:            "Radarr",
 		DirName:         ptr("Radarr-3"),
 		Path:            projectDir,
-		Status:          models.ProjectStatusStopped,
 		GitOpsManagedBy: &syncID,
 	}).Error)
 
@@ -5082,7 +5056,6 @@ func TestProjectService_UpdateProject_WritesThroughSymlinkedProjectPath(t *testi
 		Name:      "demo",
 		DirName:   new("demo"),
 		Path:      linkPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5137,7 +5110,6 @@ func TestProjectService_UpdateProject_WritesThroughExternalEnvSymlink(t *testing
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5196,7 +5168,6 @@ func TestProjectService_UpdateProject_RestoresExternalEnvSymlinkTargetWhenProjec
 		Name:      dirName,
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5349,7 +5320,6 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackUncommittedDirecto
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5403,7 +5373,6 @@ func TestProjectService_RecoverProjectRenameJournals_StartedPhaseSkipsVolumeRoll
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5466,7 +5435,6 @@ func TestProjectService_RecoverProjectRenameJournals_RelocatesTargetWhenBothPath
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5529,7 +5497,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsStartedJournalWhenDir
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5575,7 +5542,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsPreservedTargetJourna
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5656,7 +5622,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournal(t *t
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5696,7 +5661,6 @@ func TestProjectService_FinalizeProjectRenameAfterCommit_ClearsJournalAfterSourc
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      filepath.Join(t.TempDir(), newDir),
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5737,7 +5701,6 @@ func TestProjectService_FinalizeProjectRenameAfterCommit_KeepsJournalWhenSourceC
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      filepath.Join(t.TempDir(), newDir),
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5821,7 +5784,6 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsJournalWhenDirectoryRo
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5915,7 +5877,6 @@ func TestProjectService_RecoverProjectRenameJournals_CompletesCommittedVolumeJou
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -5988,7 +5949,6 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackCommittedJournalWh
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6098,7 +6058,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalAfterDBRestore
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6176,7 +6135,6 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsRollbackCleanupWhenDoc
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6238,7 +6196,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournalWhenS
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6324,7 +6281,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsCommittedJournalAndCl
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6407,7 +6363,6 @@ func TestProjectService_RecoverProjectRenameJournals_MarksSourceCleanupPendingWh
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6492,7 +6447,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsSourceCleanupPendingJ
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6591,7 +6545,6 @@ func TestProjectService_RecoverProjectRenameJournals_RollsBackSourceCleanupPendi
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6681,7 +6634,6 @@ func TestProjectService_RecoverProjectRenameJournals_KeepsSourceCleanupPendingJo
 		Name:      "web",
 		DirName:   &newDir,
 		Path:      newPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6748,7 +6700,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsStartedJournalWhenDir
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6817,7 +6768,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsMissingPathJournalWhe
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6891,7 +6841,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenRollbackSo
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -6970,7 +6919,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenRollbackTa
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 
@@ -7055,7 +7003,6 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenTargetPres
 		Name:      "nginx",
 		DirName:   &oldDir,
 		Path:      oldPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 

--- a/backend/internal/project/service_unix_test.go
+++ b/backend/internal/project/service_unix_test.go
@@ -51,7 +51,6 @@ func TestProjectService_ApplyGitSyncProjectFiles_TolerantOfPermissionLockedEnv(t
 		Name:      "git-sync-locked-env",
 		DirName:   &dirName,
 		Path:      projectPath,
-		Status:    models.ProjectStatusStopped,
 	}
 	require.NoError(t, db.Create(project).Error)
 

--- a/backend/internal/project/workspace.go
+++ b/backend/internal/project/workspace.go
@@ -144,9 +144,6 @@ func (s *ProjectService) UpdateProjectWorkspace(ctx context.Context, projectID s
 	}
 
 	s.refreshProjectImageRefsInternal(ctx, proj)
-	if err := s.updateProjectStatusandCountsInternal(ctx, proj.ID, proj.Status); err != nil {
-		return nil, errors.WrapIf(err, "refresh project after workspace update")
-	}
 	s.logProjectEventInternal(ctx, models.EventTypeProjectUpdate, proj.ID, proj.Name, user, models.JSON{
 		"action":          "update_project_workspace",
 		"fileChangeCount": len(manifest.FileChanges),

--- a/backend/internal/updater/service.go
+++ b/backend/internal/updater/service.go
@@ -14,7 +14,6 @@ import (
 
 	"emperror.dev/errors"
 
-	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
@@ -1236,40 +1235,87 @@ func (s *UpdaterService) collectUsedImagesFromProjectsInternal(ctx context.Conte
 		return err
 	}
 
-	activeProjectNames := activeComposeProjectNameSetInternal(projects)
-	if len(activeProjectNames) == 0 {
-		return nil
-	}
-
 	composeContainers, err := projectspkg.ListGlobalComposeContainers(ctx)
 	if err != nil {
 		return err
+	}
+
+	runningComposeProjects := make(map[string]struct{})
+	for _, summary := range composeContainers {
+		if summary.State != container.StateRunning {
+			continue
+		}
+		if name := dockerutil.ComposeProjectLabel(summary.Labels); name != "" {
+			runningComposeProjects[name] = struct{}{}
+		}
+	}
+
+	activeProjectNames := activeComposeProjectNameSetInternal(projects, runningComposeProjects)
+	addActiveComposeProjectNamesByWorkingDirInternal(projects, composeContainers, activeProjectNames)
+	if len(activeProjectNames) == 0 {
+		return nil
 	}
 
 	s.collectUsedImagesFromComposeContainersInternal(ctx, composeContainers, activeProjectNames, out)
 	return nil
 }
 
-func activeComposeProjectNameSetInternal(projects []models.Project) map[string]struct{} {
+// activeComposeProjectNameSetInternal returns the compose names of non-archived
+// projects with at least one running container, per the live container list.
+func activeComposeProjectNameSetInternal(projects []models.Project, runningComposeProjects map[string]struct{}) map[string]struct{} {
 	active := make(map[string]struct{})
 	for _, project := range projects {
 		if project.IsArchived {
 			continue
 		}
-		if project.Status != models.ProjectStatusRunning && project.Status != models.ProjectStatusPartiallyRunning {
-			continue
+
+		candidateNames := []string{project.Name}
+		if project.ComposeProjectName != nil {
+			candidateNames = append(candidateNames, *project.ComposeProjectName)
 		}
 
-		name := strings.TrimSpace(project.Name)
-		if name == "" {
-			continue
-		}
-		active[name] = struct{}{}
-		if normalized := loader.NormalizeProjectName(name); normalized != "" {
-			active[normalized] = struct{}{}
+		for _, candidate := range candidateNames {
+			name := strings.TrimSpace(candidate)
+			if name == "" {
+				continue
+			}
+			if _, running := runningComposeProjects[name]; running {
+				active[name] = struct{}{}
+			}
+
+			normalized := projectspkg.NormalizeProjectName(name)
+			if normalized != name {
+				if _, running := runningComposeProjects[normalized]; running {
+					active[normalized] = struct{}{}
+				}
+			}
 		}
 	}
 	return active
+}
+
+func addActiveComposeProjectNamesByWorkingDirInternal(projects []models.Project, composeContainers []container.Summary, active map[string]struct{}) {
+	projectPaths := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		if project.IsArchived {
+			continue
+		}
+		if projectPath := strings.TrimSpace(project.Path); projectPath != "" {
+			projectPaths[projectPath] = struct{}{}
+		}
+	}
+
+	for _, summary := range composeContainers {
+		if summary.State != container.StateRunning {
+			continue
+		}
+		if _, knownProject := projectPaths[dockerutil.ComposeWorkingDirLabel(summary.Labels)]; !knownProject {
+			continue
+		}
+		if projectName := dockerutil.ComposeProjectLabel(summary.Labels); projectName != "" {
+			active[projectName] = struct{}{}
+		}
+	}
 }
 
 func addNormalizedImageUpdateRefInternal(ctx context.Context, out map[string]struct{}, imageRef, logMessage string, attrs ...any) {

--- a/backend/internal/updater/service_test.go
+++ b/backend/internal/updater/service_test.go
@@ -872,6 +872,36 @@ func TestUpdaterService_ApplyPending_RoutesLegacyArcaneServerThroughSelfUpgradeI
 	assert.Empty(t, projectUpdater.calls, "legacy Arcane server should not be updated through project services")
 }
 
+func TestActiveComposeProjectNameSetInternal_UsesEffectiveComposeName(t *testing.T) {
+	tests := []struct {
+		name                  string
+		composeProjectName    string
+		runningComposeProject string
+	}{
+		{
+			name:                  "raw effective name",
+			composeProjectName:    "runtime-project",
+			runningComposeProject: "runtime-project",
+		},
+		{
+			name:                  "normalized effective name",
+			composeProjectName:    "Runtime Project!",
+			runningComposeProject: "runtimeproject",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			active := activeComposeProjectNameSetInternal([]models.Project{{
+				Name:               "arcane-project",
+				ComposeProjectName: new(tt.composeProjectName),
+			}}, map[string]struct{}{tt.runningComposeProject: {}})
+
+			assert.Equal(t, map[string]struct{}{tt.runningComposeProject: {}}, active)
+		})
+	}
+}
+
 // The engine picks the reference Arcane's updates are applied to, so its choice
 // is worth pinning here as well as in the library.
 func TestPullableImageRefInternal(t *testing.T) {

--- a/backend/pkg/dockerutil/compose_labels.go
+++ b/backend/pkg/dockerutil/compose_labels.go
@@ -5,8 +5,9 @@ import "strings"
 // Docker Compose attaches these labels to every container it manages. They
 // identify the owning project and the service within that project.
 const (
-	ComposeProjectLabelKey = "com.docker.compose.project"
-	ComposeServiceLabelKey = "com.docker.compose.service"
+	ComposeProjectLabelKey    = "com.docker.compose.project"
+	ComposeServiceLabelKey    = "com.docker.compose.service"
+	ComposeWorkingDirLabelKey = "com.docker.compose.project.working_dir"
 )
 
 // ComposeProjectLabel returns the trimmed Docker Compose project name from a
@@ -19,4 +20,10 @@ func ComposeProjectLabel(labels map[string]string) string {
 // container's labels, or "" when unset.
 func ComposeServiceLabel(labels map[string]string) string {
 	return strings.TrimSpace(labels[ComposeServiceLabelKey])
+}
+
+// ComposeWorkingDirLabel returns the trimmed Docker Compose project working
+// directory from a container's labels.
+func ComposeWorkingDirLabel(labels map[string]string) string {
+	return strings.TrimSpace(labels[ComposeWorkingDirLabelKey])
 }

--- a/backend/resources/migrations/postgres/072_drop_project_status_columns.sql
+++ b/backend/resources/migrations/postgres/072_drop_project_status_columns.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+DROP INDEX IF EXISTS idx_projects_status;
+ALTER TABLE projects DROP COLUMN status;
+ALTER TABLE projects DROP COLUMN running_count;
+
+-- +goose Down
+ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE projects ADD COLUMN running_count INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);

--- a/backend/resources/migrations/sqlite/072_drop_project_status_columns.sql
+++ b/backend/resources/migrations/sqlite/072_drop_project_status_columns.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+DROP INDEX IF EXISTS idx_projects_status;
+ALTER TABLE projects DROP COLUMN status;
+ALTER TABLE projects DROP COLUMN running_count;
+
+-- +goose Down
+ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE projects ADD COLUMN running_count INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes persisted project status and running-count state in favor of deriving runtime status directly from Docker.
- Adds live Compose-container matching for updater image collection, including effective Compose names and a working-directory fallback.
- Updates project lifecycle, listing, archive, rename, and detail flows to use live service state.
- Adds matching SQLite and PostgreSQL migrations and updates affected tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: derive project status from live Doc..."](https://github.com/getarcaneapp/arcane/commit/b42ea491aee84648fb3408cc2aa4ed8e5b9e17fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51509595)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)
- Knowledge Base — [Projects, Builds, and Templates](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/projects-builds-templates.md)
- Knowledge Base — [Database & Models](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/database-models.md)
</details>

<!-- /greptile_comment -->