### PR TITLE
fix: editor line highlight and selection rendering fully opaque on default accent color

### DIFF
--- a/frontend/src/lib/components/code-editor/theme.ts
+++ b/frontend/src/lib/components/code-editor/theme.ts
@@ -8,24 +8,10 @@ function getAccentColor(): string {
 }
 
 function getAccentColorWithAlpha(alpha: number): string {
-	const accentColor = getAccentColor();
-
-	if (accentColor.startsWith('oklch')) {
-		const hasAlpha = accentColor.includes('/');
-		if (hasAlpha) {
-			return accentColor.replace(/\/\s*[\d.]+\s*\)/, ` / ${alpha})`);
-		}
-		return accentColor.replace(')', ` / ${alpha})`);
-	}
-
-	if (accentColor.startsWith('#')) {
-		const r = parseInt(accentColor.slice(1, 3), 16);
-		const g = parseInt(accentColor.slice(3, 5), 16);
-		const b = parseInt(accentColor.slice(5, 7), 16);
-		return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-	}
-
-	return accentColor;
+	// color-mix handles any color notation the CSS pipeline may emit for
+	// --primary (oklch, lab, rgb, hex, ...) — format-sniffing here previously
+	// returned unknown formats unchanged, i.e. fully opaque.
+	return `color-mix(in oklab, ${getAccentColor()} ${Math.round(alpha * 100)}%, transparent)`;
 }
 
 interface ArcaneThemePalette {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3492

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change replaces format-specific CodeMirror accent alpha handling with CSS `color-mix()` so editor selections, match highlights, and active-line backgrounds work with any supported CSS color notation.

A real Chromium CodeMirror rendering check compared the prior and current behavior with `oklch`, hexadecimal, `rgb`, `hsl`, and `lab` primary colors. The concern that non-OKLCH and non-hex colors would remain opaque was disproved: the current implementation generated transparent overlay colors at the intended 35%, 15%, and 5% opacity levels for every tested format. No defects were found.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the editor color-overlay behavior was rendered and verified in Chromium across representative supported CSS color formats.

The focused browser check exercised the changed CodeMirror theme behavior and compared it with the previous implementation. It confirmed that formats previously left opaque now resolve to transparent selection, match, and active-line backgrounds.

**Files Needing Attention:** No files need follow-up attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the CodeMirror primary-color browser validation script and it completed with exit code 0.
- Rendered a real CodeMirror editor in Chromium with reconstructed theme initializers using oklch, hex, rgb, hsl, and lab primary colors.
- Compared the before and after color handling: earlier results produced opaque rgb/hsl/lab values, while the updated implementation used color-mix with transparent and Chromium computed 35%, 15%, and 5% alpha overlays.
- Viewed the structured CSS and computed-color results artifact to verify alpha handling across formats.
- Watched the after-rendering video artifact to confirm the updated CodeMirror rendering preserves overlay transparency.

<a href="https://app.greptile.com/trex/runs/18011921/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: editor line highlight and selection..."](https://github.com/getarcaneapp/arcane/commit/3ba508409a412760a58b63d79c6a33b4fbac6626) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51600845)</sub>

<!-- /greptile_comment -->