### PR TITLE
fix: write workspace files as the volume's runtime identity instead of root

### DIFF
--- a/backend/internal/volume/backup.go
+++ b/backend/internal/volume/backup.go
@@ -1180,7 +1180,7 @@ func (s *VolumeService) downloadRusticBackupInternal(ctx context.Context, entry 
 		removeScratch()
 	}
 	archivePath := "/tmp/" + entry.ID + ".tar.gz"
-	if _, _, err := s.execInContainerInternal(ctx, containerID, []string{"tar", "-czf", archivePath, "-C", "/volume", "."}); err != nil {
+	if _, _, err := s.execInContainerInternal(ctx, containerID, "", []string{"tar", "-czf", archivePath, "-C", "/volume", "."}); err != nil {
 		cleanup()
 		return nil, 0, fmt.Errorf("failed to package Rustic snapshot for download: %w", err)
 	}
@@ -1283,7 +1283,7 @@ func (s *VolumeService) deleteArchiveBackupInternal(ctx context.Context, entry *
 		filename, filenameErr := s.backupArchiveFilenameInternal(backupID)
 		if filenameErr != nil {
 			slog.WarnContext(ctx, "failed to sanitize backup id for file cleanup", "backup_id", backupID, "error", filenameErr.Error())
-		} else if _, _, err = s.execInContainerInternal(ctx, containerID, []string{"rm", "-f", path.Join("/volume", filename)}); err != nil {
+		} else if _, _, err = s.execInContainerInternal(ctx, containerID, "", []string{"rm", "-f", path.Join("/volume", filename)}); err != nil {
 			slog.WarnContext(ctx, "failed to delete backup file (orphan file may remain)", "backup_id", backupID, "error", err.Error())
 		}
 	}
@@ -1376,7 +1376,7 @@ func (s *VolumeService) listArchiveBackupPathsInternal(ctx context.Context, back
 		return nil, err
 	}
 	defer cleanup()
-	stdout, _, err := s.execInContainerInternal(ctx, containerID, []string{"tar", "-tzf", path.Join("/volume", filename)})
+	stdout, _, err := s.execInContainerInternal(ctx, containerID, "", []string{"tar", "-tzf", path.Join("/volume", filename)})
 	if err != nil {
 		return nil, err
 	}
@@ -1407,7 +1407,7 @@ func (s *VolumeService) restoreBackupFilesInContainerInternal(ctx context.Contex
 	for _, cleaned := range cleanedPaths {
 		args = append(args, "./"+cleaned)
 	}
-	_, stderr, err := s.execInContainerInternal(ctx, containerID, args)
+	_, stderr, err := s.execInContainerInternal(ctx, containerID, "", args)
 	return stderr, errors.WrapIf(err, "failed to restore files")
 }
 
@@ -1502,7 +1502,7 @@ func (s *VolumeService) UploadAndRestore(ctx context.Context, volumeName string,
 	defer cleanup()
 
 	tmpDir := fmt.Sprintf("/volume/.restore_tmp_%d", time.Now().UnixNano())
-	_, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"mkdir", "-p", tmpDir})
+	_, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"mkdir", "-p", tmpDir})
 	if err != nil {
 		return errors.WrapIf(err, "failed to create temp restore dir")
 	}
@@ -1521,7 +1521,7 @@ func (s *VolumeService) UploadAndRestore(ctx context.Context, volumeName string,
 		return errors.WrapIf(err, "failed to restore from uploaded archive")
 	}
 
-	_, stderr, err = s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", fmt.Sprintf("test -n \"$(find %s -mindepth 1 -maxdepth 1 -print -quit)\"", tmpDir)})
+	_, stderr, err = s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", fmt.Sprintf("test -n \"$(find %s -mindepth 1 -maxdepth 1 -print -quit)\"", tmpDir)})
 	if err != nil {
 		return errors.WrapIf(err, "uploaded archive appears empty or invalid")
 	}
@@ -1529,7 +1529,7 @@ func (s *VolumeService) UploadAndRestore(ctx context.Context, volumeName string,
 		slog.DebugContext(ctx, "volume service: restore validate stderr", "volume", volumeName, "stderr", strings.TrimSpace(stderr))
 	}
 
