### PR TITLE
fix: backend not sending build directive for projects

### DIFF
--- a/backend/internal/project/project_details.go
+++ b/backend/internal/project/project_details.go
@@ -216,7 +216,7 @@ func (s *ProjectService) GetProjectDetails(ctx context.Context, projectID string
 	resp.UpdatedAt = proj.UpdatedAt.Format(time.RFC3339)
 	resp.IsArchived = proj.IsArchived
 	resp.ArchivedAt = proj.ArchivedAt
-	resp.HasBuildDirective = false
+	resp.HasBuildDirective = proj.BuildImageRefsJSON != nil && len(projects.ParseImageRefsJSON(*proj.BuildImageRefsJSON)) > 0
 	resp.DirName = mo.PointerToOption(proj.DirName).OrEmpty()
 	resp.RelativePath = getProjectRelativePathInternal(projectsDir, proj.Path)
 	resp.GitOpsManagedBy = proj.GitOpsManagedBy

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -805,6 +805,7 @@ func (s *ProjectService) fetchProjectStatusConcurrently(ctx context.Context, pro
 			results[i].DirName = mo.PointerToOption(p.DirName).OrEmpty()
 			results[i].RelativePath = getProjectRelativePathInternal(projectsDir, p.Path)
 			results[i].GitOpsManagedBy = p.GitOpsManagedBy
+			results[i].HasBuildDirective = p.BuildImageRefsJSON != nil && len(projects.ParseImageRefsJSON(*p.BuildImageRefsJSON)) > 0
 			meta := s.ProjectMetadata(ctx, p, metaEnv)
 			applyResolvedProjectIconInternal(&results[i], iconcatalog.Resolve(IconCatalogForContext(ctx), meta.ProjectIcon))
 			results[i].URLs = meta.ProjectURLS
@@ -837,6 +838,7 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 	resp.DirName = mo.PointerToOption(p.DirName).OrEmpty()
 	resp.RelativePath = getProjectRelativePathInternal(projectsDir, p.Path)
 	resp.GitOpsManagedBy = p.GitOpsManagedBy
+	resp.HasBuildDirective = p.BuildImageRefsJSON != nil && len(projects.ParseImageRefsJSON(*p.BuildImageRefsJSON)) > 0
 	meta := s.ProjectMetadata(ctx, p, metaEnv)
 	applyResolvedProjectIconInternal(&resp, iconcatalog.Resolve(IconCatalogForContext(ctx), meta.ProjectIcon))
 	resp.URLs = meta.ProjectURLS

--- a/backend/internal/project/service_test.go
+++ b/backend/internal/project/service_test.go
@@ -7186,3 +7186,31 @@ func TestProjectService_RecoverProjectRenameJournals_ClearsJournalWhenTargetPres
 	require.FileExists(t, filepath.Join(oldPath, "compose.yaml"))
 	require.NoDirExists(t, newPath)
 }
+
+func TestProjectService_MapProjectToDto_SeedsHasBuildDirectiveFromPersistedRefs(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDB(t)
+	settingsService, err := newSettingsServiceForTestInternal(t, ctx, db)
+	require.NoError(t, err)
+
+	svc := NewProjectService(db, settingsService, nil, nil, nil, nil, nil, nil, config.Load())
+	metaEnv := &projectMetadataEnvInternal{projectsDirectory: t.TempDir()}
+
+	now := time.Now()
+	tests := []struct {
+		name               string
+		buildImageRefsJSON *string
+		want               bool
+	}{
+		{name: "build refs persisted", buildImageRefsJSON: new(`["demo-worker"]`), want: true},
+		{name: "no build services", buildImageRefsJSON: new(`[]`), want: false},
+		{name: "refs never resolved", buildImageRefsJSON: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Project{ID: tt.name, Name: tt.name, Path: t.TempDir(), UpdatedAt: &now, BuildImageRefsJSON: tt.buildImageRefsJSON}
+			assert.Equal(t, tt.want, svc.mapProjectToDto(ctx, metaEnv.projectsDirectory, p, nil, "", nil, metaEnv).HasBuildDirective)
+		})
+	}
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3685

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change derives build-directive state from persisted build-image references for project details and normal project-listing DTOs. The regular mapper correctly reports the state, but discovered Compose projects added to update-filtered listings still use a separate DTO construction path that leaves the state unset. A focused reproduction confirmed that a discovered project with a pending update is returned without build-directive state, which can cause the client to offer Up rather than Build and Deploy. The added mapper test should also be organized as table-driven named subtests, as required by the repository’s Go testing rules.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until discovered Compose update rows report build-directive state consistently with regular project rows.

An executable in-memory reproduction exercised the discovered update-listing path and observed the missing DTO field while the regular persisted-project mapper passed as a control. The remaining test-structure finding is directly supported by the repository rule.

**Files Needing Attention:** backend/internal/project/project_listing.go needs the discovered-row mapping corrected, and backend/internal/project/service_test.go needs the new cases converted to table-driven subtests.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex authored a reproduction source for the discovered row and captured the associated reproduction outputs as part of the P1 finding proof.
- T-Rex posted a second finding-comment proof for another P1 finding, with no additional artifacts attached.
- T-Rex ran the general-contract-validation-proof and observed that the discovered DTO compose:discovered-project had isDiscovered=true, a pending update, and hasBuildDirective=false; the expected value was true, so the test exited with code 1, with no execution blockers.

<a href="https://app.greptile.com/trex/runs/19940919/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/internal/project/project_listing.go`, line 453-465 ([link](https://github.com/getarcaneapp/arcane/blob/2a2f08bebe9c0df734f1f519e02a0692ed52fbdf/backend/internal/project/project_listing.go#L453-L465)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Discovered update rows omit build state**

   When an update-filtered listing includes a discovered Compose project, this separately constructed DTO does not set `HasBuildDirective`. The normal persisted-project mapper derives that flag from build-image references, but discovered rows bypass it. A discovered project with a build directive is therefore reported as not requiring a build, so clients can offer the normal Up action instead of Build and Deploy.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Authored discovered-row reproduction source](https://app.greptile.com/trex/artifacts/19d85f0f-da34-46bf-90f8-31c36e5e90b1)**

   - Captured the exact authored Go test that uses in-memory SQLite, persisted build refs, update data, and a labeled discovered container; it defines the failing expectation.

   **[Persisted-project mapper control output](https://app.greptile.com/trex/artifacts/26e7e042-b6d8-4d34-8c28-d3fc7ab2cdcd)**

   - Ran the existing mapper test from /home/user/repo/backend and it passed, showing persisted build refs set HasBuildDirective on the regular mapped DTO.

   **[Discovered update-row reproduction output](https://app.greptile.com/trex/artifacts/41e76039-0f31-410c-91cb-2f2e25cf61ee)**

   - Ran the authored discovered update-row test from /home/user/repo/backend and it failed because the returned discovered DTO had HasBuildDirective false instead of the expected true.

   <a href="https://app.greptile.com/trex/runs/19940919/artifacts?artifact=19d85f0f-da34-46bf-90f8-31c36e5e90b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/internal/project/project_listing.go
   Line: 453-465

   Comment:
   **Discovered update rows omit build state**

   When an update-filtered listing includes a discovered Compose project, this separately constructed DTO does not set `HasBuildDirective`. The normal persisted-project mapper derives that flag from build-image references, but discovered rows bypass it. A discovered project with a build directive is therefore reported as not requiring a build, so clients can offer the normal Up action instead of Build and Deploy.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_backend_not_sending_build_directive_for_projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_backend_not_sending_build_directive_for_projects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fproject%2Fproject_listing.go%0ALine%3A%20453-465%0A%0AComment%3A%0A**Discovered%20update%20rows%20omit%20build%20state**%0A%0AWhen%20an%20update-filtered%20listing%20includes%20a%20discovered%20Compose%20project%2C%20this%20separately%20constructed%20DTO%20does%20not%20set%20%60HasBuildDirective%60.%20The%20normal%20persisted-project%20mapper%20derives%20that%20flag%20from%20build-image%20references%2C%20but%20discovered%20rows%20bypass%20it.%20A%20discovered%20project%20with%20a%20build%20directive%20is%20therefore%20reported%20as%20not%20requiring%20a%20build%2C%20so%20clients%20can%20offer%20the%20normal%20Up%20action%20instead%20of%20Build%20and%20Deploy.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Finternal%2Fproject%2Fproject_listing.go%0ALine%3A%20453-465%0A%0AComment%3A%0A**Discovered%20update%20rows%20omit%20build%20state**%0A%0AWhen%20an%20update-filtered%20listing%20includes%20a%20discovered%20Compose%20project%2C%20this%20separately%20constructed%20DTO%20does%20not%20set%20%60HasBuildDirective%60.%20The%20normal%20persisted-project%20mapper%20derives%20that%20flag%20from%20build-image%20references%2C%20but%20discovered%20rows%20bypass%20it.%20A%20discovered%20project%20with%20a%20build%20directive%20is%20therefore%20reported%20as%20not%20requiring%20a%20build%2C%20so%20clients%20can%20offer%20the%20normal%20Up%20action%20instead%20of%20Build%20and%20Deploy.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Discovered update-filtered Compose rows omit HasBuildDirective**

   - **Bug**
     - `buildDiscoveredComposeProjectUpdateRowsInternal` creates discovered `project.Details` rows without assigning `HasBuildDirective`. The executable reproduction logged `persistedBuildRefs=["example.test/discovered:latest"] ... hasBuildDirective=false expectedHasBuildDirective=true` and failed its true assertion.
   - **Cause**
     - The discovered-row literal at `backend/internal/project/project_listing.go:453-465` bypasses `mapProjectToDto`, whose persisted-project mapping assigns `HasBuildDirective` from `BuildImageRefsJSON` at line 841. The discovered path has no equivalent assignment.
   - **Fix**
     - Populate `HasBuildDirective` when constructing discovered update rows, using an available authoritative build-directive/build-image-ref source; add a regression test that covers the update-filtered discovered-row path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_backend_not_sending_build_directive_for_projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_backend_not_sending_build_directive_for_projects%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233691%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3691&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_backend_not_sending_build_directive_for_projects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_backend_not_sending_build_directive_for_projects%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fproject%2Fproject_listing.go%3A453-465%0A**Discovered%20update%20rows%20omit%20build%20state**%0A%0AWhen%20an%20update-filtered%20listing%20includes%20a%20discovered%20Compose%20project%2C%20this%20separately%20constructed%20DTO%20does%20not%20set%20%60HasBuildDirective%60.%20The%20normal%20persisted-project%20mapper%20derives%20that%20flag%20from%20build-image%20references%2C%20but%20discovered%20rows%20bypass%20it.%20A%20discovered%20project%20with%20a%20build%20directive%20is%20therefore%20reported%20as%20not%20requiring%20a%20build%2C%20so%20clients%20can%20offer%20the%20normal%20Up%20action%20instead%20of%20Build%20and%20Deploy.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fproject%2Fservice_test.go%3A7199-7206%0A**Build-state%20cases%20lack%20subtests**%0A%0AThe%20new%20test%20repeats%20three%20inputs%20and%20assertions%20instead%20of%20using%20the%20repository-required%20table-driven%20subtests%2C%20making%20additional%20cases%20more%20repetitive%20and%20preventing%20failures%20from%20being%20identified%20or%20selected%20by%20a%20named%20case.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fproject%2Fproject_listing.go%3A453-465%0A**Discovered%20update%20rows%20omit%20build%20state**%0A%0AWhen%20an%20update-filtered%20listing%20includes%20a%20discovered%20Compose%20project%2C%20this%20separately%20constructed%20DTO%20does%20not%20set%20%60HasBuildDirective%60.%20The%20normal%20persisted-project%20mapper%20derives%20that%20flag%20from%20build-image%20references%2C%20but%20discovered%20rows%20bypass%20it.%20A%20discovered%20project%20with%20a%20build%20directive%20is%20therefore%20reported%20as%20not%20requiring%20a%20build%2C%20so%20clients%20can%20offer%20the%20normal%20Up%20action%20instead%20of%20Build%20and%20Deploy.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fproject%2Fservice_test.go%3A7199-7206%0A**Build-state%20cases%20lack%20subtests**%0A%0AThe%20new%20test%20repeats%20three%20inputs%20and%20assertions%20instead%20of%20using%20the%20repository-required%20table-driven%20subtests%2C%20making%20additional%20cases%20more%20repetitive%20and%20preventing%20failures%20from%20being%20identified%20or%20selected%20by%20a%20named%20case.%0A%0ASenior%20Go%20developer%20with%20deep%20expert...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fofkm%2F-%2Fcustom-context%3Fmemory%3D214b40a8-9695-4738-986d-5949b5d65ff1%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/project/project_listing.go:453-465
**Discovered update rows omit build state**

When an update-filtered listing includes a discovered Compose project, this separately constructed DTO does not set `HasBuildDirective`. The normal persisted-project mapper derives that flag from build-image references, but discovered rows bypass it. A discovered project with a build directive is therefore reported as not requiring a build, so clients can offer the normal Up action instead of Build and Deploy.

### Issue 2
backend/internal/project/service_test.go:7199-7206
**Build-state cases lack subtests**

The new test repeats three inputs and assertions instead of using the repository-required table-driven subtests, making additional cases more repetitive and preventing failures from being identified or selected by a named case.

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: backend not sending build directive..."](https://github.com/getarcaneapp/arcane/commit/2a2f08bebe9c0df734f1f519e02a0692ed52fbdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55413309)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro

Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->