### PR TITLE
fix: surface container shell websocket close codes for disconnect diagnostics

### DIFF
--- a/frontend/src/lib/components/terminal/terminal.svelte
+++ b/frontend/src/lib/components/terminal/terminal.svelte
@@ -146,9 +146,13 @@
 			}
 		};
 
-		ws.onclose = () => {
+		ws.onclose = (event) => {
 			if (!isReconnecting && terminal) {
-				terminal.writeln(`\r\n\x1b[33m${m.terminal_connection_closed()}\x1b[0m`);
+				// Surface the close code so reports of unexpected disconnects
+				// carry the reason (server 1000/1006, proxy 1001, ...) — see #3536.
+				console.warn('Terminal websocket closed', { code: event.code, reason: event.reason, wasClean: event.wasClean });
+				const detail = event.reason ? `${event.code}: ${event.reason}` : `${event.code}`;
+				terminal.writeln(`\r\n\x1b[33m${m.terminal_connection_closed()} (${detail})\x1b[0m`);
 				onDisconnected?.();
 			}
 		};


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds WebSocket close codes, reasons, and clean-close status to container-shell disconnect diagnostics.
- Logs structured close details to the browser console.
- Displays the close code and optional reason in the terminal.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The close handler preserves existing disconnect behavior while adding diagnostic output, and the investigated terminal WebSocket paths do not expose a concrete harmful close-reason source.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface container shell websocket c..."](https://github.com/getarcaneapp/arcane/commit/09ac4abc683e33a64357d6560b8ce6b492f72e75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51642928)</sub>

**Context used:**

- Knowledge Base — [Frontend application (SvelteKit)](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/frontend-app.md)

<!-- /greptile_comment -->