### PR TITLE
fix: only log environment connect/disconnect events on real state transitions

### DIFF
--- a/backend/internal/bootstrap/edge_bootstrap.go
+++ b/backend/internal/bootstrap/edge_bootstrap.go
@@ -39,28 +39,7 @@ func registerEdgeTunnelRoutes(
 
 	// Status callback to update environment status when agent connects/disconnects
 	statusCallback := func(ctx context.Context, envID string, connected bool) {
-		envName := envID
-		env, getErr := environmentService.GetEnvironmentByID(ctx, envID)
-		if getErr != nil {
-			slog.WarnContext(ctx, "Failed to load environment before edge status update", "environment_id", envID, "error", getErr)
-		} else if env != nil && env.Name != "" {
-			envName = env.Name
-		}
-
-		if err := environmentService.UpdateEnvironmentConnectionState(ctx, envID, connected); err != nil {
-			slog.WarnContext(ctx, "Failed to update environment status on edge connect/disconnect", "environment_id", envID, "connected", connected, "error", err)
-		} else {
-			slog.InfoContext(ctx, "Updated edge environment connection state", "environment_id", envID, "connected", connected)
-		}
-
-		if err := createEdgeConnectionEvent(ctx, eventService, envID, envName, connected); err != nil {
-			slog.WarnContext(ctx, "Failed to create edge connection event", "environment_id", envID, "connected", connected, "error", err)
-		}
-
-		// This is the only funnel for "an edge tunnel came up or went down"
-		// (register, unregister and stale reaping all route through it), so it
-		// is where open status streams learn about it without polling.
-		environmentService.NotifyRuntimeStateChanged()
+		handleEdgeStatusChange(ctx, environmentService, eventService, envID, connected)
 	}
 
 	eventCallback := func(ctx context.Context, envID string, evt *edge.TunnelEvent) error {
@@ -216,6 +195,42 @@ func optionalStringPtr(value string) *string {
 		return nil
 	}
 	return &value
+}
+
+// handleEdgeStatusChange records a tunnel up/down transition: it updates the
+// stored connection state, logs an event when the state actually changed, and
+// wakes any open status streams.
+func handleEdgeStatusChange(ctx context.Context, environmentService *environment.EnvironmentService, eventService *event.EventService, envID string, connected bool) {
+	envName := envID
+	env, getErr := environmentService.GetEnvironmentByID(ctx, envID)
+	if getErr != nil {
+		slog.WarnContext(ctx, "Failed to load environment before edge status update", "environment_id", envID, "error", getErr)
+	} else if env != nil && env.Name != "" {
+		envName = env.Name
+	}
+
+	if err := environmentService.UpdateEnvironmentConnectionState(ctx, envID, connected); err != nil {
+		slog.WarnContext(ctx, "Failed to update environment status on edge connect/disconnect", "environment_id", envID, "connected", connected, "error", err)
+	} else {
+		slog.InfoContext(ctx, "Updated edge environment connection state", "environment_id", envID, "connected", connected)
+	}
+
+	// Only log an event on an actual state transition; poll-mode tunnels can
+	// re-register without the environment ever having gone offline (session
+	// replacement, transport reconnects), and those are not worth an event.
+	alreadyInState := env != nil &&
+		((connected && env.Status == string(models.EnvironmentStatusOnline)) ||
+			(!connected && env.Status == string(models.EnvironmentStatusOffline)))
+	if !alreadyInState {
+		if err := createEdgeConnectionEvent(ctx, eventService, envID, envName, connected); err != nil {
+			slog.WarnContext(ctx, "Failed to create edge connection event", "environment_id", envID, "connected", connected, "error", err)
+		}
+	}
+
+	// This is the only funnel for "an edge tunnel came up or went down"
+	// (register, unregister and stale reaping all route through it), so it
+	// is where open status streams learn about it without polling.
+	environmentService.NotifyRuntimeStateChanged()
 }
 
 func createEdgeConnectionEvent(ctx context.Context, eventService *event.EventService, envID, envName string, connected bool) error {

--- a/backend/internal/environment/environment_health.go
+++ b/backend/internal/environment/environment_health.go
@@ -220,6 +220,10 @@ func (s *EnvironmentService) TestConnection(ctx context.Context, id string, cust
 
 // testEdgeConnection tests connection to an edge agent via its tunnel
 func (s *EnvironmentService) testEdgeConnection(ctx context.Context, id string) (string, error) {
+	// The health check itself is standing demand for the tunnel; refreshing here
+	// keeps idle poll-mode tunnels open across check cycles instead of letting
+	// the demand TTL expire and the tunnel flap between checks.
+	edge.TouchTunnelDemand(id, edge.DefaultTunnelDemandTTL)
 	if !edge.HasActiveTunnel(id) {
 		if _, ok := edge.RequestTunnelAndWait(ctx, id, edge.DefaultTunnelDemandTTL, edge.DefaultTunnelAcquireTimeout()).Get(); !ok {
 			_ = s.updateEnvironmentStatusInternal(ctx, id, string(models.EnvironmentStatusOffline))

--- a/backend/pkg/libarcane/edge/poll_control.go
+++ b/backend/pkg/libarcane/edge/poll_control.go
@@ -23,8 +23,11 @@ const (
 	// runtime status reporting when no live tunnel is currently open.
 	DefaultPollRuntimeTTL = 6 * time.Second
 	// DefaultTunnelDemandTTL is how long the manager should keep an edge tunnel
-	// marked as required after a user/API request touches the environment.
-	DefaultTunnelDemandTTL = 2 * time.Minute
+	// marked as required after a user/API request touches the environment. It is
+	// deliberately longer than the default environment health interval (2m) so
+	// health checks refreshing the demand keep idle poll-mode tunnels open
+	// instead of letting them flap between checks.
+	DefaultTunnelDemandTTL = 5 * time.Minute
 
 	// TunnelStatusIdle indicates that no reverse tunnel is currently needed.
 	TunnelStatusIdle = "IDLE"


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change consolidates edge tunnel status handling, avoids emitting lifecycle events when the persisted status already matches, refreshes poll-mode tunnel demand during health checks, and extends the default demand lifetime.

The transition check still reads the stored status before performing separate update and event writes. Overlapping callbacks can therefore both observe the same prior status and record duplicate connect or disconnect events.

## T-Rex validation blocked
The focused concurrency check could not execute because the local Go toolchain panicked in `cmd/go/internal/fips140.Init` when run with the required `GOEXPERIMENT=jsonv2` setting. The initial attempt was also prevented by unavailable JSON-v2 sources and the generated frontend embed directory.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge until edge-status transitions are made atomic or otherwise serialized per environment.

The read-then-write status comparison has no atomic guard, leaving concurrent callbacks able to independently classify the same transition as new. Runtime execution could not complete because of a local Go toolchain failure.

**Files Needing Attention:** backend/internal/bootstrap/edge_bootstrap.go, especially the persisted-status comparison and the subsequent status and event writes.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a focused Go validation to exercise the production edge-status handler with a SQLite-backed environment and event services, synchronizing two callbacks after both read the same persisted status.
- The initial command could not compile because JSON-v2 sources and the generated frontend embed directory were unavailable.
- A retry with GOEXPERIMENT=jsonv2 and a temporary embed prerequisite led to a Go toolchain panic in cmd/go/internal/fips140.Init before the handler tests could run.
- Artifacts including a Go validation source, logs, and a stack trace were prepared to support inspection of the failure and retry.

<a href="https://app.greptile.com/trex/runs/18022985/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_only_log_environment_connect%2Fdisconnect_events_on_real_state_transitions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_only_log_environment_connect%2Fdisconnect_events_on_real_state_transitions%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fbootstrap%2Fedge_bootstrap.go%3A221-224%0A**Non-atomic%20transition%20deduplication**%0A%0AIf%20two%20tunnel%20status%20callbacks%20for%20the%20same%20environment%20overlap%2C%20both%20read%20the%20same%20previous%20status%20before%20either%20update%20completes%2C%20so%20both%20treat%20the%20callback%20as%20a%20real%20transition%20and%20create%20duplicate%20connect%20or%20disconnect%20events.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3564&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fbootstrap%2Fedge_bootstrap.go%3A221-224%0A**Non-atomic%20transition%20deduplication**%0A%0AIf%20two%20tunnel%20status%20callbacks%20for%20the%20same%20environment%20overlap%2C%20both%20read%20the%20same%20previous%20status%20before%20either%20update%20completes%2C%20so%20both%20treat%20the%20callback%20as%20a%20real%20transition%20and%20create%20duplicate%20connect%20or%20disconnect%20events.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3564&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/bootstrap/edge_bootstrap.go:221-224
**Non-atomic transition deduplication**

If two tunnel status callbacks for the same environment overlap, both read the same previous status before either update completes, so both treat the callback as a real transition and create duplicate connect or disconnect events.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only log environment connect/discon..."](https://github.com/getarcaneapp/arcane/commit/5797ecad532447a1ac38fc7b283e9580ef784ba7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51624646)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->