### PR TITLE
fix: use WithExtensionCredProps for go-webauthn v0.18.0 compatibility

### DIFF
--- a/backend/internal/passkey/service.go
+++ b/backend/internal/passkey/service.go
@@ -456,7 +456,7 @@ func (s *passkeyService) BeginRegistration(ctx context.Context, userID, sessionI
 	creation, session, err := s.webAuthn.BeginRegistration(
 		adapter,
 		webauthn.WithExclusions(exclusions),
-		webauthn.WithExtensions(map[string]any{"credProps": true}),
+		webauthn.WithExtensions(webauthn.WithExtensionCredProps()),
 		webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementRequired),
 	)
 	if err != nil {


### PR DESCRIPTION
## Checklist

- [X] This PR is **not** opened from my fork’s `main` branch
- [X] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes a backend build failure introduced by the go-webauthn/webauthn v0.17.4 → v0.18.0 dependency bump in abb15c73 ("chore: bump remaining backend deps"). No existing issue was open for this - it was caught locally while running the dev environment after pulling main, since the backend fails to compile:

`internal/passkey/service.go:459:27: cannot use map[string]any{…} (value of type map[string]any) as webauthn.ExtensionOption value in argument to webauthn.WithExtensions`

Fixes: Can create if needed

## Changes Made

## Testing Done

go build / air hot-reload in the Docker dev environment: build succeeds, no compile errors. Backend container healthcheck reports healthy again (was failing with FailingStreak climbing before this fix). 
Manual passkey registration flow through the UI has not been re-verified yet.


## AI Tool Used (if applicable)

## Additional Context

This currently blocks main from building for anyone pulling latest after abb15c73


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores compatibility with go-webauthn v0.18.0 by replacing the obsolete raw extension map with the library’s typed credential-properties helper.
- Uses `WithExtensionCredProps()` when constructing passkey registration options.
- Preserves the existing `credProps: true` registration behavior while fixing the backend compilation failure.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the typed helper preserves the existing credential-properties extension while restoring compatibility with go-webauthn v0.18.0.

The changed registration option compiles against the upgraded dependency and emits the same `credProps` request independently of the unchanged resident-key requirement.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use WithExtensionCredProps for go-w..."](https://github.com/getarcaneapp/arcane/commit/d5c110b6d6dd23a9ef79a5db3b49518a1e13ce39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57969550)</sub>

<!-- /greptile_comment -->