### PR TITLE
fix: forward registry auth when deploying a Swarm stack from Git Sync or a source edit

### DIFF
--- a/backend/internal/gitops/gitops_sync.go
+++ b/backend/internal/gitops/gitops_sync.go
@@ -1139,6 +1139,24 @@ func entriesNeedDirectorySyncInternal(entries []string, allowed map[string]struc
 	return false
 }
 
+// buildSwarmStackDeployRequestInternal assembles the deploy request for a Git Sync that targets
+// a Swarm stack. WithRegistryAuth is always set so the Git Sync path resolves stored registry
+// credentials the same way a direct stack deploy does. Resolution happens per image at deploy
+// time and yields nothing unless a configured container registry matches that image's host, so
+// stacks built only from public images are unaffected.
+func buildSwarmStackDeployRequestInternal(sync *projectpkg.GitOpsSync, source *preparedSyncSource, overrideContent string, envContent string, swarmFiles []swarmtypes.SyncFile) swarmtypes.StackDeployRequest {
+	return swarmtypes.StackDeployRequest{
+		Name:             sync.ProjectName,
+		ComposeContent:   source.composeContent,
+		OverrideContent:  overrideContent,
+		EnvContent:       envContent,
+		Files:            swarmFiles,
+		Prune:            true,
+		WithRegistryAuth: true,
+		WorkingDir:       filepath.Dir(filepath.Join(source.repoPath, sync.ComposePath)),
+	}
+}
+
 // performSwarmStackSyncInternal executes a single file sync targeted at a Swarm Stack
 func (s *GitOpsSyncService) performSwarmStackSyncInternal(ctx context.Context, sync *projectpkg.GitOpsSync, id string, actor common.User, result *gitops.SyncResult, source *preparedSyncSource) (*gitops.SyncResult, error) {
 	slog.InfoContext(ctx, "Deploying Swarm Stack from GitOps sync", "syncId", id, "stackName", sync.ProjectName)
@@ -1176,15 +1194,7 @@ func (s *GitOpsSyncService) performSwarmStackSyncInternal(ctx context.Context, s
 		syncedFiles = append(syncedFiles, f.RelativePath)
 	}
 
-	req := swarmtypes.StackDeployRequest{
-		Name:            sync.ProjectName,
-		ComposeContent:  source.composeContent,
-		OverrideContent: overrideContent,
-		EnvContent:      envContent,
-		Files:           swarmFiles,
-		Prune:           true,
-		WorkingDir:      filepath.Dir(filepath.Join(source.repoPath, sync.ComposePath)),
-	}
+	req := buildSwarmStackDeployRequestInternal(sync, source, overrideContent, envContent, swarmFiles)
 
 	if _, err := s.swarmService.DeployStack(ctx, sync.EnvironmentID, req); err != nil {
 		return result, s.failSync(ctx, id, result, sync, actor, "Failed to deploy swarm stack", err.Error())

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -1390,21 +1390,56 @@ func TestGitOpsSyncService_GetOrCreateProjectInternal_FailsWhenBoundProjectMissi
 }
 
 func TestBuildSwarmStackDeployRequestInternal(t *testing.T) {
-	sync := &projectpkg.GitOpsSync{ProjectName: "descent", ComposePath: "deploy/swarm/compose.yaml"}
-	source := &preparedSyncSource{repoPath: "/tmp/repo", composeContent: "services: {}\n"}
 	files := []swarmtypes.SyncFile{{RelativePath: "configs/app.conf", Content: []byte("k=v")}}
 
-	req := buildSwarmStackDeployRequestInternal(sync, source, "override", "A=1", files)
+	tests := []struct {
+		name            string
+		sync            *projectpkg.GitOpsSync
+		source          *preparedSyncSource
+		overrideContent string
+		envContent      string
+		files           []swarmtypes.SyncFile
+		want            swarmtypes.StackDeployRequest
+	}{
+		{
+			name:            "populates all fields and enables registry auth",
+			sync:            &projectpkg.GitOpsSync{ProjectName: "descent", ComposePath: "deploy/swarm/compose.yaml"},
+			source:          &preparedSyncSource{repoPath: "/tmp/repo", composeContent: "services: {}\n"},
+			overrideContent: "override",
+			envContent:      "A=1",
+			files:           files,
+			want: swarmtypes.StackDeployRequest{
+				Name:             "descent",
+				ComposeContent:   "services: {}\n",
+				OverrideContent:  "override",
+				EnvContent:       "A=1",
+				Files:            files,
+				Prune:            true,
+				WithRegistryAuth: true,
+				WorkingDir:       filepath.Join("/tmp/repo", "deploy/swarm"),
+			},
+		},
+		{
+			name:   "enables registry auth with empty optional content and a root-level compose path",
+			sync:   &projectpkg.GitOpsSync{ProjectName: "ptest", ComposePath: "compose.yaml"},
+			source: &preparedSyncSource{repoPath: "/tmp/repo", composeContent: "services: {}\n"},
+			want: swarmtypes.StackDeployRequest{
+				Name:             "ptest",
+				ComposeContent:   "services: {}\n",
+				Prune:            true,
+				WithRegistryAuth: true,
+				WorkingDir:       "/tmp/repo",
+			},
+		},
+	}
 
-	// Private images can only be pulled by swarm tasks when the deploy carries registry auth.
-	assert.True(t, req.WithRegistryAuth)
-	assert.Equal(t, "descent", req.Name)
-	assert.Equal(t, "services: {}\n", req.ComposeContent)
-	assert.Equal(t, "override", req.OverrideContent)
-	assert.Equal(t, "A=1", req.EnvContent)
-	assert.Equal(t, files, req.Files)
-	assert.True(t, req.Prune)
-	assert.Equal(t, filepath.Join("/tmp/repo", "deploy/swarm"), req.WorkingDir)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Private images can only be pulled by swarm tasks when the deploy carries registry auth.
+			got := buildSwarmStackDeployRequestInternal(tc.sync, tc.source, tc.overrideContent, tc.envContent, tc.files)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestEnvContentChangedInternal(t *testing.T) {

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -1389,10 +1389,15 @@ func TestGitOpsSyncService_GetOrCreateProjectInternal_FailsWhenBoundProjectMissi
 	assert.Contains(t, testScheduler.removed, entityjobs.GitOpsSyncJobPrefix+sync.ID)
 }
 
+// TestBuildSwarmStackDeployRequestInternal guards the Git Sync swarm deploy request.
+// WithRegistryAuth must always be set: swarm tasks pull with only the auth embedded in
+// the service spec, so a request without it makes every private image fail to pull.
 func TestBuildSwarmStackDeployRequestInternal(t *testing.T) {
+	t.Parallel()
+
 	files := []swarmtypes.SyncFile{{RelativePath: "configs/app.conf", Content: []byte("k=v")}}
 
-	tests := []struct {
+	cases := []struct {
 		name            string
 		sync            *projectpkg.GitOpsSync
 		source          *preparedSyncSource
@@ -1431,11 +1436,25 @@ func TestBuildSwarmStackDeployRequestInternal(t *testing.T) {
 				WorkingDir:       "/tmp/repo",
 			},
 		},
+		{
+			name:   "passes an empty file list through unchanged",
+			sync:   &projectpkg.GitOpsSync{ProjectName: "ptest", ComposePath: "stacks/compose.yaml"},
+			source: &preparedSyncSource{repoPath: "/tmp/repo", composeContent: "services: {}\n"},
+			// performSwarmStackSyncInternal always passes a non-nil slice; the builder must not reshape it.
+			files: []swarmtypes.SyncFile{},
+			want: swarmtypes.StackDeployRequest{
+				Name:             "ptest",
+				ComposeContent:   "services: {}\n",
+				Files:            []swarmtypes.SyncFile{},
+				Prune:            true,
+				WithRegistryAuth: true,
+				WorkingDir:       filepath.Join("/tmp/repo", "stacks"),
+			},
+		},
 	}
 
-	for _, tc := range tests {
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Private images can only be pulled by swarm tasks when the deploy carries registry auth.
 			got := buildSwarmStackDeployRequestInternal(tc.sync, tc.source, tc.overrideContent, tc.envContent, tc.files)
 			assert.Equal(t, tc.want, got)
 		})

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/scheduler/entityjobs"
 	"github.com/getarcaneapp/arcane/types/v2/gitops"
 	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
+	swarmtypes "github.com/getarcaneapp/arcane/types/v2/swarm"
 	"github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1386,6 +1387,24 @@ func TestGitOpsSyncService_GetOrCreateProjectInternal_FailsWhenBoundProjectMissi
 	require.NotNil(t, storedSync.LastSyncError)
 	assert.Contains(t, *storedSync.LastSyncError, "project binding")
 	assert.Contains(t, testScheduler.removed, entityjobs.GitOpsSyncJobPrefix+sync.ID)
+}
+
+func TestBuildSwarmStackDeployRequestInternal(t *testing.T) {
+	sync := &projectpkg.GitOpsSync{ProjectName: "descent", ComposePath: "deploy/swarm/compose.yaml"}
+	source := &preparedSyncSource{repoPath: "/tmp/repo", composeContent: "services: {}\n"}
+	files := []swarmtypes.SyncFile{{RelativePath: "configs/app.conf", Content: []byte("k=v")}}
+
+	req := buildSwarmStackDeployRequestInternal(sync, source, "override", "A=1", files)
+
+	// Private images can only be pulled by swarm tasks when the deploy carries registry auth.
+	assert.True(t, req.WithRegistryAuth)
+	assert.Equal(t, "descent", req.Name)
+	assert.Equal(t, "services: {}\n", req.ComposeContent)
+	assert.Equal(t, "override", req.OverrideContent)
+	assert.Equal(t, "A=1", req.EnvContent)
+	assert.Equal(t, files, req.Files)
+	assert.True(t, req.Prune)
+	assert.Equal(t, filepath.Join("/tmp/repo", "deploy/swarm"), req.WorkingDir)
 }
 
 func TestEnvContentChangedInternal(t *testing.T) {

--- a/backend/internal/swarm/service_test.go
+++ b/backend/internal/swarm/service_test.go
@@ -147,16 +147,22 @@ func TestSwarmService_FetchSwarmNodeIdentityViaEdgeInternal_UsesEnvironmentAcces
 	require.True(t, identity.SwarmActive)
 }
 
-func stubStackSourceUpdateDeployInternal(t *testing.T) *int {
+type stackSourceDeployRecorder struct {
+	calls   int
+	lastReq swarmtypes.StackDeployRequest
+}
+
+func stubStackSourceUpdateDeployInternal(t *testing.T) *stackSourceDeployRecorder {
 	t.Helper()
 	original := deployStackAfterSourceUpdateInternal
 	t.Cleanup(func() { deployStackAfterSourceUpdateInternal = original })
-	calls := 0
+	rec := &stackSourceDeployRecorder{}
 	deployStackAfterSourceUpdateInternal = func(_ *SwarmService, _ context.Context, _ string, req swarmtypes.StackDeployRequest) (*swarmtypes.StackDeployResponse, error) {
-		calls++
+		rec.calls++
+		rec.lastReq = req
 		return &swarmtypes.StackDeployResponse{Name: req.Name}, nil
 	}
-	return &calls
+	return rec
 }
 
 func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager(t *testing.T) {
@@ -169,7 +175,7 @@ func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager
 	require.NoError(t, err)
 
 	svc := NewSwarmService(nil, settingsSvc, nil, nil, nil)
-	deployCalls := stubStackSourceUpdateDeployInternal(t)
+	deployRec := stubStackSourceUpdateDeployInternal(t)
 
 	updated, err := svc.UpdateStackSource(ctx, "0", "demo-stack", swarmtypes.StackSourceUpdateRequest{
 		ComposeContent: "services:\n  web:\n    image: nginx:alpine\n",
@@ -178,7 +184,10 @@ func TestSwarmService_UpdateAndGetStackSource_UsesStoredFilesWithoutSwarmManager
 	require.NoError(t, err)
 	require.Equal(t, "demo-stack", updated.Name)
 	// Saving stack source must trigger an actual stack deploy (#3463).
-	require.Equal(t, 1, *deployCalls)
+	require.Equal(t, 1, deployRec.calls)
+	// The edit-path redeploy must carry registry auth, the same as Git Sync (#3778):
+	// a service added in the edit has no previous spec to fall back on.
+	require.True(t, deployRec.lastReq.WithRegistryAuth)
 
 	composePath := filepath.Join(rootDir, "0", "demo-stack", "compose.yaml")
 	envPath := filepath.Join(rootDir, "0", "demo-stack", ".env")

--- a/backend/internal/swarm/swarm.go
+++ b/backend/internal/swarm/swarm.go
@@ -1846,13 +1846,18 @@ func (s *SwarmService) UpdateStackSource(ctx context.Context, environmentID, sta
 	// push the updated spec to the running services so the edit takes effect.
 	// The saved source is the full stack spec, so services removed from it
 	// must also be removed from the swarm.
+	// WithRegistryAuth is always set, the same as the Git Sync deploy path:
+	// resolution is per image and yields nothing unless a configured container
+	// registry matches the image host. Without it, a service added in the edit
+	// has no previous spec to fall back on and private images fail to pull.
 	if _, err := deployStackAfterSourceUpdateInternal(s, ctx, environmentID, swarmtypes.StackDeployRequest{
-		Name:            stackName,
-		ComposeContent:  req.ComposeContent,
-		OverrideContent: req.OverrideContent,
-		EnvContent:      req.EnvContent,
-		Files:           req.Files,
-		Prune:           true,
+		Name:             stackName,
+		ComposeContent:   req.ComposeContent,
+		OverrideContent:  req.OverrideContent,
+		EnvContent:       req.EnvContent,
+		Files:            req.Files,
+		Prune:            true,
+		WithRegistryAuth: true,
 	}); err != nil {
 		// Roll back the persisted source so reads never return an edit that
 		// was never successfully deployed.


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`) — not applicable, no user-facing strings

## What This PR Implements

Two call sites built a `StackDeployRequest` without `WithRegistryAuth`, so their deploys carried no `X-Registry-Auth` header and private images failed to pull with `no basic auth credentials`:

- `performSwarmStackSyncInternal` (Git Sync to a Swarm stack) — every private image fails on every sync.
- `UpdateStackSource` (the save-edited-stack redeploy, #3463) — usually masked, because Docker falls back to the auth in the previous service spec. The fallback breaks when an edit adds a service (no previous spec) or after a credential rotation. The edit form cannot opt in: the UI renders the registry-auth checkbox only for new stacks.

This PR sets the flag at both call sites. Both paths now resolve stored registry credentials the same as a direct stack deploy.

Auth resolution occurs for each image at deploy time. `GetRegistryAuthForImage` returns `""` when no configured container registry matches the image host. Thus the change has no effect on stacks that use only public images.

Fixes: #3778

## Changes Made

- Git Sync: move the request construction into `buildSwarmStackDeployRequestInternal` and set `WithRegistryAuth: true` there. `swarmService` is a concrete `*swarm.SwarmService`, not an interface. The helper makes the request visible to a test without a refactor of the service seam.
- Stack-source edit: set `WithRegistryAuth: true` on the request in `UpdateStackSource`.
- Tests: add table-driven `TestBuildSwarmStackDeployRequestInternal` (gitops), and extend the existing `UpdateStackSource` test stub to record the deploy request and assert the flag (swarm).

## Testing Done

Unit level:

- `go test -race ./internal/gitops/... ./internal/swarm/... ./pkg/libarcane/swarm/...` — all three packages pass (Go 1.27.0).
- `go vet` on the same packages is clean. `gofmt -s -l` is clean.
- `.bin/golangci-lint-custom run -c .github/.golangci.yml` on the touched packages reports 0 issues.
- Each new assertion fails when its `WithRegistryAuth` change is reverted.

End to end: I built the image from this branch with `docker/Dockerfile`. I tested on a single-node swarm with a local htpasswd-protected `registry:2` and a real git remote.

| Path | Build | Result |
|---|---|---|
| Git Sync → swarm stack, private image | v2.9.0 | tasks `Rejected` — `no basic auth credentials` |
| Direct `POST /swarm/stacks` with `withRegistryAuth: true`, same credential | v2.9.0 | Running |
| Git Sync → swarm stack, private image | this branch | **Running** |
| Re-sync after a repo change (service update path) | this branch | Running, with a fresh pull |
| Git Sync → swarm stack, public image, no matching registry configured | this branch | Running — confirms the no-op claim |
| Edit stack source, add a service on an uncached private image | v2.9.0 | new task `Rejected` — `no basic auth credentials` (existing service keeps running on previous-spec auth) |
| Edit stack source, add a service on an uncached private image | this branch | **Running** |

I first hit this failure on my own cluster (3 arm64 Swarm managers, a private `ghcr.io` image, a GHCR PAT stored in Arcane).

## AI Tool Used (if applicable)

Claude Code. It traced the call path across `gitops_sync.go` → `swarm.go` → `deploy.go`, wrote the patch, and scripted the end-to-end verification above. I reviewed the change and the test results. I found and reproduced the original failure by hand on my own cluster.

## Additional Context

The alternative shape is a `withRegistryAuth` flag on the GitOps sync itself (model, migration, API, UI), the same as the direct deploy. I chose the always-on version for two reasons. It needs no schema change and no UI change. It cannot affect a user without a matching registry — the end-to-end test above confirms this. Tell me if you prefer the explicit toggle, and I will change the PR.
