### PR TITLE
fix: webhook trigger endpoint responds 202 immediately instead of blocking until action completes

### DIFF
--- a/backend/api/webhooks_trigger.go
+++ b/backend/api/webhooks_trigger.go
@@ -21,7 +21,7 @@ func RegisterWebhookTrigger(g *echo.Group, webhookService *webhook.WebhookServic
 		}
 
 		token := c.Param("token")
-		result, err := webhookService.TriggerByToken(utils.ActivityRuntimeContext(c.Request().Context(), appCtx.Context()), token)
+		err := webhookService.TriggerByToken(utils.ActivityRuntimeContext(c.Request().Context(), appCtx.Context()), token)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if errors.Is(err, webhook.ErrWebhookNotFound) || errors.Is(err, webhook.ErrWebhookInvalid) {
@@ -36,6 +36,7 @@ func RegisterWebhookTrigger(g *echo.Group, webhookService *webhook.WebhookServic
 			return c.JSON(status, map[string]any{"success": false, "error": msg})
 		}
 
-		return c.JSON(http.StatusOK, map[string]any{"success": true, "data": result})
+		// The action runs in the background; its outcome lands in the event log.
+		return c.JSON(http.StatusAccepted, map[string]any{"success": true, "data": map[string]string{"status": "accepted"}})
 	})
 }

--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -405,8 +405,8 @@ func provideSystemModuleInternal(db *database.DB, cfg *config.Config, docker *do
 	})
 }
 
