### PR TITLE
fix: report CPU count from scheduler affinity so LXC core limits are respected

### DIFF
--- a/backend/api/ws/handler.go
+++ b/backend/api/ws/handler.go
@@ -1178,6 +1178,7 @@ func (h *WebSocketHandler) applyCgroupLimits(cpuCount int, memUsed, memTotal uin
 	if cgroup.IsDockerContainer() {
 		return cpuCount, memUsed, memTotal
 	}
+	cpuCount = applyCPUAffinityLimitInternal(cpuCount)
 	cgroupLimits := h.getCachedCgroupLimitsInternal()
 	if cgroupLimits == nil {
 		return cpuCount, memUsed, memTotal
@@ -1196,6 +1197,20 @@ func (h *WebSocketHandler) applyCgroupLimits(cpuCount int, memUsed, memTotal uin
 		cpuCount = cgroupLimits.CPUCount
 	}
 	return cpuCount, memUsed, memTotal
+}
+
+// applyCPUAffinityLimitInternal caps the CPU count at the scheduler affinity
+// mask size. In an unprivileged LXC guest the cgroup cpu quota is usually
+// unset at the guest root (the limit lives host-side), so the affinity mask is
+// the only signal of the cores actually assigned — including gap bindings like
+// CPU1+CPU7 — while /proc/cpuinfo shows the whole host (#3161). runtime.NumCPU
+// reads that mask at process start. Not applied inside Docker, matching
+// applyCgroupLimits' host-totals convention there.
+func applyCPUAffinityLimitInternal(cpuCount int) int {
+	if n := runtime.NumCPU(); n > 0 && (cpuCount == 0 || n < cpuCount) {
+		return n
+	}
+	return cpuCount
 }
 
 // getDiskInfo returns disk usage and total.

--- a/backend/api/ws/handler_test.go
+++ b/backend/api/ws/handler_test.go
@@ -1,0 +1,20 @@
+package ws
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyCPUAffinityLimitInternal(t *testing.T) {
+	affinity := runtime.NumCPU()
+
+	// A host-wide count larger than the affinity mask (LXC without lxcfs,
+	// #3161) is capped at the mask size; a smaller cgroup-derived count wins.
+	require.Equal(t, affinity, applyCPUAffinityLimitInternal(affinity+8))
+	require.Equal(t, affinity, applyCPUAffinityLimitInternal(0))
+	if affinity > 1 {
+		require.Equal(t, 1, applyCPUAffinityLimitInternal(1))
+	}
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3161

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR caps the WebSocket system-statistics CPU count using the process scheduler affinity before applying cgroup limits, allowing LXC guests to report assigned cores rather than the host-wide `/proc/cpuinfo` count.

- Adds an affinity-aware CPU-count cap while retaining the existing Docker bypass and cgroup-limit behavior.
- Adds focused coverage for host-wide, zero, and already-narrower CPU counts.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking request to convert the new test to table-driven subtests.

The changed CPU-count path retains the existing lower-bound selection behavior, while the new test’s inline assertions conflict with the repository’s required Go testing pattern.

**Files Needing Attention:** backend/api/ws/handler_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_report_cpu_count_from_scheduler_affinity_so_lxc_core_limits_are_respected%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_report_cpu_count_from_scheduler_affinity_so_lxc_core_limits_are_respected%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fapi%2Fws%2Fhandler_test.go%3A10-20%0A**Inline%20assertions%20bypass%20subtests**%0A%0AThe%20new%20test%20embeds%20each%20case%20as%20a%20sequential%20assertion%20rather%20than%20the%20repository-required%20table-driven%20subtests%2C%20making%20individual%20cases%20harder%20to%20identify%2C%20select%2C%20and%20extend.%0A%0A%60%60%60suggestion%0Afunc%20TestApplyCPUAffinityLimitInternal%28t%20*testing.T%29%20%7B%0A%09affinity%20%3A%3D%20runtime.NumCPU%28%29%0A%09tests%20%3A%3D%20%5B%5Dstruct%20%7B%0A%09%09name%20%20%20%20%20string%0A%09%09cpuCount%20int%0A%09%09want%20%20%20%20%20int%0A%09%7D%7B%0A%09%09%7B%0A%09%09%09name%3A%20%20%20%20%20%22caps%20host-wide%20count%20at%20affinity%20mask%20size%22%2C%0A%09%09%09cpuCount%3A%20affinity%20%2B%208%2C%0A%09%09%09want%3A%20%20%20%20%20affinity%2C%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%20%20%20%20%22uses%20affinity%20mask%20size%20for%20an%20unknown%20count%22%2C%0A%09%09%09cpuCount%3A%200%2C%0A%09%09%09want%3A%20%20%20%20%20affinity%2C%0A%09%09%7D%2C%0A%09%7D%0A%09if%20affinity%20%3E%201%20%7B%0A%09%09tests%20%3D%20append%28tests%2C%20struct%20%7B%0A%09%09%09name%20%20%20%20%20string%0A%09%09%09cpuCount%20int%0A%09%09%09want%20%20%20%20%20int%0A%09%09%7D%7B%0A%09%09%09name%3A%20%20%20%20%20%22preserves%20a%20smaller%20cgroup-derived%20count%22%2C%0A%09%09%09cpuCount%3A%201%2C%0A%09%09%09want%3A%20%20%20%20%201%2C%0A%09%09%7D%29%0A%09%7D%0A%0A%09for%20_%2C%20tt%20%3A%3D%20range%20tests%20%7B%0A%09%09t.Run%28tt.name%2C%20func%28t%20*testing.T%29%20%7B%0A%09%09%09require.Equal%28t%2C%20tt.want%2C%20applyCPUAffinityLimitInternal%28tt.cpuCount%29%29%0A%09%09%7D%29%0A%09%7D%0A%7D%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fapi%2Fws%2Fhandler_test.go%3A10-20%0A**Inline%20assertions%20bypass%20subtests**%0A%0AThe%20new%20test%20embeds%20each%20case%20as%20a%20sequential%20assertion%20rather%20than%20the%20repository-required%20table-driven%20subtests%2C%20making%20individual%20cases%20harder%20to%20identify%2C%20select%2C%20and%20extend.%0A%0A%60%60%60suggestion%0Afunc%20TestApplyCPUAffinityLimitInternal%28t%20*testing.T%29%20%7B%0A%09affinity%20%3A%3D%20runtime.NumCPU%28%29%0A%09tests%20%3A%3D%20%5B%5Dstruct%20%7B%0A%09%09name%20%20%20%20%20string%0A%09%09cpuCount%20int%0A%09%09want%20%20%20%20%20int%0A%09%7D%7B%0A%09%09%7B%0A%09%09%09name%3A%20%20%20%20%20%22caps%20host-wide%20count%20at%20affinity%20mask%20size%22%2C%0A%09%09%09cpuCount%3A%20affinity%20%2B%208%2C%0A%09%09%09want%3A%20%20%20%20%20affinity%2C%0A%09%09%7D%2C%0A%09%09%7B%0A%09%09%09name%3A%20%20%20%20%20%22uses%20affinity%20mask%20size%20for%20an%20unknown%20count%22%2C%0A%09%09%09cpuCount%3A%200%2C%0A%09%09%09want%3A%20%20%20%20%20affinity%2C%0A%09%09%7D%2C%0A%09%7D%0A%09if%20affinity%20%3E%201%20%7B%0A%09%09tests%20%3D%20append%28tests%2C%20struct%20%7B%0A%09%09%09name%20%20%20%20%20string%0A%09%09%09cpuCount%20int%0A%09%09%09want%20%20%20%20%20int%0A%09%09%7D%7B%0A%09%09%09name%3A%20%20%20%20%20%22preserves%20a%20smaller%20cgroup-derived%20count%22%2C%0A%09%09%09cpuCount%3A%201%2C%0A%09%09%09want%3A%20%20%20%20%201%2C%0A%09%09%7D%29%0A%09%7D%0A%0A%09for%20_%2C%20tt%20%3A%3D%20range%20tests%20%7B%0A%09%09t.Run%28tt.name%2C%20func%28t%20*testing.T%29%20%7B%0A%09%09%09require.Equal%28t%2C%20tt.want%2C%20applyCPUAffinityLimitInternal%28tt.cpuCount%29%29%0A%09%09%7D%29%0A%09%7D%0A%7D%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/api/ws/handler_test.go:10-20
**Inline assertions bypass subtests**

The new test embeds each case as a sequential assertion rather than the repository-required table-driven subtests, making individual cases harder to identify, select, and extend.

```suggestion
func TestApplyCPUAffinityLimitInternal(t *testing.T) {
	affinity := runtime.NumCPU()
	tests := []struct {
		name     string
		cpuCount int
		want     int
	}{
		{
			name:     "caps host-wide count at affinity mask size",
			cpuCount: affinity + 8,
			want:     affinity,
		},
		{
			name:     "uses affinity mask size for an unknown count",
			cpuCount: 0,
			want:     affinity,
		},
	}
	if affinity > 1 {
		tests = append(tests, struct {
			name     string
			cpuCount int
			want     int
		}{
			name:     "preserves a smaller cgroup-derived count",
			cpuCount: 1,
			want:     1,
		})
	}

	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			require.Equal(t, tt.want, applyCPUAffinityLimitInternal(tt.cpuCount))
		})
	}
}
```

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: report CPU count from scheduler aff..."](https://github.com/getarcaneapp/arcane/commit/f97db163d445e98dad4d4898f46adba088f7f3c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51640886)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Backend API Server](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/backend-api-server.md)

<!-- /greptile_comment -->