### PR TITLE
perf: materialize the effective config once per refresh

### DIFF
--- a/backend/internal/settings/service.go
+++ b/backend/internal/settings/service.go
@@ -41,13 +41,20 @@ const (
 )
 
 type SettingsService struct {
-	db           *database.DB
-	config       atomic.Pointer[models.Settings]
-	envOverrides []settingsEnvOverride
-	writes       *actors.Executor
-	effects      *actors.Executor
-	lifecycleCtx context.Context
-	changes      *actors.Signal[[]libarcane.SettingUpdate]
+	db     *database.DB
+	config atomic.Pointer[models.Settings]
+	// effectiveConfig is the env-override-applied snapshot, rebuilt whenever
+	// config is stored. Overrides are resolved once at startup and never
+	// change, so materializing them here turns every read (GetSettings and
+	// the typed getters — ~100 call sites, some in per-project loops) into a
+	// pointer load instead of a full struct Clone plus a reflection pass.
+	// The snapshot is shared: readers must never mutate it.
+	effectiveConfig atomic.Pointer[models.Settings]
+	envOverrides    []settingsEnvOverride
+	writes          *actors.Executor
+	effects         *actors.Executor
+	lifecycleCtx    context.Context
+	changes         *actors.Signal[[]libarcane.SettingUpdate]
 }
 
 type settingsUpdateResultInternal struct {
@@ -165,6 +172,10 @@ func (s *SettingsService) LoadDatabaseSettings(ctx context.Context) (err error) 
 	}
 
 	s.config.Store(dst)
+
+	effective := dst.Clone()
+	s.applyEnvOverrides(ctx, effective)
+	s.effectiveConfig.Store(effective)
 
 	return nil
 }
@@ -436,6 +447,9 @@ func (s *SettingsService) IsEnvOverrideActive(key string) bool {
 	return false
 }
 
+// GetSettings returns the effective (env-override-applied) settings snapshot.
+// The snapshot is shared across callers and must be treated as read-only;
+// mutation flows go through UpdateSettings, which works on an explicit clone.
 func (s *SettingsService) GetSettings(ctx context.Context) (*models.Settings, error) {
 	settingsCfg := s.getEffectiveSettingsConfigInternal(ctx)
 	return settingsCfg, nil
@@ -457,6 +471,12 @@ func (s *SettingsService) GetSettingsOrDefaults(ctx context.Context) *models.Set
 }
 
 func (s *SettingsService) getEffectiveSettingsConfigInternal(ctx context.Context) *models.Settings {
+	if effective := s.effectiveConfig.Load(); effective != nil {
+		return effective
+	}
+
+	// Only reachable before LoadDatabaseSettings has completed in the
+	// constructor; fall back to building the snapshot per call.
 	settingsCfg := s.GetSettingsConfig().Clone()
 	s.applyEnvOverrides(ctx, settingsCfg)
 	return settingsCfg

--- a/backend/internal/settings/service_test.go
+++ b/backend/internal/settings/service_test.go
@@ -1204,3 +1204,39 @@ func TestSettingsService_NormalizeProjectsDirectoryPublishesChangeInternal(t *te
 	require.Equal(t, "projectsDirectory", updates[0].Key)
 	require.True(t, filepath.IsAbs(updates[0].Value))
 }
+
+// TestSettingsServiceEffectiveSnapshotMaterializedInternal verifies the
+// env-override-applied snapshot is built once per refresh: reads share one
+// pointer (no per-call clone), env overrides win over database values, and
+// an update rebuilds the snapshot while keeping the override applied.
+func TestSettingsServiceEffectiveSnapshotMaterializedInternal(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("PROJECTS_DIRECTORY", "/env/projects")
+
+	db := setupSettingsTestDB(t)
+	require.NoError(t, db.Create(&models.SettingVariable{Key: "projectsDirectory", Value: "/db/projects"}).Error)
+	require.NoError(t, db.Create(&models.SettingVariable{Key: "baseServerUrl", Value: "http://before.example"}).Error)
+
+	svc, err := newSettingsServiceForTestInternal(t, ctx, db)
+	require.NoError(t, err)
+
+	// Env override beats the database value on the effective snapshot.
+	require.Equal(t, "/env/projects", svc.GetStringSetting(ctx, "projectsDirectory", ""))
+
+	// Reads share the materialized snapshot instead of cloning per call.
+	first, err := svc.GetSettings(ctx)
+	require.NoError(t, err)
+	again, err := svc.GetSettings(ctx)
+	require.NoError(t, err)
+	require.Same(t, first, again)
+
+	// A settings update rebuilds the snapshot: the new value is visible and
+	// the env override is still applied.
+	require.NoError(t, svc.UpdateSetting(ctx, "baseServerUrl", "http://after.example"))
+	require.Equal(t, "http://after.example", svc.GetStringSetting(ctx, "baseServerUrl", ""))
+	require.Equal(t, "/env/projects", svc.GetStringSetting(ctx, "projectsDirectory", ""))
+
+	refreshed, err := svc.GetSettings(ctx)
+	require.NoError(t, err)
+	require.NotSame(t, first, refreshed)
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR materializes an environment-override-applied settings snapshot during each database refresh, replacing repeated cloning and reflection work on effective-setting reads.
- Adds an atomic effective-settings snapshot alongside the raw settings cache.
- Rebuilds the snapshot whenever database settings are loaded.
- Adds coverage for pointer reuse, environment-override precedence, and snapshot replacement after an update.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-structure issue.

The settings snapshot remains immutable under all current callers, and normal mutation paths rebuild both caches before returning; the only accepted concern is that the added test does not use the required table-driven subtest pattern.

**Files Needing Attention:** backend/internal/settings/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-12-perf_materialize_the_effective_config_once_per_refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-12-perf_materialize_the_effective_config_once_per_refresh%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fsettings%2Fservice_test.go%3A1208%0A**Use%20table-driven%20snapshot%20tests**%0A%0AThis%20new%20coverage%20uses%20one%20linear%20setup%20and%20assertion%20sequence%20rather%20than%20the%20required%20table-driven%20structure%20with%20%60t.Run%60%20subtests%2C%20making%20additional%20snapshot%20scenarios%20harder%20to%20extend%20and%20identify%20independently.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fsettings%2Fservice_test.go%3A1208%0A**Use%20table-driven%20snapshot%20tests**%0A%0AThis%20new%20coverage%20uses%20one%20linear%20setup%20and%20assertion%20sequence%20rather%20than%20the%20required%20table-driven%20structure%20with%20%60t.Run%60%20subtests%2C%20making%20additional%20snapshot%20scenarios%20harder%20to%20extend%20and%20identify%20independently.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3619&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/settings/service_test.go:1208
**Use table-driven snapshot tests**

This new coverage uses one linear setup and assertion sequence rather than the required table-driven structure with `t.Run` subtests, making additional snapshot scenarios harder to extend and identify independently.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: materialize the effective config o..."](https://github.com/getarcaneapp/arcane/commit/c0c0542ed3094df78a62bc28d8ff7100fa78bbfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52801227)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [System Diagnostics, Notifications, Webhooks, and Activity/Event Logging](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/system-diagnostics.md)

<!-- /greptile_comment -->