### PR TITLE
fix: redeploy swarm stack when saving edited stack source

### DIFF
--- a/backend/internal/swarm/handler.go
+++ b/backend/internal/swarm/handler.go
@@ -1216,7 +1216,8 @@ func (h *SwarmHandler) GetStackSource(ctx context.Context, input *GetSwarmStackS
 	return &GetSwarmStackSourceOutput{Body: base.ApiResponse[swarmtypes.StackSource]{Success: true, Data: *source}}, nil
 }
 
-// UpdateStackSource persists the saved compose and env source for a swarm stack.
+// UpdateStackSource persists the saved compose and env source for a swarm
+// stack and redeploys the stack so the edit takes effect on running services.
 //
 // It requires admin privileges because stack source content can include
 // sensitive configuration. The stack name comes from the route, and the body

--- a/backend/internal/swarm/service_test.go
+++ b/backend/internal/swarm/service_test.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -147,6 +148,18 @@ func TestSwarmService_FetchSwarmNodeIdentityViaEdgeInternal_UsesEnvironmentAcces
 	require.True(t, identity.SwarmActive)
 }
 
+func stubStackSourceUpdateDeployInternal(t *testing.T) *int {
+	t.Helper()
+	original := deployStackAfterSourceUpdateInternal
+	t.Cleanup(func() { deployStackAfterSourceUpdateInternal = original })
+	calls := 0
+	deployStackAfterSourceUpdateInternal = func(_ *SwarmService, _ context.Context, _ string, req swarmtypes.StackDeployRequest) (*swarmtypes.StackDeployResponse, error) {
+		calls++
+		return &swarmtypes.StackDeployResponse{Name: req.Name}, nil
+	}
+	return &calls
+}
+
 func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager(t *testing.T) {
 	ctx := context.Background()
 	db := setupSwarmServiceTestDBInternal(t)
@@ -157,6 +170,7 @@ func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager
 	require.NoError(t, err)
 
 	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
+	deployCalls := stubStackSourceUpdateDeployInternal(t)
 
 	updated, err := svc.UpdateStackSource(ctx, "0", "demo-stack", swarmtypes.StackSourceUpdateRequest{
 		ComposeContent: "services:\n  web:\n    image: nginx:alpine\n",
@@ -164,6 +178,8 @@ func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager
 	})
 	require.NoError(t, err)
 	require.Equal(t, "demo-stack", updated.Name)
+	// Saving stack source must trigger an actual stack deploy (#3463).
+	require.Equal(t, 1, *deployCalls)
 
 	composePath := filepath.Join(rootDir, "0", "demo-stack", "compose.yaml")
 	envPath := filepath.Join(rootDir, "0", "demo-stack", ".env")
@@ -215,6 +231,7 @@ func TestSwarmService_UpdateAndGetStackSource_RoundTripsOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
+	stubStackSourceUpdateDeployInternal(t)
 
 	overridePath := filepath.Join(rootDir, "0", "demo-stack", "compose.override.yaml")
 
@@ -242,6 +259,50 @@ func TestSwarmService_UpdateAndGetStackSource_RoundTripsOverride(t *testing.T) {
 	source, err = svc.GetStackSource(ctx, "0", "demo-stack")
 	require.NoError(t, err)
 	require.Empty(t, source.OverrideContent)
+}
+
+func TestSwarmService_UpdateStackSource_PrunesAndRestoresOnDeployFailure(t *testing.T) {
+	ctx := context.Background()
+	db := setupSwarmServiceTestDBInternal(t)
+	rootDir := t.TempDir()
+	t.Setenv("SWARM_STACK_SOURCES_DIRECTORY", rootDir)
+
+	settingsSvc, err := newSettingsServiceForSwarmTestInternal(t, ctx, db)
+	require.NoError(t, err)
+
+	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
+
+	original := deployStackAfterSourceUpdateInternal
+	t.Cleanup(func() { deployStackAfterSourceUpdateInternal = original })
+	var lastReq swarmtypes.StackDeployRequest
+	var deployErr error
+	deployStackAfterSourceUpdateInternal = func(_ *SwarmService, _ context.Context, _ string, req swarmtypes.StackDeployRequest) (*swarmtypes.StackDeployResponse, error) {
+		lastReq = req
+		if deployErr != nil {
+			return nil, deployErr
+		}
+		return &swarmtypes.StackDeployResponse{Name: req.Name}, nil
+	}
+
+	firstCompose := "services:\n  web:\n    image: nginx:alpine\n"
+	_, err = svc.UpdateStackSource(ctx, "0", "demo-stack", swarmtypes.StackSourceUpdateRequest{
+		ComposeContent: firstCompose,
+	})
+	require.NoError(t, err)
+	// The saved source is the full stack spec: services removed from it must
+	// be pruned from the swarm on redeploy.
+	require.True(t, lastReq.Prune)
+
+	deployErr = errors.New("deploy failed")
+	_, err = svc.UpdateStackSource(ctx, "0", "demo-stack", swarmtypes.StackSourceUpdateRequest{
+		ComposeContent: "services:\n  web:\n    image: nginx:broken\n",
+	})
+	require.ErrorContains(t, err, "deploy failed")
+
+	// A failed deploy must not commit the edited source.
+	source, err := svc.GetStackSource(ctx, "0", "demo-stack")
+	require.NoError(t, err)
+	require.Equal(t, firstCompose, source.ComposeContent)
 }
 
 func TestSwarmService_ScaleService_HandlesServiceModesInternal(t *testing.T) {

--- a/backend/internal/swarm/swarm.go
+++ b/backend/internal/swarm/swarm.go
@@ -1830,6 +1830,8 @@ func (s *SwarmService) GetStackSource(ctx context.Context, environmentID, stackN
 	}, nil
 }
 
+var deployStackAfterSourceUpdateInternal = (*SwarmService).DeployStack
+
 func (s *SwarmService) UpdateStackSource(ctx context.Context, environmentID, stackName string, req swarmtypes.StackSourceUpdateRequest) (*swarmtypes.StackSource, error) {
 	stackName = strings.TrimSpace(stackName)
 	if stackName == "" {
@@ -1839,8 +1841,39 @@ func (s *SwarmService) UpdateStackSource(ctx context.Context, environmentID, sta
 		return nil, errors.New("stack compose source is required")
 	}
 
+	previous, err := s.GetStackSource(ctx, environmentID, stackName)
+	if err != nil && !errors.Is(err, cerrdefs.ErrNotFound) {
+		return nil, err
+	}
+
 	if err := s.upsertStackSourceInternal(ctx, environmentID, stackName, req.ComposeContent, req.OverrideContent, req.EnvContent, req.Files); err != nil {
 		return nil, err
+	}
+
+	// Saving an edited stack must behave like `docker stack deploy` (#3463):
+	// push the updated spec to the running services so the edit takes effect.
+	// The saved source is the full stack spec, so services removed from it
+	// must also be removed from the swarm.
+	if _, err := deployStackAfterSourceUpdateInternal(s, ctx, environmentID, swarmtypes.StackDeployRequest{
+		Name:            stackName,
+		ComposeContent:  req.ComposeContent,
+		OverrideContent: req.OverrideContent,
+		EnvContent:      req.EnvContent,
+		Files:           req.Files,
+		Prune:           true,
+	}); err != nil {
+		// Roll back the persisted source so reads never return an edit that
+		// was never successfully deployed.
+		var restoreErr error
+		if previous != nil {
+			restoreErr = s.upsertStackSourceInternal(ctx, environmentID, stackName, previous.ComposeContent, previous.OverrideContent, previous.EnvContent, previous.Files)
+		} else {
+			restoreErr = s.deleteStackSourceInternal(ctx, environmentID, stackName)
+		}
+		if restoreErr != nil {
+			slog.WarnContext(ctx, "failed to restore swarm stack source after deploy failure", "environmentID", normalizeSwarmEnvironmentIDInternal(environmentID), "stackName", stackName, "error", restoreErr)
+		}
+		return nil, errors.WrapIf(err, "failed to redeploy swarm stack from updated source")
 	}
 
 	return &swarmtypes.StackSource{


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3463

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Editing a saved Swarm stack source now triggers a redeploy with pruning and restores the prior saved source when deployment reports an error. A failed deployment can still leave the running stack partially changed while the saved source has been restored, so later reads may describe a revision different from what is running.

### T-Rex validation blocked

The focused rollback test could not run because the installed Go tool panics in `cmd/go/internal/fips140.Init` before compilation. The uploaded execution records also lacked the required artifact labels, so they cannot be attached as review evidence.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is not safe to merge until failed redeployments restore or reconcile the actual Swarm state as well as the saved source.

One non-security failure remains: a partially applied deployment may leave the running stack inconsistent with the restored saved source.

**Files Needing Attention:** backend/internal/swarm/swarm.go
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A rollback test and a deployment-harness flow were started to exercise the rollback path, but the run stopped before package compilation due to a panic in the Go test runner.
- The blocker was a runtime panic inside the Go command, originating in cmd/go/internal/fips140.Init and cascading to cmd/go/internal/modload.Init and cmd/go/internal/toolchain.Select when GOEXPERIMENT=jsonv2 was set.
- A non-experiment attempt also failed before execution because certain imports were excluded by build constraints (encoding/json/v2 and encoding/json/jsontext).
- Uploaded the investigation artifacts, including the stack-source-runtime-divergence-harness.go source and two log captures, to aid validation.

<a href="https://app.greptile.com/trex/runs/18015878/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_redeploy_swarm_stack_when_saving_edited_stack_source%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_redeploy_swarm_stack_when_saving_edited_stack_source%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fswarm%2Fswarm.go%3A1867-1872%0A**Rollback%20leaves%20swarm%20state%20divergent**%0A%0AWhen%20deployment%20mutates%20some%20swarm%20resources%20or%20services%20before%20a%20later%20operation%20fails%2C%20this%20branch%20restores%20only%20the%20previous%20source%20files%20and%20does%20not%20reconcile%20the%20running%20stack.%20%60GetStackSource%60%20then%20returns%20the%20old%20specification%20while%20the%20swarm%20remains%20partially%20updated%2C%20including%20services%20removed%20by%20pruning%20or%20resources%20created%20from%20the%20failed%20edit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fswarm%2Fswarm.go%3A1867-1872%0A**Rollback%20leaves%20swarm%20state%20divergent**%0A%0AWhen%20deployment%20mutates%20some%20swarm%20resources%20or%20services%20before%20a%20later%20operation%20fails%2C%20this%20branch%20restores%20only%20the%20previous%20source%20files%20and%20does%20not%20reconcile%20the%20running%20stack.%20%60GetStackSource%60%20then%20returns%20the%20old%20specification%20while%20the%20swarm%20remains%20partially%20updated%2C%20including%20services%20removed%20by%20pruning%20or%20resources%20created%20from%20the%20failed%20edit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/swarm/swarm.go:1867-1872
**Rollback leaves swarm state divergent**

When deployment mutates some swarm resources or services before a later operation fails, this branch restores only the previous source files and does not reconcile the running stack. `GetStackSource` then returns the old specification while the swarm remains partially updated, including services removed by pruning or resources created from the failed edit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: [0c8f9ad](https://github.com/getarcaneapp/arcane/commit/0c8f9ad6e28791aeb21d04828351f010fa7f62db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51606079)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->