### PR TITLE
refactor: use ai generation for github release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,8 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           NODE_VERSION: ${{ steps.frontend-versions.outputs.node_version }}
           SVELTEKIT_VERSION: ${{ steps.frontend-versions.outputs.sveltekit_version }}
+          OPENAI_BASE_URL: https://openrouter.ai/api/v1
+          OPENAI_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
       - name: Resolve image digests
         id: digests

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -397,7 +397,34 @@ blobs:
     disable: '{{ if not (index .Env "BUILD_NEXT") }}true{{ end }}'
 
 changelog:
-  disable: true
+  disable: '{{ if isEnvSet "SKIP_CHANGELOG" }}true{{ else if isEnvSet "OPENAI_API_KEY" }}false{{ else }}true{{ end }}'
+  use: github
+  filters:
+    include:
+      - '^feat'
+      - '^fix'
+      - '^perf'
+      - '^docs'
+      - '^refactor'
+      - '^test'
+      - '^style'
+      - '^build'
+      - '^ci'
+      - '^revert'
+      - '^chore\(deps\)'
+  ai:
+    use: openai
+    model: openai/gpt-5.6-luna-pro
+    prompt: |
+      Rewrite these release notes for Arcane, a Docker management app.
+      Start with a short intro highlighting the most notable changes, wrapped
+      in a GitHub alert blockquote (a "> [!NOTE]" line followed by "> " prefixed
+      lines). The intro's first sentence must begin with "This release adds" or
+      "This release fixes". Group related changes, merge dependency bumps of the same
+      dependency into one line, and keep it concise. Keep each entry's pull
+      request or commit reference and its author attribution. No emojis.
+
+      {{ .ReleaseNotes }}
 
 announce:
   discord:
@@ -419,9 +446,5 @@ release:
   replace_existing_artifacts: true
   prerelease: auto
   make_latest: true
-  mode: keep-existing
+  mode: replace
   name_template: '{{.Tag}}'
-  footer: |
-    ---
-
-    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change enables AI-generated GitHub release notes through OpenRouter and replaces the content of existing draft releases. The release configuration was exercised with an empty OpenRouter key and showed that generated notes are disabled while the existing draft body is still replaced with an empty value, so a release can be published without release notes.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until the release flow preserves curated draft notes or avoids replacement when AI note generation is unavailable.

The empty-key release path was executed with a non-empty existing draft body and confirmed that the configured replacement behavior clears it.

**Files Needing Attention:** .goreleaser.yaml needs attention at the changelog disable expression and existing-draft release mode settings.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a posted P1 finding and attached two artifacts describing the missing-key release validation harness and the missing OpenAI key that replaces the curated existing draft body.
- T-Rex produced a second finding-comment-proof for another posted P1 finding.
- T-Rex performed a general contract validation that confirms the execution state, including changelog.disable set to true, use\_existing\_draft true, release.mode set to replace, a non-empty existing draft body, empty generated notes, and body after mode=replace being empty.

<a href="https://app.greptile.com/trex/runs/20514973/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing OpenRouter key erases existing draft release notes**

   - **Bug**
     - When the workflow supplies an absent or empty OpenRouter secret as `OPENAI_API_KEY`, changelog generation is disabled. GoReleaser then uses the configured `replace` release-notes mode for an existing GitHub draft, selecting empty generated notes and overwriting its curated body.
   - **Cause**
     - The changelog disable expression returns true when `OPENAI_API_KEY` is empty (`.goreleaser.yaml:400`), while `use_existing_draft: true` (`.goreleaser.yaml:445`) and `mode: replace` (`.goreleaser.yaml:449`) direct the release path to replace the draft’s notes rather than retain them.
   - **Fix**
     - Use `mode: keep-existing` for draft releases whose curated body must survive unavailable AI changelog generation, or conditionally prevent publishing/replacing when the OpenRouter key is absent.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor_use_ai_generation_for_github_release_notes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor_use_ai_generation_for_github_release_notes%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233739%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3739&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22refactor_use_ai_generation_for_github_release_notes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor_use_ai_generation_for_github_release_notes%22.%0A%0A%23%23%23%20Issue%201%0A.goreleaser.yaml%3A449%0A**Replacement%20erases%20fallback%20release%20notes**%0A%0AIf%20%60OPENROUTER_API_KEY%60%20is%20absent%20or%20empty%2C%20the%20workflow%20supplies%20an%20empty%20%60OPENAI_API_KEY%60%2C%20so%20the%20changelog%20setting%20at%20line%20400%20disables%20note%20generation.%20However%2C%20this%20release%20reuses%20an%20existing%20draft%20%28line%20445%29%20and%20%60mode%3A%20replace%60%20then%20overwrites%20its%20curated%20body%20with%20the%20empty%20generated-notes%20value.%20The%20published%20release%20and%20Arcane%20update%20dialog%20can%20therefore%20have%20no%20release%20notes.%20Preserve%20the%20existing%20body%20when%20generation%20is%20unavailable%2C%20or%20avoid%20replacing%20the%20draft%20unless%20note%20generation%20succeeds.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3739&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.goreleaser.yaml%3A449%0A**Replacement%20erases%20fallback%20release%20notes**%0A%0AIf%20%60OPENROUTER_API_KEY%60%20is%20absent%20or%20empty%2C%20the%20workflow%20supplies%20an%20empty%20%60OPENAI_API_KEY%60%2C%20so%20the%20changelog%20setting%20at%20line%20400%20disables%20note%20generation.%20However%2C%20this%20release%20reuses%20an%20existing%20draft%20%28line%20445%29%20and%20%60mode%3A%20replace%60%20then%20overwrites%20its%20curated%20body%20with%20the%20empty%20generated-notes%20value.%20The%20published%20release%20and%20Arcane%20update%20dialog%20can%20therefore%20have%20no%20release%20notes.%20Preserve%20the%20existing%20body%20when%20generation%20is%20unavailable%2C%20or%20avoid%20replacing%20the%20draft%20unless%20note%20generation%20succeeds.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3739&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.goreleaser.yaml:449
**Replacement erases fallback release notes**

If `OPENROUTER_API_KEY` is absent or empty, the workflow supplies an empty `OPENAI_API_KEY`, so the changelog setting at line 400 disables note generation. However, this release reuses an existing draft (line 445) and `mode: replace` then overwrites its curated body with the empty generated-notes value. The published release and Arcane update dialog can therefore have no release notes. Preserve the existing body when generation is unavailable, or avoid replacing the draft unless note generation succeeds.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use ai generation for github r..."](https://github.com/getarcaneapp/arcane/commit/2111291d4573805426b907412d1ac0309a0a9b0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56514948)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->