### PR TITLE
fix: show git-synced project files read-only instead of hiding or crashing

### DIFF
--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -626,7 +626,7 @@
 		// cached detail instead of replacing it wholesale.
 		queryClient.setQueryData(
 			queryKeys.projects.detail(currentEnvId, updatedProject.id),
-			(old: Project | undefined) => ({ ...(old ?? {}), ...updatedProject }) as Project
+			(old: Project | undefined) => ({ ...old, ...updatedProject }) as Project
 		);
 		await Promise.all([
 			queryClient.invalidateQueries({ queryKey: ['projects', currentEnvId] }),
@@ -851,10 +851,12 @@
 	function updateLoadedProjectWorkspaceSource(kind: ProjectWorkspaceSource, relativePath: string, content: string) {
 		if (kind === 'include') {
 			ensureIncludeFileUiState(relativePath);
-			loadedIncludeFileContents = {
-				...loadedIncludeFileContents,
-				[relativePath]: content
-			};
+			if (loadedIncludeFileContents[relativePath] !== content) {
+				loadedIncludeFileContents = {
+					...loadedIncludeFileContents,
+					[relativePath]: content
+				};
+			}
 			if (includeFilesState[relativePath] === undefined) {
 				includeFilesState = {
 					...includeFilesState,
@@ -864,6 +866,7 @@
 			return;
 		}
 
+		if (loadedDirectoryFileContents[relativePath] === content) return;
 		loadedDirectoryFileContents = {
 			...loadedDirectoryFileContents,
 			[relativePath]: content
@@ -1098,6 +1101,40 @@
 		}
 
 		void loadProjectWorkspaceFileDraft(relativePath);
+	});
+
+	async function loadProjectSourceFile(kind: 'include' | 'directory', relativePath: string) {
+		projectWorkspaceLoading = {
+			...projectWorkspaceLoading,
+			[relativePath]: true
+		};
+		projectWorkspaceLoadErrors = removeWorkspaceFileRecord(projectWorkspaceLoadErrors, relativePath);
+
+		try {
+			await getProjectWorkspaceFileResource(kind, relativePath);
+		} catch (error) {
+			projectWorkspaceLoadErrors = {
+				...projectWorkspaceLoadErrors,
+				[relativePath]: error instanceof Error ? error.message : String(error)
+			};
+		} finally {
+			projectWorkspaceLoading = removeWorkspaceFileRecord(projectWorkspaceLoading, relativePath);
+		}
+	}
+
+	$effect(() => {
+		const relativePath = selectedIncludeTab;
+		if (!relativePath) return;
+		const kind = includeFilePaths.has(relativePath) ? 'include' : 'directory';
+		const loaded =
+			kind === 'include'
+				? includeFilesState[relativePath] !== undefined
+				: loadedDirectoryFileContents[relativePath] !== undefined;
+		if (loaded || projectWorkspaceLoading[relativePath] || projectWorkspaceLoadErrors[relativePath] !== undefined) {
+			return;
+		}
+
+		void loadProjectSourceFile(kind, relativePath);
 	});
 
 	function remapProjectWorkspaceState(oldPath: string, newPath: string) {
@@ -1708,7 +1745,7 @@
 															<div class="flex h-full min-h-0 items-center justify-center px-4 text-sm text-destructive">
 																{projectWorkspaceLoadErrors[relativePath]}
 															</div>
-														{:else if selectedProjectWorkspaceMetadata?.editable === false}
+														{:else if selectedProjectWorkspaceMetadata?.editable === false && selectedProjectWorkspaceMetadata.content === undefined}
 															<div
 																class="flex h-full min-h-0 items-center justify-center px-4 text-center text-sm text-muted-foreground"
 															>
@@ -1717,6 +1754,17 @@
 																	projectWorkspaceMaxFileSizeMb
 																)}
 															</div>
+														{:else if selectedProjectWorkspaceMetadata?.editable === false}
+															<CodePanel
+																variant="plain"
+																open={true}
+																title={relativePath}
+																language={workspaceFileLanguage(relativePath)}
+																validationMode="none"
+																value={selectedProjectWorkspaceMetadata.content ?? ''}
+																readOnly={true}
+																editorContext={codeEditorContext}
+															/>
 														{:else if projectWorkspaceContents[relativePath] === undefined}
 															<div class="flex h-full min-h-0 items-center justify-center text-muted-foreground">
 																{m.common_loading()}
@@ -1782,43 +1830,41 @@
 
 								{#if selectedIncludeTab}
 									{@const includeFile = project?.includeFiles?.find((f) => f.relativePath === selectedIncludeTab)}
-									{@const dirFile = !includeFile
-										? projectWorkspaceEntries.find((f) => f.relativePath === selectedIncludeTab)
-										: undefined}
-									{@const fileKind = includeFile ? 'include' : 'directory'}
-									{#await getProjectWorkspaceFileResource(fileKind, selectedIncludeTab)}
+									{@const workspaceEntry = projectWorkspaceEntries.find((f) => f.relativePath === selectedIncludeTab)}
+									{@const dirFile = !includeFile ? workspaceEntry : undefined}
+									{@const sourceLocked = workspaceEntry?.locked === true}
+									{#if projectWorkspaceLoadErrors[selectedIncludeTab]}
+										<div class="flex h-full min-h-0 items-center justify-center rounded-lg border px-4 text-sm text-destructive">
+											{projectWorkspaceLoadErrors[selectedIncludeTab]}
+										</div>
+									{:else if includeFile && includeFilesState[includeFile.relativePath] !== undefined}
+										<CodePanel
+											bind:open={includeFilesPanelStates[includeFile.relativePath]}
+											title={includeFile.relativePath}
+											language="yaml"
+											validationMode="compose"
+											bind:value={includeFilesState[includeFile.relativePath]}
+											readOnly={sourceLocked}
+											bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
+											bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
+											fileId={`project:${projectId}:include:${includeFile.relativePath}`}
+											originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
+											enableDiff={true}
+											editorContext={codeEditorContext}
+										/>
+									{:else if dirFile && loadedDirectoryFileContents[dirFile.relativePath] !== undefined}
+										<CodePanel
+											open={true}
+											title={dirFile.relativePath}
+											language="env"
+											value={loadedDirectoryFileContents[dirFile.relativePath]}
+											readOnly={true}
+										/>
+									{:else}
 										<div class="flex h-full min-h-0 items-center justify-center rounded-lg border text-muted-foreground">
 											{m.common_loading()}
 										</div>
-									{:then loaded}
-										{#if includeFile}
-											<CodePanel
-												bind:open={includeFilesPanelStates[includeFile.relativePath]}
-												title={includeFile.relativePath}
-												language="yaml"
-												validationMode="compose"
-												bind:value={includeFilesState[includeFile.relativePath]}
-												bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
-												bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
-												fileId={`project:${projectId}:include:${includeFile.relativePath}`}
-												originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
-												enableDiff={true}
-												editorContext={codeEditorContext}
-											/>
-										{:else if dirFile}
-											<CodePanel
-												open={true}
-												title={loaded.relativePath}
-												language="env"
-												value={loaded.content ?? ''}
-												readOnly={true}
-											/>
-										{/if}
-									{:catch error}
-										<div class="flex h-full min-h-0 items-center justify-center rounded-lg border px-4 text-sm text-destructive">
-											{error instanceof Error ? error.message : String(error)}
-										</div>
-									{/await}
+									{/if}
 								{:else}
 									<ResizableSplit
 										class="min-h-0 flex-1 lg:gap-2"


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3660

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change lazy-loads workspace, include, and directory source files so text files can be shown in read-only editors. A reproduced navigation race can place a previous project's file content into the currently viewed project's editor when both projects use the same relative path. The source-loading effect also updates the reactive state it observes, contrary to the linked repository rule.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not ready to merge until delayed source-file responses cannot update a different project's editor state.

A focused executable harness reproduced cross-project cache contamination after navigation, and the route source confirms that asynchronous responses write into caches keyed only by relative path. The remaining finding is an explicit repository-rule violation in the same route.

**Files Needing Attention:** frontend/src/routes/(app)/projects/[projectId]/+page.svelte
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached artifacts showing the focused stale project response harness and related page lifecycle traces.
- T-Rex captured and indexed logs illustrating cache behavior across navigation, including cache states before and after stale responses and during A/B transitions.
- T-Rex performed general contract validation, confirming that clearLoadedProjectWorkspaceCache is only invoked via explicit rebase, and that the async loader captures currentProjectId but writes through path-keyed helpers, with no post-await project-current guard.
- T-Rex produced a second finding-proof for a posted P1 finding.

<a href="https://app.greptile.com/trex/runs/19939302/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `frontend/src/routes/(app)/projects/[projectId]/+page.svelte`, line 963-967 ([link](https://github.com/getarcaneapp/arcane/blob/022f06d65d3b076c13136c9fa266824751f20e89/frontend/src/routes/(app)/projects/[projectId]/+page.svelte#L963-L967)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale responses cross project boundaries**

   A source-file request captures project A's ID for the request but, after `await`, writes its result into state keyed only by `relativePath`. If the user switches to project B before the response returns and B has the same path, A's content is stored in B's include/directory caches and can be rendered as B's file. Ignore responses whose captured project ID is no longer current, or namespace and clear these caches on project changes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused stale project response harness source](https://app.greptile.com/trex/artifacts/39a8f6ab-b921-4996-9b58-f3847178d1aa)**

   - Executable Node harness copied the relevant loader and cache-write flow, defers the project A response until project B is current, and asserts the resulting cache state; the focused path is reproducible.

   **[Captured stale project response harness source](https://app.greptile.com/trex/artifacts/7c5cd823-7d1b-497b-bf23-6b1b8b2457b1)**

   - Captured command output prints the exact executable harness source used for the focused validation; the tested request and cache flow are auditable.

   **[Cache state after navigation before stale response resolves](https://app.greptile.com/trex/artifacts/92c02430-9e20-443c-8572-673da285a884)**

   - The executed before run shows requests originated from project A while project B is current and all relevant path-keyed caches remain empty; navigation alone does not populate them.

   **[Cache state after project A response resolves on project B](https://app.greptile.com/trex/artifacts/fca5feeb-857c-40a6-89fa-1fb28b0a9203)**

   - The executed after run shows the still-current project B has \`A-only-content\` in include state, loaded include cache, and directory cache for the shared path; the stale response contaminates B-visible cache state.

   **[Page loader and lifecycle source excerpts](https://app.greptile.com/trex/artifacts/4b6d725d-59ab-4dd1-9cf7-a1e459052684)**

   - Captured page excerpts show cache clearing is rebase-option-dependent and the asynchronous completion writes by relative path without checking that the original project is still current; the source confirms the reproduced mechanism.

   <a href="https://app.greptile.com/trex/runs/19939302/artifacts?artifact=39a8f6ab-b921-4996-9b58-f3847178d1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: frontend/src/routes/(app)/projects/[projectId]/+page.svelte
   Line: 963-967

   Comment:
   **Stale responses cross project boundaries**

   A source-file request captures project A's ID for the request but, after `await`, writes its result into state keyed only by `relativePath`. If the user switches to project B before the response returns and B has the same path, A's content is stored in B's include/directory caches and can be rendered as B's file. Ignore responses whose captured project ID is no longer current, or namespace and clear these caches on project changes.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%0ALine%3A%20963-967%0A%0AComment%3A%0A**Stale%20responses%20cross%20project%20boundaries**%0A%0AA%20source-file%20request%20captures%20project%20A's%20ID%20for%20the%20request%20but%2C%20after%20%60await%60%2C%20writes%20its%20result%20into%20state%20keyed%20only%20by%20%60relativePath%60.%20If%20the%20user%20switches%20to%20project%20B%20before%20the%20response%20returns%20and%20B%20has%20the%20same%20path%2C%20A's%20content%20is%20stored%20in%20B's%20include%2Fdirectory%20caches%20and%20can%20be%20rendered%20as%20B's%20file.%20Ignore%20responses%20whose%20captured%20project%20ID%20is%20no%20longer%20current%2C%20or%20namespace%20and%20clear%20these%20caches%20on%20project%20changes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20frontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%0ALine%3A%20963-967%0A%0AComment%3A%0A**Stale%20responses%20cross%20project%20boundaries**%0A%0AA%20source-file%20request%20captures%20project%20A's%20ID%20for%20the%20request%20but%2C%20after%20%60await%60%2C%20writes%20its%20result%20into%20state%20keyed%20only%20by%20%60relativePath%60.%20If%20the%20user%20switches%20to%20project%20B%20before%20the%20response%20returns%20and%20B%20has%20the%20same%20path%2C%20A's%20content%20is%20stored%20in%20B's%20include%2Fdirectory%20caches%20and%20can%20be%20rendered%20as%20B's%20file.%20Ignore%20responses%20whose%20captured%20project%20ID%20is%20no%20longer%20current%2C%20or%20namespace%20and%20clear%20these%20caches%20on%20project%20changes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale project file response can populate the next project's path-keyed caches**

   - **Bug**
     - After a request starts under project A and navigation makes project B current, resolving A's request for the same relative path writes `A-only-content` into `loadedIncludeFileContents`, `includeFilesState`, and `loadedDirectoryFileContents` while B remains current.
   - **Cause**
     - `getProjectWorkspaceFileResource` captures `currentProjectId` only for the promise key and service request. Its continuation calls `updateLoadedProjectWorkspaceSource(kind, relativePath, ...)`, whose target caches are keyed solely by `relativePath`; the page has no project-change lifecycle effect that clears these caches, and the cache-clear helper is only selected by explicit rebase options.
   - **Fix**
     - Before applying an asynchronous response, verify that the captured project ID still equals the current project ID (or attach a navigation generation token). Also clear or namespace all source/load caches by project ID during project-route changes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233690%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3690&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_show_git-synced_project_files_read-only_instead_of_hiding_or_crashing%22.%0A%0A%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A963-967%0A**Stale%20responses%20cross%20project%20boundaries**%0A%0AA%20source-file%20request%20captures%20project%20A's%20ID%20for%20the%20request%20but%2C%20after%20%60await%60%2C%20writes%20its%20result%20into%20state%20keyed%20only%20by%20%60relativePath%60.%20If%20the%20user%20switches%20to%20project%20B%20before%20the%20response%20returns%20and%20B%20has%20the%20same%20path%2C%20A's%20content%20is%20stored%20in%20B's%20include%2Fdirectory%20caches%20and%20can%20be%20rendered%20as%20B's%20file.%20Ignore%20responses%20whose%20captured%20project%20ID%20is%20no%20longer%20current%2C%20or%20namespace%20and%20clear%20these%20caches%20on%20project%20changes.%0A%0A%23%23%23%20Issue%202%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A1125-1137%0A**Effect%20mutates%20reactive%20loading%20state**%0A%0AThis%20effect%20invokes%20%60loadProjectSourceFile%60%2C%20which%20rewrites%20the%20reactive%20loading%2C%20error%2C%20and%20content%20records%20observed%20by%20the%20same%20effect.%20Move%20this%20transition%20to%20an%20event-driven%20or%20resource-based%20flow%20to%20avoid%20self-triggering%20reruns%20and%20difficult-to-cancel%20lifecycle%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A963-967%0A**Stale%20responses%20cross%20project%20boundaries**%0A%0AA%20source-file%20request%20captures%20project%20A's%20ID%20for%20the%20request%20but%2C%20after%20%60await%60%2C%20writes%20its%20result%20into%20state%20keyed%20only%20by%20%60relativePath%60.%20If%20the%20user%20switches%20to%20project%20B%20before%20the%20response%20returns%20and%20B%20has%20the%20same%20path%2C%20A's%20content%20is%20stored%20in%20B's%20include%2Fdirectory%20caches%20and%20can%20be%20rendered%20as%20B's%20file.%20Ignore%20responses%20whose%20captured%20project%20ID%20is%20no%20longer%20current%2C%20or%20namespace%20and%20clear%20these%20caches%20on%20project%20changes.%0A%0A%23%23%23%20Issue%202%0Afrontend%2Fsrc%2Froutes%2F%28app%29%2Fprojects%2F%5BprojectId%5D%2F%2Bpage.svelte%3A1125-1137%0A**Effect%20mutates%20reactive%20loading%20state**%0A%0AThis%20effect%20invokes%20%60loadProjectSourceFile%60%2C%20which%20rewrites%20the%20reactive%20loading%2C%20error%2C%20and%20content%20records%20observed%20by%20the%20same%20effect.%20Move%20this%20transition%20to%20an%20event-driven%20or%20resource-based%20flow%20to%20avoid%20self-triggering%20reruns%20and%20difficult-to-cancel%20lifecycle%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
frontend/src/routes/(app)/projects/[projectId]/+page.svelte:963-967
**Stale responses cross project boundaries**

A source-file request captures project A's ID for the request but, after `await`, writes its result into state keyed only by `relativePath`. If the user switches to project B before the response returns and B has the same path, A's content is stored in B's include/directory caches and can be rendered as B's file. Ignore responses whose captured project ID is no longer current, or namespace and clear these caches on project changes.

### Issue 2
frontend/src/routes/(app)/projects/[projectId]/+page.svelte:1125-1137
**Effect mutates reactive loading state**

This effect invokes `loadProjectSourceFile`, which rewrites the reactive loading, error, and content records observed by the same effect. Move this transition to an event-driven or resource-based flow to avoid self-triggering reruns and difficult-to-cancel lifecycle behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show git-synced project files read-..."](https://github.com/getarcaneapp/arcane/commit/022f06d65d3b076c13136c9fa266824751f20e89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55410342)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Avoid updating `$state` inside `$effect` blo... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=8e0bee41-b073-4a49-a01c-2c2c8782b420))

<!-- /greptile_comment -->