### PR TITLE
fix: purge leftover git clone scratch directories

### DIFF
--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -319,6 +319,9 @@ func initializeGitOpsStartupStateInternal(appCtx context.Context, gitOpsSync *gi
 	if err := gitOpsSync.CleanupLeakedScratchDirsOnStartup(appCtx); err != nil {
 		slog.WarnContext(appCtx, "Failed to clean up leaked GitOps scratch directories on startup", "error", err)
 	}
+	if err := gitOpsSync.CleanupLeakedCloneDirsOnStartup(appCtx); err != nil {
+		slog.WarnContext(appCtx, "Failed to clean up leaked git clone directories on startup", "error", err)
+	}
 	if err := gitOpsSync.ReconcileDirectorySyncProjectsOnStartup(appCtx); err != nil {
 		slog.WarnContext(appCtx, "Failed to reconcile directory GitOps projects on startup", "error", err)
 	}

--- a/backend/internal/bootstrap/jobs_bootstrap.go
+++ b/backend/internal/bootstrap/jobs_bootstrap.go
@@ -95,6 +95,7 @@ type registerJobsParams struct {
 	AutoHeal               *scheduler.AutoHealJob
 	ActivitySweep          *scheduler.ActivitySweepJob
 	UploadSessionsCleanup  *scheduler.UploadSessionsCleanupJob
+	GitCloneCleanup        *scheduler.GitCloneCleanupJob
 }
 
 func registerJobs(params registerJobsParams) error {
@@ -137,6 +138,7 @@ func registerJobs(params registerJobsParams) error {
 		params.AutoHeal,
 		params.ActivitySweep,
 		params.UploadSessionsCleanup,
+		params.GitCloneCleanup,
 	} {
 		if err := params.Scheduler.RegisterJob(job); err != nil {
 			return err

--- a/backend/internal/build/service.go
+++ b/backend/internal/build/service.go
@@ -120,6 +120,11 @@ func (s *BuildService) BuildImage(ctx context.Context, environmentID string, req
 
 	startedAt := time.Now()
 	cleanupResolvedContext := func() error { return nil }
+	defer func() {
+		if cleanupErr := cleanupResolvedContext(); cleanupErr != nil {
+			slog.WarnContext(ctx, "failed to cleanup temporary git build context", "error", cleanupErr)
+		}
+	}()
 	var (
 		result *buildtypes.BuildResult
 		err    error
@@ -135,9 +140,6 @@ func (s *BuildService) BuildImage(ctx context.Context, environmentID string, req
 	completedAt := time.Now()
 	if logWriter != nil {
 		_ = logWriter.Close()
-	}
-	if cleanupErr := cleanupResolvedContext(); cleanupErr != nil {
-		slog.WarnContext(ctx, "failed to cleanup temporary git build context", "error", cleanupErr)
 	}
 
 	if s.db != nil && buildRecordID != "" {

--- a/backend/internal/di/di.go
+++ b/backend/internal/di/di.go
@@ -142,5 +142,6 @@ var JobOptions = fx.Options(
 		scheduler.NewAutoHealJob,
 		scheduler.NewActivitySweepJob,
 		scheduler.NewUploadSessionsCleanupJob,
+		scheduler.NewGitCloneCleanupJob,
 	),
 )

--- a/backend/internal/gitops/gitops_sync.go
+++ b/backend/internal/gitops/gitops_sync.go
@@ -1316,6 +1316,23 @@ func (s *GitOpsSyncService) CleanupLeakedScratchDirsOnStartup(ctx context.Contex
 	return nil
 }
 
+// CleanupLeakedCloneDirsOnStartup removes leaked git clone scratch dirs
+// ("gitops-*") under the git work dir; safe because no sync holds a clone yet.
+func (s *GitOpsSyncService) CleanupLeakedCloneDirsOnStartup(ctx context.Context) error {
+	if s.repoService == nil || s.repoService.Client == nil {
+		return nil
+	}
+
+	removed, err := s.repoService.PurgeScratchDirs(ctx, 0)
+	if err != nil {
+		return errors.WrapIf(err, "failed to purge leaked git clone scratch directories")
+	}
+	if removed > 0 {
+		slog.InfoContext(ctx, "Cleaned up leaked git clone scratch directories on startup", "count", removed)
+	}
+	return nil
+}
+
 func (s *GitOpsSyncService) CleanupOrphanedSyncsOnStartup(ctx context.Context) error {
 	var syncIDs []string
 	if err := s.db.WithContext(ctx).Model(&projectpkg.GitOpsSync{}).

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -390,6 +390,44 @@ func TestGitOpsSyncService_CleanupLeakedScratchDirsOnStartup_RemovesOrphans(t *t
 	assert.NoError(t, err, "real project dir must be kept")
 }
 
+// TestGitOpsSyncService_CleanupLeakedCloneDirsOnStartup_RemovesAll verifies the
+// startup sweep purges leaked git clone scratch dirs from the git work dir.
+func TestGitOpsSyncService_CleanupLeakedCloneDirsOnStartup_RemovesAll(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupGitOpsSyncDirectoryTestService(t)
+
+	workDir := t.TempDir()
+	svc.repoService = &gitrepo.GitRepositoryService{Client: git.NewClient(workDir)}
+
+	cloneDirs := []string{
+		filepath.Join(workDir, "gitops-stale"),
+		filepath.Join(workDir, "gitops-fresh"),
+	}
+	for _, p := range cloneDirs {
+		require.NoError(t, os.MkdirAll(p, 0o755))
+	}
+	unrelated := filepath.Join(workDir, "keep-me")
+	require.NoError(t, os.MkdirAll(unrelated, 0o755))
+
+	require.NoError(t, svc.CleanupLeakedCloneDirsOnStartup(ctx))
+
+	for _, p := range cloneDirs {
+		_, err := os.Stat(p)
+		require.ErrorIs(t, err, os.ErrNotExist, "clone scratch dir should be removed: %s", p)
+	}
+	_, err := os.Stat(unrelated)
+	assert.NoError(t, err, "unrelated dir must be kept")
+}
+
+// TestGitOpsSyncService_CleanupLeakedCloneDirsOnStartup_NilRepoServiceIsNoop
+// verifies the sweep tolerates a service built without a repo service.
+func TestGitOpsSyncService_CleanupLeakedCloneDirsOnStartup_NilRepoServiceIsNoop(t *testing.T) {
+	svc, _, _ := setupGitOpsSyncDirectoryTestService(t)
+	svc.repoService = nil
+
+	require.NoError(t, svc.CleanupLeakedCloneDirsOnStartup(context.Background()))
+}
+
 // TestGitOpsSyncService_SyncProjectDirectory_RefusesDuplicateOnNameCollision verifies a
 // directory sync refuses to create a "-N" sibling when its target name is already taken
 // by a non-adoptable directory; instead it errors as a broken binding and disables auto-sync.

--- a/backend/pkg/gitutil/git.go
+++ b/backend/pkg/gitutil/git.go
@@ -37,6 +37,9 @@ import (
 // binarySniffBytes is how much of a file is inspected to classify it as binary.
 const binarySniffBytes = 512
 
+// cloneScratchPrefix names the per-run clone scratch dirs created by Clone.
+const cloneScratchPrefix = "gitops-"
+
 // go-git's file transport execs the git binary, which doesn't exist in the
 // distroless image. Unregister it so a repository URL can never reach it.
 func init() {
@@ -311,7 +314,7 @@ func (c *Client) Clone(ctx context.Context, url, branch string, auth AuthConfig)
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return "", errors.WrapIf(err, "failed to create work dir")
 	}
-	tmpDir, err := os.MkdirTemp(workDir, "gitops-*")
+	tmpDir, err := os.MkdirTemp(workDir, cloneScratchPrefix+"*")
 	if err != nil {
 		return "", errors.WrapIf(err, "failed to create temp dir")
 	}
@@ -548,6 +551,50 @@ func (c *Client) BrowseTree(ctx context.Context, repoPath, targetPath string) ([
 // clone directory itself is what gets deleted.
 func (c *Client) Cleanup(repoPath string) error {
 	return os.RemoveAll(repoPath)
+}
+
+// PurgeScratchDirs removes clone scratch dirs ("gitops-*") under the work dir
+// whose mtime is older than maxAge. maxAge <= 0 removes all (boot sweep).
+func (c *Client) PurgeScratchDirs(ctx context.Context, maxAge time.Duration) (int, error) {
+	root := c.workDir
+	if root == "" {
+		root = os.TempDir()
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, errors.WrapIff(err, "failed to read git work dir %s", root)
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return removed, err
+		}
+		entryPath := filepath.Join(root, entry.Name())
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), cloneScratchPrefix) {
+			continue
+		}
+		if maxAge > 0 {
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				slog.WarnContext(ctx, "Failed to stat git clone scratch dir", "path", entryPath, "error", infoErr)
+				continue
+			}
+			if time.Since(info.ModTime()) < maxAge {
+				continue
+			}
+		}
+		if rmErr := os.RemoveAll(entryPath); rmErr != nil {
+			slog.WarnContext(ctx, "Failed to remove git clone scratch dir", "path", entryPath, "error", rmErr)
+			continue
+		}
+		removed++
+	}
+	return removed, nil
 }
 
 // CommitInfo holds information about a git commit

--- a/backend/pkg/gitutil/git_test.go
+++ b/backend/pkg/gitutil/git_test.go
@@ -727,6 +727,51 @@ func generateTestPublicKeyVariant(t *testing.T) gossh.PublicKey {
 	return key
 }
 
+func TestPurgeScratchDirs(t *testing.T) {
+	ctx := context.Background()
+	workDir := t.TempDir()
+	client := NewClient(workDir)
+
+	staleDir := filepath.Join(workDir, "gitops-stale")
+	freshDir := filepath.Join(workDir, "gitops-fresh")
+	keepDir := filepath.Join(workDir, "keep-me")
+	scratchFile := filepath.Join(workDir, "gitops-file")
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
+	require.NoError(t, os.MkdirAll(freshDir, 0o755))
+	require.NoError(t, os.MkdirAll(keepDir, 0o755))
+	require.NoError(t, os.WriteFile(scratchFile, []byte("x"), 0o644))
+	staleTime := time.Now().Add(-3 * time.Hour)
+	require.NoError(t, os.Chtimes(staleDir, staleTime, staleTime))
+
+	removed, err := client.PurgeScratchDirs(ctx, 2*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the stale clone dir should be removed")
+
+	_, err = os.Stat(staleDir)
+	require.ErrorIs(t, err, os.ErrNotExist, "stale clone dir should be removed")
+	for _, p := range []string{freshDir, keepDir, scratchFile} {
+		_, err := os.Stat(p)
+		assert.NoError(t, err, "must be kept by the age-cutoff purge: %s", p)
+	}
+
+	removed, err = client.PurgeScratchDirs(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "boot sweep should remove the remaining clone dir")
+
+	_, err = os.Stat(freshDir)
+	require.ErrorIs(t, err, os.ErrNotExist, "boot sweep should remove fresh clone dirs")
+	for _, p := range []string{keepDir, scratchFile} {
+		_, err := os.Stat(p)
+		assert.NoError(t, err, "boot sweep must keep non-scratch entries: %s", p)
+	}
+
+	t.Run("missing work dir is not an error", func(t *testing.T) {
+		removed, err := NewClient(filepath.Join(t.TempDir(), "missing")).PurgeScratchDirs(ctx, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, removed)
+	})
+}
+
 func TestNormalizeURL(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/backend/pkg/scheduler/git_clone_cleanup_job.go
+++ b/backend/pkg/scheduler/git_clone_cleanup_job.go
@@ -1,0 +1,66 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/gitrepo"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
+)
+
+// GitCloneCleanupJobName identifies the hourly purge of leaked git clone
+// scratch directories.
+const GitCloneCleanupJobName = "git-clone-scratch-cleanup"
+
+// gitCloneScratchMinAge is the base mtime cutoff for purging clone scratch dirs.
+const gitCloneScratchMinAge = 2 * time.Hour
+
+// gitCloneScratchBuildHold pads the configured build timeout.
+const gitCloneScratchBuildHold = 30 * time.Minute
+
+// GitCloneCleanupJob purges orphaned "gitops-*" clone dirs under the git work
+// dir. Internal job: no job_metadata entry, invisible in the Jobs UI.
+type GitCloneCleanupJob struct {
+	repoService     *gitrepo.GitRepositoryService
+	settingsService *settings.SettingsService
+}
+
+// NewGitCloneCleanupJob builds the cleanup job for the scheduler.
+func NewGitCloneCleanupJob(repoService *gitrepo.GitRepositoryService, settingsService *settings.SettingsService) *GitCloneCleanupJob {
+	return &GitCloneCleanupJob{repoService: repoService, settingsService: settingsService}
+}
+
+func (j *GitCloneCleanupJob) Name() string {
+	return GitCloneCleanupJobName
+}
+
+func (j *GitCloneCleanupJob) Schedule(_ context.Context) string {
+	// Staggered from the upload-sessions cleanup, which fires at minute 0.
+	return "0 30 * * * *"
+}
+
+func (j *GitCloneCleanupJob) Run(ctx context.Context) {
+	if j.repoService == nil || j.repoService.Client == nil {
+		return
+	}
+
+	maxAge := gitCloneScratchMinAge
+	if j.settingsService != nil {
+		if buildTimeout := j.settingsService.GetSettingsConfig().BuildTimeout.AsDurationSeconds(); buildTimeout+gitCloneScratchBuildHold > maxAge {
+			maxAge = buildTimeout + gitCloneScratchBuildHold
+		}
+	}
+	removed, err := j.repoService.PurgeScratchDirs(ctx, maxAge)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to purge leaked git clone scratch dirs", "jobName", GitCloneCleanupJobName, "removed", removed, "error", err)
+		return
+	}
+	if removed > 0 {
+		slog.InfoContext(ctx, "Purged leaked git clone scratch dirs", "jobName", GitCloneCleanupJobName, "removed", removed)
+	}
+}
+
+func (j *GitCloneCleanupJob) Reschedule(_ context.Context) error {
+	return nil
+}

--- a/backend/pkg/scheduler/git_clone_cleanup_job_test.go
+++ b/backend/pkg/scheduler/git_clone_cleanup_job_test.go
@@ -1,0 +1,47 @@
+package scheduler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/gitrepo"
+	git "github.com/getarcaneapp/arcane/backend/v2/pkg/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitCloneCleanupJob_NameAndSchedule(t *testing.T) {
+	job := NewGitCloneCleanupJob(nil, nil)
+
+	assert.Equal(t, GitCloneCleanupJobName, job.Name())
+	assert.Equal(t, "0 30 * * * *", job.Schedule(context.Background()))
+}
+
+// TestGitCloneCleanupJob_RunPurgesStaleCloneDirs pins the nil-settings guard.
+func TestGitCloneCleanupJob_RunPurgesStaleCloneDirs(t *testing.T) {
+	workDir := t.TempDir()
+	job := NewGitCloneCleanupJob(&gitrepo.GitRepositoryService{Client: git.NewClient(workDir)}, nil)
+
+	stale := filepath.Join(workDir, "gitops-stale")
+	fresh := filepath.Join(workDir, "gitops-fresh")
+	require.NoError(t, os.MkdirAll(stale, 0o755))
+	require.NoError(t, os.MkdirAll(fresh, 0o755))
+	staleTime := time.Now().Add(-3 * time.Hour)
+	require.NoError(t, os.Chtimes(stale, staleTime, staleTime))
+
+	job.Run(context.Background())
+
+	_, err := os.Stat(stale)
+	require.ErrorIs(t, err, os.ErrNotExist, "stale clone dir should be removed")
+	_, err = os.Stat(fresh)
+	assert.NoError(t, err, "fresh clone dir must be kept")
+}
+
+func TestGitCloneCleanupJob_RunNilRepoServiceIsNoop(t *testing.T) {
+	job := NewGitCloneCleanupJob(nil, nil)
+
+	assert.NotPanics(t, func() { job.Run(context.Background()) })
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3750

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds startup and hourly cleanup of leaked Git clone scratch directories and defers temporary build-context cleanup so it also runs on early exits.

- Adds age-based scratch-directory purging to the Git client.
- Registers a scheduled cleanup job with build-timeout-aware retention.
- Runs an unconditional cleanup sweep during startup.
- Adds coverage for purge filtering, startup cleanup, and scheduled cleanup behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only the non-blocking omission of documentation on the new exported scheduler methods.

The cleanup lifecycle and scheduler integration have no established blocking failure, but the newly exported job methods violate the repository's Go documentation requirement.

**Files Needing Attention:** backend/pkg/scheduler/git_clone_cleanup_job.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-27-fix_purge_leftover_git_clone_scratch_directories%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-27-fix_purge_leftover_git_clone_scratch_directories%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233771%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3771&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%2208-27-fix_purge_leftover_git_clone_scratch_directories%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2208-27-fix_purge_leftover_git_clone_scratch_directories%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fscheduler%2Fgit_clone_cleanup_job.go%3A36%0A**Exported%20methods%20lack%20documentation**%0A%0AThe%20new%20exported%20%60Name%60%2C%20%60Schedule%60%2C%20%60Run%60%2C%20and%20%60Reschedule%60%20methods%20lack%20documentation%20comments%2C%20leaving%20the%20API%20undocumented%20and%20violating%20the%20repository's%20Go%20documentation%20standard.%20The%20same%20pattern%20occurs%20on%20lines%2041%2C%2047%2C%20and%2064.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fscheduler%2Fgit_clone_cleanup_job.go%3A36%0A**Exported%20methods%20lack%20documentation**%0A%0AThe%20new%20exported%20%60Name%60%2C%20%60Schedule%60%2C%20%60Run%60%2C%20and%20%60Reschedule%60%20methods%20lack%20documentation%20comments%2C%20leaving%20the%20API%20undocumented%20and%20violating%20the%20repository's%20Go%20documentation%20standard.%20The%20same%20pattern%20occurs%20on%20lines%2041%2C%2047%2C%20and%2064.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/scheduler/git_clone_cleanup_job.go:36
**Exported methods lack documentation**

The new exported `Name`, `Schedule`, `Run`, and `Reschedule` methods lack documentation comments, leaving the API undocumented and violating the repository's Go documentation standard. The same pattern occurs on lines 41, 47, and 64.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: purge leftover git clone scratch di..."](https://github.com/getarcaneapp/arcane/commit/f2f31d2cacd3984ff599f14d13414bb1bc9c1461) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57727806)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [GitOps and project automation](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/gitops-and-project-automation.md)
- Knowledge Base — [Projects, repositories, and buildables](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/projects-repositories-and-buildables.md)
- Knowledge Base — [Platform operations and reliability](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/platform-operations.md)
</details>


<!-- /greptile_comment -->