### PR TITLE
perf: filter unhealthy containers at the daemon in auto-heal

### DIFF
--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -210,6 +210,9 @@ func (j *AutoHealJob) processCandidateInternal(
 	containerID := candidate.ID
 	containerName := dockerutil.ContainerNameFromNames(candidate.Names)
 
+	// The daemon-side health filter already selected unhealthy containers; the
+	// inspect re-confirms right before restarting so a container that recovered
+	// (or was restarted by someone else) since the list isn't bounced again.
 	inspect, err := j.inspectContainerInternal(ctx, dockerClient, containerID)
 	if err != nil {
 		slog.WarnContext(ctx, "auto-heal failed to inspect container", "container", containerName, "error", err)
@@ -422,12 +425,21 @@ func (j *AutoHealJob) getDockerClientInternal(ctx context.Context) (*client.Clie
 	return j.dockerClientService.GetClient(ctx)
 }
 
+// autoHealListOptionsInternal filters unhealthy containers at the daemon, so
+// the common all-healthy case returns an empty list and nothing is inspected.
+func autoHealListOptionsInternal() client.ContainerListOptions {
+	return client.ContainerListOptions{
+		All:     false,
+		Filters: make(client.Filters).Add("health", string(container.Unhealthy)),
+	}
+}
+
 func (j *AutoHealJob) ListContainers(ctx context.Context, dockerClient *client.Client) ([]container.Summary, error) {
 	if j.listContainers != nil {
 		return j.listContainers(ctx, dockerClient)
 	}
 
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
+	containerList, err := dockerClient.ContainerList(ctx, autoHealListOptionsInternal())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/scheduler/auto_heal_job_test.go
+++ b/backend/pkg/scheduler/auto_heal_job_test.go
@@ -21,6 +21,12 @@ func newTestAutoHealJob() *AutoHealJob {
 	}
 }
 
+func TestAutoHeal_ListOptionsFilterUnhealthyAtDaemon(t *testing.T) {
+	opts := autoHealListOptionsInternal()
+	require.False(t, opts.All)
+	require.Equal(t, make(client.Filters).Add("health", string(container.Unhealthy)), opts.Filters)
+}
+
 func TestAutoHeal_FilterCandidates_SkipsSelfContainer(t *testing.T) {
 	job := newTestAutoHealJob()
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves initial unhealthy-container filtering into the Docker daemon while retaining the pre-restart inspection that prevents restarting containers that have recovered.
- Adds a reusable container-list option with `health=unhealthy`.
- Uses the filtered list in the auto-heal job.
- Adds focused coverage for the generated Docker list options.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-structure issue.

The daemon-side filter uses the supported Docker health-filter contract, preserves the existing running-container scope, and leaves the final inspect-based health check intact; only the repository-required test organization needs adjustment.

**Files Needing Attention:** backend/pkg/scheduler/auto_heal_job_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-12-perf_filter_unhealthy_containers_at_the_daemon_in_auto-heal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-12-perf_filter_unhealthy_containers_at_the_daemon_in_auto-heal%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fscheduler%2Fauto_heal_job_test.go%3A24-28%0A**Use%20table-driven%20option%20coverage**%0A%0AThe%20new%20test%20directly%20asserts%20one%20case%20without%20the%20repository-required%20table%20and%20subtest%20structure%2C%20so%20adding%20further%20list-option%20scenarios%20requires%20restructuring%20it%20instead%20of%20extending%20a%20consistent%20case%20table.%0A%0A%60%60%60suggestion%0Afunc%20TestAutoHeal_ListOptionsFilterUnhealthyAtDaemon%28t%20*testing.T%29%20%7B%0A%09tests%20%3A%3D%20%5B%5Dstruct%20%7B%0A%09%09name%20string%0A%09%09want%20client.ContainerListOptions%0A%09%7D%7B%0A%09%09%7B%0A%09%09%09name%3A%20%22filters%20unhealthy%20running%20containers%22%2C%0A%09%09%09want%3A%20client.ContainerListOptions%7B%0A%09%09%09%09All%3A%20%20%20%20%20false%2C%0A%09%09%09%09Filters%3A%20make%28client.Filters%29.Add%28%22health%22%2C%20string%28container.Unhealthy%29%29%2C%0A%09%09%09%7D%2C%0A%09%09%7D%2C%0A%09%7D%0A%0A%09for%20_%2C%20tt%20%3A%3D%20range%20tests%20%7B%0A%09%09t.Run%28tt.name%2C%20func%28t%20*testing.T%29%20%7B%0A%09%09%09require.Equal%28t%2C%20tt.want%2C%20autoHealListOptionsInternal%28%29%29%0A%09%09%7D%29%0A%09%7D%0A%7D%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fscheduler%2Fauto_heal_job_test.go%3A24-28%0A**Use%20table-driven%20option%20coverage**%0A%0AThe%20new%20test%20directly%20asserts%20one%20case%20without%20the%20repository-required%20table%20and%20subtest%20structure%2C%20so%20adding%20further%20list-option%20scenarios%20requires%20restructuring%20it%20instead%20of%20extending%20a%20consistent%20case%20table.%0A%0A%60%60%60suggestion%0Afunc%20TestAutoHeal_ListOptionsFilterUnhealthyAtDaemon%28t%20*testing.T%29%20%7B%0A%09tests%20%3A%3D%20%5B%5Dstruct%20%7B%0A%09%09name%20string%0A%09%09want%20client.ContainerListOptions%0A%09%7D%7B%0A%09%09%7B%0A%09%09%09name%3A%20%22filters%20unhealthy%20running%20containers%22%2C%0A%09%09%09want%3A%20client.ContainerListOptions%7B%0A%09%09%09%09All%3A%20%20%20%20%20false%2C%0A%09%09%09%09Filters%3A%20make%28client.Filters%29.Add%28%22health%22%2C%20string%28container.Unhealthy%29%29%2C%0A%09%09%09%7D%2C%0A%09%09%7D%2C%0A%09%7D%0A%0A%09for%20_%2C%20tt%20%3A%3D%20range%20tests%20%7B%0A%09%09t.Run%28tt.name%2C%20func%28t%20*testing.T%29%20%7B%0A%09%09%09require.Equal%28t%2C%20tt.want%2C%20autoHealListOptionsInternal%28%29%29%0A%09%09%7D%29%0A%09%7D%0A%7D%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3605&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/scheduler/auto_heal_job_test.go:24-28
**Use table-driven option coverage**

The new test directly asserts one case without the repository-required table and subtest structure, so adding further list-option scenarios requires restructuring it instead of extending a consistent case table.

```suggestion
func TestAutoHeal_ListOptionsFilterUnhealthyAtDaemon(t *testing.T) {
	tests := []struct {
		name string
		want client.ContainerListOptions
	}{
		{
			name: "filters unhealthy running containers",
			want: client.ContainerListOptions{
				All:     false,
				Filters: make(client.Filters).Add("health", string(container.Unhealthy)),
			},
		},
	}

	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			require.Equal(t, tt.want, autoHealListOptionsInternal())
		})
	}
}
```

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: filter unhealthy containers at the..."](https://github.com/getarcaneapp/arcane/commit/4748d4872d4374caacb7a7e1f16473a92262c4c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52423705)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->