### PR TITLE
fix: serve named pprof profiles instead of the index page

### DIFF
--- a/backend/api/ws/diagnostics.go
+++ b/backend/api/ws/diagnostics.go
@@ -68,7 +68,13 @@ func (h *WebSocketHandler) registerDiagnosticsRoutesInternal(group *echo.Group, 
 	pprofGroup.POST("/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
 	pprofGroup.GET("/symbol", echo.WrapHandler(http.HandlerFunc(pprof.Symbol)))
 	pprofGroup.GET("/trace", echo.WrapHandler(http.HandlerFunc(pprof.Trace)))
-	pprofGroup.GET("/:name", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
+	// pprof.Index only serves a named profile when the request path starts with the
+	// literal "/debug/pprof/". This group is mounted under /api, so that never
+	// matches and every named profile would render the index page instead.
+	pprofGroup.GET("/:name", func(c *echo.Context) error {
+		pprof.Handler(c.Param("name")).ServeHTTP(c.Response(), c.Request())
+		return nil
+	})
 }
 
 // DiagnosticsStream pushes a fresh diagnostics snapshot on connect and then every


### PR DESCRIPTION
The pprof routes are mounted under /api, but net/http/pprof.Index only dispatches a named profile when it can cut the literal prefix "/debug/pprof/" off r.URL.Path. With /api in front that never matches, so heap, goroutine, allocs, block, mutex and threadcreate all rendered the pprof index page instead of a profile.

Dispatch on the route param instead. Unknown names now return 404 rather than the index page.

## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Named pprof profiles served the pprof index page instead of a profile. heap, goroutine, allocs, block, mutex and threadcreate all returned the same 2601-byte text/html body, so the Download pprof Profiles buttons on Settings > Diagnostics saved an HTML file with a .pprof extension.

The catch-all route was wired to pprof.Index:

pprofGroup.GET("/:name", echo.WrapHandler(http.HandlerFunc(pprof.Index)))
net/http/pprof.Index only serves a named profile when it can cut the literal prefix /debug/pprof/ off r.URL.Path. The group is mounted under /api, so the cut never matches & it falls through to rendering its own index page. profile, trace, cmdline and symbol were never affected because they are wired to explicit handlers.

Fixes: #3562

## Changes Made

One route in backend/api/ws/diagnostics.go.
Side effect worth flagging: an unknown profile name now returns 404 Unknown profile rather than quietly rendering the index page.

## Testing Done

Ran the dev environment (./scripts/development/dev.sh start), logged in as the seeded admin, and hit every endpoint on the group.

Before, on v2.7.0:
```
heap         -> text/html; charset=utf-8 2601
goroutine    -> text/html; charset=utf-8 2601
allocs       -> text/html; charset=utf-8 2601
block        -> text/html; charset=utf-8 2601
mutex        -> text/html; charset=utf-8 2601
threadcreate -> text/html; charset=utf-8 2601
```
After:
```
heap         -> 200 application/octet-stream 28140b magic=1f8b
goroutine    -> 200 application/octet-stream  5668b magic=1f8b
allocs       -> 200 application/octet-stream 29197b magic=1f8b
block        -> 200 application/octet-stream   364b magic=1f8b
mutex        -> 200 application/octet-stream   363b magic=1f8b
threadcreate -> 200 application/octet-stream   541b magic=1f8b
bogus        -> 404 Unknown profile
```
go tool pprof opens all six and reports the expected type for each (inuse_space, goroutine, alloc_space, delay, delay, threadcreate), with symbols resolving normally.

Regression checks: profile?seconds=2, cmdline and the group index still behave as before. Frontend and backend hot reload both work, the Diagnostics page renders, and just format all, just lint all and just test backend are clean.

## AI Tool Used (if applicable)

Claude Code. It found the cause, wrote the change & helped draft parts of the issue descriptions. I ran the dev environment and verified every result above myself.

## Additional Context

I found this while wiring Arcane into continuous profiling. Grafana Alloy’s pyroscope.scrape can reach these endpoints with path_prefix = "/api" and an X-API-Key header, but until this change only process_cpu could be enabled - every memory-side profile type had to be turned off.

Unrelated and unaffected, in case it comes up in review: the Diagnostics page’s own heap, GC & goroutine figures were always correct. They come from runtime.ReadMemStats and runtime.NumGoroutine in backend/internal/diagnostics/service.go, which never touches net/http/pprof.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes named pprof profile downloads under the `/api/debug/pprof` prefix by dispatching the Echo route parameter directly to `pprof.Handler`.
- Known profile names now return the corresponding binary pprof data instead of the index page.
- Unknown profile names return the standard pprof 404 response.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with named and unknown pprof profile requests handled correctly through Echo’s response writer.

The new handler selects profiles from the captured route parameter, preserves the existing authentication boundary, and correctly commits both successful profile responses and unknown-profile 404 responses.
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/pprof-named..."](https://github.com/getarcaneapp/arcane/commit/2f8b4d094060d457b8363b74196811767f4f450d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51626292)</sub>

**Context used:**

- Knowledge Base — [Backend API Server](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/backend-api-server.md)

<!-- /greptile_comment -->