### PR TITLE
fix: git sync no longer fails on sockets or unreadable files outside the repo

### DIFF
--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -354,6 +354,16 @@ func CopyDirectoryContents(srcDir, destDir string, skipUnreadable func(relPath s
 		if d.Type()&os.ModeSymlink != 0 {
 			return nil
 		}
+		if !d.Type().IsRegular() {
+			// Sockets, FIFOs, and device nodes left behind by running containers
+			// have no copyable content — reading one fails with ENXIO, not a
+			// permission error (#3003). Record them like unreadable entries so a
+			// later restore preserves rather than prunes them.
+			if skipUnreadable != nil {
+				skipUnreadable(relPath)
+			}
+			return nil
+		}
 
 		return copyRegularFileInternal(srcRoot, destRoot, relPath, d, skipUnreadable)
 	})
@@ -361,8 +371,8 @@ func CopyDirectoryContents(srcDir, destDir string, skipUnreadable func(relPath s
 
 func handleCopyWalkErrorInternal(srcDir, path string, d os.DirEntry, walkErr error, skipUnreadable func(relPath string)) error {
 	// An unreadable subdirectory surfaces here as a permission error on the
-	// directory entry itself.
-	if skipUnreadable == nil || !errors.Is(walkErr, os.ErrPermission) {
+	// directory entry itself; an entry deleted mid-walk surfaces as not-exist.
+	if skipUnreadable == nil || (!errors.Is(walkErr, os.ErrPermission) && !errors.Is(walkErr, os.ErrNotExist)) {
 		return walkErr
 	}
 	if relPath, relErr := filepath.Rel(srcDir, path); relErr == nil {
@@ -382,7 +392,7 @@ func copyRegularFileInternal(srcRoot, destRoot *os.Root, relPath string, d os.Di
 
 	content, err := srcRoot.ReadFile(relPath)
 	if err != nil {
-		if skipUnreadable != nil && errors.Is(err, os.ErrPermission) {
+		if skipUnreadable != nil && (errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist)) {
 			skipUnreadable(relPath)
 			return nil
 		}
@@ -412,7 +422,11 @@ func MirrorDirectoryContentsPreserving(srcDir, destDir string, preserve []string
 	if err := pruneDirectoryContentsInternal(srcDir, destDir, preserveSet); err != nil {
 		return err
 	}
-	return CopyDirectoryContents(srcDir, destDir, nil)
+	// Tolerate unreadable source entries during the copy-over: a mirror runs
+	// while promoting or restoring a live project directory, and failing
+	// half-way leaves it in a mixed state — worse than leaving a stale copy of
+	// one unreadable file (#3509, #3085).
+	return CopyDirectoryContents(srcDir, destDir, func(string) {})
 }
 
 func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]struct{}) error {
@@ -430,6 +444,13 @@ func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]
 
 	return filepath.WalkDir(destDir, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
+			// An unreadable destination subdirectory (e.g. foreign-owned
+			// bind-mount data) cannot be pruned; leave it in place instead of
+			// failing the whole mirror mid-restore (#3509, #3085). Entries that
+			// vanished mid-walk need no pruning either.
+			if errors.Is(walkErr, os.ErrPermission) || errors.Is(walkErr, os.ErrNotExist) {
+				return keepUnprunableEntryInternal(d)
+			}
 			return walkErr
 		}
 		if path == destDir {
@@ -443,10 +464,7 @@ func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]
 
 		// Never delete a preserved entry.
 		if _, ok := preserve[relPath]; ok {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+			return keepUnprunableEntryInternal(d)
 		}
 
 		srcInfo, err := srcRoot.Lstat(relPath)
@@ -454,6 +472,11 @@ func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]
 			return nil
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			// Cannot inspect the source counterpart — keep the destination
+			// entry rather than deleting something the source may still have.
+			if errors.Is(err, os.ErrPermission) {
+				return keepUnprunableEntryInternal(d)
+			}
 			return err
 		}
 
@@ -472,6 +495,15 @@ func pruneDirectoryContentsInternal(srcDir, destDir string, preserve map[string]
 		}
 		return nil
 	})
+}
+
+// keepUnprunableEntryInternal continues a prune walk past an entry that must
+// stay: descend no further into directories, ignore files.
+func keepUnprunableEntryInternal(d os.DirEntry) error {
+	if d != nil && d.IsDir() {
+		return filepath.SkipDir
+	}
+	return nil
 }
 
 // hasPreservedDescendantInternal reports whether any preserved path lives under

