### PR TITLE
fix: validate cgroup-derived container ID during self-detection under network_mode service

### DIFF
--- a/backend/pkg/dockerutil/mount_utils.go
+++ b/backend/pkg/dockerutil/mount_utils.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/moby/moby/api/types/container"
@@ -10,28 +9,23 @@ import (
 	"github.com/moby/moby/client"
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
-	"go.getarcane.app/sys/cgroup"
 )
 
 // MountForCurrentContainerSubpath inspects the current container, finds the
 // existing mount whose destination covers containerPath, and returns a Mount
 // suitable for use in another container creation that exposes the same data
-// at target. Returns nil + no error if Arcane isn't running inside a
-// container or no suitable mount is found — callers can fall back to a
-// plain bind on containerPath in that case.
+// at target. Returns nil + no error when no suitable mount is found, and an
+// error when the current container can't be detected — callers can fall back
+// to a plain bind on containerPath in either case.
 func MountForCurrentContainerSubpath(ctx context.Context, dockerCli *client.Client, containerPath, target string) (*mount.Mount, error) {
 	if dockerCli == nil {
 		return nil, nil
 	}
-	inspectTarget, _, err := libarcane.CurrentContainerInspectTarget(cgroup.CurrentContainerID, os.Hostname)
+	inspect, err := libarcane.InspectCurrentArcaneContainer(ctx, dockerCli)
 	if err != nil {
 		return nil, err
 	}
-	inspect, err := libarcane.ContainerInspectWithCompatibility(ctx, dockerCli, inspectTarget, client.ContainerInspectOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return MountForSubpath(inspect.Container.Mounts, containerPath, target), nil
+	return MountForSubpath(inspect.Mounts, containerPath, target), nil
 }
 
 // MountForSubpath returns a Mount that exposes a subpath of one of the

--- a/backend/pkg/libarcane/internal_resource.go
+++ b/backend/pkg/libarcane/internal_resource.go
@@ -77,18 +77,17 @@ func InspectCurrentArcaneContainer(ctx context.Context, dockerClient *client.Cli
 		return nil, errors.New("docker client is not available")
 	}
 
-	// A cgroup-derived container ID is definitively the current container, so
-	// that inspect is trusted even without the Arcane label (custom images).
-	// With network_mode: service:<sidecar> the hostname belongs to the sidecar
-	// container, so a hostname-derived inspect is only trusted directly when it
-	// carries the Arcane label (#3544); an unlabeled hostname hit is kept as a
-	// last resort so the label lookup can't hijack detection either way.
+	// With network_mode: service:<sidecar> both the hostname and the cgroup
+	// mountinfo fallback resolve the netns-owning sidecar — the container's
+	// /etc/hostname, /etc/hosts and /etc/resolv.conf bind-mounts come from the
+	// sidecar's container directory — so no derived target is authoritative. A
+	// derived inspect is only trusted directly when it carries the Arcane label
+	// (#3544, #3693); an unlabeled hit is kept as a last resort so the label
+	// lookup can't hijack detection either way. Custom images without the label
+	// behind a sidecar stay undetectable and must carry the label themselves.
 	var unlabeled *container.InspectResponse
-	if target, fromContainerID, err := CurrentContainerInspectTarget(cgroup.CurrentContainerID, os.Hostname); err == nil && target != "" {
+	if target, err := CurrentContainerInspectTarget(cgroup.CurrentContainerID, os.Hostname); err == nil && target != "" {
 		if inspect, inspectErr := ContainerInspectWithCompatibility(ctx, dockerClient, target, client.ContainerInspectOptions{}); inspectErr == nil {
-			if fromContainerID {
-				return &inspect.Container, nil
-			}
 			if inspect.Container.Config != nil && strings.EqualFold(strings.TrimSpace(inspect.Container.Config.Labels[labels.LabelArcane]), "true") {
 				return &inspect.Container, nil
 			}
@@ -101,10 +100,10 @@ func InspectCurrentArcaneContainer(ctx context.Context, dockerClient *client.Cli
 		if err != nil {
 			return nil, errors.WrapIf(err, "inspect Arcane container")
 		}
-		// An unlabeled hostname hit is only overridden by the labeled match when
-		// that match shares the hostname container's network namespace — i.e. the
-		// hostname really belonged to its sidecar (#3544). Otherwise the labeled
-		// container is a different Arcane instance and the hostname hit is us.
+		// An unlabeled derived hit is only overridden by the labeled match when
+		// that match shares the derived container's network namespace — i.e. the
+		// derived target really was its sidecar (#3544, #3693). Otherwise the
+		// labeled container is a different Arcane instance and the hit is us.
 		if unlabeled == nil || sharesNetworkNamespaceInternal(&inspect.Container, unlabeled) {
 			return &inspect.Container, nil
 		}
@@ -133,13 +132,15 @@ func sharesNetworkNamespaceInternal(candidate, owner *container.InspectResponse)
 }
 
 // CurrentContainerInspectTarget resolves the identifier used to inspect Arcane's
-// current container. The second return reports whether the target came from the
-// cgroup container ID (authoritative) rather than the hostname fallback.
-func CurrentContainerInspectTarget(currentContainerID func() (string, error), hostname func() (string, error)) (string, bool, error) {
+// current container: the detected container ID when available, the hostname
+// otherwise. Neither source is authoritative — under network_mode:
+// container:<sidecar> both can resolve the netns-owning sidecar — so callers
+// must validate the inspected container (see InspectCurrentArcaneContainer).
+func CurrentContainerInspectTarget(currentContainerID func() (string, error), hostname func() (string, error)) (string, error) {
 	if currentContainerID != nil {
 		if containerID, err := currentContainerID(); err == nil {
 			if containerID = strings.TrimSpace(containerID); containerID != "" {
-				return containerID, true, nil
+				return containerID, nil
 			}
 		}
 	}
@@ -150,8 +151,8 @@ func CurrentContainerInspectTarget(currentContainerID func() (string, error), ho
 
 	value, err := hostname()
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
-	return strings.TrimSpace(value), false, nil
+	return strings.TrimSpace(value), nil
 }

--- a/backend/pkg/libarcane/internal_resource_test.go
+++ b/backend/pkg/libarcane/internal_resource_test.go
@@ -13,40 +13,37 @@ import (
 
 func TestCurrentContainerInspectTarget(t *testing.T) {
 	t.Run("prefers detected container id over hostname", func(t *testing.T) {
-		target, fromContainerID, err := CurrentContainerInspectTarget(
+		target, err := CurrentContainerInspectTarget(
 			func() (string, error) { return "0123456789ab", nil },
 			func() (string, error) { return "rpi4", nil },
 		)
 
 		require.NoError(t, err)
 		require.Equal(t, "0123456789ab", target)
-		require.True(t, fromContainerID)
 	})
 
 	t.Run("falls back to hostname when container id unavailable", func(t *testing.T) {
-		target, fromContainerID, err := CurrentContainerInspectTarget(
+		target, err := CurrentContainerInspectTarget(
 			func() (string, error) { return "", errors.New("no container id found") },
 			func() (string, error) { return "rpi4", nil },
 		)
 
 		require.NoError(t, err)
 		require.Equal(t, "rpi4", target)
-		require.False(t, fromContainerID)
 	})
 
 	t.Run("trims whitespace from detected container id", func(t *testing.T) {
-		target, fromContainerID, err := CurrentContainerInspectTarget(
+		target, err := CurrentContainerInspectTarget(
 			func() (string, error) { return "  0123456789ab  ", nil },
 			func() (string, error) { return "rpi4", nil },
 		)
 
 		require.NoError(t, err)
 		require.Equal(t, "0123456789ab", target)
-		require.True(t, fromContainerID)
 	})
 
 	t.Run("returns hostname error when fallback fails", func(t *testing.T) {
-		target, fromContainerID, err := CurrentContainerInspectTarget(
+		target, err := CurrentContainerInspectTarget(
 			func() (string, error) { return "", errors.New("no container id found") },
 			func() (string, error) { return "", errors.New("hostname unavailable") },
 		)
@@ -54,14 +51,14 @@ func TestCurrentContainerInspectTarget(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "hostname unavailable")
 		require.Empty(t, target)
-		require.False(t, fromContainerID)
 	})
 }
 
 func TestInspectCurrentArcaneContainer_FallsBackToLabelWhenHostnameIsSidecar(t *testing.T) {
-	// With network_mode: service:<sidecar> the hostname inspect returns the
-	// sidecar container (no Arcane label); detection must fall back to the
-	// label lookup instead of trusting it (#3544).
+	// With network_mode: service:<sidecar> both the hostname and the cgroup
+	// mountinfo fallback resolve the sidecar container (no Arcane label);
+	// detection must fall back to the label lookup instead of trusting the
+	// derived inspect (#3544, #3693).
 	dockerClient := newTestDockerClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3693

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change strengthens Arcane self-container detection by checking derived container targets against the Arcane label and shared network namespace. A focused Docker API-stub test reproduced a remaining failure: when the derived target is an unlabeled sidecar and no labeled Arcane container exists, detection returns the sidecar instead of failing. Self-resource operations, including mount discovery, can therefore use the sidecar's container resources.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until unlabeled derived sidecar targets cannot be accepted when Arcane identity cannot be verified.

A focused, isolated test exercised the exact empty-label-lookup path and observed the function return the unlabeled sidecar rather than its documented detection error.

**Files Needing Attention:** backend/pkg/libarcane/internal_resource.go, particularly the unlabeled fallback at lines 112-113.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Go test to reproduce the unlabeled derived sidecar scenario and produced a finding-comment-proof for P1.
- The focused test output confirmed the unlabeled sidecar was returned.
- Produced another finding-comment-proof for a second posted P1 finding.
- Validated the arcane-sidecar no-label path by running the Go test for the TestInspectCurrentArcaneContainer\_ReturnsDerivedUnlabeledSidecarWhenLabelListIsEmpty; the command completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/20301711/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `backend/pkg/libarcane/internal_resource.go`, line 112-113 ([link](https://github.com/getarcaneapp/arcane/blob/66953dee3b4b1e475f38a2f430d7344cd8446cc0/backend/pkg/libarcane/internal_resource.go#L112-L113)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unlabeled sidecar is accepted as Arcane**

   When Arcane shares a sidecar's network namespace and the derived inspect resolves to that unlabeled sidecar, an empty Arcane-label lookup still falls through to `return unlabeled`. This makes self-resource operations such as mount discovery target the sidecar's container ID, mounts, and network rather than failing detection. Do not accept an unlabeled derived target when no verified Arcane-labeled container is available.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused Go test source for an unlabeled derived sidecar with no label candidates](https://app.greptile.com/trex/artifacts/d5565108-b546-46eb-8a0a-6559590a12f2)**

   - Captured the authored in-process Docker API-stub test that returns an unlabeled sidecar for inspect and an empty labeled-container list, demonstrating the exact requested setup.

   **[Focused Go test output showing the unlabeled sidecar was returned](https://app.greptile.com/trex/artifacts/9ea56b4c-64ff-408f-9281-e584ab7a38b6)**

   - Ran the focused Go test; it passed while logging one empty label-list call and returned ID sidecar456, confirming the claimed fallback behavior.

   <a href="https://app.greptile.com/trex/runs/20301711/artifacts?artifact=d5565108-b546-46eb-8a0a-6559590a12f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: backend/pkg/libarcane/internal_resource.go
   Line: 112-113

   Comment:
   **Unlabeled sidecar is accepted as Arcane**

   When Arcane shares a sidecar's network namespace and the derived inspect resolves to that unlabeled sidecar, an empty Arcane-label lookup still falls through to `return unlabeled`. This makes self-resource operations such as mount discovery target the sidecar's container ID, mounts, and network rather than failing detection. Do not accept an unlabeled derived target when no verified Arcane-labeled container is available.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Flibarcane%2Finternal_resource.go%0ALine%3A%20112-113%0A%0AComment%3A%0A**Unlabeled%20sidecar%20is%20accepted%20as%20Arcane**%0A%0AWhen%20Arcane%20shares%20a%20sidecar's%20network%20namespace%20and%20the%20derived%20inspect%20resolves%20to%20that%20unlabeled%20sidecar%2C%20an%20empty%20Arcane-label%20lookup%20still%20falls%20through%20to%20%60return%20unlabeled%60.%20This%20makes%20self-resource%20operations%20such%20as%20mount%20discovery%20target%20the%20sidecar's%20container%20ID%2C%20mounts%2C%20and%20network%20rather%20than%20failing%20detection.%20Do%20not%20accept%20an%20unlabeled%20derived%20target%20when%20no%20verified%20Arcane-labeled%20container%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3710&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20backend%2Fpkg%2Flibarcane%2Finternal_resource.go%0ALine%3A%20112-113%0A%0AComment%3A%0A**Unlabeled%20sidecar%20is%20accepted%20as%20Arcane**%0A%0AWhen%20Arcane%20shares%20a%20sidecar's%20network%20namespace%20and%20the%20derived%20inspect%20resolves%20to%20that%20unlabeled%20sidecar%2C%20an%20empty%20Arcane-label%20lookup%20still%20falls%20through%20to%20%60return%20unlabeled%60.%20This%20makes%20self-resource%20operations%20such%20as%20mount%20discovery%20target%20the%20sidecar's%20container%20ID%2C%20mounts%2C%20and%20network%20rather%20than%20failing%20detection.%20Do%20not%20accept%20an%20unlabeled%20derived%20target%20when%20no%20verified%20Arcane-labeled%20container%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3710&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unlabeled sidecar is returned when Arcane-label detection has no match**

   - **Bug**
     - For the requested network-namespace sidecar path, the derived inspect response is unlabeled and the Docker `ContainerList` response has zero Arcane-label candidates. The function nevertheless succeeds and returns `sidecar456` rather than returning `could not detect Arcane container`.
   - **Cause**
     - After label lookup finds no candidate, `unlabeled` remains non-nil and the fallback at `backend/pkg/libarcane/internal_resource.go:112-113` returns it unconditionally.
   - **Fix**
     - Remove or constrain the unlabeled fallback so a derived unlabeled container is not accepted when no verified Arcane-label match exists; return the detection error instead for this condition.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233710%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3710&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_validate_cgroup-derived_container_id_during_self-detection_under_network_mode_service%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Flibarcane%2Finternal_resource.go%3A112-113%0A**Unlabeled%20sidecar%20is%20accepted%20as%20Arcane**%0A%0AWhen%20Arcane%20shares%20a%20sidecar's%20network%20namespace%20and%20the%20derived%20inspect%20resolves%20to%20that%20unlabeled%20sidecar%2C%20an%20empty%20Arcane-label%20lookup%20still%20falls%20through%20to%20%60return%20unlabeled%60.%20This%20makes%20self-resource%20operations%20such%20as%20mount%20discovery%20target%20the%20sidecar's%20container%20ID%2C%20mounts%2C%20and%20network%20rather%20than%20failing%20detection.%20Do%20not%20accept%20an%20unlabeled%20derived%20target%20when%20no%20verified%20Arcane-labeled%20container%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3710&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Flibarcane%2Finternal_resource.go%3A112-113%0A**Unlabeled%20sidecar%20is%20accepted%20as%20Arcane**%0A%0AWhen%20Arcane%20shares%20a%20sidecar's%20network%20namespace%20and%20the%20derived%20inspect%20resolves%20to%20that%20unlabeled%20sidecar%2C%20an%20empty%20Arcane-label%20lookup%20still%20falls%20through%20to%20%60return%20unlabeled%60.%20This%20makes%20self-resource%20operations%20such%20as%20mount%20discovery%20target%20the%20sidecar's%20container%20ID%2C%20mounts%2C%20and%20network%20rather%20than%20failing%20detection.%20Do%20not%20accept%20an%20unlabeled%20derived%20target%20when%20no%20verified%20Arcane-labeled%20container%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3710&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/libarcane/internal_resource.go:112-113
**Unlabeled sidecar is accepted as Arcane**

When Arcane shares a sidecar's network namespace and the derived inspect resolves to that unlabeled sidecar, an empty Arcane-label lookup still falls through to `return unlabeled`. This makes self-resource operations such as mount discovery target the sidecar's container ID, mounts, and network rather than failing detection. Do not accept an unlabeled derived target when no verified Arcane-labeled container is available.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: validate cgroup-derived container I..."](https://github.com/getarcaneapp/arcane/commit/66953dee3b4b1e475f38a2f430d7344cd8446cc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56113259)</sub>

<!-- /greptile_comment -->