### PR TITLE
fix: resolve upgrade target image for blank-target self-upgrades

### DIFF
--- a/backend/internal/system/upgrade_service.go
+++ b/backend/internal/system/upgrade_service.go
@@ -16,6 +16,7 @@ import (
 	"emperror.dev/errors"
 
 	cerrdefs "github.com/containerd/errdefs"
+	ref "github.com/distribution/reference"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/docker"
@@ -29,16 +30,17 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/vuln"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/remenv"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	versiontypes "github.com/getarcaneapp/arcane/types/v2/version"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
+	"github.com/opencontainers/go-digest"
 	"go.getarcane.app/sys/cgroup"
 	"go.getarcane.app/updater"
 	"go.getarcane.app/updater/labels"
+	"golang.org/x/mod/semver"
 )
-
-const defaultArcaneUpgraderImageInternal = "ghcr.io/getarcaneapp/arcane:latest"
 
 type SystemUpgradeService struct {
 	upgrading       atomic.Bool
@@ -102,9 +104,10 @@ func (s *SystemUpgradeService) AlreadyOnNewestImage(ctx context.Context) bool {
 
 // TriggerUpgradeViaCLI spawns the upgrade CLI command in a separate container and
 // returns that upgrader container's ID. This avoids self-termination issues by running
-// the upgrade from outside. A zero-value target upgrades the current container to its
-// own image tag; the updater engine passes an explicit target with the resolved new
-// image. Update-all uses the returned ID to tell an upgrade that recreated this
+// the upgrade from outside. A zero-value target resolves the image to upgrade to from
+// the version check (see resolveSelfUpgradeTargetImageInternal); the updater engine
+// passes an explicit target with the resolved new image, which is used as-is.
+// Update-all uses the returned ID to tell an upgrade that recreated this
 // container from one that found nothing to do — see watchManagerUpgraderInternal.
 func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user common.User, target updater.SelfUpdateTarget) (string, error) {
 	if !s.upgrading.CompareAndSwap(false, true) {
@@ -135,7 +138,10 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user co
 		binaryPath = determineUpgradeBinaryPathInternal(currentContainer.Config.Labels)
 	}
 
-	targetImage := strings.TrimSpace(target.NewImageRef)
+	targetImage, err := s.resolveUpgradeTargetImageInternal(ctx, currentContainer, target.NewImageRef)
+	if err != nil {
+		return "", err
+	}
 
 	// Log upgrade event
 	metadata := database.JSON{
@@ -150,17 +156,8 @@ func (s *SystemUpgradeService) TriggerUpgradeViaCLI(ctx context.Context, user co
 	}
 
 	// Run the upgrader from the image we are upgrading to, so the upgrade CLI
-	// is the new version. Without a resolved target image, fall back to the
-	// running container's own image reference.
+	// is the new version.
 	upgraderImage := targetImage
-	if upgraderImage == "" {
-		upgraderImage = defaultArcaneUpgraderImageInternal
-		if currentContainer.Config != nil {
-			if img := strings.TrimSpace(currentContainer.Config.Image); img != "" {
-				upgraderImage = img
-			}
-		}
-	}
 	slog.Debug("Using upgrader image", "image", upgraderImage)
 
 	slog.Info("Spawning upgrade CLI command", "containerName", containerName, "upgraderImage", upgraderImage)
@@ -320,6 +317,130 @@ func determineUpgradeBinaryPathInternal(containerLabels map[string]string) strin
 	}
 
 	return "/app/arcane"
+}
+
+// resolveUpgradeTargetImageInternal picks the image the upgrade should move to.
+// Explicit targets from the updater engine are authoritative. A blank target
+// (manual trigger, update-all) resolves against the version check so a
+// version-pinned install actually moves to the newest release (#3687).
+func (s *SystemUpgradeService) resolveUpgradeTargetImageInternal(ctx context.Context, currentContainer container.InspectResponse, explicitImageRef string) (string, error) {
+	if targetImage := strings.TrimSpace(explicitImageRef); targetImage != "" {
+		return targetImage, nil
+	}
+
+	currentImageRef := ""
+	if currentContainer.Config != nil {
+		currentImageRef = strings.TrimSpace(currentContainer.Config.Image)
+	}
+	var info *versiontypes.Info
+	if s.versionService != nil {
+		info = s.versionService.GetAppVersionInfo(ctx)
+	}
+	resolved, err := resolveSelfUpgradeTargetImageInternal(currentImageRef, info)
+	if err != nil {
+		return "", errors.WrapIf(err, "resolve upgrade target image")
+	}
+	return resolved, nil
+}
+
+// resolveSelfUpgradeTargetImageInternal resolves the image for a blank-target
+// self-upgrade from the running container's reference and the version check.
+// Exact release tags (vX.Y.Z) move to the newest release; mutable channels and
+// untagged references keep theirs; digest pins move only to a resolved newest
+// digest. Unresolved or older exact-version targets fail instead of
+// reinstalling or downgrading (#3687).
+func resolveSelfUpgradeTargetImageInternal(currentImageRef string, info *versiontypes.Info) (string, error) {
+	currentImageRef = strings.TrimSpace(currentImageRef)
+	if currentImageRef == "" {
+		return "", errors.New("running container has no image reference to upgrade from")
+	}
+
+	parsed, err := ref.Parse(currentImageRef)
+	if err != nil {
+		return "", errors.WrapIff(err, "parse current image reference %q", currentImageRef)
+	}
+	named, ok := parsed.(ref.Named)
+	if !ok {
+		return "", errors.Errorf("current image reference %q is not a named image", currentImageRef)
+	}
+
+	newestDigest, newestVersion := newestTargetIdentifiersInternal(info)
+
+	// Digest-pinned installs only move when the version check resolved a new
+	// digest; otherwise there is nothing to point them at.
+	if _, isDigested := parsed.(ref.Digested); isDigested {
+		if newestDigest == "" {
+			return "", errors.New("image is digest-pinned but no newest digest could be resolved; refusing an upgrade that could not move it")
+		}
+		targetDigest := digest.Digest(newestDigest)
+		if err := targetDigest.Validate(); err != nil {
+			return "", errors.WrapIff(err, "resolved newest digest %q is not a valid digest", newestDigest)
+		}
+		withDigest, err := ref.WithDigest(named, targetDigest)
+		if err != nil {
+			return "", errors.WrapIff(err, "build target reference for %q", named.Name())
+		}
+		return withDigest.String(), nil
+	}
+
+	tagged, isTagged := parsed.(ref.Tagged)
+	if !isTagged || !isExactReleaseTagInternal(tagged.Tag()) {
+		// Mutable channel or untagged: the pull re-resolves whatever the name
+		// points at, so keeping the reference advances the digest in place.
+		return currentImageRef, nil
+	}
+
+	if newestVersion == "" {
+		return "", errors.Errorf("running exact release %q but the newest release could not be resolved", tagged.Tag())
+	}
+	newest := utils.EnsureVPrefix(newestVersion)
+	if !semver.IsValid(newest) {
+		return "", errors.Errorf("resolved newest version %q is not a valid semver release", newestVersion)
+	}
+	if semver.Compare(newest, utils.EnsureVPrefix(tagged.Tag())) < 0 {
+		return "", errors.Errorf("newest release %q is older than the running %q; refusing to downgrade", newestVersion, tagged.Tag())
+	}
+
+	withTag, err := ref.WithTag(named, newest)
+	if err != nil {
+		return "", errors.WrapIff(err, "build target reference for %q", named.Name())
+	}
+	return withTag.String(), nil
+}
+
+// isExactReleaseTagInternal reports whether tag pins an exact release version
+// (vX.Y.Z, prereleases included). Short channels like v2 or v2.9 are mutable.
+// The x/mod/semver parser is deliberately lenient (it accepts v2 and v2.9), so
+// the three numeric components are checked explicitly.
+func isExactReleaseTagInternal(tag string) bool {
+	core := strings.TrimPrefix(strings.TrimSpace(tag), "v")
+	if i := strings.IndexAny(core, "-+"); i >= 0 {
+		core = core[:i]
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, c := range part {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// newestTargetIdentifiersInternal reads the version-check result nil-safely: the
+// service may be unavailable and the check itself may resolve neither identifier.
+func newestTargetIdentifiersInternal(info *versiontypes.Info) (newestDigest, newestVersion string) {
+	if info == nil {
+		return "", ""
+	}
+	return strings.TrimSpace(info.NewestDigest), strings.TrimSpace(info.NewestVersion)
 }
 
 // ResolveUpgraderRuntimeOptions determines how a helper container reaches the Docker daemon.

--- a/backend/internal/system/upgrade_service_test.go
+++ b/backend/internal/system/upgrade_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/remenv"
+	versiontypes "github.com/getarcaneapp/arcane/types/v2/version"
 	containertypes "github.com/moby/moby/api/types/container"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
@@ -302,6 +303,79 @@ func TestUpdateAllAgentFailureStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, updateAllAgentFailureStatusInternal(tt.err))
+		})
+	}
+}
+
+// A blank-target self-upgrade resolves its image from the version check (#3687).
+// Explicit targets from the updater engine never reach this function.
+func TestResolveSelfUpgradeTargetImageInternal(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentImage string
+		info         *versiontypes.Info
+		want         string
+		wantErr      string
+	}{
+		{
+			name:         "agent pinned to an older release moves to the newest",
+			currentImage: "ghcr.io/getarcaneapp/arcane-agent:v2.8.0",
+			info:         &versiontypes.Info{NewestVersion: "v2.9.0"},
+			want:         "ghcr.io/getarcaneapp/arcane-agent:v2.9.0",
+		},
+		{
+			name:         "already-current exact version keeps its reference",
+			currentImage: "ghcr.io/getarcaneapp/arcane:v2.9.0",
+			info:         &versiontypes.Info{NewestVersion: "v2.9.0"},
+			want:         "ghcr.io/getarcaneapp/arcane:v2.9.0",
+		},
+		{
+			name:         "older newest release refuses a downgrade",
+			currentImage: "ghcr.io/getarcaneapp/arcane:v2.9.0",
+			info:         &versiontypes.Info{NewestVersion: "v2.8.0"},
+			wantErr:      "downgrade",
+		},
+		{
+			name:         "unresolved newest release aborts an exact-version upgrade",
+			currentImage: "ghcr.io/getarcaneapp/arcane:v2.8.0",
+			info:         &versiontypes.Info{},
+			wantErr:      "could not be resolved",
+		},
+		{
+			name:         "latest channel keeps its reference",
+			currentImage: "ghcr.io/getarcaneapp/arcane:latest",
+			info:         &versiontypes.Info{NewestVersion: "v2.9.0"},
+			want:         "ghcr.io/getarcaneapp/arcane:latest",
+		},
+		{
+			name:         "minor channel keeps its reference",
+			currentImage: "ghcr.io/getarcaneapp/arcane:v2.9",
+			info:         &versiontypes.Info{NewestVersion: "v2.9.1"},
+			want:         "ghcr.io/getarcaneapp/arcane:v2.9",
+		},
+		{
+			name:         "digest pin moves to the resolved newest digest",
+			currentImage: "ghcr.io/getarcaneapp/arcane@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			info:         &versiontypes.Info{NewestDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+			want:         "ghcr.io/getarcaneapp/arcane@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		{
+			name:         "digest pin without a resolved newest digest fails",
+			currentImage: "ghcr.io/getarcaneapp/arcane@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			info:         &versiontypes.Info{},
+			wantErr:      "digest-pinned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSelfUpgradeTargetImageInternal(tt.currentImage, tt.info)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/backend/pkg/utils/strings.go
+++ b/backend/pkg/utils/strings.go
@@ -168,3 +168,13 @@ func GetStringOrDefault(m map[string]any, key, defaultValue string) string {
 	}
 	return defaultValue
 }
+
+// EnsureVPrefix guarantees a version string carries the "v" prefix that
+// semver comparisons and release tags expect.
+func EnsureVPrefix(version string) string {
+	trimmed := strings.TrimSpace(version)
+	if strings.HasPrefix(trimmed, "v") {
+		return trimmed
+	}
+	return "v" + trimmed
+}


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3687

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR resolves blank self-upgrade targets from the running image and version-check result so version-pinned installations can advance to the newest release.

- Preserves explicit updater targets unchanged.
- Resolves exact release tags and digest pins while preventing unresolved targets and downgrades.
- Adds table-driven coverage for release, mutable-channel, and digest-pinned image references.
- Adds a shared helper for normalizing semantic-version prefixes.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking inconsistency in its new error-wrapping calls.

The target-resolution behavior has concrete coverage for the supported image-reference forms, and the only accepted concern is that four newly added propagation sites do not follow the repository-mandated fmt.Errorf wrapping convention.

**Files Needing Attention:** backend/internal/system/upgrade_service.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_resolve_upgrade_target_image_for_blank-target_self-upgrades%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_resolve_upgrade_target_image_for_blank-target_self-upgrades%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233772%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3772&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_resolve_upgrade_target_image_for_blank-target_self-upgrades%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_resolve_upgrade_target_image_for_blank-target_self-upgrades%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fsystem%2Fupgrade_service.go%3A342%0A**Inconsistent%20error%20wrapping**%0A%0AThe%20new%20resolver%20propagates%20errors%20with%20%60errors.WrapIf%60%20and%20%60errors.WrapIff%60%20here%20and%20at%20lines%20363%2C%20373%2C%20and%20389%20instead%20of%20the%20repository-required%20%60fmt.Errorf%60%20with%20%60%25w%60%2C%20making%20these%20error%20paths%20inconsistent%20with%20the%20prescribed%20Go%20error-wrapping%20convention.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fsystem%2Fupgrade_service.go%3A342%0A**Inconsistent%20error%20wrapping**%0A%0AThe%20new%20resolver%20propagates%20errors%20with%20%60errors.WrapIf%60%20and%20%60errors.WrapIff%60%20here%20and%20at%20lines%20363%2C%20373%2C%20and%20389%20instead%20of%20the%20repository-required%20%60fmt.Errorf%60%20with%20%60%25w%60%2C%20making%20these%20error%20paths%20inconsistent%20with%20the%20prescribed%20Go%20error-wrapping%20convention.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3772&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/system/upgrade_service.go:342
**Inconsistent error wrapping**

The new resolver propagates errors with `errors.WrapIf` and `errors.WrapIff` here and at lines 363, 373, and 389 instead of the repository-required `fmt.Errorf` with `%w`, making these error paths inconsistent with the prescribed Go error-wrapping convention.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve upgrade target image for bl..."](https://github.com/getarcaneapp/arcane/commit/c1a6ec819585592b1e9da82b7de757464602529c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57739128)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Platform operations and reliability](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/platform-operations.md)
- Knowledge Base — [System resilience and administration](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/system-resilience-and-administration.md)
- Knowledge Base — [Registry and image update workflows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/registry-and-image-update-workflows.md)
</details>


<!-- /greptile_comment -->