### PR TITLE
fix: false 409 workspace conflict when saving files in imported projects

### DIFF
--- a/backend/internal/volume/workspace.go
+++ b/backend/internal/volume/workspace.go
@@ -562,7 +562,7 @@ func (s *VolumeService) UpdateVolumeWorkspace(ctx context.Context, volumeName st
 	}
 	uploadReferences := make([]workspacepkg.UploadReference, 0, len(manifest.FileChanges))
 	for _, change := range manifest.FileChanges {
-		uploadReferences = append(uploadReferences, workspacepkg.UploadReference{Operation: change.Operation, UploadIndex: change.UploadIndex})
+		uploadReferences = append(uploadReferences, workspacepkg.UploadReference{Operation: change.Operation, UploadIndex: change.UploadIndex, BaselineIndex: change.BaselineIndex})
 		if err := validateVolumeWorkspaceFileChangeInternal(change); err != nil {
 			return nil, common.Classify(common.ErrVolumeWorkspaceBadRequest, err)
 		}

--- a/backend/pkg/projects/workspace.go
+++ b/backend/pkg/projects/workspace.go
@@ -176,7 +176,12 @@ func (w *projectWorkspaceTreeWalkerInternal) visit(rel string, entry fs.DirEntry
 	case !info.Mode().IsRegular():
 		kind = "special"
 	}
-	pkgutils.WriteFileTreeRevisionEntry(w.revisionHash, rel, kind, info.Size(), info.ModTime().UnixNano(), info.Mode().String(), false)
+	// The revision is structural (path + kind only): running containers write
+	// into their own project directory continuously (logs, certs, app state),
+	// so keying on mtime/size would invalidate every workspace draft for a
+	// live project and make saves 409 forever (#3199). Structural changes —
+	// files appearing, disappearing, or changing kind — still conflict.
+	pkgutils.WriteFileTreeRevisionEntry(w.revisionHash, rel, kind, 0, 0, "", false)
 	w.entryCount++
 
 	size := info.Size()
@@ -222,13 +227,18 @@ func classifyProjectWorkspaceFileInternal(filePath string, size, maxFileSizeByte
 	return true, ""
 }
 
+// ApplyProjectWorkspaceChanges applies changes in order without internal
+// rollback: on any error, earlier changes remain on disk. Callers own
+// atomicity — ProjectService.UpdateProjectWorkspace wraps every save in
+// BackupProjectUpdateScope / RestoreProjectUpdateBackup, and project creation
+// removes the whole directory on failure.
 func ApplyProjectWorkspaceChanges(projectPath string, changes []project.WorkspaceFileChange, uploads map[int][]byte, opts ProjectWorkspaceApplyOptions) error {
 	if opts.MaxFileSizeBytes <= 0 {
 		opts.MaxFileSizeBytes = workspacepkg.MaxFileSizeBytes(workspacepkg.DefaultMaxFileSizeMB)
 	}
 	uploadReferences := make([]workspacepkg.UploadReference, 0, len(changes))
 	for _, change := range changes {
-		uploadReferences = append(uploadReferences, workspacepkg.UploadReference{Operation: change.Operation, UploadIndex: change.UploadIndex})
+		uploadReferences = append(uploadReferences, workspacepkg.UploadReference{Operation: change.Operation, UploadIndex: change.UploadIndex, BaselineIndex: change.BaselineIndex})
 	}
 	if err := workspacepkg.ValidateUploadIndices(uploadReferences, len(uploads), project.FileOpCreateFile, project.FileOpUpdateFile); err != nil {
 		return err
@@ -293,7 +303,11 @@ func applyWorkspaceFileChangeInternal(root *os.Root, protected map[string]bool, 
 	case project.FileOpCreateFolder:
 		return createProjectWorkspaceFolderInternal(root, protected, rel)
 	case project.FileOpUpdateFile:
-		return updateProjectWorkspaceFileInternal(root, protected, rel, uploads[*change.UploadIndex], maxFileSizeBytes)
+		var baseline []byte
+		if change.BaselineIndex != nil {
+			baseline = uploads[*change.BaselineIndex]
+		}
+		return updateProjectWorkspaceFileInternal(root, protected, rel, uploads[*change.UploadIndex], baseline, change.BaselineIndex != nil, maxFileSizeBytes)
 	case project.FileOpRename:
 		newName, err := pkgutils.ValidateFileName(change.NewName)
 		if err != nil {
@@ -362,7 +376,7 @@ func createProjectWorkspaceFolderInternal(root *os.Root, protected map[string]bo
 	return nil
 }
 
-func updateProjectWorkspaceFileInternal(root *os.Root, protected map[string]bool, rel string, content []byte, maxFileSizeBytes int64) error {
+func updateProjectWorkspaceFileInternal(root *os.Root, protected map[string]bool, rel string, content, baseline []byte, baselineSet bool, maxFileSizeBytes int64) error {
 	if err := ensureWritableProjectRelPathInternal(protected, rel); err != nil {
 		return err
 	}
@@ -387,10 +401,36 @@ func updateProjectWorkspaceFileInternal(root *os.Root, protected map[string]bool
 		return errors.WrapIf(ErrProjectWorkspaceSymlinkPath, "symlink files are not supported")
 	}
 
+	// The workspace revision is structural only, so an external edit to this
+	// same file would otherwise be silently overwritten. The client uploads
+	// the content its draft was based on; a mismatch with the current on-disk
+	// content is a real per-file conflict. Checked here, in apply order, so an
+	// earlier rename/move in the same manifest has already landed and the
+	// comparison targets the right path. The read is capped just past the
+	// baseline length: a longer on-disk file differs by definition.
+	if baselineSet {
+		current, err := readProjectWorkspaceFileLimitedInternal(root, rel, int64(len(baseline))+1)
+		if err != nil {
+			return errors.WrapIf(err, "read project workspace file")
+		}
+		if !bytes.Equal(current, baseline) {
+			return errors.WrapIf(ErrProjectWorkspaceRevisionConflict, "file content changed since it was loaded")
+		}
+	}
+
 	if err := root.WriteFile(rel, content, pkgutils.FilePerm); err != nil {
 		return errors.WrapIf(err, "update project workspace file")
 	}
 	return nil
+}
+
+func readProjectWorkspaceFileLimitedInternal(root *os.Root, rel string, maxBytes int64) ([]byte, error) {
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(io.LimitReader(f, maxBytes))
 }
 
 func renameProjectWorkspacePathInternal(root *os.Root, protected map[string]bool, rel, newName string) error {

--- a/backend/pkg/projects/workspace_test.go
+++ b/backend/pkg/projects/workspace_test.go
@@ -391,3 +391,58 @@ func TestProtectedProjectFilePaths_IncludesComposeOverrideCandidates(t *testing.
 		assert.Truef(t, protected[candidate], "expected %q to be protected", candidate)
 	}
 }
+
+func TestApplyProjectWorkspaceChanges_ContentChurnDoesNotConflict(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("services: {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "app.log"), []byte("line1\n"), 0o644))
+
+	_, revision, _, err := ReadProjectWorkspace(projectDir, 3, "", "compose.yaml", 0, 0)
+	require.NoError(t, err)
+
+	// A running container appending to files in its own project directory
+	// (changed size + mtime) must not invalidate the workspace draft (#3199).
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "app.log"), []byte("line1\nline2\n"), 0o644))
+
+	err = ApplyProjectWorkspaceChanges(projectDir, []project.WorkspaceFileChange{
+		{Operation: project.FileOpCreateFile, RelativePath: "notes.txt", UploadIndex: new(0)},
+	}, map[int][]byte{0: []byte("hello")}, ProjectWorkspaceApplyOptions{ComposeFileName: "compose.yaml", ExpectedRevision: revision, MaxDepth: 3})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(projectDir, "notes.txt"))
+
+	// Structural drift (notes.txt now exists) does conflict against the old revision.
+	err = ApplyProjectWorkspaceChanges(projectDir, []project.WorkspaceFileChange{
+		{Operation: project.FileOpDelete, RelativePath: "app.log"},
+	}, nil, ProjectWorkspaceApplyOptions{ComposeFileName: "compose.yaml", ExpectedRevision: revision, MaxDepth: 3})
+	require.ErrorIs(t, err, ErrProjectWorkspaceRevisionConflict)
+}
+
+func TestApplyProjectWorkspaceChanges_BaselineGuardsConcurrentEdit(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "compose.yaml"), []byte("services: {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "config.txt"), []byte("original\n"), 0o644))
+
+	_, revision, _, err := ReadProjectWorkspace(projectDir, 3, "", "compose.yaml", 0, 0)
+	require.NoError(t, err)
+
+	// The structural revision still matches after an external content edit,
+	// but the uploaded baseline no longer matches the on-disk content: the
+	// stale draft must conflict instead of silently overwriting the newer file.
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "config.txt"), []byte("external newer edit\n"), 0o644))
+	err = ApplyProjectWorkspaceChanges(projectDir, []project.WorkspaceFileChange{
+		{Operation: project.FileOpUpdateFile, RelativePath: "config.txt", UploadIndex: new(0), BaselineIndex: new(1)},
+	}, map[int][]byte{0: []byte("stale draft\n"), 1: []byte("original\n")}, ProjectWorkspaceApplyOptions{ComposeFileName: "compose.yaml", ExpectedRevision: revision, MaxDepth: 3})
+	require.ErrorIs(t, err, ErrProjectWorkspaceRevisionConflict)
+	content, err := os.ReadFile(filepath.Join(projectDir, "config.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "external newer edit\n", string(content))
+
+	// A baseline matching the current on-disk content saves normally.
+	err = ApplyProjectWorkspaceChanges(projectDir, []project.WorkspaceFileChange{
+		{Operation: project.FileOpUpdateFile, RelativePath: "config.txt", UploadIndex: new(0), BaselineIndex: new(1)},
+	}, map[int][]byte{0: []byte("fresh draft\n"), 1: []byte("external newer edit\n")}, ProjectWorkspaceApplyOptions{ComposeFileName: "compose.yaml", ExpectedRevision: revision, MaxDepth: 3})
+	require.NoError(t, err)
+	content, err = os.ReadFile(filepath.Join(projectDir, "config.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "fresh draft\n", string(content))
+}

--- a/backend/pkg/workspace/workspace.go
+++ b/backend/pkg/workspace/workspace.go
@@ -11,8 +11,9 @@ import (
 const DefaultMaxFileSizeMB = 10
 
 type UploadReference struct {
-	Operation   string
-	UploadIndex *int
+	Operation     string
+	UploadIndex   *int
+	BaselineIndex *int
 }
 
 func EffectiveMaxFileSizeMB(configured int) int {
@@ -72,6 +73,22 @@ func ValidateUploadIndices(changes []UploadReference, uploadCount int, createFil
 		}
 		if _, exists := used[index]; exists {
 			return errors.Errorf("uploadIndex %d is duplicated", index)
+		}
+		used[index] = struct{}{}
+	}
+	for _, change := range changes {
+		if change.BaselineIndex == nil {
+			continue
+		}
+		if change.Operation != updateFileOperation {
+			return errors.Errorf("baselineIndex is not allowed for %s", change.Operation)
+		}
+		index := *change.BaselineIndex
+		if index < 0 || index >= uploadCount {
+			return errors.Errorf("baselineIndex %d is out of range", index)
+		}
+		if _, exists := used[index]; exists {
+			return errors.Errorf("baselineIndex %d is duplicated", index)
 		}
 		used[index] = struct{}{}
 	}

--- a/frontend/src/lib/types/workspace.ts
+++ b/frontend/src/lib/types/workspace.ts
@@ -40,6 +40,7 @@ export interface WorkspaceFileChange {
 	newName?: string;
 	newParentPath?: string;
 	uploadIndex?: number;
+	baselineIndex?: number;
 	recursive?: boolean;
 }
 

--- a/frontend/src/lib/utils/workspace-files.ts
+++ b/frontend/src/lib/utils/workspace-files.ts
@@ -28,7 +28,9 @@ export function buildWorkspaceMultipartUpdate<T extends WorkspaceDisplayFileChan
 	fileContents: Record<string, string>,
 	loadedFileContents: Record<string, string>
 ): { fileChanges: T[]; files: File[] } {
-	const fileChanges = draftChanges.map(({ uploadIndex: _uploadIndex, ...change }) => ({ ...change }) as T);
+	const fileChanges = draftChanges.map(
+		({ uploadIndex: _uploadIndex, baselineIndex: _baselineIndex, ...change }) => ({ ...change }) as T
+	);
 	const files: File[] = [];
 	const changedPaths = Object.keys(fileContents).filter(
 		(relativePath) => fileContents[relativePath] !== loadedFileContents[relativePath]
@@ -59,6 +61,17 @@ export function buildWorkspaceMultipartUpdate<T extends WorkspaceDisplayFileChan
 			fileChanges.push(change);
 		}
 		if (change.uploadIndex === undefined) stageText(change, fileContents[relativePath] ?? '');
+	}
+
+	// Every update also carries the content the draft was based on, so the
+	// backend can reject a save that would overwrite a concurrent external
+	// edit to the same file.
+	for (const change of fileChanges) {
+		if (change.operation !== 'update_file') continue;
+		const baseline = loadedFileContents[change.relativePath];
+		if (baseline === undefined) continue;
+		change.baselineIndex = files.length;
+		files.push(new File([baseline], workspaceFileBasename(change.relativePath), { type: 'text/plain' }));
 	}
 
 	return { fileChanges, files };

--- a/types/volume/workspace.go
+++ b/types/volume/workspace.go
@@ -18,6 +18,11 @@ type WorkspaceFileChange struct {
 	NewName       string `json:"newName,omitempty"`
 	NewParentPath string `json:"newParentPath,omitempty"`
 	UploadIndex   *int   `json:"uploadIndex,omitempty" minimum:"0"`
+	// BaselineIndex references an uploaded copy of the content an update_file
+	// change was drafted against. The volume workspace revision is already
+	// content-aware, so the baseline is accepted for API symmetry with
+	// project workspaces but not separately compared.
+	BaselineIndex *int   `json:"baselineIndex,omitempty" minimum:"0"`
 	BackupID      string `json:"backupId,omitempty"`
 	Recursive     bool   `json:"recursive,omitempty"`
 }

--- a/types/workspace/workspace.go
+++ b/types/workspace/workspace.go
@@ -38,7 +38,14 @@ type FileChange struct {
 	NewName       string `json:"newName,omitempty"`
 	NewParentPath string `json:"newParentPath,omitempty"`
 	UploadIndex   *int   `json:"uploadIndex,omitempty" minimum:"0"`
-	Recursive     bool   `json:"recursive,omitempty"`
+	// BaselineIndex references an uploaded copy of the content this
+	// update_file change was drafted against. When set, the apply conflicts
+	// if the on-disk content no longer matches it, so a concurrent edit to
+	// the same file is not silently overwritten. Deliberately optional:
+	// imperative clients like the CLI overwrite without ever reading the
+	// file (last-write-wins), while the web editor always sends it.
+	BaselineIndex *int `json:"baselineIndex,omitempty" minimum:"0"`
+	Recursive     bool `json:"recursive,omitempty"`
 }
 
 type Workspace struct {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3199

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes project workspace revisions ignore content-only filesystem churn and adds uploaded file baselines so editor saves can detect concurrent edits. However, callers can still omit the optional baseline and silently overwrite newer file contents, and a later conflict in a multi-file save can leave earlier changes on disk.

The prior Web Crypto concern was disproved: the multipart builder attaches the baseline upload and index even when `globalThis.crypto` is unavailable.

## T-Rex validation blocked

- Tool: the available Go toolchain could not execute the focused multi-file conflict reproduction. The repository requires `encoding/json/v2`; without the experiment it is unavailable, and enabling `GOEXPERIMENT=jsonv2` causes the Go command to panic during initialization.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is not safe to merge until workspace saves consistently preserve data when concurrent edits or late conflicts occur.

A reproduced stale-overwrite failure remains, along with an actionable partial-save failure path in the sequential workspace apply logic.

**Files Needing Attention:** backend/pkg/projects/workspace.go; types/workspace/workspace.go
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for four posted P1 findings and linked them to reviewer comments.
- An attempt to reproduce a focused, valid earlier mutation could not execute due to the Go toolchain blocking the jsonv2 experiment.
- T-Rex validated the web crypto baseline scenarios, including an executable test harness, a baseline run that succeeded with update to baselineIndex 1, and a Web Crypto-unavailable run.
- T-Rex captured the stale-baseline partial-apply flow, including the focused harness source, two attempted runs, and the execution-blocked record showing a Go toolchain panic when enabling jsonv2.
- The requested verification was performed, but local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/18021250/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `backend/pkg/projects/workspace.go`, line 262-265 ([link](https://github.com/getarcaneapp/arcane/blob/ac0b8a1b429d66a68b147aaf8ce51f2c689f0c1b/backend/pkg/projects/workspace.go#L262-L265)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Late conflict leaves partial save**

   A multi-change manifest applies operations in order. If an earlier mutation succeeds and a later `update_file` detects a stale baseline, the method returns a conflict without rolling back the earlier mutation. The user sees a failed save even though part of the draft has already changed the workspace. Validate the manifest before writing, or make application atomic with rollback.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/projects/workspace.go
   Line: 262-265

   Comment:
   **Late conflict leaves partial save**

   A multi-change manifest applies operations in order. If an earlier mutation succeeds and a later `update_file` detects a stale baseline, the method returns a conflict without rolling back the earlier mutation. The user sees a failed save even though part of the draft has already changed the workspace. Validate the manifest before writing, or make application atomic with rollback.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_false_409_workspace_conflict_when_saving_files_in_imported_projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_false_409_workspace_conflict_when_saving_files_in_imported_projects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fworkspace.go%0ALine%3A%20262-265%0A%0AComment%3A%0A**Late%20conflict%20leaves%20partial%20save**%0A%0AA%20multi-change%20manifest%20applies%20operations%20in%20order.%20If%20an%20earlier%20mutation%20succeeds%20and%20a%20later%20%60update_file%60%20detects%20a%20stale%20baseline%2C%20the%20method%20returns%20a%20conflict%20without%20rolling%20back%20the%20earlier%20mutation.%20The%20user%20sees%20a%20failed%20save%20even%20though%20part%20of%20the%20draft%20has%20already%20changed%20the%20workspace.%20Validate%20the%20manifest%20before%20writing%2C%20or%20make%20application%20atomic%20with%20rollback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Fprojects%2Fworkspace.go%0ALine%3A%20262-265%0A%0AComment%3A%0A**Late%20conflict%20leaves%20partial%20save**%0A%0AA%20multi-change%20manifest%20applies%20operations%20in%20order.%20If%20an%20earlier%20mutation%20succeeds%20and%20a%20later%20%60update_file%60%20detects%20a%20stale%20baseline%2C%20the%20method%20returns%20a%20conflict%20without%20rolling%20back%20the%20earlier%20mutation.%20The%20user%20sees%20a%20failed%20save%20even%20though%20part%20of%20the%20draft%20has%20already%20changed%20the%20workspace.%20Validate%20the%20manifest%20before%20writing%2C%20or%20make%20application%20atomic%20with%20rollback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **No-baseline workspace update silently overwrites externally edited content**

   - **Bug**
     - After capturing a structural workspace revision, an external write to the target file leaves that revision unchanged. A submitted `update_file` that has `UploadIndex` but omits `BaselineIndex` succeeds and replaces the external content rather than returning a conflict.
   - **Cause**
     - `updateProjectWorkspaceFileInternal` performs its per-file byte comparison only when `baselineSet` is true (`backend/pkg/projects/workspace.go:406-414`). `BaselineIndex` is optional by contract (`types/workspace/workspace.go:41-47`), so an omitted baseline reaches `root.WriteFile` at `backend/pkg/projects/workspace.go:416` without any content-concurrency check.
   - **Fix**
     - Require a baseline for read-modify-write workspace updates, or reject no-baseline `update_file` requests when an `ExpectedRevision` is supplied; retain an explicit separate force-overwrite operation for intentional last-write-wins clients.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Omitted BaselineIndex appears to allow silent concurrent-content overwrite**

   - **Bug**
     - When an update request retains an ExpectedRevision captured before an external content-only change but omits BaselineIndex, the revision remains equal because it hashes only path and kind. The update path then skips the content comparison and calls WriteFile, which would replace the newer external content with the stale upload. Runtime confirmation is blocked by the supplied Go toolchain.
   - **Cause**
     - The structural revision intentionally excludes file content (`backend/pkg/projects/workspace.go:179-184`), and `updateProjectWorkspaceFileInternal` runs its content-conflict check only if `baselineSet` is true (`backend/pkg/projects/workspace.go:406-414`). `BaselineIndex` is intentionally optional (`types/workspace/workspace.go:41-46`).
   - **Fix**
     - Require a baseline/content precondition for API-originated update_file requests that supply ExpectedRevision, or include a per-file content revision in the update request and reject missing or mismatched values; retain explicit last-write-wins only for a separately authorized imperative path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Blocked: stale-baseline multi-change behavior could not be executed**

   - **Bug**
     - The requested valid earlier mutation followed by a stale-BaselineIndex `update_file` was prepared at the required scope but never reached `ApplyProjectWorkspaceChanges`: default compilation excludes `encoding/json/v2`, while `GOEXPERIMENT=jsonv2` causes the Go command to panic in `cmd/go/internal/fips140.Init`. Therefore the claim that conflict leaves an earlier mutation applied is not runtime-supported or disproved in this environment.
   - **Cause**
     - The installed Go 1.26.5 toolchain lacks the JSON-v2 experiment by default, and enabling it crashes the Go command during initialization.
   - **Fix**
     - Use a working Go toolchain/configuration compatible with this repository's `encoding/json/v2` dependency, then rerun the captured harness. If the runtime confirms the predicted behavior, validate all manifest operations before writes or apply them atomically with rollback.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_false_409_workspace_conflict_when_saving_files_in_imported_projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_false_409_workspace_conflict_when_saving_files_in_imported_projects%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fworkspace.go%3A406-416%0A**Optional%20baseline%20permits%20stale%20overwrite**%0A%0A%60BaselineIndex%60%20remains%20optional%2C%20so%20an%20%60update_file%60%20can%20pass%20a%20structural%20%60ExpectedRevision%60%20after%20another%20process%20has%20changed%20only%20that%20file's%20contents.%20With%20no%20baseline%2C%20this%20branch%20skips%20the%20per-file%20comparison%20and%20%60root.WriteFile%60%20replaces%20the%20newer%20content%20with%20the%20stale%20draft.%20Require%20a%20content%20precondition%20for%20read-modify-write%20updates%2C%20or%20expose%20force%20overwrite%20as%20a%20distinct%20intentional%20operation.%0A%0A%23%23%23%20Issue%202%0Abackend%2Fpkg%2Fprojects%2Fworkspace.go%3A262-265%0A**Late%20conflict%20leaves%20partial%20save**%0A%0AA%20multi-change%20manifest%20applies%20operations%20in%20order.%20If%20an%20earlier%20mutation%20succeeds%20and%20a%20later%20%60update_file%60%20detects%20a%20stale%20baseline%2C%20the%20method%20returns%20a%20conflict%20without%20rolling%20back%20the%20earlier%20mutation.%20The%20user%20sees%20a%20failed%20save%20even%20though%20part%20of%20the%20draft%20has%20already%20changed%20the%20workspace.%20Validate%20the%20manifest%20before%20writing%2C%20or%20make%20application%20atomic%20with%20rollback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fworkspace.go%3A406-416%0A**Optional%20baseline%20permits%20stale%20overwrite**%0A%0A%60BaselineIndex%60%20remains%20optional%2C%20so%20an%20%60update_file%60%20can%20pass%20a%20structural%20%60ExpectedRevision%60%20after%20another%20process%20has%20changed%20only%20that%20file's%20contents.%20With%20no%20baseline%2C%20this%20branch%20skips%20the%20per-file%20comparison%20and%20%60root.WriteFile%60%20replaces%20the%20newer%20content%20with%20the%20stale%20draft.%20Require%20a%20content%20precondition%20for%20read-modify-write%20updates%2C%20or%20expose%20force%20overwrite%20as%20a%20distinct%20intentional%20operation.%0A%0A%23%23%23%20Issue%202%0Abackend%2Fpkg%2Fprojects%2Fworkspace.go%3A262-265%0A**Late%20conflict%20leaves%20partial%20save**%0A%0AA%20multi-change%20manifest%20applies%20operations%20in%20order.%20If%20an%20earlier%20mutation%20succeeds%20and%20a%20later%20%60update_file%60%20detects%20a%20stale%20baseline%2C%20the%20method%20returns%20a%20conflict%20without%20rolling%20back%20the%20earlier%20mutation.%20The%20user%20sees%20a%20failed%20save%20even%20though%20part%20of%20the%20draft%20has%20already%20changed%20the%20workspace.%20Validate%20the%20manifest%20before%20writing%2C%20or%20make%20application%20atomic%20with%20rollback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3560&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/projects/workspace.go:406-416
**Optional baseline permits stale overwrite**

`BaselineIndex` remains optional, so an `update_file` can pass a structural `ExpectedRevision` after another process has changed only that file's contents. With no baseline, this branch skips the per-file comparison and `root.WriteFile` replaces the newer content with the stale draft. Require a content precondition for read-modify-write updates, or expose force overwrite as a distinct intentional operation.

### Issue 2
backend/pkg/projects/workspace.go:262-265
**Late conflict leaves partial save**

A multi-change manifest applies operations in order. If an earlier mutation succeeds and a later `update_file` detects a stale baseline, the method returns a conflict without rolling back the earlier mutation. The user sees a failed save even though part of the draft has already changed the workspace. Validate the manifest before writing, or make application atomic with rollback.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: false 409 workspace conflict when s..."](https://github.com/getarcaneapp/arcane/commit/ac0b8a1b429d66a68b147aaf8ce51f2c689f0c1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51606764)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->