### PR TITLE
fix: pick a DOCKER_HOST-reachable network for the self-update upgrader

### DIFF
--- a/backend/internal/system/upgrade_service.go
+++ b/backend/internal/system/upgrade_service.go
@@ -223,6 +223,9 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user mo
 			_, err := cgroup.CurrentContainerID()
 			return err == nil
 		},
+		func(ctx context.Context, inspect *container.InspectResponse, dockerHost string) string {
+			return dockerutils.SelectDockerHostReachableNetworkMode(ctx, dockerClient, inspect, dockerHost)
+		},
 	)
 	if err != nil {
 		return "", errors.WrapIf(err, "resolve upgrader docker runtime")
@@ -332,6 +335,7 @@ func resolveSystemUpgraderRuntimeOptionsInternal(
 	currentContainer *container.InspectResponse,
 	discoverHostPath func(context.Context, string) (string, error),
 	isRunningInDocker func() bool,
+	selectReachableNetwork func(context.Context, *container.InspectResponse, string) string,
 ) (upgraderRuntimeOptionsInternal, error) {
 	options := upgraderRuntimeOptionsInternal{
 		ContainerEnv: vuln.BuildDockerHostEnv(dockerHost),
@@ -343,7 +347,13 @@ func resolveSystemUpgraderRuntimeOptionsInternal(
 	}
 
 	if scheme != "unix" {
-		options.NetworkMode = container.NetworkMode(vuln.SelectAutoNetworkMode(currentContainer))
+		// The upgrader must reach the tcp DOCKER_HOST, so prefer a network the
+		// daemon proxy is actually on over the plain auto heuristic (#3533).
+		if selectReachableNetwork != nil {
+			options.NetworkMode = container.NetworkMode(selectReachableNetwork(ctx, currentContainer, dockerHost))
+		} else {
+			options.NetworkMode = container.NetworkMode(dockerutils.SelectAutoNetworkMode(currentContainer))
+		}
 		return options, nil
 	}
 

--- a/backend/internal/system/upgrade_service_test.go
+++ b/backend/internal/system/upgrade_service_test.go
@@ -212,6 +212,7 @@ func TestResolveSystemUpgraderRuntimeOptionsInternal_TCPDockerHost(t *testing.T)
 		currentContainer,
 		nil,
 		func() bool { return true },
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{"DOCKER_HOST=tcp://docker-socket-proxy:2375"}, options.ContainerEnv)
@@ -228,6 +229,7 @@ func TestResolveSystemUpgraderRuntimeOptionsInternal_UnixDockerHost(t *testing.T
 			return "/host/run/docker.sock", nil
 		},
 		func() bool { return true },
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{"DOCKER_HOST=unix:///var/run/docker.sock"}, options.ContainerEnv)
@@ -250,6 +252,7 @@ func TestResolveSystemUpgraderRuntimeOptionsInternal_DefaultDockerHost(t *testin
 			return "/var/run/docker.sock", nil
 		},
 		func() bool { return true },
+		nil,
 	)
 	require.NoError(t, err)
 	require.Nil(t, options.ContainerEnv)
@@ -271,6 +274,7 @@ func TestResolveSystemUpgraderRuntimeOptionsInternal_UnixDockerHostResolutionErr
 			return "", errors.New("inspect failed")
 		},
 		func() bool { return true },
+		nil,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "resolve unix socket source")

