### PR TITLE
fix: allow logging in with email address

### DIFF
--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -252,11 +252,30 @@ func (s *AuthService) AuthenticateLocalPrimary(ctx context.Context, username, pa
 	}
 
 	user, err := s.userService.GetUserByUsername(ctx, username)
-	if err != nil {
-		if strings.Contains(err.Error(), "user not found") {
-			return nil, ErrInvalidCredentials
-		}
+	if err != nil && !errors.Is(err, common.ErrUserNotFound) {
 		return nil, err
+	}
+	// When the identifier looks like an email, resolve the email identity too:
+	// a collision between one account's username and a different account's
+	// email is rejected instead of silently validating against whichever
+	// account the username lookup happened to return.
+	if strings.Contains(username, "@") {
+		emailUser, emailErr := s.userService.GetUserByEmail(ctx, username)
+		switch {
+		case errors.Is(emailErr, common.ErrAmbiguousUserEmail):
+			slog.WarnContext(ctx, "Rejecting email login: multiple accounts share this email", "email", username)
+			return nil, ErrInvalidCredentials
+		case emailErr != nil && !errors.Is(emailErr, common.ErrUserNotFound):
+			return nil, emailErr
+		case emailErr == nil && user != nil && emailUser.ID != user.ID:
+			slog.WarnContext(ctx, "Rejecting login: identifier matches one account's username and a different account's email", "identifier", username)
+			return nil, ErrInvalidCredentials
+		case emailErr == nil && user == nil:
+			user = emailUser
+		}
+	}
+	if user == nil {
+		return nil, ErrInvalidCredentials
 	}
 	if err := s.userService.ValidatePassword(user.PasswordHash, password); err != nil {
 		return nil, ErrInvalidCredentials

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -29,6 +29,11 @@ func setupAuthServiceTestDB(t *testing.T) *database.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// Each pooled connection to a ":memory:" DSN gets its own empty database;
+	// keep a single connection so every query sees the migrated schema.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SettingVariable{},
 		&models.User{},
@@ -846,4 +851,55 @@ func TestFindOrCreateOidcUser_MergeEnabled_EmailVerificationMissing_WithExisting
 	require.NoError(t, err)
 	require.NotNil(t, fetched.OidcSubjectId)
 	require.Equal(t, userInfo.Subject, *fetched.OidcSubjectId)
+}
+
+func TestAuthenticateLocalPrimary_EmailFallback(t *testing.T) {
+	db := setupAuthServiceTestDB(t)
+	userSvc := user.NewUserService(db)
+	settingsSvc, err := newSettingsServiceForAuthTestInternal(t, context.Background(), db)
+	require.NoError(t, err)
+	s := newTestAuthService("")
+	s.userService = userSvc
+	s.settingsService = settingsSvc
+
+	hash, err := userSvc.HashPassword("hunter22!")
+	require.NoError(t, err)
+	dupHash, err := userSvc.HashPassword("dup-two-pass!")
+	require.NoError(t, err)
+	for _, u := range []*models.User{
+		{BaseModel: models.BaseModel{ID: "u-email-login"}, Username: "bob", Email: new("bob@example.com"), PasswordHash: hash},
+		{BaseModel: models.BaseModel{ID: "u-dup-1"}, Username: "dup1", Email: new("dup@example.com"), PasswordHash: hash},
+		{BaseModel: models.BaseModel{ID: "u-dup-2"}, Username: "dup2", Email: new("dup@example.com"), PasswordHash: dupHash},
+		{BaseModel: models.BaseModel{ID: "u-carol"}, Username: "carol@example.com", Email: new("carol@example.com"), PasswordHash: hash},
+		{BaseModel: models.BaseModel{ID: "u-col-a"}, Username: "owner@example.com", PasswordHash: hash},
+		{BaseModel: models.BaseModel{ID: "u-col-b"}, Username: "colb", Email: new("owner@example.com"), PasswordHash: dupHash},
+	} {
+		_, err = userSvc.CreateUser(context.Background(), u)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name     string
+		login    string
+		password string
+		wantID   string
+		wantErr  error
+	}{
+		{name: "email resolves user", login: "bob@example.com", password: "hunter22!", wantID: "u-email-login"},
+		{name: "unknown email", login: "nobody@example.com", password: "hunter22!", wantErr: ErrInvalidCredentials},
+		{name: "duplicate email rejected", login: "dup@example.com", password: "dup-two-pass!", wantErr: ErrInvalidCredentials},
+		{name: "username equal to own email", login: "carol@example.com", password: "hunter22!", wantID: "u-carol"},
+		{name: "username-email collision rejected", login: "owner@example.com", password: "dup-two-pass!", wantErr: ErrInvalidCredentials},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := s.AuthenticateLocalPrimary(context.Background(), tc.login, tc.password)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantID, got.ID)
+		})
+	}
 }