--- a/backend/pkg/projects/fs_util_unix_test.go
+++ b/backend/pkg/projects/fs_util_unix_test.go
@@ -113,3 +113,47 @@ func TestMirrorDirectoryContentsPreserving_KeepsSkippedFile(t *testing.T) {
 	// The straggler created during the failed update is pruned.
 	assert.NoFileExists(t, filepath.Join(live, "straggler.txt"))
 }
+
+func TestCopyDirectoryContentsTolerant_SkipsNonRegularFiles(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "compose.yaml"), []byte("services: {}\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "config"), 0o755))
+	// A FIFO stands in for the sockets running containers leave behind
+	// (e.g. config/.XDG/wayland-0 in #3003); reading either fails with a
+	// non-permission error.
+	require.NoError(t, syscall.Mkfifo(filepath.Join(src, "config", "app.sock"), 0o644))
+
+	dst := t.TempDir()
+	skipped, err := CopyDirectoryContentsTolerant(src, dst)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join("config", "app.sock")}, skipped)
+	assert.FileExists(t, filepath.Join(dst, "compose.yaml"))
+	assert.NoFileExists(t, filepath.Join(dst, "config", "app.sock"))
+}
+
+func TestMirrorDirectoryContentsPreserving_ToleratesUnreadableDestSubdir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission bits are not enforced")
+	}
+
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "compose.yaml"), []byte("old\n"), 0o644))
+	locked := filepath.Join(dst, "volumes")
+	require.NoError(t, os.MkdirAll(filepath.Join(locked, "config"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(locked, "config", "app.conf"), []byte("keep"), 0o644))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "compose.yaml"), []byte("new\n"), 0o644))
+
+	// The unreadable live-project subdir must be left intact instead of
+	// failing the whole mirror (#3509, #3085).
+	require.NoError(t, MirrorDirectoryContentsPreserving(src, dst, []string{"volumes"}))
+
+	content, err := os.ReadFile(filepath.Join(dst, "compose.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "new\n", string(content))
+	require.NoError(t, os.Chmod(locked, 0o755))
+	assert.FileExists(t, filepath.Join(locked, "config", "app.conf"))
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3509
Fixes: https://github.com/getarcaneapp/arcane/issues/3085
Fixes: https://github.com/getarcaneapp/arcane/issues/3003

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes project-directory copy and mirror operations tolerate unreadable, non-regular, and concurrently removed filesystem entries, helping promotion and restore complete around live runtime artifacts. One P2 test-organization requirement remains: the related filesystem scenarios should be expressed as table-driven subtests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The runtime filesystem-handling change is merge-safe apart from the repository's required test structure.

There is one independent, non-security P2 finding, which maps to a score of 4.

**Files Needing Attention:** backend/pkg/projects/fs_util_unix_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_git_sync_no_longer_fails_on_sockets_or_unreadable_files_outside_the_repo%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_git_sync_no_longer_fails_on_sockets_or_unreadable_files_outside_the_repo%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Ffs_util_unix_test.go%3A117-134%0A**Standalone%20filesystem%20test%20cases**%0A%0AThe%20two%20new%20filesystem%20scenarios%20are%20implemented%20as%20standalone%20tests%20rather%20than%20the%20required%20table-driven%20subtests.%20Put%20these%20related%20cases%20into%20the%20established%20table-driven%20form%20so%20shared%20setup%20and%20assertions%20do%20not%20continue%20to%20duplicate%20as%20coverage%20grows.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3561&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Ffs_util_unix_test.go%3A117-134%0A**Standalone%20filesystem%20test%20cases**%0A%0AThe%20two%20new%20filesystem%20scenarios%20are%20implemented%20as%20standalone%20tests%20rather%20than%20the%20required%20table-driven%20subtests.%20Put%20these%20related%20cases%20into%20the%20established%20table-driven%20form%20so%20shared%20setup%20and%20assertions%20do%20not%20continue%20to%20duplicate%20as%20coverage%20grows.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3561&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/projects/fs_util_unix_test.go:117-134
**Standalone filesystem test cases**

The two new filesystem scenarios are implemented as standalone tests rather than the required table-driven subtests. Put these related cases into the established table-driven form so shared setup and assertions do not continue to duplicate as coverage grows.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: git sync no longer fails on sockets..."](https://github.com/getarcaneapp/arcane/commit/e1ab20fac09797e503b2732b7f83a903a6581938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51607582)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->