### PR TITLE
fix: accept display name in email notification From Address

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2349,7 +2349,7 @@
   "notifications_email_password_help": "SMTP authentication password",
   "notifications_email_from_address_label": "From Address",
   "notifications_email_from_address_placeholder": "notifications@example.com",
-  "notifications_email_from_address_help": "Email address to send notifications from",
+  "notifications_email_from_address_help": "Email address to send notifications from. You can optionally include a display name, e.g. Arcane <notifications@example.com>",
   "notifications_email_to_addresses_label": "To Addresses",
   "notifications_email_to_addresses_placeholder": "user1@example.com, user2@example.com",
   "notifications_email_to_addresses_help": "Comma-separated list of email addresses to send notifications to",

--- a/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
@@ -21,6 +21,13 @@
 	const GENERIC_PAYLOAD_TEMPLATE_VARS =
 		'{{.title}}, {{.message}}, {{.environment}}, {{.environmentId}}, {{.event}}, {{.timestamp}}';
 
+	// Accepts RFC 5322 "Display Name <addr@example.com>" as well as a bare address,
+	// matching what backend/pkg/utils/notifications parses with net/mail.ParseAddress.
+	function extractEmailAddress(value: string): string {
+		const match = value.match(/<([^<>]+)>\s*$/);
+		return match ? match[1].trim() : value;
+	}
+
 	interface Props {
 		provider: NotificationProviderKey;
 		values: AnyBuiltInValues;
@@ -150,7 +157,7 @@
 				if (!d.fromAddress.trim()) {
 					ctx.addIssue({ code: 'custom', message: 'From address is required when email is enabled', path: ['fromAddress'] });
 				} else {
-					const v = z.string().email().safeParse(d.fromAddress.trim());
+					const v = z.string().email().safeParse(extractEmailAddress(d.fromAddress.trim()));
 					if (!v.success) {
 						ctx.addIssue({ code: 'custom', message: 'Invalid email address format', path: ['fromAddress'] });
 					}
@@ -469,8 +476,7 @@
 				id: 'from-address',
 				label: m.notifications_email_from_address_label(),
 				placeholder: m.notifications_email_from_address_placeholder(),
-				helpText: m.notifications_email_from_address_help(),
-				inputType: 'email'
+				helpText: m.notifications_email_from_address_help()
 			},
 			{
 				kind: 'textarea',

--- a/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
+++ b/frontend/src/routes/(app)/settings/notifications/providers/BuiltInProviderForm.svelte
@@ -23,9 +23,18 @@
 
 	// Accepts RFC 5322 "Display Name <addr@example.com>" as well as a bare address,
 	// matching what backend/pkg/utils/notifications parses with net/mail.ParseAddress.
+	// The display name must be either a quoted string (which may contain "<"/">") or an
+	// unquoted phrase without "@", angle brackets, quotes, or commas; anything else is left
+	// as-is so the surrounding email check rejects the whole malformed string.
 	function extractEmailAddress(value: string): string {
-		const match = value.match(/<([^<>]+)>\s*$/);
-		return match ? match[1].trim() : value;
+		const match = value.match(/^\s*(.*?)\s*<([^<>]+)>\s*$/);
+		if (!match) return value;
+		const namePart = (match[1] ?? '').trim();
+		const address = (match[2] ?? '').trim();
+		if (namePart === '') return address;
+		const isQuotedName = /^"(?:[^"\\]|\\.)*"$/.test(namePart);
+		const isUnquotedName = /^[^"<>,@]+$/.test(namePart);
+		return isQuotedName || isUnquotedName ? address : value;
 	}
 
 	interface Props {


### PR DESCRIPTION
## Checklist

- [X] This PR is **not** opened from my fork’s `main` branch
- [X] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Fixes the email notification "From Address" field rejecting the standard RFC 5322 `Display Name <addr@example.com>` format (e.g. `Arcane <notifications@example.com>`), even though the backend already fully supports it. No existing issue was open for this.

Fixes: #1762

## Changes Made

The backend was never the problem: `backend/pkg/utils/notifications/deliver.go`, `backend/internal/notification/notification.go`, and the `go-mail` library used for SMTP delivery all parse the From address with the stdlib's RFC-5322-compliant `net/mail.ParseAddress`, which already accepts the display-name form.

The blocker was entirely on the frontend, in `BuiltInProviderForm.svelte`:
- The field was rendered as `<input type="email">`, which browsers reject natively as soon as a display name is present.
- The Zod validation used `z.string().email()` directly on the raw field value, which only accepts a bare address.

Changes:
- Added a small helper, `extractEmailAddress()`, that pulls the address out of a trailing `<...>` before validating (falls back to the raw value for a bare address), and used it in the `fromAddress` Zod check.
- Dropped `inputType: 'email'` on the `fromAddress` field config so the native browser constraint no longer blocks entry.
- Updated the field's help text to mention the display-name form is supported.

## Testing Done

- Verified in the local dev environment: entered `Arcane <noreply@example.com>` in From Address, saved settings successfully (previously blocked by both the native input and Zod validation).
- Sent a real test email through the configured SMTP provider and received it in the inbox with the display name correctly shown as the sender.
- `go build`/backend untouched by this change; frontend type-check to be run via `just lint frontend`.

## AI Tool Used (if applicable)

Claude Code was used to trace the validation path (frontend vs backend), implement the fix.

## Additional Context



<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates notification settings validation to accept display-name email addresses while rejecting malformed prefixes.
- Adds display-name-aware extraction before frontend email validation.
- Removes native `type="email"` validation from the From Address field.
- Documents the supported `Display Name <address>` format.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reject malformed display names in e..."](https://github.com/getarcaneapp/arcane/commit/9c574139038758ff10dcc7a080b7cdff9a42ed7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58057454)</sub>

<!-- /greptile_comment -->