### PR TITLE
fix: honor UI container exclusions in image update discovery

### DIFF
--- a/backend/internal/imageupdate/image_update.go
+++ b/backend/internal/imageupdate/image_update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -712,7 +713,14 @@ func (s *ImageUpdateService) getAllImageRefsInternal(ctx context.Context, limit 
 		return imageRefsFromSummariesInternal(imageList.Items, limit), nil
 	}
 
-	return filterImageSummariesByContainerOptOutInternal(imageList.Items, containerList.Items, limit), nil
+	excludedContainers := make(map[string]bool)
+	if s.settingsService != nil {
+		for _, name := range settings.ParseExcludedContainerNames(s.settingsService.GetStringSetting(ctx, "autoUpdateExcludedContainers", "")) {
+			excludedContainers[name] = true
+		}
+	}
+
+	return filterImageSummariesByContainerOptOutInternal(imageList.Items, containerList.Items, excludedContainers, limit), nil
 }
 
 func imageRefsFromSummariesInternal(images []image.Summary, limit int) []string {
@@ -744,12 +752,14 @@ type imageContainerUsageInternal struct {
 	eligible bool
 }
 
-func filterImageSummariesByContainerOptOutInternal(images []image.Summary, containers []container.Summary, limit int) []string {
+func filterImageSummariesByContainerOptOutInternal(images []image.Summary, containers []container.Summary, excludedContainers map[string]bool, limit int) []string {
 	usageByImageID := make(map[string]imageContainerUsageInternal)
 	usageByRef := make(map[string]imageContainerUsageInternal)
 
 	for _, summary := range containers {
-		disabled := labels.IsUpdateDisabled(summary.Labels)
+		disabled := labels.IsUpdateDisabled(summary.Labels) || slices.ContainsFunc(summary.Names, func(name string) bool {
+			return excludedContainers[strings.TrimPrefix(name, "/")]
+		})
 		usage := imageContainerUsageInternal{
 			optedOut: disabled,
 			eligible: !disabled,

--- a/backend/internal/imageupdate/service_test.go
+++ b/backend/internal/imageupdate/service_test.go
@@ -2250,6 +2250,29 @@ func TestImageUpdateService_GetAllImageRefsFallsBackWhenContainerDiscoveryFailsI
 	assert.Equal(t, []string{firstRef, secondRef}, got)
 }
 
+func TestFilterImageSummariesByContainerOptOutHonorsSettingsExclusionsInternal(t *testing.T) {
+	const (
+		excludedRef = "local/excluded:latest"
+		sharedRef   = "local/shared:latest"
+	)
+
+	images := []dockertypesimage.Summary{
+		{ID: "sha256:excluded", RepoTags: []string{excludedRef}},
+		{ID: "sha256:shared", RepoTags: []string{sharedRef}},
+	}
+	containers := []dockertypescontainer.Summary{
+		{ID: "c1", Names: []string{"/excluded-app"}, ImageID: "sha256:excluded", Image: excludedRef},
+		{ID: "c2", Names: []string{"/shared-excluded"}, ImageID: "sha256:shared", Image: sharedRef},
+		{ID: "c3", Names: []string{"/shared-enabled"}, ImageID: "sha256:shared", Image: sharedRef},
+	}
+	excluded := map[string]bool{"excluded-app": true, "shared-excluded": true, "unknown-name": true}
+
+	got := filterImageSummariesByContainerOptOutInternal(images, containers, excluded, 0)
+
+	assert.NotContains(t, got, excludedRef)
+	assert.Contains(t, got, sharedRef)
+}
+
 // testProjectRow is a minimal stand-in for project.Project: the project
 // package imports this one, so the in-package test cannot import it back.
 type testProjectRow struct {

--- a/backend/internal/settings/service.go
+++ b/backend/internal/settings/service.go
@@ -938,27 +938,32 @@ func (s *SettingsService) SetStringSetting(ctx context.Context, key, value strin
 	return s.UpdateSetting(ctx, key, value)
 }
 
+// ParseExcludedContainerNames returns the trimmed, deduplicated names from a comma-separated exclusion list.
+func ParseExcludedContainerNames(raw string) []string {
+	seen := make(map[string]struct{})
+	var ordered []string
+	for part := range strings.SplitSeq(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			ordered = append(ordered, name)
+		}
+	}
+	return ordered
+}
+
 // SetContainerAutoUpdateExclusionInternal adds or removes a container name from
 // the autoUpdateExcludedContainers setting. When excluded is true the container
 // is added to the list; when false it is removed.
 func (s *SettingsService) SetContainerAutoUpdateExclusionInternal(ctx context.Context, containerName string, excluded bool) error {
 	_, err := actors.Execute(ctx, s.writes, "update container auto-update exclusion", func(writeCtx context.Context) (actors.NoPayload, error) {
-		raw := s.GetStringSetting(writeCtx, "autoUpdateExcludedContainers", "")
-		existing := make(map[string]struct{})
-		var ordered []string
-		for part := range strings.SplitSeq(raw, ",") {
-			name := strings.TrimSpace(part)
-			if name == "" {
-				continue
-			}
-			if _, ok := existing[name]; !ok {
-				existing[name] = struct{}{}
-				ordered = append(ordered, name)
-			}
-		}
+		ordered := ParseExcludedContainerNames(s.GetStringSetting(writeCtx, "autoUpdateExcludedContainers", ""))
 
 		if excluded {
-			if _, ok := existing[containerName]; !ok {
+			if !slices.Contains(ordered, containerName) {
 				ordered = append(ordered, containerName)
 			}
 		} else {

--- a/backend/internal/updater/service.go
+++ b/backend/internal/updater/service.go
@@ -655,15 +655,10 @@ func (s *UpdaterService) ExcludedContainers(ctx context.Context) ([]string, erro
 	if s == nil {
 		return nil, nil
 	}
-	excluded := s.buildExcludedContainerSetInternal(ctx)
-	if len(excluded) == 0 {
+	if s.deps.Settings == nil {
 		return nil, nil
 	}
-	out := make([]string, 0, len(excluded))
-	for name := range excluded {
-		out = append(out, name)
-	}
-	return out, nil
+	return settings.ParseExcludedContainerNames(s.deps.Settings.GetStringSetting(ctx, "autoUpdateExcludedContainers", "")), nil
 }
 
 // ProjectByComposeName resolves an Arcane project from a Docker Compose project name.
@@ -1270,15 +1265,13 @@ func (s *UpdaterService) buildExcludedContainerSetInternal(ctx context.Context) 
 	if s.deps.Settings == nil {
 		return nil
 	}
-	raw := s.deps.Settings.GetStringSetting(ctx, "autoUpdateExcludedContainers", "")
-	if raw == "" {
+	names := settings.ParseExcludedContainerNames(s.deps.Settings.GetStringSetting(ctx, "autoUpdateExcludedContainers", ""))
+	if len(names) == 0 {
 		return nil
 	}
-	excluded := make(map[string]bool)
-	for part := range strings.SplitSeq(raw, ",") {
-		if name := strings.TrimSpace(part); name != "" {
-			excluded[name] = true
-		}
+	excluded := make(map[string]bool, len(names))
+	for _, name := range names {
+		excluded[name] = true
 	}
 	return excluded
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3705

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reuses a shared parser for configured container exclusions and applies those exclusions when discovering image updates. It also makes updater exclusion output deterministic and adds coverage for excluded-only and shared images.

- Filters all-image discovery using UI-managed container exclusions.
- Centralizes parsing and deduplication of the exclusion setting.
- Preserves discovery for images shared with an eligible container.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until image discovery preserves UI exclusions when Docker container listing fails.

The normal discovery path correctly filters excluded-only images, but a supported container-list failure returns all local references before exclusions are loaded, allowing excluded workloads to regain persisted update state and notifications.

**Files Needing Attention:** backend/internal/imageupdate/image_update.go, backend/internal/imageupdate/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_honor_ui_container_exclusions_in_image_update_discovery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_honor_ui_container_exclusions_in_image_update_discovery%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233763%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=getarcaneapp%2Farcane&pr=3763&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_honor_ui_container_exclusions_in_image_update_discovery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_honor_ui_container_exclusions_in_image_update_discovery%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimageupdate%2Fimage_update.go%3A716-721%0A**Fallback%20bypasses%20UI%20exclusions**%0A%0AWhen%20Docker%20image%20listing%20succeeds%20but%20container%20listing%20fails%2C%20%60getAllImageRefsInternal%60%20returns%20every%20local%20image%20reference%20before%20loading%20%60autoUpdateExcludedContainers%60%2C%20causing%20excluded-only%20workloads%20to%20regain%20persisted%20update%20records%20and%20update-available%20notifications.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fimageupdate%2Fservice_test.go%3A2253%0A**Exclusion%20test%20lacks%20subtests**%0A%0AThe%20new%20exclusion-filter%20test%20encodes%20excluded-only%20and%20shared-image%20behavior%20in%20one%20fixed%20fixture%20instead%20of%20the%20required%20table-driven%20subtests%2C%20making%20additional%20matching%20cases%20harder%20to%20extend%20and%20diagnose%20independently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3763&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimageupdate%2Fimage_update.go%3A716-721%0A**Fallback%20bypasses%20UI%20exclusions**%0A%0AWhen%20Docker%20image%20listing%20succeeds%20but%20container%20listing%20fails%2C%20%60getAllImageRefsInternal%60%20returns%20every%20local%20image%20reference%20before%20loading%20%60autoUpdateExcludedContainers%60%2C%20causing%20excluded-only%20workloads%20to%20regain%20persisted%20update%20records%20and%20update-available%20notifications.%0A%0A%23%23%23%20Issue%202%0Abackend%2Finternal%2Fimageupdate%2Fservice_test.go%3A2253%0A**Exclusion%20test%20lacks%20subtests**%0A%0AThe%20new%20exclusion-filter%20test%20encodes%20excluded-only%20and%20shared-image%20behavior%20in%20one%20fixed%20fixture%20instead%20of%20the%20required%20table-driven%20subtests%2C%20making%20additional%20matching%20cases%20harder%20to%20extend%20and%20diagnose%20independently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3763&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/imageupdate/image_update.go:716-721
**Fallback bypasses UI exclusions**

When Docker image listing succeeds but container listing fails, `getAllImageRefsInternal` returns every local image reference before loading `autoUpdateExcludedContainers`, causing excluded-only workloads to regain persisted update records and update-available notifications.

### Issue 2
backend/internal/imageupdate/service_test.go:2253
**Exclusion test lacks subtests**

The new exclusion-filter test encodes excluded-only and shared-image behavior in one fixed fixture instead of the required table-driven subtests, making additional matching cases harder to extend and diagnose independently.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: honor UI container exclusions in im..."](https://github.com/getarcaneapp/arcane/commit/b09f5ad2f0c1c470886ab13c0778453c932c8b57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57317963)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Registry and image update workflows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/registry-and-image-update-workflows.md)

<!-- /greptile_comment -->