--- a/backend/internal/vulnerability/vulnerability_trivy.go
+++ b/backend/internal/vulnerability/vulnerability_trivy.go
@@ -501,7 +501,7 @@ func (s *VulnerabilityService) resolveTrivyNetworkModeInternal(ctx context.Conte
 
 	inspect, err := libarcane.InspectCurrentArcaneContainer(ctx, dockerClient)
 	if err == nil {
-		return vuln.SelectAutoNetworkMode(inspect)
+		return dockerutils.SelectAutoNetworkMode(inspect)
 	}
 
 	slog.DebugContext(ctx, "failed to auto-detect Trivy network; falling back to bridge", "error", err)

--- a/backend/pkg/dockerutil/network_utils.go
+++ b/backend/pkg/dockerutil/network_utils.go
@@ -1,5 +1,19 @@
 package docker
 
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+const defaultNetworkModeInternal = "bridge"
+
 func IsDefaultNetwork(name string) bool {
 	switch name {
 	case "bridge", "host", "none", "ingress":
@@ -7,4 +21,118 @@ func IsDefaultNetwork(name string) bool {
 	default:
 		return false
 	}
+}
+
+func SelectAutoNetworkMode(inspect *container.InspectResponse) string {
+	if inspect == nil {
+		return defaultNetworkModeInternal
+	}
+
+	if inspect.HostConfig != nil {
+		networkMode := strings.TrimSpace(string(inspect.HostConfig.NetworkMode))
+		if networkMode != "" && networkMode != "default" && networkMode != defaultNetworkModeInternal &&
+			!container.NetworkMode(networkMode).IsContainer() {
+			return networkMode
+		}
+	}
+
+	if inspect.NetworkSettings != nil && len(inspect.NetworkSettings.Networks) > 0 {
+		networkNames := make([]string, 0, len(inspect.NetworkSettings.Networks))
+		for networkName := range inspect.NetworkSettings.Networks {
+			networkName = strings.TrimSpace(networkName)
+			if networkName != "" {
+				networkNames = append(networkNames, networkName)
+			}
+		}
+		sort.Strings(networkNames)
+
+		for _, networkName := range networkNames {
+			if !IsDefaultNetwork(networkName) {
+				return networkName
+			}
+		}
+
+		for _, networkName := range networkNames {
+			if container.NetworkMode(networkName).IsContainer() {
+				continue
+			}
+			if networkName == "host" || networkName == "none" || networkName == defaultNetworkModeInternal {
+				return networkName
+			}
+		}
+	}
+
+	if inspect.HostConfig != nil {
+		networkMode := strings.TrimSpace(string(inspect.HostConfig.NetworkMode))
+		if networkMode != "" && networkMode != "default" && !container.NetworkMode(networkMode).IsContainer() {
+			return networkMode
+		}
+	}
+
+	return defaultNetworkModeInternal
+}
+
+// SelectDockerHostReachableNetworkMode picks the network for a helper container
+// that must reach a tcp DOCKER_HOST (e.g. a docker-socket-proxy). When the
+// DOCKER_HOST hostname matches a running container — by name, compose service,
+// or DNS alias — that shares a network with the current container, that shared
+// network wins. SelectAutoNetworkMode's alphabetical heuristic routinely lands
+// on an unrelated external network on multi-network setups, leaving the helper
+// unable to reach the daemon (#3533).
+func SelectDockerHostReachableNetworkMode(ctx context.Context, dockerClient *client.Client, inspect *container.InspectResponse, dockerHost string) string {
+	fallback := SelectAutoNetworkMode(inspect)
+
+	host := ""
+	if parsed, err := url.Parse(strings.TrimSpace(dockerHost)); err == nil {
+		host = parsed.Hostname()
+	}
+	if host == "" || dockerClient == nil || inspect == nil || inspect.NetworkSettings == nil || len(inspect.NetworkSettings.Networks) == 0 {
+		return fallback
+	}
+
+	list, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{})
+	if err != nil {
+		slog.DebugContext(ctx, "select docker-host network: list failed", "error", err)
+		return fallback
+	}
+
+	shared := make([]string, 0, 2)
+	for _, c := range list.Items {
+		if c.NetworkSettings == nil || !containerAnswersToHostnameInternal(&c, host) {
+			continue
+		}
+		for networkName := range c.NetworkSettings.Networks {
+			if _, ok := inspect.NetworkSettings.Networks[networkName]; ok {
+				shared = append(shared, networkName)
+			}
+		}
+	}
+	if len(shared) == 0 {
+		return fallback
+	}
+	sort.Strings(shared)
+	return shared[0]
+}
+
+// containerAnswersToHostnameInternal reports whether the container is
+// addressable as host on some network: by container name, compose service
+// name, or an endpoint DNS name/alias.
+func containerAnswersToHostnameInternal(c *container.Summary, host string) bool {
+	for _, name := range c.Names {
+		if strings.TrimPrefix(name, "/") == host {
+			return true
+		}
+	}
+	if c.Labels["com.docker.compose.service"] == host {
+		return true
+	}
+	for _, endpoint := range c.NetworkSettings.Networks {
+		if endpoint == nil {
+			continue
+		}
+		if slices.Contains(endpoint.DNSNames, host) || slices.Contains(endpoint.Aliases, host) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/pkg/dockerutil/network_utils_test.go
+++ b/backend/pkg/dockerutil/network_utils_test.go
@@ -1,0 +1,90 @@
+package docker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectAutoNetworkMode(t *testing.T) {
+	t.Run("prefers explicit host network mode", func(t *testing.T) {
+		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
+			HostConfig: &containertypes.HostConfig{NetworkMode: "host"},
+		})
+
+		require.Equal(t, "host", mode)
+	})
+
+	t.Run("prefers attached custom network over bridge", func(t *testing.T) {
+		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
+			HostConfig: &containertypes.HostConfig{NetworkMode: "bridge"},
+			NetworkSettings: &containertypes.NetworkSettings{
+				Networks: map[string]*networktypes.EndpointSettings{
+					"bridge":          {},
+					"arcane-internal": {},
+				},
+			},
+		})
+
+		require.Equal(t, "arcane-internal", mode)
+	})
+
+	t.Run("falls back to bridge when no custom network is attached", func(t *testing.T) {
+		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
+			HostConfig: &containertypes.HostConfig{NetworkMode: "bridge"},
+			NetworkSettings: &containertypes.NetworkSettings{
+				Networks: map[string]*networktypes.EndpointSettings{
+					"bridge": {},
+				},
+			},
+		})
+
+		require.Equal(t, "bridge", mode)
+	})
+}
+
+func TestSelectDockerHostReachableNetworkMode(t *testing.T) {
+	// Server container on an external tunnel network plus a compose-prefixed
+	// socket-proxy network. Plain alphabetical selection picks the tunnel (#3533).
+	inspect := &containertypes.InspectResponse{
+		NetworkSettings: &containertypes.NetworkSettings{
+			Networks: map[string]*networktypes.EndpointSettings{
+				"cloudflare-tunnel":       {},
+				"myproj_socket-proxy-net": {},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/containers/json") {
+			_, _ = w.Write([]byte(`[{"Id":"proxy1","Names":["/myproj-socket-proxy-1"],"Labels":{"com.docker.compose.service":"socket-proxy"},"State":"running","NetworkSettings":{"Networks":{"myproj_socket-proxy-net":{"Aliases":["socket-proxy"]}}}}]`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	dockerClient, err := client.New(
+		client.WithHost("tcp://"+strings.TrimPrefix(server.URL, "http://")),
+		client.WithAPIVersion("1.41"),
+	)
+	require.NoError(t, err)
+	defer func() { _ = dockerClient.Close() }()
+
+	t.Run("prefers shared network with the DOCKER_HOST container", func(t *testing.T) {
+		got := SelectDockerHostReachableNetworkMode(context.Background(), dockerClient, inspect, "tcp://socket-proxy:2375")
+		require.Equal(t, "myproj_socket-proxy-net", got)
+	})
+
+	t.Run("falls back to auto heuristic when nothing matches", func(t *testing.T) {
+		got := SelectDockerHostReachableNetworkMode(context.Background(), dockerClient, inspect, "tcp://unknown-host:2375")
+		require.Equal(t, "cloudflare-tunnel", got)
+	})
+}

--- a/backend/pkg/libarcane/vuln/driver.go
+++ b/backend/pkg/libarcane/vuln/driver.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -82,55 +81,6 @@ func ResolveUnixSocketSource(
 	}
 
 	return socketPath, nil
-}
-
-func SelectAutoNetworkMode(inspect *containertypes.InspectResponse) string {
-	if inspect == nil {
-		return DefaultNetworkMode
-	}
-
-	if inspect.HostConfig != nil {
-		networkMode := strings.TrimSpace(string(inspect.HostConfig.NetworkMode))
-		if networkMode != "" && networkMode != "default" && networkMode != DefaultNetworkMode &&
-			!containertypes.NetworkMode(networkMode).IsContainer() {
-			return networkMode
-		}
-	}
-
-	if inspect.NetworkSettings != nil && len(inspect.NetworkSettings.Networks) > 0 {
-		networkNames := make([]string, 0, len(inspect.NetworkSettings.Networks))
-		for networkName := range inspect.NetworkSettings.Networks {
-			networkName = strings.TrimSpace(networkName)
-			if networkName != "" {
-				networkNames = append(networkNames, networkName)
-			}
-		}
-		sort.Strings(networkNames)
-
-		for _, networkName := range networkNames {
-			if !dockerutils.IsDefaultNetwork(networkName) {
-				return networkName
-			}
-		}
-
-		for _, networkName := range networkNames {
-			if containertypes.NetworkMode(networkName).IsContainer() {
-				continue
-			}
-			if networkName == "host" || networkName == "none" || networkName == DefaultNetworkMode {
-				return networkName
-			}
-		}
-	}
-
-	if inspect.HostConfig != nil {
-		networkMode := strings.TrimSpace(string(inspect.HostConfig.NetworkMode))
-		if networkMode != "" && networkMode != "default" && !containertypes.NetworkMode(networkMode).IsContainer() {
-			return networkMode
-		}
-	}
-
-	return DefaultNetworkMode
 }
 
 func NewOutputPath() string {

--- a/backend/pkg/libarcane/vuln/driver_test.go
+++ b/backend/pkg/libarcane/vuln/driver_test.go
@@ -12,7 +12,6 @@ import (
 	"emperror.dev/errors"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
-	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
@@ -429,43 +428,6 @@ func TestResolveTrivyUnixSocketSourceInternal(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, "/var/run/docker.sock", source)
-	})
-}
-
-func TestSelectTrivyAutoNetworkModeInternal(t *testing.T) {
-	t.Run("prefers explicit host network mode", func(t *testing.T) {
-		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
-			HostConfig: &containertypes.HostConfig{NetworkMode: "host"},
-		})
-
-		require.Equal(t, "host", mode)
-	})
-
-	t.Run("prefers attached custom network over bridge", func(t *testing.T) {
-		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
-			HostConfig: &containertypes.HostConfig{NetworkMode: "bridge"},
-			NetworkSettings: &containertypes.NetworkSettings{
-				Networks: map[string]*networktypes.EndpointSettings{
-					"bridge":          {},
-					"arcane-internal": {},
-				},
-			},
-		})
-
-		require.Equal(t, "arcane-internal", mode)
-	})
-
-	t.Run("falls back to bridge when no custom network is attached", func(t *testing.T) {
-		mode := SelectAutoNetworkMode(&containertypes.InspectResponse{
-			HostConfig: &containertypes.HostConfig{NetworkMode: "bridge"},
-			NetworkSettings: &containertypes.NetworkSettings{
-				Networks: map[string]*networktypes.EndpointSettings{
-					"bridge": {},
-				},
-			},
-		})
-
-		require.Equal(t, "bridge", mode)
 	})
 }
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3533

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves automatic Docker network selection into the shared dockerutil package and adds a TCP-DOCKER_HOST-aware selector for self-update containers.

