### PR TITLE
perf: stop building a new Docker CLI per compose call

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -411,7 +411,12 @@ _deps-install-frontend:
 [group('deps')]
 _deps-install-tests:
     pnpm -C tests install
-    pnpm -C tests exec playwright install --with-deps chromium
+    # --with-deps shells out to apt-get, so skip it on non-Debian systems
+    if command -v apt-get >/dev/null 2>&1; then \
+        pnpm -C tests exec playwright install --with-deps chromium; \
+    else \
+        pnpm -C tests exec playwright install chromium; \
+    fi
 
 # Install backend Go dependencies
 [group('deps')]

--- a/backend/internal/container/service.go
+++ b/backend/internal/container/service.go
@@ -532,7 +532,7 @@ func (s *ContainerService) tryRedeployViaComposeProjectInternal(ctx context.Cont
 // linger during recreation), the first running one is preferred; otherwise the
 // first match is returned. Returns "" when none found.
 func (s *ContainerService) findComposeServiceContainerIDInternal(ctx context.Context, projectName, serviceName string) string {
-	containers, err := projects.ComposePs(ctx, &composetypes.Project{Name: projectName}, []string{serviceName}, true)
+	containers, err := projects.ComposePs(ctx, s.dockerService.DockerHost(), &composetypes.Project{Name: projectName}, []string{serviceName}, true)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to resolve container via compose ps after redeploy",
 			"project", projectName,

--- a/backend/internal/project/project_details.go
+++ b/backend/internal/project/project_details.go
@@ -108,7 +108,7 @@ func (s *ProjectService) GetProjectServices(ctx context.Context, projectID strin
 		slog.WarnContext(ctx, "failed to parse Arcane compose metadata", "path", composeFileFullPath, "error", metaErr)
 	}
 
-	containers, err := projects.ComposePs(ctx, composeProject, nil, true)
+	containers, err := projects.ComposePs(ctx, s.dockerService.DockerHost(), composeProject, nil, true)
 	if err != nil {
 		slog.Error("compose ps error", "projectName", composeProject.Name, "error", err)
 		return nil, errors.WrapIf(err, "failed to get compose services status")

--- a/backend/internal/project/project_lifecycle.go
+++ b/backend/internal/project/project_lifecycle.go
@@ -569,7 +569,7 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 		return err
 	}
 
-	disabled := projectRedeployDisabledInternal(ctx, *proj)
+	disabled := s.projectRedeployDisabledInternal(ctx, *proj)
 	if disabled {
 		return errors.New("arcane cannot redeploy itself; use the system upgrade flow (Settings -> Updates) instead")
 	}
@@ -593,8 +593,8 @@ func (s *ProjectService) RedeployProject(ctx context.Context, projectID string, 
 	return s.DeployProject(ctx, projectID, user, options)
 }
 
-func projectRedeployDisabledInternal(ctx context.Context, proj models.Project) bool {
-	containers, err := projects.ListGlobalComposeContainers(ctx)
+func (s *ProjectService) projectRedeployDisabledInternal(ctx context.Context, proj models.Project) bool {
+	containers, err := s.listGlobalComposeContainersInternal(ctx)
 	if err != nil {
 		slog.WarnContext(ctx, "could not list compose containers to check self-redeploy guard; skipping guard", "error", err)
 		return false

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -20,11 +20,27 @@ import (
 	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/getarcaneapp/arcane/types/v2/project"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/samber/mo"
 	"go.getarcane.app/sys/cgroup"
 	"go.getarcane.app/updater/labels"
 	"gorm.io/gorm"
 )
+
+// listGlobalComposeContainersInternal routes the global compose-container
+// list through the shared Docker client singleton when one is wired, avoiding
+// a fresh docker CLI per call.
+func (s *ProjectService) listGlobalComposeContainersInternal(ctx context.Context) ([]container.Summary, error) {
+	var dockerClient client.APIClient
+	if s.dockerService != nil {
+		cli, err := s.dockerService.GetClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		dockerClient = cli
+	}
+	return projects.ListGlobalComposeContainers(ctx, dockerClient, s.dockerService.DockerHost())
+}
 
 func groupComposeContainersByProjectInternal(containers []container.Summary) map[string][]container.Summary {
 	containersByProject := make(map[string][]container.Summary)
@@ -120,7 +136,7 @@ func (s *ProjectService) GetProjectStatusCounts(ctx context.Context) (folderCoun
 	}
 
 	// 1. Fetch all compose containers
-	containers, err := projects.ListGlobalComposeContainers(ctx)
+	containers, err := s.listGlobalComposeContainersInternal(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to list global compose containers for counts", "error", err)
 		// Fallback to DB status
@@ -315,7 +331,7 @@ func (s *ProjectService) appendDiscoveredComposeProjectUpdatesInternal(
 		return items
 	}
 
-	composeContainers, err := projects.ListGlobalComposeContainers(ctx)
+	composeContainers, err := s.listGlobalComposeContainersInternal(ctx)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to list compose containers for project update rows", "error", err)
 		return items
@@ -725,7 +741,7 @@ func (s *ProjectService) CountProjectsWithPendingUpdates(ctx context.Context, al
 func (s *ProjectService) countDiscoveredComposeProjectUpdatesInternal(ctx context.Context, projectsArray []models.Project, allContainers []container.Summary) int {
 	if allContainers == nil {
 		var err error
-		allContainers, err = projects.ListGlobalComposeContainers(ctx)
+		allContainers, err = s.listGlobalComposeContainersInternal(ctx)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to list compose containers for project update count", "error", err)
 			return 0
@@ -763,7 +779,7 @@ func (s *ProjectService) fetchProjectStatusConcurrently(ctx context.Context, pro
 	}
 
 	// 1. Fetch all compose containers in one go
-	containers, err := projects.ListGlobalComposeContainers(ctx)
+	containers, err := s.listGlobalComposeContainersInternal(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to list global compose containers", "error", err)
 		// Fallback: return basic info with unknown status

--- a/backend/internal/updater/service.go
+++ b/backend/internal/updater/service.go
@@ -1241,7 +1241,15 @@ func (s *UpdaterService) collectUsedImagesFromProjectsInternal(ctx context.Conte
 		return nil
 	}
 
-	composeContainers, err := projectspkg.ListGlobalComposeContainers(ctx)
+	var dockerClient client.APIClient
+	if s.deps.Docker != nil {
+		cli, cliErr := s.deps.Docker.GetClient(ctx)
+		if cliErr != nil {
+			return cliErr
+		}
+		dockerClient = cli
+	}
+	composeContainers, err := projectspkg.ListGlobalComposeContainers(ctx, dockerClient, s.deps.Docker.DockerHost())
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/projects/cmds.go
+++ b/backend/pkg/projects/cmds.go
@@ -39,7 +39,7 @@ func ComposeRestart(ctx context.Context, proj *types.Project, services []string)
 	restartCtx, cancel := detachFromHTTPContextInternal(ctx, defaultComposeTimeout)
 	defer cancel()
 
-	c, err := NewClient(restartCtx, nil, nil)
+	c, err := NewClient(restartCtx, "", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func ComposeStop(ctx context.Context, proj *types.Project, services []string) er
 	stopCtx, cancel := detachFromHTTPContextInternal(ctx, defaultComposeTimeout)
 	defer cancel()
 
-	c, err := NewClient(stopCtx, nil, nil)
+	c, err := NewClient(stopCtx, "", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func ComposeUp(ctx context.Context, proj *types.Project, services []string, remo
 		prompt = compose.AlwaysOkPrompt()
 	}
 
-	c, err := NewClient(composeCtx, authConfigs, prompt)
+	c, err := NewClient(composeCtx, "", authConfigs, prompt)
 	if err != nil {
 		return err
 	}
@@ -123,12 +123,17 @@ func composeUpOptions(proj *types.Project, services []string, removeOrphans bool
 	return upOptions, startOptions
 }
 
-func ComposePs(ctx context.Context, proj *types.Project, services []string, all bool) ([]api.ContainerSummary, error) {
-	c, err := NewClient(ctx, nil, nil)
+// ComposePs lists a project's compose containers. dockerHost is the
+// config-resolved docker host used to reuse the shared read-only compose
+// client; empty falls back to a one-shot environment-resolved client.
+func ComposePs(ctx context.Context, dockerHost string, proj *types.Project, services []string, all bool) ([]api.ContainerSummary, error) {
+	c, shared, err := plainComposeClientInternal(ctx, dockerHost)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = c.Close() }()
+	if !shared {
+		defer func() { _ = c.Close() }()
+	}
 
 	return c.svc.Ps(ctx, proj.Name, api.PsOptions{All: all, Services: services})
 }
@@ -137,7 +142,7 @@ func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) e
 	downCtx, cancel := detachFromHTTPContextInternal(ctx, defaultComposeTimeout)
 	defer cancel()
 
-	c, err := NewClient(downCtx, nil, nil)
+	c, err := NewClient(downCtx, "", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -147,7 +152,7 @@ func ComposeDown(ctx context.Context, proj *types.Project, removeVolumes bool) e
 }
 
 func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow bool, tail, since string, timestamps bool) error {
-	c, err := NewClient(ctx, nil, nil)
+	c, err := NewClient(ctx, "", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -156,14 +161,24 @@ func ComposeLogs(ctx context.Context, projectName string, out io.Writer, follow 
 	return c.svc.Logs(ctx, projectName, writerConsumer{out: out}, api.LogOptions{Follow: follow, Tail: tail, Since: since, Timestamps: timestamps})
 }
 
-func ListGlobalComposeContainers(ctx context.Context) ([]container.Summary, error) {
-	c, err := NewClient(ctx, nil, nil)
-	if err != nil {
-		return nil, err
+// ListGlobalComposeContainers lists every container carrying a compose
+// project label. This is a plain ContainerList — no compose service is
+// needed — so dockerClient should be the process-wide Docker client
+// singleton. When nil (callers wired without one, e.g. tests), a compose
+// client for the config-resolved dockerHost is used instead.
+func ListGlobalComposeContainers(ctx context.Context, dockerClient client.APIClient, dockerHost string) ([]container.Summary, error) {
+	cli := dockerClient
+	if cli == nil {
+		c, shared, err := plainComposeClientInternal(ctx, dockerHost)
+		if err != nil {
+			return nil, err
+		}
+		if !shared {
+			defer func() { _ = c.Close() }()
+		}
+		cli = c.dockerCli.Client()
 	}
-	defer func() { _ = c.Close() }()
 
-	cli := c.dockerCli.Client()
 	filter := make(client.Filters)
 	filter = filter.Add("label", "com.docker.compose.project")
 

--- a/backend/pkg/projects/cmds_test.go
+++ b/backend/pkg/projects/cmds_test.go
@@ -2,12 +2,17 @@ package projects
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,4 +120,31 @@ func TestComposeUpOptions_RemoveOrphans(t *testing.T) {
 		require.False(t, upOptions.RemoveOrphans)
 		require.Equal(t, api.RecreateForce, upOptions.Recreate)
 	})
+}
+
+func TestListGlobalComposeContainersUsesProvidedClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/containers/json") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"Id":"abc123","Labels":{"com.docker.compose.project":"demo"}}]`)
+	}))
+	t.Cleanup(server.Close)
+
+	apiClient, err := client.New(
+		client.WithHost(server.URL),
+		client.WithAPIVersion("1.41"),
+		client.WithHTTPClient(server.Client()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = apiClient.Close() })
+
+	// The bogus dockerHost proves the provided client wins over the
+	// fallback host.
+	containers, err := ListGlobalComposeContainers(context.Background(), apiClient, "tcp://unused.example.com:2375")
+	require.NoError(t, err)
+	require.Len(t, containers, 1)
+	require.Equal(t, "abc123", containers[0].ID)
 }

--- a/backend/pkg/projects/compose.go
+++ b/backend/pkg/projects/compose.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"strings"
+	"sync/atomic"
 
 	"github.com/docker/cli/cli/command"
 	clitypes "github.com/docker/cli/cli/config/types"
@@ -26,12 +27,18 @@ type Client struct {
 	logWriter io.WriteCloser
 }
 
-func NewClient(ctx context.Context, authConfigs map[string]registry.AuthConfig, prompt compose.Prompt) (*Client, error) {
+// NewClient builds a compose client. dockerHost, when non-empty, pins the
+// docker CLI to that daemon endpoint instead of letting it resolve one from
+// the environment.
+func NewClient(ctx context.Context, dockerHost string, authConfigs map[string]registry.AuthConfig, prompt compose.Prompt) (*Client, error) {
 	cli, err := command.NewDockerCli()
 	if err != nil {
 		return nil, err
 	}
 	opts := flags.NewClientOptions()
+	if dockerHost != "" {
+		opts.Hosts = []string{dockerHost}
+	}
 	if err := cli.Initialize(opts); err != nil {
 		return nil, err
 	}
@@ -86,6 +93,35 @@ func NewClient(ctx context.Context, authConfigs map[string]registry.AuthConfig, 
 	}
 
 	return &Client{svc: svc, dockerCli: composeCLI, logWriter: logWriter}, nil
+}
+
+type plainComposeClientEntryInternal struct {
+	dockerHost string
+	client     *Client
+}
+
+var plainComposeClient atomic.Pointer[plainComposeClientEntryInternal]
+
+func plainComposeClientInternal(ctx context.Context, dockerHost string) (*Client, bool, error) {
+	if dockerHost == "" {
+		c, err := NewClient(ctx, "", nil, nil)
+		return c, false, err
+	}
+
+	if entry := plainComposeClient.Load(); entry != nil && entry.dockerHost == dockerHost {
+		return entry.client, true, nil
+	}
+
+	// Built on context.Background so request-scoped values (progress
+	// writers, deadlines) do not leak into the long-lived client.
+	c, err := NewClient(context.Background(), dockerHost, nil, nil) //nolint:contextcheck // deliberate: see comment above
+	if err != nil {
+		return nil, false, err
+	}
+	// Concurrent first calls may race and briefly duplicate a client; the
+	// last store wins and later calls converge on it.
+	plainComposeClient.Store(&plainComposeClientEntryInternal{dockerHost: dockerHost, client: c})
+	return c, true, nil
 }
 
 func buildComposeAuthConfigsInternal(authConfigs map[string]registry.AuthConfig) map[string]clitypes.AuthConfig {

--- a/backend/pkg/projects/compose_test.go
+++ b/backend/pkg/projects/compose_test.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -29,6 +30,30 @@ func TestWrapDockerCLIWithInspectCompatibility(t *testing.T) {
 	require.NotNil(t, wrapped)
 	require.NotSame(t, baseCLI, wrapped)
 	require.NotEqual(t, reflect.TypeFor[*mobyclient.Client](), reflect.TypeOf(wrapped.Client()))
+}
+
+func TestPlainComposeClientCachedPerDockerHost(t *testing.T) {
+	ctx := context.Background()
+
+	first, shared, err := plainComposeClientInternal(ctx, "tcp://first.example.com:2375")
+	require.NoError(t, err)
+	require.True(t, shared)
+
+	again, shared, err := plainComposeClientInternal(ctx, "tcp://first.example.com:2375")
+	require.NoError(t, err)
+	require.True(t, shared)
+	require.Same(t, first, again)
+
+	other, shared, err := plainComposeClientInternal(ctx, "tcp://second.example.com:2375")
+	require.NoError(t, err)
+	require.True(t, shared)
+	require.NotSame(t, first, other)
+
+	// No configured host: a one-shot client the caller owns and closes.
+	oneShot, shared, err := plainComposeClientInternal(ctx, "")
+	require.NoError(t, err)
+	require.False(t, shared)
+	require.NoError(t, oneShot.Close())
 }
 
 func TestBuildComposeAuthConfigs(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reuses shared Docker and Compose clients for read-only compose queries instead of constructing a new Docker CLI for each call.
- Threads the configured Docker host and shared API client through project, container, and updater compose-listing paths.
- Adds a host-keyed cached Compose client and tests client selection and caching.
- Makes Playwright dependency installation portable to systems without apt-get.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking test error-handling issue.

The shared-client paths preserve fallback behavior and no reachable runtime regression was established; only the new HTTP fixture silently discards a write error.

**Files Needing Attention:** backend/pkg/projects/cmds_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-11-perf_stop_building_a_new_docker_cli_per_compose_call%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-11-perf_stop_building_a_new_docker_cli_per_compose_call%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fcmds_test.go%3A132%0A**Handle%20fixture%20response%20errors**%0A%0AThe%20new%20HTTP%20fixture%20discards%20the%20error%20from%20%60io.WriteString%60%2C%20detaching%20a%20failed%20or%20truncated%20response%20from%20its%20cause%20and%20producing%20misleading%20downstream%20test%20failures.%0A%0A%60%60%60suggestion%0A%09%09_%2C%20err%20%3A%3D%20io.WriteString%28w%2C%20%60%5B%7B%22Id%22%3A%22abc123%22%2C%22Labels%22%3A%7B%22com.docker.compose.project%22%3A%22demo%22%7D%7D%5D%60%29%0A%09%09require.NoError%28t%2C%20err%29%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fcmds_test.go%3A132%0A**Handle%20fixture%20response%20errors**%0A%0AThe%20new%20HTTP%20fixture%20discards%20the%20error%20from%20%60io.WriteString%60%2C%20detaching%20a%20failed%20or%20truncated%20response%20from%20its%20cause%20and%20producing%20misleading%20downstream%20test%20failures.%0A%0A%60%60%60suggestion%0A%09%09_%2C%20err%20%3A%3D%20io.WriteString%28w%2C%20%60%5B%7B%22Id%22%3A%22abc123%22%2C%22Labels%22%3A%7B%22com.docker.compose.project%22%3A%22demo%22%7D%7D%5D%60%29%0A%09%09require.NoError%28t%2C%20err%29%0A%60%60%60%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/projects/cmds_test.go:132
**Handle fixture response errors**

The new HTTP fixture discards the error from `io.WriteString`, detaching a failed or truncated response from its cause and producing misleading downstream test failures.

```suggestion
		_, err := io.WriteString(w, `[{"Id":"abc123","Labels":{"com.docker.compose.project":"demo"}}]`)
		require.NoError(t, err)
```

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: stop building a new Docker CLI per..."](https://github.com/getarcaneapp/arcane/commit/4962f3f4fd6baa9b7d7702af9c362ae01b08a7c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52453741)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)
- Knowledge Base — [Projects, Builds, and Templates](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/projects-builds-templates.md)
- Knowledge Base — [Docker Build and Deploy](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/docker-build-deploy.md)
</details>

<!-- /greptile_comment -->