### PR TITLE
fix: coalesce concurrent Docker image/container list calls to cut duplicate decodes

### DIFF
--- a/backend/internal/dashboard/service.go
+++ b/backend/internal/dashboard/service.go
@@ -223,11 +223,7 @@ func (s *DashboardService) buildSnapshotInternal(ctx context.Context, options Da
 		imagePage = limitDashboardItemsInternal(imageItems, dashboardSnapshotPreloadLimit)
 	}
 
-	imageUsageCounts := imagetypes.UsageCounts{}
-	imageUsageCounts.Inuse, imageUsageCounts.Unused, imageUsageCounts.Total = docker.CountImageUsage(dockerImages, filteredContainers)
-	for _, img := range dockerImages {
-		imageUsageCounts.TotalSize += img.Size
-	}
+	imageUsageCounts := docker.CountImageUsage(dockerImages, filteredContainers)
 
 	// Uses the unfiltered container list so a volume mounted only by an internal
 	// container still counts as in use, matching the volumes page.

--- a/backend/internal/docker/service.go
+++ b/backend/internal/docker/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	dashboardtypes "github.com/getarcaneapp/arcane/types/v2/dashboard"
+	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
@@ -28,6 +29,7 @@ import (
 	"github.com/moby/moby/client"
 	"go.getarcane.app/streams/bus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 const dockerClientNegotiationTimeout = 5 * time.Second
@@ -42,6 +44,13 @@ type DockerClientService struct {
 	clientLastProbe time.Time
 	mu              sync.Mutex
 	eventBus        *bus.DockerEventBus
+
+	// Coalesce concurrent full-inventory list calls so overlapping requests
+	// (e.g. the Homepage widget's simultaneous counts endpoints) decode one
+	// Docker response instead of one per caller. Per-instance on purpose:
+	// a WithClient copy talks to a different daemon and must not share flights.
+	imageListFlight     singleflight.Group
+	containerListFlight singleflight.Group
 }
 
 func NewDockerClientService(_ context.Context, db *database.DB, cfg *config.Config, settingsService *settings.SettingsService) *DockerClientService {
@@ -305,38 +314,72 @@ func sleepDockerEventBackoffInternal(ctx context.Context, eventBackoff *backoff.
 	}
 }
 
+// listCoalescedInternal runs op through the given singleflight group so
+// concurrent callers share one Docker request and one decoded result. The
+// flight runs on a context detached from the initiating caller, bounded only
+// by op's own Docker API timeout, so one canceled waiter cannot cancel work
+// other waiters still need; each waiter stops waiting when its own context
+// ends. Results and errors are shared only among concurrent callers —
+// singleflight drops the key once the flight completes, so nothing is cached.
+// Callers must treat the shared result as immutable.
+func listCoalescedInternal[T any](ctx context.Context, group *singleflight.Group, op func(context.Context) (T, error)) (T, error) {
+	var zero T
+
+	ch := group.DoChan("list", func() (any, error) {
+		return op(context.WithoutCancel(ctx))
+	})
+
+	select {
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return zero, res.Err
+		}
+		val, ok := res.Val.(T)
+		if !ok {
+			return zero, errors.New("docker list flight returned unexpected type")
+		}
+		return val, nil
+	}
+}
+
 func (s *DockerClientService) ListContainers(ctx context.Context) ([]container.Summary, error) {
-	dockerClient, err := s.GetClient(ctx)
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to connect to Docker")
-	}
+	return listCoalescedInternal(ctx, &s.containerListFlight, func(ctx context.Context) ([]container.Summary, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to connect to Docker")
+		}
 
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
-	defer cancel()
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+		defer cancel()
 
-	containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to list Docker containers")
-	}
-	return containerList.Items, nil
+		containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to list Docker containers")
+		}
+		return containerList.Items, nil
+	})
 }
 
 func (s *DockerClientService) ListImages(ctx context.Context) ([]image.Summary, error) {
-	dockerClient, err := s.GetClient(ctx)
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to connect to Docker")
-	}
+	return listCoalescedInternal(ctx, &s.imageListFlight, func(ctx context.Context) ([]image.Summary, error) {
+		dockerClient, err := s.GetClient(ctx)
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to connect to Docker")
+		}
 
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
-	defer cancel()
+		settings := s.settingsService.GetSettingsConfig()
+		apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+		defer cancel()
 
-	imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
-	if err != nil {
-		return nil, errors.WrapIf(err, "failed to list Docker images")
-	}
-	return imageList.Items, nil
+		imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
+		if err != nil {
+			return nil, errors.WrapIf(err, "failed to list Docker images")
+		}
+		return imageList.Items, nil
+	})
 }
 
 func (s *DockerClientService) listNetworksInternal(ctx context.Context) ([]network.Summary, error) {
@@ -446,23 +489,39 @@ func (s *DockerClientService) GetAllContainers(ctx context.Context) ([]container
 	return containers, running, stopped, total, nil
 }
 
-func (s *DockerClientService) GetAllImages(ctx context.Context) ([]image.Summary, int, int, int, error) {
-	images, err := s.ListImages(ctx)
-	if err != nil {
-		return nil, 0, 0, 0, err
+// GetAllImages lists images and containers concurrently and returns the
+// images together with their usage counts, including total image size.
+func (s *DockerClientService) GetAllImages(ctx context.Context) ([]image.Summary, imagetypes.UsageCounts, error) {
+	g, groupCtx := errgroup.WithContext(ctx)
+
+	var images []image.Summary
+	var containers []container.Summary
+
+	g.Go(func() (workerErr error) {
+		defer utils.RecoverToError(&workerErr, "docker image list worker")
+
+		var err error
+		images, err = s.ListImages(groupCtx)
+		return err
+	})
+	g.Go(func() (workerErr error) {
+		defer utils.RecoverToError(&workerErr, "docker container list worker")
+
+		var err error
+		containers, err = s.ListContainers(groupCtx)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, imagetypes.UsageCounts{}, err
 	}
 
-	containers, err := s.ListContainers(ctx)
-	if err != nil {
-		return nil, 0, 0, 0, err
-	}
-
-	inuse, unused, total := CountImageUsage(images, containers)
-
-	return images, inuse, unused, total, nil
+	return images, CountImageUsage(images, containers), nil
 }
 
-func CountImageUsage(images []image.Summary, containers []container.Summary) (inuse int, unused int, total int) {
+// CountImageUsage tallies in-use, unused, and total image counts, plus the
+// summed size of all images. An image is in use when a container references
+// its ID.
+func CountImageUsage(images []image.Summary, containers []container.Summary) imagetypes.UsageCounts {
 	inUseImageIDs := make(map[string]struct{}, len(containers))
 	for _, c := range containers {
 		if c.ImageID == "" {
@@ -471,16 +530,18 @@ func CountImageUsage(images []image.Summary, containers []container.Summary) (in
 		inUseImageIDs[c.ImageID] = struct{}{}
 	}
 
+	var counts imagetypes.UsageCounts
 	for _, img := range images {
-		total++
+		counts.Total++
+		counts.TotalSize += img.Size
 		if _, ok := inUseImageIDs[img.ID]; ok {
-			inuse++
+			counts.Inuse++
 			continue
 		}
-		unused++
+		counts.Unused++
 	}
 
-	return inuse, unused, total
+	return counts
 }
 
 func (s *DockerClientService) GetAllNetworks(ctx context.Context) ([]network.Summary, int, int, int, error) {

--- a/backend/internal/docker/service_test.go
+++ b/backend/internal/docker/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/actors"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	docker "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
+	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
@@ -256,9 +257,9 @@ func TestDockerClientService_EventActorStopCancelsAndJoinsStreamInternal(t *test
 
 func TestCountImageUsage_UsesContainerImageIDs(t *testing.T) {
 	images := []image.Summary{
-		{ID: "sha256:image-a", Containers: -1},
-		{ID: "sha256:image-b", Containers: 0},
-		{ID: "sha256:image-c", Containers: 99},
+		{ID: "sha256:image-a", Containers: -1, Size: 100},
+		{ID: "sha256:image-b", Containers: 0, Size: 25},
+		{ID: "sha256:image-c", Containers: 99, Size: 3},
 	}
 
 	containers := []container.Summary{
@@ -268,19 +269,18 @@ func TestCountImageUsage_UsesContainerImageIDs(t *testing.T) {
 		{ImageID: ""},
 	}
 
-	inuse, unused, total := CountImageUsage(images, containers)
+	counts := CountImageUsage(images, containers)
 
-	assert.Equal(t, 2, inuse)
-	assert.Equal(t, 1, unused)
-	assert.Equal(t, 3, total)
+	assert.Equal(t, 2, counts.Inuse)
+	assert.Equal(t, 1, counts.Unused)
+	assert.Equal(t, 3, counts.Total)
+	assert.Equal(t, int64(128), counts.TotalSize)
 }
 
 func TestCountImageUsage_NoImages(t *testing.T) {
-	inuse, unused, total := CountImageUsage(nil, []container.Summary{{ImageID: "sha256:image-a"}})
+	counts := CountImageUsage(nil, []container.Summary{{ImageID: "sha256:image-a"}})
 
-	assert.Equal(t, 0, inuse)
-	assert.Equal(t, 0, unused)
-	assert.Equal(t, 0, total)
+	assert.Equal(t, imagetypes.UsageCounts{}, counts)
 }
 
 func newDockerClientServiceForTestInternal(host string) *DockerClientService {

--- a/backend/internal/image/handler.go
+++ b/backend/internal/image/handler.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -826,39 +825,15 @@ func resolveLegacyPruneImageModeInternal(dangling bool) string {
 
 // GetImageUsageCounts returns counts of images by usage status.
 func (h *ImageHandler) GetImageUsageCounts(ctx context.Context, input *GetImageUsageCountsInput) (*GetImageUsageCountsOutput, error) {
-	var (
-		inuse, unused, total int
-		totalSize            int64
-		errs                 []error
-	)
-
-	_, iu, un, tot, err := h.dockerService.GetAllImages(ctx)
+	_, counts, err := h.dockerService.GetAllImages(ctx)
 	if err != nil {
-		errs = append(errs, errors.WrapIf(err, "get images"))
-	} else {
-		inuse, unused, total = iu, un, tot
-	}
-
-	sz, err := h.imageService.GetTotalImageSize(ctx)
-	if err != nil {
-		errs = append(errs, errors.WrapIf(err, "get total image size"))
-	} else {
-		totalSize = sz
-	}
-
-	if len(errs) > 0 {
-		return nil, huma.Error500InternalServerError(errors.WithMessage(stderrors.Join(errs...), "Failed to get image usage counts").Error())
+		return nil, huma.Error500InternalServerError(errors.WithMessage(err, "Failed to get image usage counts").Error())
 	}
 
 	return &GetImageUsageCountsOutput{
 		Body: base.ApiResponse[image.UsageCounts]{
 			Success: true,
-			Data: image.UsageCounts{
-				Inuse:     inuse,
-				Unused:    unused,
-				Total:     total,
-				TotalSize: totalSize,
-			},
+			Data:    counts,
 		},
 	}, nil
 }

--- a/backend/internal/image/image.go
+++ b/backend/internal/image/image.go
@@ -802,20 +802,6 @@ func convertLabels(labels map[string]string) map[string]any {
 	return result
 }
 
-func (s *ImageService) GetTotalImageSize(ctx context.Context) (int64, error) {
-	images, err := s.dockerService.ListImages(ctx)
-	if err != nil {
-		return 0, errors.WrapIf(err, "failed to list images")
-	}
-
-	var total int64
-	for _, img := range images {
-		total += img.Size
-	}
-
-	return total, nil
-}
-
 // projectIDCacheTTL bounds how long a snapshot of all (name → id) project rows is reused.
 // Dashboard polls frequently; the projects table changes rarely, so a short TTL is safe.
 const projectIDCacheTTL = 5 * time.Second

--- a/backend/internal/vulnerability/vulnerability_query.go
+++ b/backend/internal/vulnerability/vulnerability_query.go
@@ -157,11 +157,11 @@ func (s *VulnerabilityService) GetEnvironmentSummary(ctx context.Context) (*vuln
 	}
 
 	if s.dockerService != nil {
-		_, _, _, total, err := s.dockerService.GetAllImages(ctx)
+		_, counts, err := s.dockerService.GetAllImages(ctx)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to list images for vulnerability summary", "error", err)
 		} else {
-			summary.TotalImages = total
+			summary.TotalImages = counts.Total
 		}
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3626

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR coalesces concurrent Docker image and container inventory requests with per-service singleflight groups and consolidates image usage and size calculation into UsageCounts.
- Runs image and container inventory requests concurrently in GetAllImages.
- Reuses the resulting UsageCounts in dashboard, image, and vulnerability paths.
- Removes the redundant second image-list request previously used for total-size calculation.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only non-blocking documentation needed for the changed exported Docker helpers.

The investigated coalescing paths preserve per-waiter cancellation and current consumers treat shared inventory results as immutable; the remaining accepted concern is that the changed exported contracts are undocumented.

**Files Needing Attention:** backend/internal/docker/service.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_coalesce_concurrent_docker_image%2Fcontainer_list_calls_to_cut_duplicate_decodes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_coalesce_concurrent_docker_image%2Fcontainer_list_calls_to_cut_duplicate_decodes%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233635%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3635&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_coalesce_concurrent_docker_image%2Fcontainer_list_calls_to_cut_duplicate_decodes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_coalesce_concurrent_docker_image%2Fcontainer_list_calls_to_cut_duplicate_decodes%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fdocker%2Fservice.go%3A492%0A**Document%20changed%20exported%20contracts**%0A%0A%60GetAllImages%60%20now%20returns%20a%20consolidated%20%60UsageCounts%60%20value%2C%20and%20%60CountImageUsage%60%20at%20line%20516%20also%20calculates%20%60TotalSize%60%2C%20but%20neither%20exported%20function%20documents%20these%20new%20semantics%2C%20increasing%20the%20maintenance%20cost%20for%20package%20consumers.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3635&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fdocker%2Fservice.go%3A492%0A**Document%20changed%20exported%20contracts**%0A%0A%60GetAllImages%60%20now%20returns%20a%20consolidated%20%60UsageCounts%60%20value%2C%20and%20%60CountImageUsage%60%20at%20line%20516%20also%20calculates%20%60TotalSize%60%2C%20but%20neither%20exported%20function%20documents%20these%20new%20semantics%2C%20increasing%20the%20maintenance%20cost%20for%20package%20consumers.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3635&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/docker/service.go:492
**Document changed exported contracts**

`GetAllImages` now returns a consolidated `UsageCounts` value, and `CountImageUsage` at line 516 also calculates `TotalSize`, but neither exported function documents these new semantics, increasing the maintenance cost for package consumers.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: coalesce concurrent Docker image/co..."](https://github.com/getarcaneapp/arcane/commit/ce64565aa9a788ad1cc0a34a5e4b851b3bd2fa7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53826050)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->