- Matches the configured Docker hostname against running container names, Compose service labels, and endpoint aliases.
- Prefers a network shared by Arcane and the matching Docker proxy, with the existing automatic heuristic as fallback.
- Updates vulnerability scanning to use the relocated shared helper and adds network-selection tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only non-blocking Go documentation and test error-handling cleanup needed.

The network-selection behavior is wired into the intended self-upgrade path and the relocated helper preserves prior Trivy behavior; the accepted concern is limited to repository-required documentation and explicit error handling.

**Files Needing Attention:** backend/pkg/dockerutil/network_utils.go and backend/pkg/dockerutil/network_utils_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_pick_a_docker_host-reachable_network_for_the_self-update_upgrader%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_pick_a_docker_host-reachable_network_for_the_self-update_upgrader%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fdockerutil%2Fnetwork_utils.go%3A26%0A**Document%20the%20exported%20network%20helper**%0A%0A%60SelectAutoNetworkMode%60%20is%20newly%20exported%20without%20the%20required%20Go%20documentation%20comment%2C%20and%20the%20associated%20test%20also%20discards%20the%20error%20from%20%60w.Write%60%20without%20justification.%20Document%20the%20exported%20contract%20and%20handle%20the%20test%20response-write%20error%20explicitly%20so%20API%20intent%20and%20test%20failures%20remain%20diagnosable.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fdockerutil%2Fnetwork_utils.go%3A26%0A**Document%20the%20exported%20network%20helper**%0A%0A%60SelectAutoNetworkMode%60%20is%20newly%20exported%20without%20the%20required%20Go%20documentation%20comment%2C%20and%20the%20associated%20test%20also%20discards%20the%20error%20from%20%60w.Write%60%20without%20justification.%20Document%20the%20exported%20contract%20and%20handle%20the%20test%20response-write%20error%20explicitly%20so%20API%20intent%20and%20test%20failures%20remain%20diagnosable.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3566&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/dockerutil/network_utils.go:26
**Document the exported network helper**

`SelectAutoNetworkMode` is newly exported without the required Go documentation comment, and the associated test also discards the error from `w.Write` without justification. Document the exported contract and handle the test response-write error explicitly so API intent and test failures remain diagnosable.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pick a DOCKER\_HOST-reachable networ..."](https://github.com/getarcaneapp/arcane/commit/b50d7bdf6c8b03df6723ba6be18138b4eda44192) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51633359)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [System Diagnostics, Notifications, Webhooks, and Activity/Event Logging](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/system-diagnostics.md)
- Knowledge Base — [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)
</details>

<!-- /greptile_comment -->