### PR TITLE
fix: handle discovered Compose project updates

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrSessionRevoked                          = Classify(ErrUnauthorized, errors.Sentinel("Session has been revoked"))
 	ErrUpgradeInProgress                       = Classify(ErrConflict, errors.Sentinel("an upgrade is already in progress"))
 	ErrUpdateAllInProgress                     = Classify(ErrConflict, errors.Sentinel("an update-all job is already in progress"))
+	ErrUpdaterNoContainersMatched              = Classify(ErrBadRequest, errors.Sentinel("no compose-managed containers matched the requested resources"))
 	ErrTemplateNotFound                        = Classify(ErrNotFound, errors.Sentinel("Template not found"))
 	ErrInvalidEnvKey                           = Classify(ErrValidation, errors.Sentinel("Invalid environment key"))
 	ErrGlobalVariableNotFound                  = Classify(ErrNotFound, errors.Sentinel("Global variable not found"))

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -408,6 +408,9 @@ func buildDiscoveredComposeProjectUpdateRowsInternal(
 ) []project.Details {
 	containersByProject := make(map[string][]container.Summary)
 	for _, c := range composeContainers {
+		if dockerutil.ComposeServiceLabel(c.Labels) == "" {
+			continue
+		}
 		projectName := dockerutil.ComposeProjectLabel(c.Labels)
 		if projectName == "" {
 			continue

--- a/backend/internal/project/service_test.go
+++ b/backend/internal/project/service_test.go
@@ -3684,7 +3684,6 @@ func TestBuildDiscoveredComposeProjectUpdateRowsInternal(t *testing.T) {
 		CurrentVersion: "7",
 		CheckTime:      now,
 	}).Error)
-
 	rows := buildDiscoveredComposeProjectUpdateRowsInternal(ctx, []container.Summary{
 		{
 			ID:      "media-web",

--- a/backend/internal/updater/handler.go
+++ b/backend/internal/updater/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/middleware"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
@@ -115,6 +116,9 @@ func (h *UpdaterHandler) RunUpdater(ctx context.Context, input *RunUpdaterInput)
 	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
 	out, err := h.updaterService.ApplyPending(runtimeCtx, options)
 	if err != nil {
+		if errors.Is(err, common.ErrBadRequest) {
+			return nil, huma.Error400BadRequest(errors.WithMessage(err, "Failed to run updater").Error())
+		}
 		return nil, huma.Error500InternalServerError(errors.WithMessage(err, "Failed to run updater").Error())
 	}
 

--- a/backend/internal/updater/service.go
+++ b/backend/internal/updater/service.go
@@ -261,7 +261,7 @@ func (s *UpdaterService) applyScopedUpdatesInternal(ctx context.Context, options
 		return err
 	}
 	if len(containerIDs) == 0 {
-		return errors.Errorf("no containers matched the requested %s resources", strings.TrimSpace(options.Type))
+		return common.ErrUpdaterNoContainersMatched
 	}
 
 	engineOpts := updater.Options{Force: options.ForceUpdate, DryRun: options.DryRun}
@@ -329,8 +329,10 @@ func (s *UpdaterService) containerIDsForProjectsInternal(ctx context.Context, pr
 
 	names := make(map[string]struct{}, len(projectRefs))
 	for _, ref := range projectRefs {
-		name := ref
-		if s.deps.Projects != nil {
+		name := strings.TrimSpace(ref)
+		if discoveredName, discovered := strings.CutPrefix(name, "compose:"); discovered {
+			name = discoveredName
+		} else if s.deps.Projects != nil {
 			if project, lookupErr := s.deps.Projects.GetProjectFromDatabaseByID(ctx, ref); lookupErr == nil && project != nil {
 				switch {
 				case project.ComposeProjectName != nil && strings.TrimSpace(*project.ComposeProjectName) != "":
@@ -350,6 +352,9 @@ func (s *UpdaterService) containerIDsForProjectsInternal(ctx context.Context, pr
 
 	var ids []string
 	for _, summary := range containers {
+		if dockerutil.ComposeServiceLabel(summary.Labels) == "" {
+			continue
+		}
 		project := strings.ToLower(strings.TrimSpace(dockerutil.ComposeProjectLabel(summary.Labels)))
 		if project == "" {
 			continue


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3702

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change allows updater runs for discovered Docker Compose projects, limits project targets to Compose-managed services, and returns a client error when a scoped selection contains no eligible containers.

Focused backend checks exercised the scoped project flow. They disproved the potential failure that discovered `compose:` references would include containers without Compose service metadata, fail to report an empty selection as a client error, or fail when whitespace follows the prefix: only `target-web` was selected, `compose:empty` returned the classified bad-request error, and `compose: target` resolved successfully.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the exercised scoped updater behavior.

The focused backend harness verified discovered-project resolution, Compose service filtering, empty-match handling, and whitespace normalization without finding a failure.

**Files Needing Attention:** No files require follow-up changes.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Go backend test through UpdaterService.ApplyPending using the Docker HTTP harness.
- Validated the test outputs showed an empty compose:empty selection produced no match with bad-request classification, and a compose:target selection updated only target-web while excluding non-matching containers.

<a href="https://app.greptile.com/trex/runs/20314502/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: handle discovered Compose project u..."](https://github.com/getarcaneapp/arcane/commit/6dc139605ef886f6f19ce4b55fd2afb424c3debd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56142909)</sub>

<!-- /greptile_comment -->