### PR TITLE
perf(build): omit the output column from the build history list query

### DIFF
--- a/backend/internal/build/service.go
+++ b/backend/internal/build/service.go
@@ -405,7 +405,9 @@ func (s *BuildService) ListImageBuildsByEnvironmentPaginated(ctx context.Context
 	}
 
 	var builds []models.ImageBuild
-	q := s.db.WithContext(ctx).Model(&models.ImageBuild{}).Where("environment_id = ?", environmentID)
+	// The list DTO never includes the build output (buildToRecord with
+	// includeOutput=false), so skip reading the up-to-2-MiB output column.
+	q := s.db.WithContext(ctx).Model(&models.ImageBuild{}).Omit("output").Where("environment_id = ?", environmentID)
 
 	if term := strings.TrimSpace(params.Search); term != "" {
 		searchPattern := "%" + term + "%"

--- a/backend/internal/build/service_test.go
+++ b/backend/internal/build/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/gitrepo"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/models"
 	buildgit "github.com/getarcaneapp/arcane/backend/v2/pkg/gitutil"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -436,6 +437,34 @@ func (b testBuildRecorder) BuildImage(_ context.Context, req buildtypes.BuildReq
 		return nil, b.err
 	}
 	return &buildtypes.BuildResult{Provider: "local"}, nil
+}
+
+func TestBuildService_ListImageBuilds_OmitsOutputColumn(t *testing.T) {
+	db, err := setupBuildHistoryTestDB()
+	require.NoError(t, err)
+	svc := &BuildService{db: db}
+
+	output := "large build output"
+	require.NoError(t, db.WithContext(context.Background()).Create(&models.ImageBuild{
+		BaseModel:     models.BaseModel{ID: "build-omit-output"},
+		EnvironmentID: "0",
+		Status:        models.ImageBuildStatusSuccess,
+		ContextDir:    "/ctx",
+		Output:        &output,
+	}).Error)
+
+	records, _, err := svc.ListImageBuildsByEnvironmentPaginated(context.Background(), "0", pagination.QueryParams{
+		Params: pagination.Params{Limit: 10},
+	})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Nil(t, records[0].Output)
+
+	// The detail endpoint must still return the stored output.
+	detail, err := svc.GetImageBuildByID(context.Background(), "0", "build-omit-output")
+	require.NoError(t, err)
+	require.NotNil(t, detail.Output)
+	assert.Equal(t, output, *detail.Output)
 }
 
 func setupBuildHistoryTestDB() (*database.DB, error) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR improves build-history list performance by excluding the potentially large output column while preserving output retrieval through the detail endpoint.

- Adds `Omit("output")` to the paginated build-history query.
- Adds coverage confirming list records omit output and detail records retain it.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-structure issue.

The query optimization preserves the existing list response and leaves detail output retrieval intact; the sole accepted concern is that the added test does not follow the repository’s table-driven testing requirement.

**Files Needing Attention:** backend/internal/build/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-12-perf_build_omit_the_output_column_from_the_build_history_list_query%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-12-perf_build_omit_the_output_column_from_the_build_history_list_query%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fbuild%2Fservice_test.go%3A442%0A**Use%20table-driven%20test%20structure**%0A%0AThis%20new%20procedural%20test%20does%20not%20follow%20the%20repository%20requirement%20that%20Go%20tests%20use%20case%20tables%20and%20subtests%2C%20making%20additional%20build-history%20query%20scenarios%20less%20consistent%20to%20extend.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3604&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fbuild%2Fservice_test.go%3A442%0A**Use%20table-driven%20test%20structure**%0A%0AThis%20new%20procedural%20test%20does%20not%20follow%20the%20repository%20requirement%20that%20Go%20tests%20use%20case%20tables%20and%20subtests%2C%20making%20additional%20build-history%20query%20scenarios%20less%20consistent%20to%20extend.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3604&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/build/service_test.go:442
**Use table-driven test structure**

This new procedural test does not follow the repository requirement that Go tests use case tables and subtests, making additional build-history query scenarios less consistent to extend.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(build): omit the output column from..."](https://github.com/getarcaneapp/arcane/commit/00a99982bae976a51fdc9a74b4872966bc68320d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52422865)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Projects, Builds, and Templates](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/projects-builds-templates.md)

<!-- /greptile_comment -->