-	_, stderr, err = s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", "rm -rf /volume/* /volume/.[!.]* /volume/..?* 2>/dev/null || true"})
+	_, stderr, err = s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", "rm -rf /volume/* /volume/.[!.]* /volume/..?* 2>/dev/null || true"})
 	if err != nil {
 		return errors.WrapIf(err, "failed to clear volume before restore")
 	}
@@ -1538,7 +1538,7 @@ func (s *VolumeService) UploadAndRestore(ctx context.Context, volumeName string,
 	}
 
 	moveCmd := fmt.Sprintf("find %s -mindepth 1 -maxdepth 1 -exec mv -- {} /volume/ \\; && rmdir %s", tmpDir, tmpDir)
-	_, stderr, err = s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", moveCmd})
+	_, stderr, err = s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", moveCmd})
 	if err != nil {
 		return errors.WrapIf(err, "failed to move restored files into place")
 	}

--- a/backend/internal/volume/helper_container.go
+++ b/backend/internal/volume/helper_container.go
@@ -46,7 +46,7 @@ func (s *VolumeService) requireVolumeHelperACFSInternal(ctx context.Context, vol
 	}
 	s.helperMu.Unlock()
 
-	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"acfs", "version"})
+	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"acfs", "version"})
 	if err != nil {
 		return errors.WrapIf(err, "volume workspace requires an ACFS-capable tools image: "+strings.TrimSpace(stderr))
 	}
@@ -472,8 +472,8 @@ func (s *VolumeService) removeHelperEntry(volumeName string) {
 	s.helperMu.Unlock()
 }
 
-func (s *VolumeService) execInContainerInternal(ctx context.Context, containerID string, cmd []string) (string, string, error) {
-	slog.DebugContext(ctx, "volume service: exec in container", "container_id", containerID, "cmd", cmd)
+func (s *VolumeService) execInContainerInternal(ctx context.Context, containerID, execUser string, cmd []string) (string, string, error) {
+	slog.DebugContext(ctx, "volume service: exec in container", "container_id", containerID, "user", execUser, "cmd", cmd)
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		return "", "", err
@@ -481,6 +481,7 @@ func (s *VolumeService) execInContainerInternal(ctx context.Context, containerID
 
 	var stdout, stderr bytes.Buffer
 	exitCode, err := dockerutil.ExecInContainer(ctx, dockerClient, containerID, client.ExecCreateOptions{
+		User:         execUser,
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          cmd,

--- a/backend/internal/volume/workspace.go
+++ b/backend/internal/volume/workspace.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	dockerutil "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/volumehelper"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	acfsutils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/acfs"
@@ -241,7 +242,7 @@ func (s *VolumeService) GetVolumeWorkspaceFile(ctx context.Context, volumeName, 
 	if err := s.requireVolumeHelperACFSInternal(ctx, volumeName, containerID); err != nil {
 		return nil, err
 	}
-	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, []string{
+	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{
 		"acfs", "stat", "--root", "/volume", "--path", "/" + rel,
 	})
 	if err != nil {
@@ -522,7 +523,7 @@ func (s *VolumeService) validateVolumeWorkspacePathInternal(ctx context.Context,
 	if allowMissing {
 		allowMissingValue = "1"
 	}
-	_, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", volumeWorkspaceValidatePathScriptInternal, "sh", relativePath, allowMissingValue})
+	_, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", volumeWorkspaceValidatePathScriptInternal, "sh", relativePath, allowMissingValue})
 	if err != nil {
 		return classifyVolumeWorkspaceExecErrorInternal(err, stderr, "validate volume workspace path")
 	}
@@ -609,7 +610,8 @@ func (s *VolumeService) UpdateVolumeWorkspace(ctx context.Context, volumeName st
 	if err != nil {
 		return nil, err
 	}
-	stagedFiles, err := s.stageVolumeWorkspaceChangesInternal(ctx, dockerClient, containerID, manifest.FileChanges, uploads)
+	identity := s.resolveVolumeWorkspaceWriteIdentityInternal(ctx, dockerClient, containerID, volumeName)
+	stagedFiles, err := s.stageVolumeWorkspaceChangesInternal(ctx, dockerClient, containerID, manifest.FileChanges, uploads, identity)
 	if err != nil {
 		return nil, err
 	}
@@ -639,6 +641,7 @@ func (s *VolumeService) UpdateVolumeWorkspace(ctx context.Context, volumeName st
 		volumeName,
 		manifest.FileChanges,
 		stagedFiles,
+		identity,
 		func() error { return s.restoreVolumeWorkspaceScopeInternal(ctx, containerID, backup) },
 	); err != nil {
 		return nil, err
@@ -661,6 +664,84 @@ func (s *VolumeService) UpdateVolumeWorkspace(ctx context.Context, volumeName st
 	return workspace, nil
 }
 
+// volumeWorkspaceWriteIdentityInternal is the identity workspace file mutations run as,
+// so files land owned by the user the consuming container runs with. The zero value means root.
+type volumeWorkspaceWriteIdentityInternal struct {
+	execUser string
+	uid      int
+	gid      int
+}
+
+func volumeWorkspaceWriteIdentityFromConfigUserInternal(configUser string) volumeWorkspaceWriteIdentityInternal {
+	trimmed := strings.TrimSpace(configUser)
+	if trimmed == "" {
+		return volumeWorkspaceWriteIdentityInternal{}
+	}
+	// Named users cannot be resolved against the helper image, and uid 0 is already the default.
+	uidPart, gidPart, hasGID := strings.Cut(trimmed, ":")
+	uid, err := strconv.ParseUint(uidPart, 10, 32)
+	if err != nil || uid == 0 {
+		return volumeWorkspaceWriteIdentityInternal{}
+	}
+	var gid uint64
+	if hasGID {
+		gid, err = strconv.ParseUint(gidPart, 10, 32)
+		if err != nil {
+			return volumeWorkspaceWriteIdentityInternal{}
+		}
+	}
+	return volumeWorkspaceWriteIdentityInternal{execUser: trimmed, uid: int(uid), gid: int(gid)}
+}
+
+func (s *VolumeService) resolveVolumeWorkspaceWriteIdentityInternal(ctx context.Context, dockerClient *client.Client, containerID, volumeName string) volumeWorkspaceWriteIdentityInternal {
+	consumerIDs, err := dockerutil.GetContainersUsingVolume(ctx, dockerClient, volumeName)
+	if err != nil {
+		slog.WarnContext(ctx, "could not list containers for volume workspace write identity", "volume", volumeName, "error", err.Error())
+	}
+	identity := volumeWorkspaceWriteIdentityInternal{}
+	identitySource := ""
+	for _, consumerID := range consumerIDs {
+		inspect, inspectErr := libarcane.ContainerInspectWithCompatibility(ctx, dockerClient, consumerID, client.ContainerInspectOptions{})
+		if inspectErr != nil || inspect.Container.Config == nil {
+			// An uninspectable consumer could declare a conflicting user, so the identity is
+			// indeterminate; defer to the volume root's owner.
+			slog.WarnContext(ctx, "could not inspect volume consumer; using volume root owner for workspace writes", "volume", volumeName, "container_id", consumerID)
+			identity = volumeWorkspaceWriteIdentityInternal{}
+			break
+		}
+		parsed := volumeWorkspaceWriteIdentityFromConfigUserInternal(inspect.Container.Config.User)
+		if parsed.execUser == "" {
+			continue
+		}
+		if identity.execUser == "" {
+			identity, identitySource = parsed, consumerID
+			continue
+		}
+		// Consumers disagree; picking either would depend on Docker's list order, so defer to
+		// the volume root's owner instead.
+		if identity.execUser != parsed.execUser {
+			slog.WarnContext(ctx, "volume consumers declare conflicting users; using volume root owner for workspace writes", "volume", volumeName, "identity", identity.execUser, "conflicting_identity", parsed.execUser)
+			identity = volumeWorkspaceWriteIdentityInternal{}
+			break
+		}
+	}
+	if identity.execUser != "" {
+		slog.InfoContext(ctx, "volume workspace writes run as container user", "volume", volumeName, "identity", identity.execUser, "source_container_id", identitySource)
+		return identity
+	}
+	// PUID-style images drop privileges after start, so Config.User stays empty; the owner of the
+	// volume root is the next best signal for the runtime identity.
+	stdout, _, err := s.execInContainerInternal(ctx, containerID, "", []string{"stat", "-c", "%u:%g", "/volume"})
+	if err != nil {
+		return volumeWorkspaceWriteIdentityInternal{}
+	}
+	identity = volumeWorkspaceWriteIdentityFromConfigUserInternal(stdout)
+	if identity.execUser != "" {
+		slog.InfoContext(ctx, "volume workspace writes run as volume root owner", "volume", volumeName, "identity", identity.execUser)
+	}
+	return identity
+}
+
 type volumeWorkspaceStagedFileInternal struct {
 	path string
 	size int64
@@ -672,8 +753,8 @@ type volumeWorkspaceStagedContentInternal struct {
 	size    int64
 }
 
-func (s *VolumeService) stageVolumeWorkspaceChangesInternal(ctx context.Context, dockerClient *client.Client, containerID string, changes []volumetypes.WorkspaceFileChange, uploads map[int][]byte) (map[int]volumeWorkspaceStagedFileInternal, error) {
-	if _, _, err := s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", "rm -rf -- /tmp/arcane-workspace && mkdir -p -- /tmp/arcane-workspace"}); err != nil {
+func (s *VolumeService) stageVolumeWorkspaceChangesInternal(ctx context.Context, dockerClient *client.Client, containerID string, changes []volumetypes.WorkspaceFileChange, uploads map[int][]byte, identity volumeWorkspaceWriteIdentityInternal) (map[int]volumeWorkspaceStagedFileInternal, error) {
+	if _, _, err := s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", "rm -rf -- /tmp/arcane-workspace && mkdir -p -- /tmp/arcane-workspace"}); err != nil {
 		return nil, errors.WrapIf(err, "prepare volume workspace staging directory")
 	}
 
@@ -697,7 +778,7 @@ func (s *VolumeService) stageVolumeWorkspaceChangesInternal(ctx context.Context,
 	if len(stagedContents) == 0 {
 		return stagedFiles, nil
 	}
-	if err := s.copyVolumeWorkspaceFilesToContainerInternal(ctx, dockerClient, containerID, stagedContents); err != nil {
+	if err := s.copyVolumeWorkspaceFilesToContainerInternal(ctx, dockerClient, containerID, stagedContents, identity); err != nil {
 		return nil, err
 	}
 	return stagedFiles, nil
@@ -717,6 +798,7 @@ func (s *VolumeService) applyVolumeWorkspaceChangesInternal(
 	volumeName string,
 	changes []volumetypes.WorkspaceFileChange,
 	stagedFiles map[int]volumeWorkspaceStagedFileInternal,
+	identity volumeWorkspaceWriteIdentityInternal,
 	rollback func() error,
 ) error {
 	rollbackFailureInternal := func(applyErr error) error {
@@ -740,7 +822,7 @@ func (s *VolumeService) applyVolumeWorkspaceChangesInternal(
 		for end < len(changes) && changes[end].Operation != volumetypes.FileOpRestoreFile {
 			end++
 		}
-		if err := s.executeVolumeWorkspaceACFSBatchInternal(ctx, dockerClient, containerID, changes[index:end], stagedFiles, index); err != nil {
+		if err := s.executeVolumeWorkspaceACFSBatchInternal(ctx, dockerClient, containerID, changes[index:end], stagedFiles, index, identity); err != nil {
 			return rollbackFailureInternal(err)
 		}
 		index = end
@@ -755,6 +837,7 @@ func (s *VolumeService) executeVolumeWorkspaceACFSBatchInternal(
 	changes []volumetypes.WorkspaceFileChange,
 	stagedFiles map[int]volumeWorkspaceStagedFileInternal,
 	startIndex int,
+	identity volumeWorkspaceWriteIdentityInternal,
 ) error {
 	applyChanges := make([]acfstypes.ApplyChange, 0, len(changes))
 	for offset, change := range changes {
@@ -777,11 +860,11 @@ func (s *VolumeService) executeVolumeWorkspaceACFSBatchInternal(
 		name:    manifestName,
 		content: io.NopCloser(bytes.NewReader(manifestContent)),
 		size:    int64(len(manifestContent)),
-	}}); err != nil {
+	}}, identity); err != nil {
 		return err
 	}
 
-	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, []string{
+	stdout, stderr, err := s.execInContainerInternal(ctx, containerID, identity.execUser, []string{
 		"acfs", "apply", "--root", "/volume", "--staging", "/tmp/arcane-workspace", "--manifest", manifestName,
 	})
 	if err != nil {
@@ -885,14 +968,14 @@ func validateVolumeWorkspaceFileChangeInternal(change volumetypes.WorkspaceFileC
 	return nil
 }
 
-func (s *VolumeService) copyVolumeWorkspaceFilesToContainerInternal(ctx context.Context, dockerClient *client.Client, containerID string, contents []volumeWorkspaceStagedContentInternal) error {
+func (s *VolumeService) copyVolumeWorkspaceFilesToContainerInternal(ctx context.Context, dockerClient *client.Client, containerID string, contents []volumeWorkspaceStagedContentInternal, identity volumeWorkspaceWriteIdentityInternal) error {
 	pipeReader, pipeWriter := io.Pipe()
 	archiveDone := make(chan error, 1)
 	go func() {
 		tarWriter := tar.NewWriter(pipeWriter)
 		var err error
 		for _, stagedContent := range contents {
-			if err = tarWriter.WriteHeader(&tar.Header{Name: stagedContent.name, Mode: 0o600, Size: stagedContent.size}); err != nil {
+			if err = tarWriter.WriteHeader(&tar.Header{Name: stagedContent.name, Mode: 0o600, Size: stagedContent.size, Uid: identity.uid, Gid: identity.gid}); err != nil {
 				break
 			}
 			if _, err = io.CopyN(tarWriter, stagedContent.content, stagedContent.size); err != nil {
@@ -905,7 +988,7 @@ func (s *VolumeService) copyVolumeWorkspaceFilesToContainerInternal(ctx context.
 		_ = pipeWriter.CloseWithError(err)
 		archiveDone <- err
 	}()
-	_, copyErr := dockerClient.CopyToContainer(ctx, containerID, client.CopyToContainerOptions{DestinationPath: "/tmp/arcane-workspace", Content: pipeReader})
+	_, copyErr := dockerClient.CopyToContainer(ctx, containerID, client.CopyToContainerOptions{DestinationPath: "/tmp/arcane-workspace", Content: pipeReader, CopyUIDGID: identity.execUser != ""})
 	_ = pipeReader.Close()
 	archiveErr := <-archiveDone
 	for _, stagedContent := range contents {
@@ -1041,7 +1124,7 @@ tar -cf "$archive" "./$entry"
 printf 'present\0'`
 
 func (s *VolumeService) backupVolumeWorkspaceScopeInternal(ctx context.Context, containerID string, scope []string) (*volumeWorkspaceBackupInternal, error) {
-	if _, _, err := s.execInContainerInternal(ctx, containerID, []string{"mkdir", "-p", "/tmp/arcane-workspace"}); err != nil {
+	if _, _, err := s.execInContainerInternal(ctx, containerID, "", []string{"mkdir", "-p", "/tmp/arcane-workspace"}); err != nil {
 		return nil, errors.WrapIf(err, "prepare volume workspace backup directory")
 	}
 	backup := &volumeWorkspaceBackupInternal{
@@ -1050,7 +1133,7 @@ func (s *VolumeService) backupVolumeWorkspaceScopeInternal(ctx context.Context, 
 	}
 	for index, relativePath := range scope {
 		archivePath := fmt.Sprintf("/tmp/arcane-workspace/backup-%d.tar", index)
-		stdout, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"sh", "-c", volumeWorkspaceBackupCreateScriptInternal, "sh", relativePath, archivePath})
+		stdout, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"sh", "-c", volumeWorkspaceBackupCreateScriptInternal, "sh", relativePath, archivePath})
 		if err != nil {
 			return nil, classifyVolumeWorkspaceExecErrorInternal(err, stderr, "back up volume workspace path")
 		}
@@ -1091,7 +1174,7 @@ func (s *VolumeService) restoreVolumeWorkspaceScopeInternal(ctx context.Context,
 	removePaths := volumeWorkspaceRollbackPathsInternal(backup)
 	args := append([]string{"sh", "-c", `set -e
 for rel do rm -rf -- "/volume/$rel"; done`, "sh"}, removePaths...)
-	if _, stderr, err := s.execInContainerInternal(ctx, containerID, args); err != nil {
+	if _, stderr, err := s.execInContainerInternal(ctx, containerID, "", args); err != nil {
 		return classifyVolumeWorkspaceExecErrorInternal(err, stderr, "remove failed volume workspace changes")
 	}
 
@@ -1101,10 +1184,10 @@ for rel do rm -rf -- "/volume/$rel"; done`, "sh"}, removePaths...)
 		if parent != "." {
 			containerParent = path.Join(containerParent, parent)
 		}
-		if _, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"mkdir", "-p", containerParent}); err != nil {
+		if _, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"mkdir", "-p", containerParent}); err != nil {
 			return classifyVolumeWorkspaceExecErrorInternal(err, stderr, "recreate volume workspace backup parent")
 		}
-		if _, stderr, err := s.execInContainerInternal(ctx, containerID, []string{"tar", "-xf", archive.archivePath, "-C", containerParent}); err != nil {
+		if _, stderr, err := s.execInContainerInternal(ctx, containerID, "", []string{"tar", "-xf", archive.archivePath, "-C", containerParent}); err != nil {
 			return classifyVolumeWorkspaceExecErrorInternal(err, stderr, "restore volume workspace backup")
 		}
 	}

--- a/backend/internal/volume/workspace_test.go
+++ b/backend/internal/volume/workspace_test.go
@@ -62,7 +62,7 @@ func writeDockerExecAttachResponseInternal(t *testing.T, w http.ResponseWriter, 
 		t.Errorf("hijack Docker exec response: %v", err)
 		return
 	}
-	defer connection.Close()
+	defer func() { _ = connection.Close() }()
 	if _, err := fmt.Fprint(buffer, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n"); err != nil {
 		t.Errorf("write Docker exec response headers: %v", err)
 		return
@@ -439,12 +439,12 @@ func TestStageVolumeWorkspaceChangesClearsAndCopiesContentsInOneArchive(t *testi
 		{UploadIndex: &firstUpload},
 		{},
 		{UploadIndex: &secondUpload},
-	}, map[int][]byte{0: []byte("alpha"), 1: {}})
+	}, map[int][]byte{0: []byte("alpha"), 1: {}}, volumeWorkspaceWriteIdentityInternal{})
 	require.NoError(t, err)
 	require.Equal(t, volumeWorkspaceStagedFileInternal{path: "/tmp/arcane-workspace/change-0", size: 5}, firstStaged[0])
 	require.Equal(t, volumeWorkspaceStagedFileInternal{path: "/tmp/arcane-workspace/change-2", size: 0}, firstStaged[2])
 
-	secondStaged, err := service.stageVolumeWorkspaceChangesInternal(context.Background(), dockerClient, "helper", []volumetypes.WorkspaceFileChange{{UploadIndex: &firstUpload}}, map[int][]byte{0: []byte("second")})
+	secondStaged, err := service.stageVolumeWorkspaceChangesInternal(context.Background(), dockerClient, "helper", []volumetypes.WorkspaceFileChange{{UploadIndex: &firstUpload}}, map[int][]byte{0: []byte("second")}, volumeWorkspaceWriteIdentityInternal{})
 	require.NoError(t, err)
 	require.Equal(t, volumeWorkspaceStagedFileInternal{path: "/tmp/arcane-workspace/change-0", size: 6}, secondStaged[0])
 
@@ -456,6 +456,99 @@ func TestStageVolumeWorkspaceChangesClearsAndCopiesContentsInOneArchive(t *testi
 		{"change-0": "alpha", "change-2": ""},
 		{"change-0": "second"},
 	}, copiedArchives)
+}
+
+func TestVolumeWorkspaceWriteIdentityFromConfigUserInternal(t *testing.T) {
+	root := volumeWorkspaceWriteIdentityInternal{}
+	for _, configUser := range []string{"", "root", "0", "0:0", "0:1000", "node", "1000:node", "99999999999999999999"} {
+		require.Equalf(t, root, volumeWorkspaceWriteIdentityFromConfigUserInternal(configUser), "config user %q", configUser)
+	}
+	require.Equal(t, volumeWorkspaceWriteIdentityInternal{execUser: "1000", uid: 1000}, volumeWorkspaceWriteIdentityFromConfigUserInternal("1000"))
+	require.Equal(t, volumeWorkspaceWriteIdentityInternal{execUser: "1000:1000", uid: 1000, gid: 1000}, volumeWorkspaceWriteIdentityFromConfigUserInternal(" 1000:1000 "))
+	require.Equal(t, volumeWorkspaceWriteIdentityInternal{execUser: "1000:0", uid: 1000, gid: 0}, volumeWorkspaceWriteIdentityFromConfigUserInternal("1000:0"))
+}
+
+func TestVolumeWorkspaceWritesUseRuntimeIdentity(t *testing.T) {
+	type execRequestInternal struct {
+		user string
+		cmd  []string
+	}
+	var execRequests []execRequestInternal
+	var archiveQueries []string
+	var archiveHeaders []*tar.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/containers/helper/exec"):
+			var request struct {
+				User string   `json:"User"`
+				Cmd  []string `json:"Cmd"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode exec request: %v", err)
+				return
+			}
+			execRequests = append(execRequests, execRequestInternal{user: request.User, cmd: request.Cmd})
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{"Id": fmt.Sprintf("exec-%d", len(execRequests))}); err != nil {
+				t.Errorf("encode exec response: %v", err)
+			}
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/exec/exec-") && strings.HasSuffix(r.URL.Path, "/start"):
+			_, _ = io.Copy(io.Discard, r.Body)
+			applyResponse, err := json.Marshal(acfstypes.ApplyResponse{Version: acfstypes.ProtocolVersion, Applied: 1})
+			if err != nil {
+				t.Errorf("encode apply response: %v", err)
+				return
+			}
+			writeDockerExecAttachResponseInternal(t, w, string(applyResponse))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/exec/exec-") && strings.HasSuffix(r.URL.Path, "/json"):
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{"Running": false, "ExitCode": 0}); err != nil {
+				t.Errorf("encode exec inspect response: %v", err)
+			}
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/containers/helper/archive"):
+			archiveQueries = append(archiveQueries, r.URL.Query().Get("copyUIDGID"))
+			tarReader := tar.NewReader(r.Body)
+			for {
+				header, err := tarReader.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Errorf("read staging archive: %v", err)
+					return
+				}
+				archiveHeaders = append(archiveHeaders, header)
+				if _, err := io.Copy(io.Discard, tarReader); err != nil {
+					t.Errorf("read staging archive content: %v", err)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected Docker request: "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dockerClient := newVolumeWorkspaceTestDockerClientInternal(t, server)
+	service := &VolumeService{dockerService: docker.NewDockerClientService(t.Context(), nil, nil, nil).WithClient(dockerClient)}
+	identity := volumeWorkspaceWriteIdentityFromConfigUserInternal("1000:1000")
+	uploadIndex := 0
+	changes := []volumetypes.WorkspaceFileChange{{Operation: volumetypes.FileOpCreateFile, RelativePath: "config.txt", UploadIndex: &uploadIndex}}
+	stagedFiles, err := service.stageVolumeWorkspaceChangesInternal(context.Background(), dockerClient, "helper", changes, map[int][]byte{0: []byte("content")}, identity)
+	require.NoError(t, err)
+	require.NoError(t, service.executeVolumeWorkspaceACFSBatchInternal(context.Background(), dockerClient, "helper", changes, stagedFiles, 0, identity))
+
+	require.Len(t, execRequests, 2)
+	require.Empty(t, execRequests[0].user)
+	require.Equal(t, "1000:1000", execRequests[1].user)
+	require.Equal(t, []string{"acfs", "apply", "--root", "/volume", "--staging", "/tmp/arcane-workspace", "--manifest", "manifest-0.json"}, execRequests[1].cmd)
+	require.Equal(t, []string{"true", "true"}, archiveQueries)
+	require.Len(t, archiveHeaders, 2)
+	for _, header := range archiveHeaders {
+		require.Equal(t, 1000, header.Uid)
+		require.Equal(t, 1000, header.Gid)
+	}
 }
 
 func TestUpdateVolumeWorkspaceRejectsStaleRevisionBeforeStaging(t *testing.T) {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1640,6 +1640,7 @@ github.com/lestrrat-go/blackmagic v1.0.4 h1:IwQibdnf8l2KoO+qC3uT4OaTWsW7tuRQXy9T
 github.com/lestrrat-go/blackmagic v1.0.4/go.mod h1:6AWFyKNNj0zEXQYfTMPfZrAXUWUfTIZ5ECEUEJaijtw=
 github.com/lestrrat-go/dsig v1.0.0 h1:OE09s2r9Z81kxzJYRn07TFM9XA4akrUdoMwr0L8xj38=
 github.com/lestrrat-go/dsig v1.0.0/go.mod h1:dEgoOYYEJvW6XGbLasr8TFcAxoWrKlbQvmJgCR0qkDo=
+github.com/lestrrat-go/dsig v1.2.1 h1:MwxzZhE4+4fguHi+uDALKVlC3Cn+O1QU1Q/F8D7hVIc=
 github.com/lestrrat-go/dsig v1.2.1/go.mod h1:RD2eOaidyPvpc7IJQoO3Qq52RWdy8ZcJs8lrOnoa1Kc=
 github.com/lestrrat-go/dsig-secp256k1 v1.0.0 h1:JpDe4Aybfl0soBvoVwjqDbp+9S1Y2OM7gcrVVMFPOzY=
 github.com/lestrrat-go/dsig-secp256k1 v1.0.0/go.mod h1:CxUgAhssb8FToqbL8NjSPoGQlnO4w3LG1P0qPWQm/NU=
@@ -1649,6 +1650,7 @@ github.com/lestrrat-go/httprc/v3 v3.0.1 h1:3n7Es68YYGZb2Jf+k//llA4FTZMl3yCwIjFIk
 github.com/lestrrat-go/httprc/v3 v3.0.1/go.mod h1:2uAvmbXE4Xq8kAUjVrZOq1tZVYYYs5iP62Cmtru00xk=
 github.com/lestrrat-go/httprc/v3 v3.0.2 h1:7u4HUaD0NQbf2/n5+fyp+T10hNCsAnwKfqn4A4Baif0=
 github.com/lestrrat-go/httprc/v3 v3.0.2/go.mod h1:mSMtkZW92Z98M5YoNNztbRGxbXHql7tSitCvaxvo9l0=
+github.com/lestrrat-go/httprc/v3 v3.0.5 h1:S+Mb4L2I+bM6JGTibLmxExhyTOqnXjqx+zi9MoXw/TM=
 github.com/lestrrat-go/httprc/v3 v3.0.5/go.mod h1:mSMtkZW92Z98M5YoNNztbRGxbXHql7tSitCvaxvo9l0=
 github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
@@ -1658,6 +1660,7 @@ github.com/lestrrat-go/jwx/v3 v3.0.11 h1:yEeUGNUuNjcez/Voxvr7XPTYNraSQTENJgtVTfw
 github.com/lestrrat-go/jwx/v3 v3.0.11/go.mod h1:XSOAh2SiXm0QgRe3DulLZLyt+wUuEdFo81zuKTLcvgQ=
 github.com/lestrrat-go/jwx/v3 v3.0.13 h1:AdHKiPIYeCSnOJtvdpipPg/0SuFh9rdkN+HF3O0VdSk=
 github.com/lestrrat-go/jwx/v3 v3.0.13/go.mod h1:2m0PV1A9tM4b/jVLMx8rh6rBl7F6WGb3EG2hufN9OQU=
+github.com/lestrrat-go/jwx/v3 v3.1.1 h1:yd9AdPmZ4INnQ7k42IrzXYpnEG803+SrQ6hdMvzHJzw=
 github.com/lestrrat-go/jwx/v3 v3.1.1/go.mod h1:uw/MN2M/Xiu4FhwcIwH11Zsh9JWx9SWzgALl7/uIEkU=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
@@ -2242,6 +2245,7 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/fastjson v1.6.7 h1:ZE4tRy0CIkh+qDc5McjatheGX2czdn8slQjomexVpBM=
 github.com/valyala/fastjson v1.6.7/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vbauerster/mpb/v8 v8.10.2 h1:2uBykSHAYHekE11YvJhKxYmLATKHAGorZwFlyNw4hHM=
@@ -2252,6 +2256,7 @@ github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsL
 github.com/vektah/gqlparser/v2 v2.5.30/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
 github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
 github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
+github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
 github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/veraison/go-cose v1.1.0 h1:AalPS4VGiKavpAzIlBjrn7bhqXiXi4jbMYY/2+UC+4o=
 github.com/veraison/go-cose v1.1.0/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3743

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->






<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes workspace mutations run as a resolved volume-consumer identity and falls back to the volume root owner when consumer identity is unavailable or conflicting.

- Propagates an optional Docker exec user through helper-container commands.
- Resolves workspace ownership from volume consumers or the volume root.
- Applies UID/GID ownership to staged archives and ACFS mutations.
- Adds focused runtime-identity coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: write workspace files as the volume..."](https://github.com/getarcaneapp/arcane/commit/c4271ef736b5081ab0b177e3b894746baf04e749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56893482)</sub>

**Context used:**

- Knowledge Base — [Containers, environments, and workloads](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/workload-management.md)

<!-- /greptile_comment -->