--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -59,6 +59,7 @@ var (
 	ErrExpiredToken                            = errors.Sentinel("token expired")
 	ErrTokenVersionMismatch                    = errors.Sentinel("token version mismatch")
 	ErrUserNotFound                            = errors.Sentinel("user not found")
+	ErrAmbiguousUserEmail                      = Classify(ErrConflict, errors.Sentinel("multiple accounts share this email"))
 	ErrTokenValidation                         = Classify(ErrUnauthorized, errors.Sentinel("Invalid token claims"))
 	ErrSessionRevoked                          = Classify(ErrUnauthorized, errors.Sentinel("Session has been revoked"))
 	ErrUpgradeInProgress                       = Classify(ErrConflict, errors.Sentinel("an upgrade is already in progress"))

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -163,8 +163,22 @@ func (s *UserService) GetUserByOidcSubjectId(ctx context.Context, subjectId stri
 	return dbutil.FirstWhere[models.User](ctx, s.db.DB, common.ErrUserNotFound, "oidc_subject_id = ?", subjectId)
 }
 
+// GetUserByEmail returns the user with the given email. The schema does not
+// enforce email uniqueness, so a lookup matching more than one account returns
+// common.ErrAmbiguousUserEmail instead of arbitrarily selecting one.
 func (s *UserService) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
-	return dbutil.FirstWhere[models.User](ctx, s.db.DB, common.ErrUserNotFound, "email = ?", email)
+	var users []models.User
+	if err := s.db.DB.WithContext(ctx).Where("email = ?", email).Limit(2).Find(&users).Error; err != nil {
+		return nil, errors.WrapIf(err, "failed to query users by email")
+	}
+	switch len(users) {
+	case 0:
+		return nil, common.ErrUserNotFound
+	case 1:
+		return &users[0], nil
+	default:
+		return nil, common.ErrAmbiguousUserEmail
+	}
 }
 
 // ResolveUserPermissions returns the effective PermissionSet for the given

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1380,6 +1380,7 @@
   "user_example_com_placeholder": "user@example.com",
   "users_email_description": "Email address for the user",
   "users_username_description": "Unique username for the user",
+  "users_username_no_at": "Username cannot contain @",
   "events_title": "Event Log",
   "events_subtitle": "Monitor events that have taken place in Arcane.",
   "events_total": "Total Events",

--- a/frontend/src/lib/components/sheets/user-form-sheet.svelte
+++ b/frontend/src/lib/components/sheets/user-form-sheet.svelte
@@ -50,7 +50,11 @@
 	let assignmentsDisabled = $derived(isOidcUser && hasOidcAssignments);
 
 	const formSchema = z.object({
-		username: z.string().min(1, m.common_username_required()),
+		username: z
+			.string()
+			.min(1, m.common_username_required())
+			// Legacy usernames may contain @; only new or changed usernames are restricted
+			.refine((value) => value === userToEdit?.username || !value.includes('@'), m.users_username_no_at()),
 		password: z.string().optional(),
 		displayName: z.string().optional(),
 		email: z
@@ -100,8 +104,9 @@
 			userData.email = data.email;
 		}
 
-		// Only include username if we're creating a new user or if editing is allowed
-		if (!isEditMode || canEditUsername) {
+		// Only include username when creating, or when editing changed it — an
+		// unchanged legacy username with @ would fail the backend pattern check
+		if (!isEditMode || (canEditUsername && data.username !== userToEdit?.username)) {
 			userData.username = data.username;
 		}
 

--- a/types/user/user.go
+++ b/types/user/user.go
@@ -31,7 +31,7 @@ type Preferences struct {
 // CreateUser represents the request body for creating a new user.
 // Role assignments are managed separately via PUT /users/{userId}/role-assignments.
 type CreateUser struct {
-	Username    string      `json:"username" minLength:"1" maxLength:"255" doc:"Username of the user" example:"johndoe"`
+	Username    string      `json:"username" minLength:"1" maxLength:"255" pattern:"^[^@]+$" patternDescription:"username without an @ character" doc:"Username of the user; may not contain @" example:"johndoe"`
 	Password    string      `json:"password" minLength:"8" doc:"Password of the user"`
 	DisplayName *string     `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user" example:"John Doe"`
 	Email       *string     `json:"email,omitempty" doc:"Email address of the user" example:"john@example.com"`
@@ -42,7 +42,7 @@ type CreateUser struct {
 // UpdateUser represents the request body for updating a user.
 // Role assignments are managed separately via PUT /users/{userId}/role-assignments.
 type UpdateUser struct {
-	Username    *string     `json:"username,omitempty" minLength:"1" maxLength:"255" doc:"Username of the user"`
+	Username    *string     `json:"username,omitempty" minLength:"1" maxLength:"255" pattern:"^[^@]+$" patternDescription:"username without an @ character" doc:"Username of the user; may not contain @"`
 	DisplayName *string     `json:"displayName,omitempty" maxLength:"255" doc:"Display name of the user"`
 	Email       *string     `json:"email,omitempty" doc:"Email address of the user"`
 	Locale      *string     `json:"locale,omitempty" doc:"Locale preference of the user"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3531

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Local authentication now safely supports email identifiers by rejecting ambiguous email matches and username/email identity collisions. The user form also allows profile updates for existing accounts with unchanged legacy usernames while keeping the restriction on newly entered or modified usernames.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The rendered user-management flow accepted an update for an unchanged legacy username and rejected newly created or changed usernames containing `@`. The focused local-auth test could not start because the installed Go launcher panicked before compilation, while the current implementation explicitly handles duplicate-email and username/email collisions.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I attempted targeted local-auth EmailFallback tests on both the parent revision and the current revision, but the Go toolchain panicked in cmd/go/internal/fips140.Init before tests could run.
- I captured and preserved the focused local-auth table-driven test source, including the duplicate-email and username/email-collision cases.
- I rendered the parent and current user forms in Chromium and validated updates when username editing is disabled, while usernames containing @ were rejected; the Playwright run reported a PASS.
- I ran the frontend checks, and the frontend typecheck completed successfully.
- I compared pre-PR and PR-head test captures and confirmed identical panics prevented runtime execution.

<a href="https://app.greptile.com/trex/runs/18018143/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: allow logging in with email address"](https://github.com/getarcaneapp/arcane/commit/c6da5e7d5b1e24d7273fd83558c7752303454af9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51601393)</sub>

<!-- /greptile_comment -->