### PR TITLE
fix: issue a compact browser session cookie instead of the bigger ML-DSA access JWT

### DIFF
--- a/backend/api/buildables.go
+++ b/backend/api/buildables.go
@@ -89,7 +89,7 @@ func registerAutoLoginRoutes(apiGroup *echo.Group, authService *auth.AuthService
 		maxAge += 60
 		expiresAt := tokenPair.ExpiresAt
 
-		for _, tokenCookie := range cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromRequest(c.Request())) {
+		for _, tokenCookie := range cookie.BuildTokenCookieStringFor(maxAge, tokenPair.BrowserToken, cookie.SecureCookieFromRequest(c.Request())) {
 			c.Response().Header().Add("Set-Cookie", tokenCookie)
 		}
 		return c.JSON(http.StatusOK, base.ApiResponse[authtypes.AuthenticationResponse]{

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -256,7 +256,7 @@ func (h *AuthHandler) Login(ctx context.Context, input *LoginInput) (*LoginOutpu
 	expiresAt := tokenPair.ExpiresAt
 
 	return &LoginOutput{
-		SetCookie: cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromContext(ctx)),
+		SetCookie: cookie.BuildTokenCookieStringFor(maxAge, tokenPair.BrowserToken, cookie.SecureCookieFromContext(ctx)),
 		Body: base.ApiResponse[authtypes.AuthenticationResponse]{
 			Success: true,
 			Data: authtypes.AuthenticationResponse{
@@ -338,7 +338,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, input *RefreshTokenInput
 	maxAge += 60
 
 	return &RefreshTokenOutput{
-		SetCookie: cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromContext(ctx)),
+		SetCookie: cookie.BuildTokenCookieStringFor(maxAge, tokenPair.BrowserToken, cookie.SecureCookieFromContext(ctx)),
 		Body: base.ApiResponse[authtypes.TokenRefreshResponse]{
 			Success: true,
 			Data: authtypes.TokenRefreshResponse{

--- a/backend/internal/auth/huma_middleware.go
+++ b/backend/internal/auth/huma_middleware.go
@@ -70,11 +70,18 @@ func parseSecurityRequirementsInternal(api huma.API, ctx operationProvider) secu
 // the caller can distinguish a missing/invalid token from a token-version
 // mismatch (which requires clearing the stale cookie).
 func tryBearerAuthInternal(ctx huma.Context, authService *AuthService) (*common.User, string, error) {
-	token := extractBearerTokenInternal(ctx)
+	token, fromCookie := extractBearerTokenInternal(ctx)
 	if token == "" {
 		return nil, "", nil
 	}
-	user, sessionID, err := authService.VerifyToken(ctx.Context(), token)
+	var user *common.User
+	var sessionID string
+	var err error
+	if fromCookie {
+		user, sessionID, err = authService.VerifyBrowserToken(ctx.Context(), token)
+	} else {
+		user, sessionID, err = authService.VerifyToken(ctx.Context(), token)
+	}
 	if err != nil {
 		return nil, "", err
 	}
@@ -243,7 +250,7 @@ func tryAgentAuthCtxInternal(ctx huma.Context, cfg *config.Config) (huma.Context
 // bearer token is present, but never fails the request. Used for public routes
 // (e.g. logout) that still need to know who the caller is when a token exists.
 func opportunisticBearerAuthInternal(ctx huma.Context, authService *AuthService, permResolver PermissionResolver) huma.Context {
-	if extractBearerTokenInternal(ctx) == "" {
+	if token, _ := extractBearerTokenInternal(ctx); token == "" {
 		return ctx
 	}
 	user, sessionID, err := tryBearerAuthInternal(ctx, authService)
@@ -273,7 +280,7 @@ func handleApiKeyAuthInternal(api huma.API, ctx huma.Context, authService *AuthS
 		return
 	}
 	if user, env, ok := tryEnvironmentAccessTokenAuthInternal(ctx, envTokenResolver, ctx.Header(utils.HeaderApiKey)); ok {
-		if allowBearerFallback && extractBearerTokenInternal(ctx) != "" {
+		if token, _ := extractBearerTokenInternal(ctx); allowBearerFallback && token != "" {
 			nextCtx, handled := handleBearerAuthInternal(api, ctx, authService, permResolver)
 			if handled {
 				if nextCtx != nil {
@@ -343,22 +350,22 @@ func resolveApiKeyPermissionsInternal(ctx context.Context, permResolver Permissi
 	return ps
 }
 
-// extractBearerTokenInternal extracts the JWT token from Authorization header or cookie.
-func extractBearerTokenInternal(ctx huma.Context) string {
+// extractBearerTokenInternal extracts the JWT token and reports whether it came from a cookie.
+func extractBearerTokenInternal(ctx huma.Context) (string, bool) {
 	// Try Authorization header first
 	authHeader := ctx.Header("Authorization")
 	if len(authHeader) > 7 && strings.ToLower(authHeader[:7]) == "bearer " {
-		return authHeader[7:]
+		return authHeader[7:], false
 	}
 
 	// Try cookie as fallback
 	if cookieHeader := ctx.Header("Cookie"); cookieHeader != "" {
 		if token, err := cookie.GetTokenCookieFromHeader(cookieHeader); err == nil {
-			return token
+			return token, true
 		}
 	}
 
-	return ""
+	return "", false
 }
 
 // setUserInContextInternal adds the authenticated user and the resolved

--- a/backend/internal/auth/huma_middleware_test.go
+++ b/backend/internal/auth/huma_middleware_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 
+	"bytes"
 	"context"
 	"crypto/mldsa"
 	"net/http"
@@ -23,8 +24,11 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/user"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/cookie"
 	authtypes "github.com/getarcaneapp/arcane/types/v2/auth"
 	"github.com/labstack/echo/v5"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -316,7 +320,7 @@ func TestNewHumaMiddleware_OpportunisticAuthOnPublicRoute(t *testing.T) {
 	t.Run("populates session ID when valid token presented", func(t *testing.T) {
 		sawSessionID = ""
 		req := httptest.NewRequest(http.MethodPost, "/api/public", nil)
-		req.Header.Set("Authorization", "Bearer "+token)
+		req.AddCookie(&http.Cookie{Name: cookie.InsecureTokenCookieName, Value: token})
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
@@ -353,8 +357,10 @@ func TestNewHumaMiddleware_VersionMismatchIsRecoverable(t *testing.T) {
 	sessionSvc := session.NewSessionService(db)
 
 	signingKey := newTestSigningKeyInternal()
+	browserSigningKey := bytes.Repeat([]byte{0x24}, browserSessionSigningKeySize)
 	cfg := &config.Config{JWTRefreshExpiry: 24 * time.Hour}
 	authSvc := NewAuthService(userSvc, nil, nil, sessionSvc, nil, cfg, nil).WithSigningKey(signingKey)
+	authSvc.browserSigningKey = browserSigningKey
 
 	_, err := userSvc.CreateUser(context.Background(), &common.User{
 		ID:       "u-ver",
@@ -368,19 +374,21 @@ func TestNewHumaMiddleware_VersionMismatchIsRecoverable(t *testing.T) {
 
 	// An empty appVersion omits the claim, which passes the version check (no pin).
 	mintToken := func(appVersion string) string {
-		claims := map[string]any{
-			"jti":      "u-ver",
-			"sub":      "access",
-			"iat":      time.Now().Unix(),
-			"exp":      exp.Unix(),
-			"sid":      session.ID,
-			"user_id":  "u-ver",
-			"username": "vertest",
-		}
+		builder := jwt.NewBuilder().
+			JwtID("browser-"+appVersion).
+			Subject(browserTokenSubject).
+			IssuedAt(time.Now()).
+			Expiration(exp).
+			Claim(claimSessionID, session.ID).
+			Claim(claimUserID, "u-ver")
 		if appVersion != "" {
-			claims["app_version"] = appVersion
+			builder.Claim(claimAppVersion, appVersion)
 		}
-		return signJWXTokenInternal(t, signingKey, claims)
+		token, err := builder.Build()
+		require.NoError(t, err)
+		signed, err := jwt.Sign(token, jwt.WithKey(jwa.HS512(), browserSigningKey))
+		require.NoError(t, err)
+		return string(signed)
 	}
 
 	router := echo.New()
@@ -403,7 +411,7 @@ func TestNewHumaMiddleware_VersionMismatchIsRecoverable(t *testing.T) {
 
 	t.Run("version mismatch returns a recoverable 401 without clearing cookies", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
-		req.Header.Set("Authorization", "Bearer "+mintToken("v0.0.0-stale"))
+		req.AddCookie(&http.Cookie{Name: cookie.InsecureTokenCookieName, Value: mintToken("v0.0.0-stale")})
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, req)
 
@@ -415,11 +423,18 @@ func TestNewHumaMiddleware_VersionMismatchIsRecoverable(t *testing.T) {
 	})
 
 	t.Run("token without a version pin still authenticates", func(t *testing.T) {
+		token := mintToken("")
 		req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
-		req.Header.Set("Authorization", "Bearer "+mintToken(""))
+		req.AddCookie(&http.Cookie{Name: cookie.InsecureTokenCookieName, Value: token})
 		rec := httptest.NewRecorder()
 		router.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
+
+		req = httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec = httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
 }
 

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -162,7 +162,7 @@ func (m *AuthMiddleware) managerAuth(ctx context.Context, c *echo.Context, next 
 		return m.apiKeyHeaderAuth(ctx, c, next, apiKey)
 	}
 
-	token := extractBearerOrCookieTokenInternal(c)
+	token, fromCookie := extractBearerOrCookieTokenInternal(c)
 	if token == "" {
 		if m.options.SuccessOptional {
 			return next(c)
@@ -173,7 +173,14 @@ func (m *AuthMiddleware) managerAuth(ctx context.Context, c *echo.Context, next 
 		})
 	}
 
-	user, sessionID, err := m.authService.VerifyToken(ctx, token)
+	var user *common.User
+	var sessionID string
+	var err error
+	if fromCookie {
+		user, sessionID, err = m.authService.VerifyBrowserToken(ctx, token)
+	} else {
+		user, sessionID, err = m.authService.VerifyToken(ctx, token)
+	}
 	if err != nil {
 		// A version mismatch means the app self-updated; the session is still valid
 		// (the refresh path tolerates the version change and rotates the token), so do
@@ -324,14 +331,14 @@ func environmentScopedInternal(c *echo.Context, env *environment.Environment) {
 	c.Set(string(middleware.ContextKeyAuthMethod), "environment_access_token")
 }
 
-func extractBearerOrCookieTokenInternal(c *echo.Context) string {
+func extractBearerOrCookieTokenInternal(c *echo.Context) (string, bool) {
 	req := c.Request()
 	authHeader := req.Header.Get("Authorization")
 	if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
-		return after
+		return after, false
 	}
 	if tok, err := cookie.GetTokenCookie(req); err == nil && tok != "" {
-		return tok
+		return tok, true
 	}
-	return ""
+	return "", false
 }

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -11,9 +11,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/session"
+	usersvc "github.com/getarcaneapp/arcane/backend/v2/internal/user"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/cookie"
+	authtypes "github.com/getarcaneapp/arcane/types/v2/auth"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +106,53 @@ func TestAuthMiddleware_ManagerAuthResolvesPermissionsByKeyKind(t *testing.T) {
 			require.Equal(t, http.StatusOK, rec.Code)
 		})
 	}
+
+	t.Run("browser cookie uses owner role permissions", func(t *testing.T) {
+		ctx := context.Background()
+		db := setupAuthMiddlewareTestDBInternal(t)
+		userSvc := usersvc.NewUserService(db)
+		sessionSvc := session.NewSessionService(db)
+		settingsSvc, err := newSettingsServiceForAuthTestInternal(t, ctx, db)
+		require.NoError(t, err)
+		authSvc := newTestAuthService()
+		authSvc.userService = userSvc
+		authSvc.settingsService = settingsSvc
+		authSvc.sessionService = sessionSvc
+
+		browserUser := &common.User{ID: "browser-owner", Username: "browser-owner"}
+		_, err = userSvc.CreateUser(ctx, browserUser)
+		require.NoError(t, err)
+		expiresAt := time.Now().Add(time.Hour)
+		browserSession, refreshJTI, err := sessionSvc.CreateSession(ctx, browserUser.ID, expiresAt, authtypes.SessionMeta{})
+		require.NoError(t, err)
+		tokenPair, err := authSvc.buildTokenPairInternal(ctx, browserUser, browserSession, refreshJTI)
+		require.NoError(t, err)
+
+		router := echo.New()
+		router.Use(
+			NewAuthMiddleware(authSvc, &config.Config{}).
+				WithPermissionResolver(testPermissionResolver{}).
+				Add(),
+		)
+		router.GET("/secure", func(c *echo.Context) error {
+			ps, ok := c.Get("userPermissions").(*authz.PermissionSet)
+			require.True(t, ok)
+			require.True(t, ps.Allows("containers:list", ""))
+			return c.NoContent(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/secure", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenPair.BrowserToken)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+		req = httptest.NewRequest(http.MethodGet, "/secure", nil)
+		req.AddCookie(&http.Cookie{Name: cookie.InsecureTokenCookieName, Value: tokenPair.BrowserToken})
+		rec = httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
 }
 
 func TestAuthMiddleware_ManagerAuthAcceptsEnvironmentAccessTokenViaAPIKey(t *testing.T) {

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -43,6 +43,7 @@ const (
 
 type TokenPair struct {
 	AccessToken  string    `json:"accessToken"`
+	BrowserToken string    `json:"-"`
 	RefreshToken string    `json:"refreshToken"`
 	ExpiresAt    time.Time `json:"expiresAt"`
 }
@@ -60,16 +61,17 @@ type verifiedTokenEntry struct {
 }
 
 type AuthService struct {
-	userService     *user.UserService
-	settingsService *settings.SettingsService
-	eventService    *event.EventService
-	sessionService  *session.SessionService
-	roleService     *role.RoleService
-	signingKeyMu    sync.Mutex
-	signingKey      *mldsa.PrivateKey
-	refreshExpiry   time.Duration
-	config          *config.Config
-	errorHandler    emperror.ErrorHandler
+	userService       *user.UserService
+	settingsService   *settings.SettingsService
+	eventService      *event.EventService
+	sessionService    *session.SessionService
+	roleService       *role.RoleService
+	signingKeyMu      sync.Mutex
+	signingKey        *mldsa.PrivateKey
+	browserSigningKey []byte
+	refreshExpiry     time.Duration
+	config            *config.Config
+	errorHandler      emperror.ErrorHandler
 	// tokenCache is a per-process in-memory cache for parsed user/token data.
 	// Cached entries still revalidate persisted session state so revocation
 	// performed by another process takes effect immediately.
@@ -703,6 +705,26 @@ func (s *AuthService) signingKeyInternal(ctx context.Context) (*mldsa.PrivateKey
 	return key, nil
 }
 
+func (s *AuthService) browserSigningKeyInternal(ctx context.Context) ([]byte, error) {
+	s.signingKeyMu.Lock()
+	defer s.signingKeyMu.Unlock()
+	if len(s.browserSigningKey) == browserSessionSigningKeySize {
+		return s.browserSigningKey, nil
+	}
+	if s.settingsService == nil {
+		return nil, common.Classify(common.ErrUnavailable, errors.New("browser session signing key is not configured"))
+	}
+	key, err := s.settingsService.EnsureBrowserSessionSigningKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != browserSessionSigningKeySize {
+		return nil, common.Classify(common.ErrUnavailable, errors.New("browser session signing key has invalid length"))
+	}
+	s.browserSigningKey = key
+	return key, nil
+}
+
 func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string, meta auth.SessionMeta) (*TokenPair, error) {
 	signingKey, err := s.signingKeyInternal(ctx)
 	if err != nil {
@@ -754,7 +776,33 @@ func (s *AuthService) VerifyToken(ctx context.Context, accessToken string) (*com
 	if err != nil {
 		return nil, "", err
 	}
+	return s.verifyTokenClaimsInternal(ctx, accessToken, claims)
+}
 
+func (s *AuthService) VerifyBrowserToken(ctx context.Context, browserToken string) (*common.User, string, error) {
+	algorithm, ok := signedTokenAlgorithmInternal(browserToken)
+	if !ok {
+		return nil, "", common.ErrInvalidToken
+	}
+	switch algorithm {
+	case jwa.HS512().String():
+		key, err := s.browserSigningKeyInternal(ctx)
+		if err != nil {
+			return nil, "", err
+		}
+		claims, err := parseBrowserTokenInternal(ctx, browserToken, key)
+		if err != nil {
+			return nil, "", err
+		}
+		return s.verifyTokenClaimsInternal(ctx, browserToken, claims)
+	case jwa.MLDSA87().String():
+		return s.VerifyToken(ctx, browserToken)
+	default:
+		return nil, "", common.ErrInvalidToken
+	}
+}
+
+func (s *AuthService) verifyTokenClaimsInternal(ctx context.Context, rawToken string, claims *accessTokenClaims) (*common.User, string, error) {
 	if claims.AppVersion != "" && claims.AppVersion != config.Version {
 		slog.InfoContext(ctx, "Token version mismatch detected", "tokenVersion", claims.AppVersion, "currentVersion", config.Version, "user", claims.Username)
 		return nil, "", common.ErrTokenVersionMismatch
@@ -763,7 +811,7 @@ func (s *AuthService) VerifyToken(ctx context.Context, accessToken string) (*com
 		return nil, "", common.Classify(common.ErrUnavailable, errors.New("Session service is not configured"))
 	}
 
-	tokenHash := hashTokenInternal(accessToken)
+	tokenHash := hashTokenInternal(rawToken)
 	if cached, ok, _ := s.tokenCache.Get(tokenHash); ok {
 		if cached.User.ID != claims.UserID || cached.SessionID != claims.SessionID {
 			s.tokenCache.Delete(tokenHash)
@@ -975,8 +1023,32 @@ func (s *AuthService) buildTokenPairInternal(ctx context.Context, user *common.U
 		return nil, err
 	}
 
+	browserSigningKey, err := s.browserSigningKeyInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	browserBuilder := jwt.NewBuilder().
+		JwtID(uuid.New().String()).
+		Subject(browserTokenSubject).
+		IssuedAt(now).
+		Expiration(accessTokenExpiry).
+		Claim(claimSessionID, session.ID).
+		Claim(claimUserID, user.ID)
+	if config.Version != "" {
+		browserBuilder.Claim(claimAppVersion, config.Version)
+	}
+	browserToken, err := browserBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	browserTokenBytes, err := jwt.Sign(browserToken, jwt.WithKey(jwa.HS512(), browserSigningKey))
+	if err != nil {
+		return nil, err
+	}
+
 	return &TokenPair{
 		AccessToken:  string(accessTokenBytes),
+		BrowserToken: string(browserTokenBytes),
 		RefreshToken: string(refreshTokenBytes),
 		ExpiresAt:    accessTokenExpiry,
 	}, nil

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/environment"
 
+	"bytes"
 	"context"
 	"crypto/mldsa"
 	"encoding/base64"
@@ -85,9 +86,10 @@ func newTestSigningKeyInternal() *mldsa.PrivateKey {
 
 func newTestAuthService() *AuthService {
 	return &AuthService{
-		signingKey:    newTestSigningKeyInternal(),
-		refreshExpiry: 24 * time.Hour,
-		config:        &config.Config{},
+		signingKey:        newTestSigningKeyInternal(),
+		browserSigningKey: bytes.Repeat([]byte{0x42}, browserSessionSigningKeySize),
+		refreshExpiry:     24 * time.Hour,
+		config:            &config.Config{},
 		tokenCache: hot.NewHotCache[string, verifiedTokenEntry](hot.LRU, 4096).
 			WithTTL(15 * time.Second).
 			WithJanitor().
@@ -231,7 +233,7 @@ func TestVerifyToken_ValidClaims(t *testing.T) {
 func TestVerifyToken_RejectsNonMLDSAAlg(t *testing.T) {
 	s := newTestAuthService()
 	exp := time.Now().Add(5 * time.Minute)
-	token := makeUnsignedToken(t, map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"jti":         "u1",
 		"sub":         "access",
 		"iat":         time.Now().Unix(),
@@ -240,8 +242,13 @@ func TestVerifyToken_RejectsNonMLDSAAlg(t *testing.T) {
 		"username":    "bob",
 		"app_version": config.Version,
 	})
+	require.NoError(t, err)
+	parsed, err := jwt.ParseInsecure(payload)
+	require.NoError(t, err)
+	token, err := jwt.Sign(parsed, jwt.WithKey(jwa.HS512(), s.browserSigningKey))
+	require.NoError(t, err)
 
-	_, _, err := s.VerifyToken(context.Background(), token)
+	_, _, err = s.VerifyToken(context.Background(), string(token))
 
 	assert.ErrorIs(t, err, common.ErrInvalidToken,
 		"want common.ErrInvalidToken, got %v", err)
@@ -407,7 +414,19 @@ func TestRefreshToken_Valid(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tokenPair)
 	require.NotEmpty(t, tokenPair.AccessToken)
+	require.NotEmpty(t, tokenPair.BrowserToken)
 	require.NotEmpty(t, tokenPair.RefreshToken)
+	require.Less(t, len(tokenPair.BrowserToken), 1024)
+
+	accessAlgorithm, ok := signedTokenAlgorithmInternal(tokenPair.AccessToken)
+	require.True(t, ok)
+	require.Equal(t, jwa.MLDSA87().String(), accessAlgorithm)
+	browserAlgorithm, ok := signedTokenAlgorithmInternal(tokenPair.BrowserToken)
+	require.True(t, ok)
+	require.Equal(t, jwa.HS512().String(), browserAlgorithm)
+	refreshAlgorithm, ok := signedTokenAlgorithmInternal(tokenPair.RefreshToken)
+	require.True(t, ok)
+	require.Equal(t, jwa.MLDSA87().String(), refreshAlgorithm)
 }
 
 // A refresh token minted under an older config.Version must still refresh successfully
@@ -451,6 +470,21 @@ func TestRefreshToken_VersionMismatchRotates(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "2.0.0", accessVersion)
 
+	parsedBrowser, err := jwt.ParseString(tokenPair.BrowserToken, jwt.WithKey(jwa.HS512(), s.browserSigningKey))
+	require.NoError(t, err)
+	browserSubject, ok := parsedBrowser.Subject()
+	require.True(t, ok)
+	require.Equal(t, browserTokenSubject, browserSubject)
+	browserSessionID, err := jwt.Get[string](parsedBrowser, claimSessionID)
+	require.NoError(t, err)
+	require.Equal(t, session.ID, browserSessionID)
+	browserUserID, err := jwt.Get[string](parsedBrowser, claimUserID)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, browserUserID)
+	browserVersion, err := jwt.Get[string](parsedBrowser, claimAppVersion)
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", browserVersion)
+
 	parsedRefresh, err := jwt.ParseString(tokenPair.RefreshToken, jwt.WithKey(jwa.MLDSA87(), s.signingKey.PublicKey()))
 	require.NoError(t, err)
 	refreshVersion, err := jwt.Get[string](parsedRefresh, claimAppVersion)
@@ -474,10 +508,23 @@ func TestVerifyToken_RejectsRevokedSession(t *testing.T) {
 
 	exp := time.Now().Add(5 * time.Minute)
 	session, _ := createTestSession(t, db, user.ID, exp)
-	require.NoError(t, s.RevokeSession(context.Background(), session.ID))
 	token := makeAccessToken(t, s.signingKey, "access", user.ID, user.Username, []string{"user"}, "", "", exp, session.ID)
+	browser, err := jwt.NewBuilder().
+		JwtID("revoked-browser-token").
+		Subject(browserTokenSubject).
+		IssuedAt(time.Now()).
+		Expiration(exp).
+		Claim(claimSessionID, session.ID).
+		Claim(claimUserID, user.ID).
+		Build()
+	require.NoError(t, err)
+	browserToken, err := jwt.Sign(browser, jwt.WithKey(jwa.HS512(), s.browserSigningKey))
+	require.NoError(t, err)
+	require.NoError(t, s.RevokeSession(context.Background(), session.ID))
 
 	_, _, err = s.VerifyToken(context.Background(), token)
+	require.ErrorIs(t, err, common.ErrSessionRevoked)
+	_, _, err = s.VerifyBrowserToken(context.Background(), string(browserToken))
 	require.ErrorIs(t, err, common.ErrSessionRevoked)
 }
 

--- a/backend/internal/auth/token.go
+++ b/backend/internal/auth/token.go
@@ -6,13 +6,17 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jws"
 	"github.com/lestrrat-go/jwx/v4/jwt"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 )
 
 const (
+	browserSessionSigningKeySize = 64
+
 	accessTokenSubject  = "access"
+	browserTokenSubject = "browser_session"
 	refreshTokenSubject = "refresh"
 
 	claimSessionID             = "sid"
@@ -76,6 +80,50 @@ func parseAccessTokenInternal(ctx context.Context, rawToken string, key *mldsa.P
 		return nil, common.ErrTokenValidation
 	}
 	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, Username: username, AppVersion: appVersion}), nil
+}
+
+func parseBrowserTokenInternal(ctx context.Context, rawToken string, key []byte) (*accessTokenClaims, error) {
+	token, err := jwt.ParseString(rawToken, append(tokenParseOptions, jwt.WithKey(jwa.HS512(), key), jwt.WithContext(ctx))...)
+	if err != nil {
+		switch {
+		case errors.Is(err, jwt.TokenExpiredError{}):
+			return nil, common.ErrExpiredToken
+		case errors.Is(err, jwt.MissingRequiredClaimError{}), errors.Is(err, jwt.ClaimValidationError{}):
+			return nil, common.ErrTokenValidation
+		default:
+			return nil, common.ErrInvalidToken
+		}
+	}
+
+	subject, _ := token.Subject()
+	id, _ := token.JwtID()
+	userID, _ := jwt.Get[string](token, claimUserID)
+	sessionID, _ := jwt.Get[string](token, claimSessionID)
+	if subject != browserTokenSubject || id == "" || userID == "" || sessionID == "" {
+		return nil, common.ErrTokenValidation
+	}
+
+	appVersion, appVersionErr := jwt.Get[string](token, claimAppVersion)
+	if errors.Is(appVersionErr, jwt.ClaimTypeMismatchError{}) {
+		return nil, common.ErrTokenValidation
+	}
+	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, AppVersion: appVersion}), nil
+}
+
+func signedTokenAlgorithmInternal(rawToken string) (string, bool) {
+	message, err := jws.Parse([]byte(rawToken), jws.WithCompact())
+	if err != nil {
+		return "", false
+	}
+	signatures := message.Signatures()
+	if len(signatures) != 1 || signatures[0].ProtectedHeaders() == nil {
+		return "", false
+	}
+	algorithm, ok := signatures[0].ProtectedHeaders().Algorithm()
+	if !ok {
+		return "", false
+	}
+	return algorithm.String(), true
 }
 
 func parseRefreshTokenInternal(ctx context.Context, rawToken string, key *mldsa.PublicKey) (*refreshTokenClaims, error) {

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -144,24 +144,26 @@ func createAuthValidatorInternal(deps api.HandlerDeps) middleware.AuthValidator 
 			return nil, nil, false
 		}
 
-		// Check for Bearer token authentication
-		token := ""
-		if auth := req.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-			token = strings.TrimPrefix(auth, "Bearer ")
-		} else if cookieToken, err := cookie.GetTokenCookie(req); err == nil && cookieToken != "" {
-			token = cookieToken
-		}
-
-		if token == "" {
-			return nil, nil, false
-		}
-
-		user, _, err := deps.Auth.Service().VerifyToken(ctx, token)
-		if err != nil || user == nil {
+		user, ok := verifyRouterRequestUserInternal(ctx, deps.Auth.Service(), req)
+		if !ok {
 			return nil, nil, false
 		}
 		return resolveUser(ctx, user), user, true
 	}
+}
+
+func verifyRouterRequestUserInternal(ctx context.Context, authService *auth.AuthService, req *http.Request) (*common.User, bool) {
+	if authHeader := req.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+		user, _, err := authService.VerifyToken(ctx, strings.TrimPrefix(authHeader, "Bearer "))
+		return user, err == nil && user != nil
+	}
+
+	browserToken, err := cookie.GetTokenCookie(req)
+	if err != nil || browserToken == "" {
+		return nil, false
+	}
+	user, _, err := authService.VerifyBrowserToken(ctx, browserToken)
+	return user, err == nil && user != nil
 }
 
 type RouterParams struct {

--- a/backend/internal/oidc/handler.go
+++ b/backend/internal/oidc/handler.go
@@ -100,8 +100,7 @@ type ExchangeDeviceTokenInput struct {
 }
 
 type ExchangeDeviceTokenOutput struct {
-	SetCookie []string `header:"Set-Cookie" doc:"Session token cookie"`
-	Body      authtypes.AuthenticationResponse
+	Body authtypes.AuthenticationResponse
 }
 
 // --- OIDC role mapping I/O ---
@@ -392,7 +391,7 @@ func (h *OidcHandler) HandleOidcCallback(ctx context.Context, input *HandleOidcC
 	if mobileRedirectURI == "" {
 		maxAge := max(int(time.Until(tokenPair.ExpiresAt).Seconds()), 0)
 		maxAge += 60 // Add 60 seconds buffer for clock skew
-		setCookies = append(setCookies, cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromContext(ctx))...)
+		setCookies = append(setCookies, cookie.BuildTokenCookieStringFor(maxAge, tokenPair.BrowserToken, cookie.SecureCookieFromContext(ctx))...)
 	}
 	expiresAt := tokenPair.ExpiresAt
 
@@ -480,11 +479,7 @@ func (h *OidcHandler) ExchangeDeviceToken(ctx context.Context, input *ExchangeDe
 		return nil, huma.Error500InternalServerError("Authentication failed")
 	}
 
-	maxAge := max(int(time.Until(tokenPair.ExpiresAt).Seconds()), 0)
-	maxAge += 60
 	expiresAt := tokenPair.ExpiresAt
-
-	tokenCookies := cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromContext(ctx))
 
 	userDto, err := h.userService.ToUserResponseDto(ctx, *userModel)
 	if err != nil {
@@ -492,7 +487,6 @@ func (h *OidcHandler) ExchangeDeviceToken(ctx context.Context, input *ExchangeDe
 	}
 
 	return &ExchangeDeviceTokenOutput{
-		SetCookie: tokenCookies,
 		Body: authtypes.AuthenticationResponse{
 			Success:      true,
 			Status:       authtypes.AuthenticationStatusAuthenticated,

--- a/backend/internal/passkey/handler.go
+++ b/backend/internal/passkey/handler.go
@@ -93,8 +93,7 @@ type MobilePasskeyExchangeInput struct {
 }
 
 type MobilePasskeyExchangeOutput struct {
-	SetCookie []string `header:"Set-Cookie" doc:"Session cookie"`
-	Body      base.ApiResponse[authtypes.AuthenticationResponse]
+	Body base.ApiResponse[authtypes.AuthenticationResponse]
 }
 
 type PasskeyMFAStartInput struct {
@@ -400,8 +399,7 @@ func (h *PasskeyHandler) ExchangeMobilePasskeyLogin(ctx context.Context, input *
 		return nil, err
 	}
 	return &MobilePasskeyExchangeOutput{
-		SetCookie: tokenCookieInternal(ctx, tokenPair),
-		Body:      base.ApiResponse[authtypes.AuthenticationResponse]{Success: true, Data: *response},
+		Body: base.ApiResponse[authtypes.AuthenticationResponse]{Success: true, Data: *response},
 	}, nil
 }
 
@@ -681,7 +679,7 @@ func marshalCredentialInternal(credential map[string]any) ([]byte, error) {
 
 func tokenCookieInternal(ctx context.Context, tokenPair *auth.TokenPair) []string {
 	maxAge := max(int(time.Until(tokenPair.ExpiresAt).Seconds()), 0) + 60
-	return cookie.BuildTokenCookieStringFor(maxAge, tokenPair.AccessToken, cookie.SecureCookieFromContext(ctx))
+	return cookie.BuildTokenCookieStringFor(maxAge, tokenPair.BrowserToken, cookie.SecureCookieFromContext(ctx))
 }
 
 func passkeyHTTPErrorInternal(err error) error {

--- a/backend/internal/settings/model.go
+++ b/backend/internal/settings/model.go
@@ -174,9 +174,10 @@ type Settings struct {
 	ApnsChannelID  SettingVariable `key:"apnsChannelId,internal"`
 	ApnsSigningKey SettingVariable `key:"apnsSigningKey,internal,sensitive"`
 
-	AgentToken        SettingVariable `key:"agentToken,internal,sensitive"`
-	JwtSigningKeySeed SettingVariable `key:"jwtSigningKeySeed,internal,sensitive"`
-	InstanceID        SettingVariable `key:"instanceId,internal"`
+	AgentToken               SettingVariable `key:"agentToken,internal,sensitive"`
+	BrowserSessionSigningKey SettingVariable `key:"browserSessionSigningKey,internal,sensitive"`
+	JwtSigningKeySeed        SettingVariable `key:"jwtSigningKeySeed,internal,sensitive"`
+	InstanceID               SettingVariable `key:"instanceId,internal"`
 
 	// Users category (admin management page - no actual settings)
 	UsersCategoryPlaceholder SettingVariable `key:"usersCategory,internal" meta:"label=Users;type=internal;keywords=users,accounts,management,admin,access,permissions,roles;category=users;description=Manage user accounts and permissions" catmeta:"id=users;title=Users;icon=user;url=/settings/users;description=Manage user accounts and access control"`

--- a/backend/internal/settings/service.go
+++ b/backend/internal/settings/service.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"context"
 	"crypto/mldsa"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -36,6 +37,8 @@ import (
 )
 
 const (
+	browserSessionSigningKeySize = 64
+
 	// DefaultArcaneToolsImage is the shared Arcane toolbox image used for helper commands.
 	DefaultArcaneToolsImage = "ghcr.io/getarcaneapp/tools:latest"
 	// DefaultTrivyImage is the default vulnerability scanner image setting.
@@ -1037,48 +1040,59 @@ func (s *SettingsService) EnsureEncryptionKey(ctx context.Context) (string, erro
 }
 
 func (s *SettingsService) EnsureJwtSigningKey(ctx context.Context) (*mldsa.PrivateKey, error) {
-	return s.writes.Execute(ctx, "ensure jwt signing key", func(writeCtx context.Context) (*mldsa.PrivateKey, error) {
-		const keyName = "jwtSigningKeySeed"
-		var key *mldsa.PrivateKey
+	seed, err := s.ensureEncryptedKeyInternal(ctx, "ensure jwt signing key", "jwtSigningKeySeed", mldsa.PrivateKeySize)
+	if err != nil {
+		return nil, err
+	}
+	key, err := mldsa.NewPrivateKey(mldsa.MLDSA87(), seed)
+	return key, errors.WrapIf(err, "failed to load jwt signing key")
+}
+
+func (s *SettingsService) EnsureBrowserSessionSigningKey(ctx context.Context) ([]byte, error) {
+	return s.ensureEncryptedKeyInternal(ctx, "ensure browser session signing key", "browserSessionSigningKey", browserSessionSigningKeySize)
+}
+
+func (s *SettingsService) ensureEncryptedKeyInternal(ctx context.Context, operation, keyName string, size int) ([]byte, error) {
+	return s.writes.Execute(ctx, operation, func(writeCtx context.Context) ([]byte, error) {
+		var key []byte
 
 		err := s.db.WithContext(writeCtx).Transaction(func(tx *gorm.DB) error {
 			var sv SettingVariable
 			err := tx.Where("key = ?", keyName).First(&sv).Error
-
 			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-				return errors.WrapIf(err, "failed to load jwt signing key")
+				return errors.WrapIf(err, "failed to load signing key")
 			}
 
 			if sv.Value != "" {
 				decoded, decErr := libcrypto.Decrypt(sv.Value)
 				if decErr != nil {
-					return errors.WrapIf(decErr, "failed to decrypt jwt signing key")
+					return errors.WrapIf(decErr, "failed to decrypt signing key")
 				}
-				seed, decErr := base64.StdEncoding.DecodeString(decoded)
+				key, decErr = base64.StdEncoding.DecodeString(decoded)
 				if decErr != nil {
-					return errors.WrapIf(decErr, "failed to decode jwt signing key")
+					return errors.WrapIf(decErr, "failed to decode signing key")
 				}
-				key, decErr = mldsa.NewPrivateKey(mldsa.MLDSA87(), seed)
-				return errors.WrapIf(decErr, "failed to load jwt signing key")
+				if len(key) != size {
+					return errors.Errorf("invalid signing key length: got %d, want %d", len(key), size)
+				}
+				return nil
 			}
 
-			notFound := errors.Is(err, gorm.ErrRecordNotFound)
-			generated, genErr := mldsa.GenerateKey(mldsa.MLDSA87())
-			if genErr != nil {
-				return errors.WrapIf(genErr, "failed to generate jwt signing key")
+			key = make([]byte, size)
+			if _, genErr := rand.Read(key); genErr != nil {
+				return errors.WrapIf(genErr, "failed to generate signing key")
 			}
-			encrypted, encErr := libcrypto.Encrypt(base64.StdEncoding.EncodeToString(generated.Bytes()))
+			encrypted, encErr := libcrypto.Encrypt(base64.StdEncoding.EncodeToString(key))
 			if encErr != nil {
-				return errors.WrapIf(encErr, "failed to encrypt jwt signing key")
+				return errors.WrapIf(encErr, "failed to encrypt signing key")
 			}
-			key = generated
 
-			if notFound {
-				return errors.WrapIf(tx.Create(&SettingVariable{Key: keyName, Value: encrypted}).Error, "failed to persist jwt signing key")
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.WrapIf(tx.Create(&SettingVariable{Key: keyName, Value: encrypted}).Error, "failed to persist signing key")
 			}
 			return errors.WrapIf(tx.Model(&SettingVariable{}).
 				Where("key = ?", keyName).
-				Update("value", encrypted).Error, "failed to update jwt signing key")
+				Update("value", encrypted).Error, "failed to update signing key")
 		})
 		if err != nil {
 			return nil, err

--- a/backend/internal/settings/service_test.go
+++ b/backend/internal/settings/service_test.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"context"
+	"encoding/base64"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/require"
+	libcrypto "go.getarcane.app/sys/crypto"
 	"go.uber.org/fx/fxtest"
 	"gorm.io/gorm"
 
@@ -764,6 +766,19 @@ func TestSettingsService_EnsureEncryptionKey(t *testing.T) {
 	var sv SettingVariable
 	require.NoError(t, svc.db.WithContext(ctx).Where("key = ?", "encryptionKey").First(&sv).Error)
 	require.Equal(t, k1, sv.Value)
+	libcrypto.InitEncryption(&libcrypto.Config{EncryptionKey: k1, Environment: "development"})
+
+	browserKey1, err := svc.EnsureBrowserSessionSigningKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, browserKey1, browserSessionSigningKeySize)
+	browserKey2, err := svc.EnsureBrowserSessionSigningKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, browserKey1, browserKey2, "browser signing key should be stable between calls")
+
+	var browserSetting SettingVariable
+	require.NoError(t, svc.db.WithContext(ctx).Where("key = ?", "browserSessionSigningKey").First(&browserSetting).Error)
+	require.NotEmpty(t, browserSetting.Value)
+	require.NotEqual(t, base64.StdEncoding.EncodeToString(browserKey1), browserSetting.Value)
 }
 
 func TestSettingsService_LoadDatabaseSettings_ReloadsChanges(t *testing.T) {

--- a/backend/pkg/utils/cookie/cookie_util.go
+++ b/backend/pkg/utils/cookie/cookie_util.go
@@ -13,8 +13,8 @@ var (
 	OidcStateCookieName     = "oidc_state"
 )
 
-// Browsers cap a single cookie (name + value) at 4096 bytes, so tokens larger
-// than that are split across numbered chunk cookies and reassembled on read.
+// Legacy ML-DSA browser tokens exceed the 4096-byte cookie limit, so readers
+// retain numbered chunk support until existing sessions expire or refresh.
 const (
 	tokenCookieChunkSize = 3072
 	tokenCookieMaxChunks = 4
@@ -87,9 +87,9 @@ func readTokenCookieInternal(r *http.Request, base string) (string, error) {
 }
 
 // BuildTokenCookieStringFor builds Set-Cookie header strings matching the
-// current request security context, splitting the token across chunk cookies
-// when it exceeds the per-cookie browser limit and clearing unused chunk slots
-// so stale chunks from a longer previous token cannot corrupt reassembly.
+// current request security context. Compact browser tokens use one cookie;
+// legacy oversized tokens are chunked for upgrade compatibility. Unused chunk
+// slots are cleared so stale legacy chunks cannot corrupt reassembly.
 // Callers must pass the trusted secure flag from SecureCookieFromContext /
 // SecureCookieFromRequest so the cookie name (__Host-token vs. token)
 // round-trips correctly behind HTTPS reverse proxies.

--- a/backend/pkg/utils/cookie/cookie_util_test.go
+++ b/backend/pkg/utils/cookie/cookie_util_test.go
@@ -33,9 +33,14 @@ func TestSecureCookieFromRequest(t *testing.T) {
 func TestBuildTokenCookieStringFor(t *testing.T) {
 	t.Run("secure uses host-prefixed secure cookie", func(t *testing.T) {
 		headers := BuildTokenCookieStringFor(60, "abc", true)
+		headerBytes := 0
+		for _, header := range headers {
+			headerBytes += len("Set-Cookie: ") + len(header) + len("\r\n")
+		}
 
 		cookies := readSetCookieHeadersInternal(t, headers...)
 		require.Len(t, cookies, tokenCookieMaxChunks)
+		require.Less(t, headerBytes, 1024)
 		assert.Equal(t, TokenCookieName, cookies[0].Name)
 		assert.Equal(t, "abc", cookies[0].Value)
 		assert.True(t, cookies[0].Secure)

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -372,6 +372,7 @@
   "auth_tagline_line2": "Designed for everyone.",
   "auth_login_problem_title": "Login Problem",
   "auth_failed_title": "Authentication Failed",
+  "auth_proxy_login_error": "Arcane couldn't complete login through the reverse proxy. Check that Arcane is reachable and that the proxy allows the authentication headers, then try again.",
   "auth_no_login_methods_title": "No Login Methods Configured",
   "auth_no_login_methods_description": "There are currently no login methods enabled. Please contact an administrator.",
   "auth_username_placeholder": "Enter your username or email",

--- a/frontend/src/lib/components/auth/mfa-challenge.svelte
+++ b/frontend/src/lib/components/auth/mfa-challenge.svelte
@@ -9,6 +9,7 @@
 	import * as InputGroup from '#lib/components/ui/input-group/index.js';
 	import { Label } from '#lib/components/ui/label/index.js';
 	import * as Alert from '#lib/components/ui/alert/index.js';
+	import { normalizeAuthenticationError } from '#lib/utils/auth';
 
 	let {
 		challenge,
@@ -39,7 +40,7 @@
 			await onComplete(response);
 		} catch (value) {
 			if (!isCancelledError(value)) {
-				error = value instanceof Error ? value.message : m.auth_mfa_failed();
+				error = normalizeAuthenticationError(value, m.auth_mfa_failed()).message;
 			}
 		} finally {
 			busy = false;
@@ -56,7 +57,7 @@
 			const response = await passkeyService.finishRecovery(challenge.transactionId, recoveryCode.trim());
 			await onComplete(response);
 		} catch (value) {
-			error = value instanceof Error ? value.message : m.auth_mfa_failed();
+			error = normalizeAuthenticationError(value, m.auth_mfa_failed()).message;
 		} finally {
 			busy = false;
 		}

--- a/frontend/src/lib/utils/auth.ts
+++ b/frontend/src/lib/utils/auth.ts
@@ -1,5 +1,7 @@
 import userStore from '#lib/stores/user-store';
 import { environmentStore } from '#lib/stores/environment.store.svelte';
+import { m } from '#lib/paraglide/messages';
+import { APIError } from '#lib/services/api-service';
 import {
 	canReachAccessSurface,
 	getFallbackAccessSurfaces,
@@ -8,6 +10,34 @@ import {
 } from '#lib/utils/access-policy';
 import { GLOBAL_SCOPE, SUDO_PERMISSION } from '#lib/types/auth';
 import type { PermissionsManifest, User } from '#lib/types/auth';
+
+export function normalizeAuthenticationError(error: unknown, fallback: string): { kind: 'proxy' | 'other'; message: string } {
+	if (error instanceof APIError) {
+		const responseData: unknown = error.response?.data;
+		const responseText = typeof responseData === 'string' ? responseData : '';
+		const lowerResponse = responseText.toLowerCase();
+		const isGatewayHTML =
+			error.status === 502 &&
+			(lowerResponse.includes('<html') || lowerResponse.includes('bad gateway') || lowerResponse.includes('openresty'));
+		const isHeaderLimit =
+			error.status === 431 ||
+			(error.status === 400 &&
+				(lowerResponse.includes('request header') || lowerResponse.includes('cookie')) &&
+				(lowerResponse.includes('large') || lowerResponse.includes('too big')));
+
+		if (isGatewayHTML || isHeaderLimit) {
+			return { kind: 'proxy', message: m.auth_proxy_login_error() };
+		}
+		if (responseText.trimStart().startsWith('<')) {
+			return { kind: 'other', message: fallback };
+		}
+	}
+
+	return {
+		kind: 'other',
+		message: error instanceof Error ? error.message : fallback
+	};
+}
 
 // --- Store-backed permission checks (for .svelte / runtime) ---
 

--- a/frontend/src/routes/(auth)/login/+page.svelte
+++ b/frontend/src/routes/(auth)/login/+page.svelte
@@ -14,6 +14,7 @@
 	import { authService, MFARequiredError } from '#lib/services/auth-service';
 	import { passkeyService } from '#lib/services/passkey-service';
 	import type { AuthenticationResponse, MFAChallenge as MFAChallengeData } from '#lib/types/auth';
+	import { normalizeAuthenticationError } from '#lib/utils/auth';
 	import { getEffectiveLandingPage } from '#lib/utils/navigation';
 	import { queryKeys } from '#lib/query/query-keys';
 	import { getApplicationLogo } from '#lib/utils/docker';
@@ -75,7 +76,7 @@
 				error = null;
 				return;
 			}
-			error = err instanceof Error ? err.message : m.auth_unexpected_error();
+			error = normalizeAuthenticationError(err, m.auth_unexpected_error()).message;
 		}
 	}));
 
@@ -102,7 +103,7 @@
 				error = m.auth_passkey_cancelled();
 				return;
 			}
-			error = err instanceof Error ? err.message : m.auth_passkey_failed();
+			error = normalizeAuthenticationError(err, m.auth_passkey_failed()).message;
 		}
 	}));
 

--- a/frontend/src/routes/(auth)/oidc/callback/+page.svelte
+++ b/frontend/src/routes/(auth)/oidc/callback/+page.svelte
@@ -10,7 +10,7 @@
 	import { queryKeys } from '#lib/query/query-keys';
 	import { authService } from '#lib/services/auth-service';
 	import { environmentStore } from '#lib/stores/environment.store.svelte';
-	import { getAuthRedirectPath } from '#lib/utils/auth';
+	import { getAuthRedirectPath, normalizeAuthenticationError } from '#lib/utils/auth';
 	import { getEffectiveLandingPage } from '#lib/utils/navigation';
 	import MFAChallenge from '#lib/components/auth/mfa-challenge.svelte';
 	import OidcStatusPanel from '#lib/components/oidc-status-panel.svelte';
@@ -167,12 +167,16 @@
 				redirectCode = String((err as CallbackFailure).code);
 				userMessage = String((err as CallbackFailure).userMessage);
 			} else {
+				const normalized = normalizeAuthenticationError(err, m.auth_oidc_callback_error());
 				const unknownError = err as { message?: string };
-				if (unknownError?.message?.includes('network') || unknownError?.message?.includes('timeout')) {
+				if (normalized.kind === 'proxy') {
+					userMessage = normalized.message;
+					redirectCode = 'proxy_authentication_failed';
+				} else if (unknownError?.message?.includes('network') || unknownError?.message?.includes('timeout')) {
 					userMessage = String(m.auth_oidc_network_error());
 					redirectCode = 'oidc_network_error';
-				} else if (unknownError?.message && !unknownError.message.includes('Request failed')) {
-					userMessage = unknownError.message;
+				} else if (normalized.message && !normalized.message.includes('Request failed')) {
+					userMessage = normalized.message;
 				}
 			}
 

--- a/tests/spec/token-refresh.spec.ts
+++ b/tests/spec/token-refresh.spec.ts
@@ -108,15 +108,36 @@ test('signed-in OIDC callbacks reach the callback exchange', async ({ page }) =>
 });
 
 test.describe('Token refresh behaviour', () => {
-	test('@cross-browser rejects invalid credentials and accepts the configured admin password', async ({
+	test('@cross-browser shows useful login errors and accepts the configured admin password', async ({
 		page
 	}) => {
 		await page.context().clearCookies();
+		let gatewayFailurePending = true;
+		await page.route(/\/api\/auth\/login$/, async (route) => {
+			if (!gatewayFailurePending) {
+				await route.continue();
+				return;
+			}
+			gatewayFailurePending = false;
+			await route.fulfill({
+				status: 502,
+				contentType: 'text/html',
+				body: '<html><head><title>502 Bad Gateway</title></head><body><center>openresty</center></body></html>'
+			});
+		});
 		await page.goto('/login');
 		await page.getByLabel('Username').fill('arcane');
 		await page.getByLabel('Password').fill('not-the-admin-password');
 		await page.getByRole('button', { name: 'Sign in to Arcane', exact: true }).click();
 
+		const proxyAlert = page
+			.getByRole('alert')
+			.filter({ hasText: "Arcane couldn't complete login through the reverse proxy" });
+		await expect(proxyAlert).toBeVisible();
+		await expect(proxyAlert).not.toContainText('openresty');
+
+		await page.getByLabel('Password').fill('not-the-admin-password');
+		await page.getByRole('button', { name: 'Sign in to Arcane', exact: true }).click();
 		await expect(
 			page.getByRole('alert').filter({ hasText: 'Invalid username or password' })
 		).toBeVisible();
@@ -128,6 +149,16 @@ test.describe('Token refresh behaviour', () => {
 		await expect(
 			page.locator('main').getByText('Dashboard', { exact: true }).first()
 		).toBeVisible();
+
+		const tokenCookies = (await page.context().cookies()).filter(
+			(cookie) =>
+				cookie.name === 'token' ||
+				cookie.name === '__Host-token' ||
+				cookie.name.startsWith('token.') ||
+				cookie.name.startsWith('__Host-token.')
+		);
+		expect(tokenCookies).toHaveLength(1);
+		expect(tokenCookies[0]?.value.length).toBeLessThan(1024);
 	});
 
 	test('version mismatch 401 on /auth/me during page load is silently recovered', async ({


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3793
 
## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the large ML-DSA access-token browser cookie with a compact HS512 browser-session token while retaining ML-DSA bearer tokens for API clients. It adds persistent browser-token key management, updates authentication middleware and login variants, and improves reverse-proxy login error presentation.
- Issues compact browser-session cookies from local, OIDC, passkey, MFA, refresh, and auto-login flows.
- Selects browser-token or access-token verification based on whether credentials came from a cookie or Authorization header.
- Keeps mobile and device flows bearer-token-only and adds coverage for compact cookies, legacy cookies, and session behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only non-blocking Go error-handling and exported-API documentation cleanup remaining.

The compact browser-token flow preserves session validation, legacy-cookie compatibility, bearer-token behavior, and proxy authentication; the only accepted concern is compliance with repository Go maintainability requirements.

**Files Needing Attention:** backend/internal/auth/token.go, backend/internal/auth/service.go, backend/internal/settings/service.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_issue_a_compact_browser_session_cookie_instead_of_the_bigger_ml-dsa_access_jwt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_issue_a_compact_browser_session_cookie_instead_of_the_bigger_ml-dsa_access_jwt%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233813%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3813&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_issue_a_compact_browser_session_cookie_instead_of_the_bigger_ml-dsa_access_jwt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_issue_a_compact_browser_session_cookie_instead_of_the_bigger_ml-dsa_access_jwt%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fauth%2Ftoken.go%3A105-108%0A**Handle%20browser%20claim%20errors**%0A%0AThe%20new%20browser-token%20parser%20discards%20errors%20from%20%60Subject%60%2C%20%60JwtID%60%2C%20and%20custom-claim%20accessors%2C%20losing%20the%20specific%20cause%20of%20malformed-token%20failures%3B%20the%20related%20exported%20browser-session%20methods%20also%20need%20documentation%20to%20satisfy%20the%20repository's%20Go%20requirements.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3813&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fauth%2Ftoken.go%3A105-108%0A**Handle%20browser%20claim%20errors**%0A%0AThe%20new%20browser-token%20parser%20discards%20errors%20from%20%60Subject%60%2C%20%60JwtID%60%2C%20and%20custom-claim%20accessors%2C%20losing%20the%20specific%20cause%20of%20malformed-token%20failures%3B%20the%20related%20exported%20browser-session%20methods%20also%20need%20documentation%20to%20satisfy%20the%20repository's%20Go%20requirements.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3813&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/auth/token.go:105-108
**Handle browser claim errors**

The new browser-token parser discards errors from `Subject`, `JwtID`, and custom-claim accessors, losing the specific cause of malformed-token failures; the related exported browser-session methods also need documentation to satisfy the repository's Go requirements.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: issue a compact browser session coo..."](https://github.com/getarcaneapp/arcane/commit/df7c24c85e9d4fa9d380532db928ecc3aa13dc17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59293953)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Identity, authentication, and access control](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/identity-and-access.md)
- Knowledge Base — [Authentication and authorization flows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/authentication-and-authorization-flows.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/web-application.md)
</details>


<!-- /greptile_comment -->