-func provideWebhookModuleInternal(db *database.DB, containerModule *container.Module, updaterModule *updater.Module, project *project.ProjectService, gitOpsSync *gitops.GitOpsSyncService, event *event.EventService, environment *environment.EnvironmentService) *webhook.Module {
-	return webhook.New(webhook.Dependencies{
+func provideWebhookModuleInternal(lc fx.Lifecycle, db *database.DB, containerModule *container.Module, updaterModule *updater.Module, project *project.ProjectService, gitOpsSync *gitops.GitOpsSyncService, event *event.EventService, environment *environment.EnvironmentService) *webhook.Module {
+	module := webhook.New(webhook.Dependencies{
 		DB:          db,
 		Container:   containerModule.Service(),
 		Updater:     updaterModule.Service(),
@@ -415,4 +415,16 @@ func provideWebhookModuleInternal(db *database.DB, containerModule *container.Mo
 		Event:       event,
 		Environment: environment,
 	})
+	lc.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			// Drain fails only when the stop context expires; fx then skips all
+			// remaining teardown regardless of what is returned here, so an
+			// error would only mark an expected long action as a failed stop.
+			if err := module.Service().DrainActions(ctx); err != nil {
+				slog.WarnContext(ctx, "shutdown proceeding with webhook actions still in flight", "error", err)
+			}
+			return nil
+		},
+	})
+	return module
 }

--- a/backend/internal/webhook/webhook.go
+++ b/backend/internal/webhook/webhook.go
@@ -2,27 +2,30 @@ package webhook
 
 import (
 	"context"
-	crand "crypto/rand"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/getarcaneapp/arcane/backend/v2/internal/environment"
-	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
-	"github.com/getarcaneapp/arcane/backend/v2/internal/gitops"
-	"github.com/getarcaneapp/arcane/backend/v2/internal/project"
-	"github.com/getarcaneapp/arcane/backend/v2/internal/updater"
-
+	"emperror.dev/emperror"
 	"emperror.dev/errors"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/container"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/environment"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/gitops"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/project"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/updater"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/types/v2"
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	updatertypes "github.com/getarcaneapp/arcane/types/v2/updater"
@@ -47,6 +50,9 @@ const (
 )
 
 type WebhookService struct {
+	// actions tracks in-flight background webhook actions accepted with a 202
+	// so shutdown can drain them instead of dropping acknowledged work.
+	actions            sync.WaitGroup
 	db                 *database.DB
 	containerService   *container.ContainerService
 	updaterService     *updater.UpdaterService
@@ -78,7 +84,7 @@ func isRemoteWebhookEnvironmentInternal(environmentID string) bool {
 // (to be shown to the user once), its SHA-256 hash, and the lookup prefix.
 func generateWebhookTokenInternal() (raw, hash, prefix string, err error) {
 	b := make([]byte, webhookTokenLength)
-	if _, err = crand.Read(b); err != nil {
+	if _, err = rand.Read(b); err != nil {
 		return "", "", "", errors.WrapIf(err, "failed to generate webhook token")
 	}
 	secretHex := hex.EncodeToString(b)
@@ -415,12 +421,14 @@ func (s *WebhookService) UpdateWebhook(ctx context.Context, id, environmentID st
 	return &wh, nil
 }
 
-// TriggerByToken looks up a webhook by its raw token and executes the configured action.
-// Returns an updater result for "updater" webhooks; nil for "project" and "gitops".
-func (s *WebhookService) TriggerByToken(ctx context.Context, rawToken string) (*updatertypes.Result, error) {
+// TriggerByToken looks up a webhook by its raw token, validates it, and starts
+// the configured action in the background so the HTTP caller gets an immediate
+// acknowledgement instead of holding the connection for the full action
+// duration (#3469). The action outcome is recorded in the event log.
+func (s *WebhookService) TriggerByToken(ctx context.Context, rawToken string) error {
 	prefix, err := parseWebhookPrefixInternal(rawToken)
 	if err != nil {
-		return nil, ErrWebhookInvalid
+		return ErrWebhookInvalid
 	}
 
 	// Narrow by prefix first (indexed), then verify hash
@@ -428,7 +436,7 @@ func (s *WebhookService) TriggerByToken(ctx context.Context, rawToken string) (*
 	if err := s.db.WithContext(ctx).
 		Where("token_prefix = ?", prefix).
 		Find(&candidates).Error; err != nil {
-		return nil, errors.WrapIf(err, "failed to look up webhook")
+		return errors.WrapIf(err, "failed to look up webhook")
 	}
 
 	hash := hashWebhookTokenInternal(rawToken)
@@ -440,30 +448,43 @@ func (s *WebhookService) TriggerByToken(ctx context.Context, rawToken string) (*
 		}
 	}
 	if wh == nil {
-		return nil, ErrWebhookNotFound
+		return ErrWebhookNotFound
 	}
 	if !wh.Enabled {
-		return nil, ErrWebhookDisabled
+		return ErrWebhookDisabled
 	}
 
-	var result *updatertypes.Result
 	actionType, err := resolveWebhookActionTypeInternal(wh.TargetType, wh.ActionType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	result, err = s.executeWebhookActionInternal(ctx, wh, actionType)
-	if err != nil {
-		return nil, err
-	}
-
-	// Record trigger time — best-effort, do not fail the request if this update fails.
+	// Record trigger time on accept — best-effort, do not fail the request if this update fails.
 	now := time.Now()
 	_ = s.db.WithContext(ctx).Model(wh).Update("last_triggered_at", now).Error
 
-	s.logWebhookEventInternal(ctx, wh, actionType, models.EventSeveritySuccess, "")
+	execCtx := context.WithoutCancel(ctx)
+	s.actions.Go(func() {
+		defer func() {
+			if panicErr := emperror.Recover(recover()); panicErr != nil {
+				slog.ErrorContext(execCtx, "webhook action panicked", "webhookID", wh.ID, "webhookName", wh.Name, "actionType", actionType, "error", panicErr)
+			}
+		}()
+		if _, err := s.executeWebhookActionInternal(execCtx, wh, actionType); err != nil {
+			// Action failures are recorded as error events by wrapWebhookActionErrorInternal.
+			slog.ErrorContext(execCtx, "webhook action failed", "webhookID", wh.ID, "webhookName", wh.Name, "actionType", actionType, "error", err)
+			return
+		}
+		s.logWebhookEventInternal(execCtx, wh, actionType, models.EventSeveritySuccess, "")
+	})
 
-	return result, nil
+	return nil
+}
+
+// DrainActions blocks until all accepted background webhook actions finish or
+// ctx expires, so shutdown does not silently drop acknowledged work.
+func (s *WebhookService) DrainActions(ctx context.Context) error {
+	return utils.WaitGroup(ctx, &s.actions)
 }
 
 func (s *WebhookService) executeWebhookActionInternal(ctx context.Context, wh *models.Webhook, actionType string) (*updatertypes.Result, error) {

--- a/backend/internal/webhook/webhook_test.go
+++ b/backend/internal/webhook/webhook_test.go
@@ -491,7 +491,7 @@ func TestTriggerByToken_InvalidFormat(t *testing.T) {
 	db := setupWebhookServiceTestDB(t)
 	svc := newTestWebhookService(db)
 
-	_, err := svc.TriggerByToken(ctx, "not-a-webhook-token")
+	err := svc.TriggerByToken(ctx, "not-a-webhook-token")
 	assert.ErrorIs(t, err, ErrWebhookInvalid)
 }
 
@@ -502,7 +502,7 @@ func TestTriggerByToken_NotFound(t *testing.T) {
 
 	// Well-formatted token but not in the DB
 	raw := "arc_wh_0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
-	_, err := svc.TriggerByToken(ctx, raw)
+	err := svc.TriggerByToken(ctx, raw)
 	assert.ErrorIs(t, err, ErrWebhookNotFound)
 }
 
@@ -522,7 +522,7 @@ func TestTriggerByToken_WrongHash_NotFound(t *testing.T) {
 		tampered += "a"
 	}
 
-	_, err = svc.TriggerByToken(ctx, tampered)
+	err = svc.TriggerByToken(ctx, tampered)
 	assert.ErrorIs(t, err, ErrWebhookNotFound)
 }
 
@@ -536,7 +536,7 @@ func TestTriggerByToken_DisabledWebhook(t *testing.T) {
 
 	require.NoError(t, db.WithContext(ctx).Model(&models.Webhook{}).Where("id = ?", created.ID).Update("enabled", false).Error)
 
-	_, err = svc.TriggerByToken(ctx, rawToken)
+	err = svc.TriggerByToken(ctx, rawToken)
 	assert.ErrorIs(t, err, ErrWebhookDisabled)
 }
 
@@ -561,7 +561,7 @@ func TestTriggerByToken_UnknownTargetType_ReturnsInvalidType(t *testing.T) {
 	}
 	require.NoError(t, db.WithContext(ctx).Create(wh).Error)
 
-	_, err := svc.TriggerByToken(ctx, rawToken)
+	err := svc.TriggerByToken(ctx, rawToken)
 	assert.ErrorIs(t, err, ErrWebhookInvalidType)
 }
 
@@ -585,45 +585,20 @@ func insertWebhookDirect(t *testing.T, ctx context.Context, db *database.DB, raw
 	return wh
 }
 
-func TestTriggerByToken_ContainerType_NilServiceReturnsError(t *testing.T) {
+func TestTriggerByToken_AcceptsImmediatelyAndRecordsTriggerTime(t *testing.T) {
 	ctx := context.Background()
 	db := setupWebhookServiceTestDB(t)
-	svc := newTestWebhookService(db) // updaterService is nil
+	svc := newTestWebhookService(db) // action services are nil; the async action fails, acceptance must not
 
 	rawToken := "arc_wh_ccddeeff01020304aabbccdd0102030405060708090a0b0c0d0e0f1011121314"
-	insertWebhookDirect(t, ctx, db, rawToken, models.WebhookTargetTypeContainer, models.WebhookActionTypeUpdate, "container-id", types.LocalDockerEnvironmentID)
+	wh := insertWebhookDirect(t, ctx, db, rawToken, models.WebhookTargetTypeContainer, models.WebhookActionTypeUpdate, "container-id", types.LocalDockerEnvironmentID)
 
-	assert.Panics(t, func() {
-		_, _ = svc.TriggerByToken(ctx, rawToken) //nolint:errcheck
-	})
-}
+	// Valid token is accepted synchronously; the action itself runs (and here
+	// fails against nil services) in the background without surfacing.
+	require.NoError(t, svc.TriggerByToken(ctx, rawToken))
 
-func TestTriggerByToken_UpdaterType_NilServiceReturnsError(t *testing.T) {
-	ctx := context.Background()
-	db := setupWebhookServiceTestDB(t)
-	svc := newTestWebhookService(db) // updaterService is nil
-
-	rawToken := "arc_wh_1122334401020304aabbccdd0102030405060708090a0b0c0d0e0f1011121314"
-	insertWebhookDirect(t, ctx, db, rawToken, models.WebhookTargetTypeUpdater, models.WebhookActionTypeRun, "", types.LocalDockerEnvironmentID)
-
-	// nil updaterService causes a panic, which we verify the dispatch path is reached
-	// by recovering — in production the service is always non-nil
-	assert.Panics(t, func() {
-		_, _ = svc.TriggerByToken(ctx, rawToken) //nolint:errcheck
-	})
-}
-
-func TestTriggerByToken_GitOpsType_NilServiceReturnsError(t *testing.T) {
-	ctx := context.Background()
-	db := setupWebhookServiceTestDB(t)
-	svc := newTestWebhookService(db) // gitOpsSyncService is nil
-
-	rawToken := "arc_wh_aabbccdd11223344aabbccdd0102030405060708090a0b0c0d0e0f1011121314"
-	insertWebhookDirect(t, ctx, db, rawToken, models.WebhookTargetTypeGitOps, models.WebhookActionTypeSync, "sync-id", types.LocalDockerEnvironmentID)
-
-	assert.Panics(t, func() {
-		_, _ = svc.TriggerByToken(ctx, rawToken) //nolint:errcheck
-	})
+	stored := fetchWebhook(t, db, wh.ID)
+	assert.NotNil(t, stored.LastTriggeredAt, "last_triggered_at must be set once the trigger is accepted")
 }
 
 func TestTriggerByToken_DoesNotUpdateLastTriggeredAtOnError(t *testing.T) {
@@ -634,7 +609,7 @@ func TestTriggerByToken_DoesNotUpdateLastTriggeredAtOnError(t *testing.T) {
 	rawToken := "arc_wh_1122334401020304aabbccdd0102030405060708090a0b0c0d0e0f1011121315"
 	wh := insertWebhookDirect(t, ctx, db, rawToken, "unknown-type", models.WebhookActionTypeUpdate, "some-id", "env-1")
 
-	_, err := svc.TriggerByToken(ctx, rawToken)
+	err := svc.TriggerByToken(ctx, rawToken)
 	require.Error(t, err)
 
 	stored := fetchWebhook(t, db, wh.ID)
@@ -649,7 +624,7 @@ func TestTriggerByToken_UnknownActionType_ReturnsInvalidAction(t *testing.T) {
 	rawToken := "arc_wh_0011223344556677aabbccdd0102030405060708090a0b0c0d0e0f1011121314"
 	insertWebhookDirect(t, ctx, db, rawToken, models.WebhookTargetTypeProject, "bogus", "project-id", "env-1")
 
-	_, err := svc.TriggerByToken(ctx, rawToken)
+	err := svc.TriggerByToken(ctx, rawToken)
 	assert.ErrorIs(t, err, ErrWebhookInvalidAction)
 }
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3469

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Webhook triggers now acknowledge requests immediately and run actions in the background with lifecycle draining. An accepted action can still continue after the shutdown deadline while its dependencies are being torn down, which can lose the action’s final outcome event.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until shutdown preserves the dependencies needed by accepted webhook actions.

One confirmed failure remains: the shutdown hook allows teardown to continue after the webhook action drain expires, even though detached actions can still write their final result.

**Files Needing Attention:** backend/internal/di/providers.go
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a focused webhook shutdown reproduction source for the P1 finding.
- T-Rex inspected the webhook shutdown failure-path runtime output and race-checked runtime output to validate the observed shutdown behavior.
- T-Rex documented general contract validation results, including the implicated code paths and the encoding-json build constraint blocker that led to using an alternate executable with exit code 0.
- T-Rex posted a second finding-comment-proof for the same P1 finding.

<a href="https://app.greptile.com/trex/runs/18016361/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Webhook shutdown suppresses drain timeout and tears down dependencies while accepted actions still run**

   - **Bug**
     - If an accepted webhook action exceeds the lifecycle stop deadline, `DrainActions` returns a deadline error. The shutdown hook only logs that error and returns nil, so Fx continues stopping later lifecycle hooks. Because `TriggerByToken` runs the action with `context.WithoutCancel`, cancellation does not stop it. The action can subsequently attempt its success/error event write after the relevant dependency has been torn down, losing the final event (and potentially performing other work against torn-down dependencies).
   - **Cause**
     - `provideWebhookModuleInternal` deliberately discards the error from `module.Service().DrainActions(ctx)`, while `TriggerByToken` explicitly detaches action execution from cancellation.
   - **Fix**
     - Return the `DrainActions` error from the shutdown hook (or otherwise prevent dependency teardown until accepted actions have finished), and ensure action execution has a bounded shutdown-aware context so it cannot outlive the dependency graph indefinitely.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_webhook_trigger_endpoint_responds_202_immediately_instead_of_blocking_until_action_completes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_webhook_trigger_endpoint_responds_202_immediately_instead_of_blocking_until_action_completes%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fdi%2Fproviders.go%3A420-423%0A**Webhook%20shutdown%20discards%20the%20drain%20deadline**%0A%0AWhen%20an%20accepted%20webhook%20action%20outlives%20the%20lifecycle%20shutdown%20deadline%2C%20%60DrainActions%60%20returns%20an%20error%2C%20but%20this%20hook%20logs%20it%20and%20returns%20%60nil%60.%20Fx%20can%20then%20tear%20down%20dependencies%20while%20the%20action%E2%80%94intentionally%20detached%20from%20request%20cancellation%E2%80%94continues%20running.%20Its%20final%20success%20or%20failure%20event%20can%20therefore%20be%20written%20after%20the%20event%2Fdatabase%20dependency%20has%20been%20closed%20and%20be%20lost%2C%20despite%20the%20request%20having%20already%20received%20a%20202%20response.%20Return%20the%20drain%20error%20or%20otherwise%20keep%20dependencies%20alive%20until%20accepted%20actions%20have%20completed.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3558&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fdi%2Fproviders.go%3A420-423%0A**Webhook%20shutdown%20discards%20the%20drain%20deadline**%0A%0AWhen%20an%20accepted%20webhook%20action%20outlives%20the%20lifecycle%20shutdown%20deadline%2C%20%60DrainActions%60%20returns%20an%20error%2C%20but%20this%20hook%20logs%20it%20and%20returns%20%60nil%60.%20Fx%20can%20then%20tear%20down%20dependencies%20while%20the%20action%E2%80%94intentionally%20detached%20from%20request%20cancellation%E2%80%94continues%20running.%20Its%20final%20success%20or%20failure%20event%20can%20therefore%20be%20written%20after%20the%20event%2Fdatabase%20dependency%20has%20been%20closed%20and%20be%20lost%2C%20despite%20the%20request%20having%20already%20received%20a%20202%20response.%20Return%20the%20drain%20error%20or%20otherwise%20keep%20dependencies%20alive%20until%20accepted%20actions%20have%20completed.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3558&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/di/providers.go:420-423
**Webhook shutdown discards the drain deadline**

When an accepted webhook action outlives the lifecycle shutdown deadline, `DrainActions` returns an error, but this hook logs it and returns `nil`. Fx can then tear down dependencies while the action—intentionally detached from request cancellation—continues running. Its final success or failure event can therefore be written after the event/database dependency has been closed and be lost, despite the request having already received a 202 response. Return the drain error or otherwise keep dependencies alive until accepted actions have completed.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: webhook trigger endpoint responds 2..."](https://github.com/getarcaneapp/arcane/commit/40e05749ab308d3bf31b3b093f6a466ffb2bc2e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51605428)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->