### PR TITLE
fix: use errors.Is(err, fs.ErrNotExist) for acfs error checks

### DIFF
--- a/backend/internal/gitops/gitops_sync.go
+++ b/backend/internal/gitops/gitops_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json/v2"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"maps"
 	"os"
@@ -1246,7 +1247,7 @@ func (s *GitOpsSyncService) CleanupLeakedScratchDirsOnStartup(ctx context.Contex
 
 	entries, err := acfs.List(ctx, projectsDir, "/")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return errors.WrapIff(err, "failed to list projects directory %s for gitops scratch cleanup", projectsDir)
@@ -1897,7 +1898,7 @@ func (s *GitOpsSyncService) seedStageEnvFromCandidateDirInternal(ctx context.Con
 		if readErr == nil {
 			return string(content), true, nil
 		}
-		if errors.Is(readErr, os.ErrNotExist) {
+		if errors.Is(readErr, fs.ErrNotExist) {
 			return "", false, nil
 		}
 		if errors.Is(readErr, os.ErrPermission) {
@@ -2053,7 +2054,7 @@ func (s *GitOpsSyncService) findUniqueProjectDirectoryCandidateInternal(ctx cont
 			if !composeEntry.IsDirectory {
 				matches = append(matches, candidatePath)
 			}
-		} else if !errors.Is(statErr, os.ErrNotExist) {
+		} else if !errors.Is(statErr, fs.ErrNotExist) {
 			return "", errors.WrapIff(statErr, "failed to inspect recovery candidate %s", composePath)
 		}
 	}

--- a/backend/internal/swarm/swarm.go
+++ b/backend/internal/swarm/swarm.go
@@ -6,10 +6,10 @@ import (
 	stdjson "encoding/json"
 	"encoding/json/v2"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/netip"
-	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -1768,7 +1768,7 @@ func (s *SwarmService) GetStackSource(ctx context.Context, environmentID, stackN
 
 	composeContent, err := acfs.ReadFile(ctx, stackSourceDir, "/"+swarmStackComposeFilename)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, cerrdefs.ErrNotFound
 		}
 		return nil, errors.WrapIf(err, "failed to read swarm stack compose source")
@@ -1778,7 +1778,7 @@ func (s *SwarmService) GetStackSource(ctx context.Context, environmentID, stackN
 	overrideBytes, err := acfs.ReadFile(ctx, stackSourceDir, "/"+swarmStackOverrideFilename)
 	if err == nil {
 		overrideContent = string(overrideBytes)
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return nil, errors.WrapIf(err, "failed to read swarm stack override source")
 	}
 
@@ -1786,7 +1786,7 @@ func (s *SwarmService) GetStackSource(ctx context.Context, environmentID, stackN
 	envBytes, err := acfs.ReadFile(ctx, stackSourceDir, "/"+swarmStackEnvFilename)
 	if err == nil {
 		envContent = string(envBytes)
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return nil, errors.WrapIf(err, "failed to read swarm stack env source")
 	}
 
@@ -1809,7 +1809,7 @@ func (s *SwarmService) GetStackSource(ctx context.Context, environmentID, stackN
 		})
 		return nil
 	})
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, errors.WrapIf(err, "failed to read additional swarm stack source files")
 	}
 
@@ -1885,7 +1885,7 @@ func (s *SwarmService) listPersistedStackSourcesInternal(ctx context.Context, en
 
 	entries, err := acfs.List(ctx, environmentDir, "/")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return map[string]swarmtypes.StackSummary{}, nil
 		}
 		return nil, errors.WrapIf(err, "failed to list swarm stack source directories")
@@ -1923,7 +1923,7 @@ func (s *SwarmService) getPersistedStackSourceSummaryInternal(ctx context.Contex
 func (s *SwarmService) buildPersistedStackSourceSummaryInternal(ctx context.Context, stackSourceDir, stackName string) (*swarmtypes.StackSummary, error) {
 	composeEntry, err := acfs.Stat(ctx, stackSourceDir, "/"+swarmStackComposeFilename, true)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, cerrdefs.ErrNotFound
 		}
 		return nil, errors.WrapIf(err, "failed to stat swarm stack compose source")
@@ -1940,7 +1940,7 @@ func (s *SwarmService) buildPersistedStackSourceSummaryInternal(ctx context.Cont
 		if envEntry.ModTime.After(updatedAt) {
 			updatedAt = envEntry.ModTime
 		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return nil, errors.WrapIf(err, "failed to stat swarm stack env source")
 	}
 
@@ -2621,7 +2621,7 @@ func (s *SwarmService) deleteStackSourceInternal(ctx context.Context, environmen
 	// Best-effort cleanup of now-empty environment directory.
 	environmentDir := filepath.Dir(stackSourceDir)
 	if environmentDir != rootDir {
-		if err := acfs.Remove(ctx, rootDir, path.Dir(stackLogical)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := acfs.Remove(ctx, rootDir, path.Dir(stackLogical)); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			slog.DebugContext(ctx, "swarm stack source environment directory cleanup skipped", "dir", environmentDir, "error", err)
 		}
 	}

--- a/backend/internal/variable/variable.go
+++ b/backend/internal/variable/variable.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json/v2"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -465,7 +466,7 @@ func (s *VariableService) ReadLocalEnvFile(ctx context.Context) ([]env.Variable,
 
 	content, err := acfs.ReadFile(ctx, filepath.Dir(envPath), "/"+projects.GlobalEnvFileName)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			slog.DebugContext(ctx, "Global variables file does not exist yet", "path", envPath)
 			return []env.Variable{}, nil
 		}

--- a/backend/pkg/libarcane/edge/tls.go
+++ b/backend/pkg/libarcane/edge/tls.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -227,7 +228,7 @@ func managerMTLSEnrollmentStateInternal(cfg *Config, envID string, now time.Time
 	}
 	enrolledAt, err := readMTLSEnrollmentMarkerInternal(markerPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, false, nil
 		}
 		return false, false, err

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -176,7 +177,7 @@ func syncedProjectFileMatchesInternal(ctx context.Context, projectPath string, f
 	logicalPath := "/" + filepath.ToSlash(file.RelativePath)
 	entry, err := acfs.Stat(ctx, projectPath, logicalPath, false)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		return false, err
@@ -187,7 +188,7 @@ func syncedProjectFileMatchesInternal(ctx context.Context, projectPath string, f
 
 	existingContent, err := acfs.ReadFile(ctx, projectPath, logicalPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		return false, err
@@ -278,7 +279,7 @@ func RemoveStaleComposeFiles(ctx context.Context, projectPath, composeFileName s
 		if _, exists := syncedFileSet[candidate]; exists {
 			continue
 		}
-		if err := acfs.Remove(ctx, projectPath, "/"+candidate); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := acfs.Remove(ctx, projectPath, "/"+candidate); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
@@ -309,7 +310,7 @@ func RemoveStaleComposeFiles(ctx context.Context, projectPath, composeFileName s
 			continue
 		}
 
-		if err := acfs.Remove(ctx, projectPath, entry.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := acfs.Remove(ctx, projectPath, entry.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path"
@@ -108,7 +109,7 @@ func WriteProjectFile(ctx context.Context, projectsRoot, dirPath, fileName, cont
 		// Only .env is written through a symlink (handled above); every other
 		// project file refuses one rather than clobbering an unknown target.
 		return errors.Errorf("refusing to write project file %s: destination is a symlink", fileName)
-	case statErr != nil && !errors.Is(statErr, os.ErrNotExist):
+	case statErr != nil && !errors.Is(statErr, fs.ErrNotExist):
 		return errors.WrapIff(statErr, "failed to inspect project file %s", fileName)
 	}
 
@@ -117,7 +118,7 @@ func WriteProjectFile(ctx context.Context, projectsRoot, dirPath, fileName, cont
 		if readErr == nil && string(existingContent) == content {
 			return nil
 		}
-		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		if readErr != nil && !errors.Is(readErr, fs.ErrNotExist) {
 			return errors.WrapIff(readErr, "failed to read project file %s", fileName)
 		}
 	}
@@ -191,7 +192,7 @@ func RemoveProjectFile(ctx context.Context, projectsRoot, dirPath, fileName stri
 		return errors.Errorf("invalid project file name %q", fileName)
 	}
 
-	if err := acfs.Remove(ctx, dirPath, "/"+fileName); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := acfs.Remove(ctx, dirPath, "/"+fileName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return errors.WrapIff(err, "failed to remove project file %s", fileName)
 	}
 
@@ -365,7 +366,7 @@ func WriteSyncedDirectory(ctx context.Context, projectsRoot, projectPath string,
 			if err := acfs.RemoveAll(ctx, projectPath, logicalPath); err != nil {
 				return nil, errors.WrapIff(err, "failed to replace directory at %s", file.RelativePath)
 			}
-		case statErr != nil && !errors.Is(statErr, os.ErrNotExist):
+		case statErr != nil && !errors.Is(statErr, fs.ErrNotExist):
 			return nil, errors.WrapIff(statErr, "failed to inspect target path for %s", file.RelativePath)
 		}
 
@@ -415,7 +416,7 @@ func CleanupRemovedFiles(ctx context.Context, projectsRoot, projectPath string, 
 		}
 
 		// Delete the file (best effort)
-		if err := acfs.Remove(ctx, projectPath, logicalPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := acfs.Remove(ctx, projectPath, logicalPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			// Log but continue - this is best effort
 			slog.WarnContext(ctx, "Failed to remove old synced file", "file", oldFile, "error", err)
 		}


### PR DESCRIPTION
os.IsNotExist is a legacy function that predates errors.Is. It only unwraps *PathError, *LinkError, and *SyscallError via a hardcoded type switch, so it fails on errors wrapped with fmt.Errorf("%w", ...).

ACFS wraps all OS errors with %w, which preserves the error chain for errors.Is but not for os.IsNotExist. This caused ReadLocalEnvFile on fresh agents to return HTTP 500 instead of an empty variable list, permanently breaking the .env.global sync loop (issue #3644).

Replace os.IsNotExist / errors.Is(err, os.ErrNotExist) with errors.Is(err, fs.ErrNotExist) at every acfs error-check site.

## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3644

## Changes Made

## Testing Done
- Built a Docker image for an agent
- Tested propagation of the variable to the remote agent

## AI Tool Used (if applicable)
- BigPickle model with OpenCode

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes missing-file checks on `errors.Is(err, fs.ErrNotExist)`, allowing ACFS-wrapped errors to be recognized throughout variable synchronization, GitOps cleanup, swarm source persistence, edge TLS state, and project file operations.

- Replaces legacy or inconsistently expressed not-exist checks across six backend files.
- Preserves handling of permission and other filesystem errors.
- Fixes fresh-agent `.env.global` reads so an absent file produces an empty variable list rather than an HTTP error.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or build issues identified.

The replacements preserve sentinel semantics while ensuring wrapped missing-file errors are recognized through the standard Go error chain, and the added imports are valid and used.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use errors.Is(err, fs.ErrNotExist) ..."](https://github.com/getarcaneapp/arcane/commit/4c161f8c58806639e69931108bbcbb0daddbedbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54191200)</sub>

<!-- /greptile_comment -->