### PR TITLE
fix: stop loading every scan blob to serve one list page

### DIFF
--- a/backend/internal/vulnerability/service_test.go
+++ b/backend/internal/vulnerability/service_test.go
@@ -222,17 +222,6 @@ func TestApplyListAllVulnerabilityRecordPrefiltersInternal_NoPossibleMatches(t *
 	require.True(t, ok)
 }
 
-func TestEstimatedVulnerabilityRecordCountInternal(t *testing.T) {
-	records := []models.VulnerabilityScanRecord{
-		{TotalCount: 5},
-		{TotalCount: 0},
-		{TotalCount: -3},
-		{TotalCount: 12},
-	}
-
-	require.Equal(t, 17, estimatedVulnerabilityRecordCountInternal(records))
-}
-
 func TestVulnerabilityService_ListAllVulnerabilities_FiltersIgnoredInline(t *testing.T) {
 	ctx := context.Background()
 	db := setupVulnerabilityScanTestDB(t)
@@ -386,4 +375,69 @@ func TestVulnerabilityService_ActionableCountExcludingIgnored(t *testing.T) {
 	count, err = svc.ActionableCountExcludingIgnored(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 4, count)
+}
+
+// TestVulnerabilityService_ListAllVulnerabilities_PagesAndCountsWithInlineFilters
+// verifies the batched decode path preserves the old in-memory pipeline's
+// pagination semantics: TotalItems reflects the search/filter matches,
+// GrandTotalItems reflects every non-ignored CVE, and the page is sliced
+// from the sorted matches.
+func TestVulnerabilityService_ListAllVulnerabilities_PagesAndCountsWithInlineFilters(t *testing.T) {
+	ctx := context.Background()
+	db := setupVulnerabilityScanTestDB(t)
+	svc := &VulnerabilityService{db: db}
+
+	vulnsA := []vulnerability.Vulnerability{
+		{VulnerabilityID: "CVE-A1", PkgName: "openssl", InstalledVersion: "1.0.0", Severity: vulnerability.SeverityCritical},
+		{VulnerabilityID: "CVE-A2", PkgName: "zlib", InstalledVersion: "1.2.0", Severity: vulnerability.SeverityLow},
+	}
+	rawVulnsA, err := json.Marshal(vulnsA)
+	require.NoError(t, err)
+
+	vulnsB := []vulnerability.Vulnerability{
+		{VulnerabilityID: "CVE-B1", PkgName: "glibc", InstalledVersion: "2.38", Severity: vulnerability.SeverityHigh},
+		{VulnerabilityID: "CVE-B2", PkgName: "less", InstalledVersion: "600", Severity: vulnerability.SeverityMedium},
+	}
+	rawVulnsB, err := json.Marshal(vulnsB)
+	require.NoError(t, err)
+
+	now := time.Now()
+	records := []models.VulnerabilityScanRecord{
+		{ID: "sha256:img-a", ImageName: "nginx:latest", Status: models.ScanStatusCompleted, ScanTime: now, CriticalCount: 1, LowCount: 1, TotalCount: 2, Vulnerabilities: models.StringSlice{string(rawVulnsA)}},
+		{ID: "sha256:img-b", ImageName: "redis:7", Status: models.ScanStatusCompleted, ScanTime: now, HighCount: 1, MediumCount: 1, TotalCount: 2, Vulnerabilities: models.StringSlice{string(rawVulnsB)}},
+	}
+	for i := range records {
+		require.NoError(t, db.Create(&records[i]).Error)
+	}
+
+	// Ignore the medium CVE on img-b: it must vanish from GrandTotalItems.
+	require.NoError(t, db.Create(&models.VulnerabilityIgnore{
+		ID: "ig-1", EnvironmentID: "env-1", ImageID: "sha256:img-b",
+		VulnerabilityID: "CVE-B2", PkgName: "less", InstalledVersion: "600", CreatedBy: "tester",
+	}).Error)
+
+	// Severity filter critical,high with page size 1, sorted by severity desc:
+	// matches are CVE-A1 (critical) and CVE-B1 (high); the first page holds
+	// the critical one.
+	items, page, err := svc.ListAllVulnerabilities(ctx, "env-1", pagination.QueryParams{
+		Params:     pagination.Params{Start: 0, Limit: 1},
+		SortParams: pagination.SortParams{Sort: "severity", Order: pagination.SortDesc},
+		Filters:    map[string]string{"severity": "critical,high"},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "CVE-A1", items[0].VulnerabilityID)
+	require.EqualValues(t, 2, page.TotalItems)
+	require.EqualValues(t, 3, page.GrandTotalItems)
+
+	// Search matches per-CVE fields decoded from the blobs.
+	items, page, err = svc.ListAllVulnerabilities(ctx, "env-1", pagination.QueryParams{
+		Params:      pagination.Params{Start: 0, Limit: 20},
+		SearchQuery: pagination.SearchQuery{Search: "glibc"},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "CVE-B1", items[0].VulnerabilityID)
+	require.EqualValues(t, 1, page.TotalItems)
+	require.EqualValues(t, 3, page.GrandTotalItems)
 }

--- a/backend/internal/vulnerability/vulnerability_query.go
+++ b/backend/internal/vulnerability/vulnerability_query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json/v2"
 	"log/slog"
-	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -321,45 +320,71 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 		return filtered.Items, response, nil
 	}
 
-	var records []models.VulnerabilityScanRecord
-	if err := recordsQuery.Find(&records).Error; err != nil {
-		return nil, pagination.Response{}, errors.WrapIf(err, "failed to list vulnerability scans")
-	}
-
 	ignoredKeys, err := s.getIgnoredVulnerabilityKeySetByEnvironmentInternal(ctx, envID)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to filter ignored vulnerabilities", "error", err)
 	}
 
-	items := make([]vulnerability.VulnerabilityWithImage, 0, estimatedVulnerabilityRecordCountInternal(records))
-	for _, record := range records {
-		if len(record.Vulnerabilities) == 0 || record.Vulnerabilities[0] == "" {
-			continue
-		}
+	config := listAllVulnerabilitiesPaginationConfigInternal()
 
-		var vulns []vulnerability.Vulnerability
-		if err := json.Unmarshal([]byte(record.Vulnerabilities[0]), &vulns); err != nil {
-			slog.WarnContext(ctx, "failed to unmarshal vulnerabilities", "error", err, "image_id", record.ID)
-			continue
-		}
-
-		for _, vulnEntry := range vulns {
-			if len(ignoredKeys) > 0 {
-				key := vulnerabilityIgnoreKeyInternal(record.ID, vulnEntry.VulnerabilityID, vulnEntry.PkgName, vulnEntry.InstalledVersion)
-				if _, isIgnored := ignoredKeys[key]; isIgnored {
-					continue
-				}
+	// Stream records in batches so at most one batch of scan blobs (up to
+	// ~2 MiB each) is held at a time, and apply the search term and filters
+	// while decoding so only matching CVEs are retained for sorting — the
+	// old path materialized every CVE of every image to serve one page.
+	var items []vulnerability.VulnerabilityWithImage
+	totalAvailable := 0
+	var batch []models.VulnerabilityScanRecord
+	err = recordsQuery.FindInBatches(&batch, listAllVulnerabilityRecordBatchSizeInternal, func(*gorm.DB, int) error {
+		for _, record := range batch {
+			if len(record.Vulnerabilities) == 0 || record.Vulnerabilities[0] == "" {
+				continue
 			}
 
-			items = append(items, vulnerability.VulnerabilityWithImage{
-				Vulnerability: vulnEntry,
-				ImageID:       record.ID,
-				ImageName:     record.ImageName,
-			})
+			var vulns []vulnerability.Vulnerability
+			if err := json.Unmarshal([]byte(record.Vulnerabilities[0]), &vulns); err != nil {
+				slog.WarnContext(ctx, "failed to unmarshal vulnerabilities", "error", err, "image_id", record.ID)
+				continue
+			}
+
+			for _, vulnEntry := range vulns {
+				if len(ignoredKeys) > 0 {
+					key := vulnerabilityIgnoreKeyInternal(record.ID, vulnEntry.VulnerabilityID, vulnEntry.PkgName, vulnEntry.InstalledVersion)
+					if _, isIgnored := ignoredKeys[key]; isIgnored {
+						continue
+					}
+				}
+
+				item := vulnerability.VulnerabilityWithImage{
+					Vulnerability: vulnEntry,
+					ImageID:       record.ID,
+					ImageName:     record.ImageName,
+				}
+				totalAvailable++
+				if pagination.MatchesSearchAndFilters(item, params, config) {
+					items = append(items, item)
+				}
+			}
 		}
+		return nil
+	}).Error
+	if err != nil {
+		return nil, pagination.Response{}, errors.WrapIf(err, "failed to list vulnerability scans")
 	}
 
-	config := pagination.Config[vulnerability.VulnerabilityWithImage]{
+	// Search and filters were already applied during decode; only sorting
+	// and page slicing remain.
+	page := pagination.OrderAndPaginate(items, params, config)
+	response := pagination.BuildResponse(int64(len(items)), int64(totalAvailable), params)
+
+	return page, response, nil
+}
+
+// listAllVulnerabilityRecordBatchSizeInternal bounds how many scan records
+// (each carrying a vulnerability blob of up to ~2 MiB) are loaded at once.
+const listAllVulnerabilityRecordBatchSizeInternal = 25
+
+func listAllVulnerabilitiesPaginationConfigInternal() pagination.Config[vulnerability.VulnerabilityWithImage] {
+	return pagination.Config[vulnerability.VulnerabilityWithImage]{
 		SearchAccessors: []pagination.SearchAccessor[vulnerability.VulnerabilityWithImage]{
 			func(item vulnerability.VulnerabilityWithImage) (string, error) { return item.VulnerabilityID, nil },
 			func(item vulnerability.VulnerabilityWithImage) (string, error) { return item.PkgName, nil },
@@ -424,11 +449,6 @@ func (s *VulnerabilityService) ListAllVulnerabilities(ctx context.Context, envID
 			},
 		},
 	}
-
-	filtered := pagination.SearchOrderAndPaginate(items, params, config)
-	response := pagination.BuildResponse(filtered.TotalCount, filtered.TotalAvailable, params)
-
-	return filtered.Items, response, nil
 }
 
 // ListAllVulnerabilityImageOptions returns unique image names (or image IDs when name is empty)
@@ -565,26 +585,6 @@ func splitNonEmptyCSVInternal(value string) []string {
 		parts = append(parts, part)
 	}
 	return parts
-}
-
-func estimatedVulnerabilityRecordCountInternal(records []models.VulnerabilityScanRecord) int {
-	if len(records) == 0 {
-		return 0
-	}
-
-	total := 0
-	for i := range records {
-		if records[i].TotalCount <= 0 {
-			continue
-		}
-
-		if total > math.MaxInt-records[i].TotalCount {
-			return math.MaxInt
-		}
-		total += records[i].TotalCount
-	}
-
-	return total
 }
 
 func severityRankInternal(severity vulnerability.Severity) int {

--- a/backend/pkg/pagination/filters.go
+++ b/backend/pkg/pagination/filters.go
@@ -24,16 +24,47 @@ func SearchOrderAndPaginate[T any](items []T, params QueryParams, searchConfig C
 
 	items = searchFn(items, params.SearchQuery, searchConfig.SearchAccessors)
 	items = filterFn(items, params.Filters, searchConfig.FilterAccessors)
-	items = sortFunction(items, params.SortParams, searchConfig.SortBindings)
-
-	totalCount := len(items)
-	items = paginateItemsFunction(items, params.Params)
 
 	return FilterResult[T]{
-		Items:          items,
-		TotalCount:     int64(totalCount),
+		Items:          OrderAndPaginate(items, params, searchConfig),
+		TotalCount:     int64(len(items)),
 		TotalAvailable: int64(totalAvailable),
 	}
+}
+
+// OrderAndPaginate sorts items and slices the requested page without applying
+// the search term or filters — for callers that already filtered while
+// building the item list (e.g. dropping non-matches during an incremental
+// decode) and only need ordering plus the page cut.
+func OrderAndPaginate[T any](items []T, params QueryParams, config Config[T]) []T {
+	items = sortFunction(items, params.SortParams, config.SortBindings)
+	return paginateItemsFunction(items, params.Params)
+}
+
+// MatchesSearchAndFilters reports whether a single item passes params' search
+// term and filters under config — the same predicate SearchOrderAndPaginate
+// applies. It lets callers that decode large payloads incrementally drop
+// non-matching items as they go instead of materializing everything first.
+func MatchesSearchAndFilters[T any](item T, params QueryParams, config Config[T]) bool {
+	search := strings.ToLower(strings.TrimSpace(params.Search))
+	if search != "" {
+		matched := false
+		for _, accessor := range config.SearchAccessors {
+			value, err := accessor(item)
+			if err == nil && strings.Contains(strings.ToLower(value), search) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	if len(params.Filters) == 0 {
+		return true
+	}
+	return itemMatches(item, params.Filters, config.FilterAccessors)
 }
 
 func filterFn[T any](items []T, filters map[string]string, accessors []FilterAccessor[T]) []T {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR batches vulnerability-scan blob loading and filters individual decoded vulnerabilities incrementally to reduce list-page memory use.

- Adds reusable per-item matching and sort/page helpers to the pagination package.
- Reworks the all-vulnerabilities query around GORM batch iteration.
- Adds coverage for filtered counts, sorting, searching, and ignored vulnerabilities.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The GrandTotalItems regression should be fixed before merging because filtered requests can now report an incorrect overall vulnerability count.

Record prefilters remove complete scans before totalAvailable is computed, violating the endpoint’s unfiltered grand-total contract; the test-structure concern is non-blocking.

**Files Needing Attention:** backend/internal/vulnerability/vulnerability_query.go; backend/internal/vulnerability/service_test.go
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `backend/internal/vulnerability/vulnerability_query.go`, line 312 ([link](https://github.com/getarcaneapp/arcane/blob/8e6d0c2a8494b7a19512d49240d4cafcc289c8fa/backend/internal/vulnerability/vulnerability_query.go#L312)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Record filters corrupt grand total**

   When a severity or image-name filter excludes an entire scan record, that record is removed before its vulnerabilities increment `totalAvailable`, causing `GrandTotalItems` to underreport the documented unfiltered vulnerability count and even return zero while stored vulnerabilities exist.

   **Knowledge Base Used:** [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/vulnerability/vulnerability_query.go
   Line: 312
   
   Comment:
   **Record filters corrupt grand total**
   
   When a severity or image-name filter excludes an entire scan record, that record is removed before its vulnerabilities increment `totalAvailable`, causing `GrandTotalItems` to underreport the documented unfiltered vulnerability count and even return zero while stored vulnerabilities exist.
   
   **Knowledge Base Used:** [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-11-fix_stop_loading_every_scan_blob_to_serve_one_list_page%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-11-fix_stop_loading_every_scan_blob_to_serve_one_list_page%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fvulnerability%2Fvulnerability_query.go%0ALine%3A%20312%0A%0AComment%3A%0A**Record%20filters%20corrupt%20grand%20total**%0A%0AWhen%20a%20severity%20or%20image-name%20filter%20excludes%20an%20entire%20scan%20record%2C%20that%20record%20is%20removed%20before%20its%20vulnerabilities%20increment%20%60totalAvailable%60%2C%20causing%20%60GrandTotalItems%60%20to%20underreport%20the%20documented%20unfiltered%20vulnerability%20count%20and%20even%20return%20zero%20while%20stored%20vulnerabilities%20exist.%0A%0A**Knowledge%20Base%20Used%3A**%20%5BContainer%20%26%20Image%20Lifecycle%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%2Fknowledge-base%2Fgetarcaneapp%2Farcane%2F-%2Fdocs%2Fcontainer-image-lifecycle.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fvulnerability%2Fvulnerability_query.go%0ALine%3A%20312%0A%0AComment%3A%0A**Record%20filters%20corrupt%20grand%20total**%0A%0AWhen%20a%20severity%20or%20image-name%20filter%20excludes%20an%20entire%20scan%20record%2C%20that%20record%20is%20removed%20before%20its%20vulnerabilities%20increment%20%60totalAvailable%60%2C%20causing%20%60GrandTotalItems%60%20to%20underreport%20the%20documented%20unfiltered%20vulnerability%20count%20and%20even%20return%20zero%20while%20stored%20vulnerabilities%20exist.%0A%0A**Knowledge%20Base%20Used%3A**%20%5BContainer%20%26%20Image%20Lifecycle%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%2Fknowledge-base%2Fgetarcaneapp%2Farcane%2F-%2Fdocs%2Fcontainer-image-lifecycle.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-11-fix_stop_loading_every_scan_blob_to_serve_one_list_page%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-11-fix_stop_loading_every_scan_blob_to_serve_one_list_page%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fvulnerability%2Fvulnerability_query.go%3A312%0A**Record%20filters%20corrupt%20grand%20total**%0A%0AWhen%20a%20severity%20or%20image-name%20filter%20excludes%20an%20entire%20scan%20record%2C%20that%20record%20is%20removed%20before%20its%20vulnerabilities%20increment%20%60totalAvailable%60%2C%20causing%20%60GrandTotalItems%60%20to%20underreport%20the%20documented%20unfiltered%20vulnerability%20count%20and%20even%20return%20zero%20while%20stored%20vulnerabilities%20exist.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fvulnerability%2Fservice_test.go%3A385%0A**Pagination%20test%20lacks%20subtests**%0A%0AThe%20new%20test%20hard-codes%20two%20requests%20in%20one%20linear%20body%20instead%20of%20using%20the%20required%20table-driven%20subtests%2C%20making%20batch-boundary%20and%20whole-record%20exclusion%20cases%20harder%20to%20add%20without%20duplicating%20setup%20and%20assertions.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fvulnerability%2Fvulnerability_query.go%3A312%0A**Record%20filters%20corrupt%20grand%20total**%0A%0AWhen%20a%20severity%20or%20image-name%20filter%20excludes%20an%20entire%20scan%20record%2C%20that%20record%20is%20removed%20before%20its%20vulnerabilities%20increment%20%60totalAvailable%60%2C%20causing%20%60GrandTotalItems%60%20to%20underreport%20the%20documented%20unfiltered%20vulnerability%20count%20and%20even%20return%20zero%20while%20stored%20vulnerabilities%20exist.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fvulnerability%2Fservice_test.go%3A385%0A**Pagination%20test%20lacks%20subtests**%0A%0AThe%20new%20test%20hard-codes%20two%20requests%20in%20one%20linear%20body%20instead%20of%20using%20the%20required%20table-driven%20subtests%2C%20making%20batch-boundary%20and%20whole-record%20exclusion%20cases%20harder%20to%20add%20without%20duplicating%20setup%20and%20assertions.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/vulnerability/vulnerability_query.go:312
**Record filters corrupt grand total**

When a severity or image-name filter excludes an entire scan record, that record is removed before its vulnerabilities increment `totalAvailable`, causing `GrandTotalItems` to underreport the documented unfiltered vulnerability count and even return zero while stored vulnerabilities exist.

### Issue 2
backend/internal/vulnerability/service_test.go:385
**Pagination test lacks subtests**

The new test hard-codes two requests in one linear body instead of using the required table-driven subtests, making batch-boundary and whole-record exclusion cases harder to add without duplicating setup and assertions.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop loading every scan blob to ser..."](https://github.com/getarcaneapp/arcane/commit/8e6d0c2a8494b7a19512d49240d4cafcc289c8fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52465412)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Container & Image Lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-image-lifecycle.md)

<!-- /greptile_comment -->