### PR TITLE
fix: surface container shell close reasons and drop websocket compression

### DIFF
--- a/backend/api/ws/exec.go
+++ b/backend/api/ws/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/labstack/echo/v5"
 
+	wshub "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/ws"
 	systemtypes "github.com/getarcaneapp/arcane/types/v2/system"
 )
 
@@ -43,37 +44,35 @@ func (h *WebSocketHandler) ContainerExec(c *echo.Context) error {
 		return nil
 	}
 	defer unregister()
-	defer func() {
-		if err := conn.CloseNow(); err != nil {
-			slog.Debug("Failed to close container exec websocket connection", "containerID", containerID, "error", err)
-		}
-	}()
+	defer func() { _ = conn.CloseNow() }()
 
 	// Allow large terminal pastes; coder/websocket's default limit is 32KB.
 	conn.SetReadLimit(1 << 20)
 
-	ctx, cancel := context.WithCancel(c.Request().Context())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(c.Request().Context())
+	defer cancel(nil)
 
 	// The pong is serviced by the concurrent stdin reader.
-	go keepWSConnAliveInternal(ctx, cancel, conn, 54*time.Second)
+	go keepWSConnAliveInternal(ctx, func() { cancel(errors.New("websocket ping failed")) }, conn, 54*time.Second)
 
 	h.runContainerExecInternal(ctx, cancel, conn, containerID, shell)
 	return nil
 }
 
-func (h *WebSocketHandler) runContainerExecInternal(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn, containerID, shell string) {
-	// Create exec instance
+func (h *WebSocketHandler) runContainerExecInternal(ctx context.Context, cancel context.CancelCauseFunc, conn *websocket.Conn, containerID, shell string) {
+	started := time.Now()
+
 	execID, err := h.containerService.CreateExec(ctx, containerID, []string{shell})
 	if err != nil {
 		h.writeExecErrorInternal(ctx, conn, errors.WithMessage(err, "Error creating exec"))
+		closeExecInternal(ctx, conn, containerID, "", started, errors.WithMessage(err, "create exec"))
 		return
 	}
 
-	// Attach to exec
 	execSession, err := h.containerService.AttachExec(ctx, containerID, execID)
 	if err != nil {
 		h.writeExecErrorInternal(ctx, conn, errors.WithMessage(err, "Error attaching to exec"))
+		closeExecInternal(ctx, conn, containerID, execID, started, errors.WithMessage(err, "attach exec"))
 		return
 	}
 	// Cleanup must proceed even if the parent ctx is canceled, and must also
@@ -93,11 +92,15 @@ func (h *WebSocketHandler) runContainerExecInternal(ctx context.Context, cancel 
 		cleanup()
 	}()
 
-	done := make(chan struct{})
-	go h.pipeExecOutputInternal(ctx, conn, execSession.Stdout(), execID, containerID, done)
-	go h.pipeExecInputInternal(ctx, cancel, conn, execSession.Stdin(), execID, containerID)
+	done := make(chan error, 1)
+	go h.pipeExecOutputInternal(ctx, conn, execSession.Stdout(), done)
+	go h.pipeExecInputInternal(ctx, cancel, conn, execSession.Stdin())
 
-	<-done
+	cause := <-done
+	if ctxCause := context.Cause(ctx); ctxCause != nil {
+		cause = ctxCause
+	}
+	closeExecInternal(ctx, conn, containerID, execID, started, cause)
 }
 
 func (h *WebSocketHandler) writeExecErrorInternal(ctx context.Context, conn *websocket.Conn, err error) {
@@ -106,40 +109,72 @@ func (h *WebSocketHandler) writeExecErrorInternal(ctx context.Context, conn *web
 	_ = conn.Write(wctx, websocket.MessageText, []byte(err.Error()+"\r\n"))
 }
 
-func (h *WebSocketHandler) pipeExecOutputInternal(ctx context.Context, conn *websocket.Conn, stdout io.Reader, execID, containerID string, done chan<- struct{}) {
-	defer close(done)
+// closeExecInternal completes the close handshake with a status and reason
+// derived from the terminating cause, so the browser can show why the
+// session ended, and logs the outcome with the session duration.
+func closeExecInternal(ctx context.Context, conn *websocket.Conn, containerID, execID string, started time.Time, cause error) {
+	status, reason, level := websocket.StatusNormalClosure, "shell exited", slog.LevelInfo
+	switch {
+	case cause == nil:
+	case wshub.IsExpectedClose(cause):
+		reason, level = "", slog.LevelDebug
+	case errors.Is(cause, context.Canceled):
+		status, reason = websocket.StatusGoingAway, "server shutting down"
+	default:
+		status, reason, level = websocket.StatusInternalError, cause.Error(), slog.LevelWarn
+	}
+	if len(reason) > 123 {
+		reason = reason[:123]
+	}
+	closeErr := conn.Close(status, reason)
+	slog.Log(ctx, level, "Container exec session ended",
+		"containerID", containerID,
+		"execID", execID,
+		"status", int(status),
+		"reason", reason,
+		"cause", cause,
+		"duration", time.Since(started),
+		"closeError", closeErr,
+	)
+}
+
+func (h *WebSocketHandler) pipeExecOutputInternal(ctx context.Context, conn *websocket.Conn, stdout io.Reader, done chan<- error) {
 	buf := make([]byte, 4096)
 	for {
 		select {
 		case <-ctx.Done():
+			done <- context.Cause(ctx)
 			return
 		default:
 		}
 
 		n, err := stdout.Read(buf)
 		if err != nil {
-			slog.Debug("Exec stdout read error", "execID", execID, "containerID", containerID, "error", err)
+			if errors.Is(err, io.EOF) {
+				done <- nil
+			} else {
+				done <- errors.WithMessage(err, "exec output read")
+			}
 			return
 		}
 		if n > 0 {
 			if err := conn.Write(ctx, websocket.MessageBinary, buf[:n]); err != nil {
-				slog.Debug("Exec websocket write error", "execID", execID, "containerID", containerID, "error", err)
+				done <- errors.WithMessage(err, "websocket write")
 				return
 			}
 		}
 	}
 }
 
-func (h *WebSocketHandler) pipeExecInputInternal(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn, stdin io.Writer, execID, containerID string) {
+func (h *WebSocketHandler) pipeExecInputInternal(ctx context.Context, cancel context.CancelCauseFunc, conn *websocket.Conn, stdin io.Writer) {
 	for {
 		_, data, err := conn.Read(ctx)
 		if err != nil {
-			slog.Debug("Exec websocket read error", "execID", execID, "containerID", containerID, "error", err)
-			cancel()
+			cancel(errors.WithMessage(err, "websocket read"))
 			return
 		}
 		if _, err := stdin.Write(data); err != nil {
-			slog.Debug("Exec stdin write error", "execID", execID, "containerID", containerID, "error", err)
+			cancel(errors.WithMessage(err, "exec input write"))
 			return
 		}
 	}

--- a/backend/pkg/libarcane/edge/ws_proxy.go
+++ b/backend/pkg/libarcane/edge/ws_proxy.go
@@ -164,7 +164,17 @@ func handleAgentMessage(ctx context.Context, streamCtx context.Context, clientWS
 	case MessageTypeWebSocketData, MessageTypeStreamData:
 		return false, writeWebSocketData(streamCtx, clientWS, msg)
 	case MessageTypeWebSocketClose, MessageTypeStreamClose, MessageTypeStreamEnd:
-		slog.DebugContext(ctx, "Agent closed WebSocket stream", "stream_id", streamID)
+		slog.DebugContext(ctx, "Agent closed WebSocket stream", "stream_id", streamID, "error", msg.Error)
+		status, reason := websocket.StatusNormalClosure, msg.Error
+		if reason != "" {
+			status = websocket.StatusInternalError
+			if len(reason) > 123 {
+				reason = reason[:123]
+			}
+		}
+		if err := clientWS.Close(status, reason); err != nil {
+			slog.DebugContext(ctx, "Failed to close client WebSocket", "stream_id", streamID, "status", int(status), "error", err)
+		}
 		return true, nil
 	case MessageTypeRequest,
 		MessageTypeResponse,

--- a/backend/pkg/libarcane/ws/accept.go
+++ b/backend/pkg/libarcane/ws/accept.go
@@ -18,7 +18,6 @@ func Accept(w http.ResponseWriter, r *http.Request, checkOrigin func(*http.Reque
 	}
 	return websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true, // origin validated above
-		CompressionMode:    websocket.CompressionContextTakeover,
 	})
 }
 

--- a/backend/pkg/libarcane/ws/proxy.go
+++ b/backend/pkg/libarcane/ws/proxy.go
@@ -71,6 +71,7 @@ func ProxyHTTP(w http.ResponseWriter, r *http.Request, remoteWS string, header h
 		for {
 			mt, msg, err := clientConn.Read(pumpCtx)
 			if err != nil {
+				relayCloseInternal(remoteConn, err)
 				return
 			}
 			if err := remoteConn.Write(pumpCtx, mt, msg); err != nil {
@@ -85,6 +86,7 @@ func ProxyHTTP(w http.ResponseWriter, r *http.Request, remoteWS string, header h
 		for {
 			mt, msg, err := remoteConn.Read(pumpCtx)
 			if err != nil {
+				relayCloseInternal(clientConn, err)
 				return
 			}
 			if err := clientConn.Write(pumpCtx, mt, msg); err != nil {
@@ -95,4 +97,20 @@ func ProxyHTTP(w http.ResponseWriter, r *http.Request, remoteWS string, header h
 
 	<-errc
 	return nil
+}
+
+// relayCloseInternal forwards a peer's close status to the other side of the
+// bridge so the terminating reason survives the proxy hop.
+func relayCloseInternal(conn *websocket.Conn, err error) {
+	var ce websocket.CloseError
+	if !errors.As(err, &ce) {
+		return
+	}
+	code := ce.Code
+	if code == websocket.StatusNoStatusRcvd {
+		code = websocket.StatusNormalClosure
+	}
+	if closeErr := conn.Close(code, ce.Reason); closeErr != nil {
+		slog.Debug("failed to relay websocket close", "status", int(code), "err", closeErr)
+	}
 }

--- a/backend/pkg/libarcane/ws/proxy_test.go
+++ b/backend/pkg/libarcane/ws/proxy_test.go
@@ -102,6 +102,7 @@ func TestProxyHTTP_RemoteClose(t *testing.T) {
 	defer func() {
 		_ = clientConn.CloseNow()
 	}()
+	clientConn.CloseRead(t.Context())
 
 	// The proxy should complete (not hang)
 	select {

--- a/frontend/src/lib/components/terminal/terminal.svelte
+++ b/frontend/src/lib/components/terminal/terminal.svelte
@@ -23,6 +23,7 @@
 	let fitAddon: FitAddon | null = null;
 	let ws: WebSocket | null = null;
 	let isReconnecting = false;
+	let openedAt = 0;
 	let resizeObserver: ResizeObserver | null = null;
 	let isReady = $state(false);
 
@@ -126,6 +127,7 @@
 		ws.binaryType = 'arraybuffer';
 
 		ws.onopen = () => {
+			openedAt = Date.now();
 			onConnected?.();
 		};
 
@@ -150,7 +152,12 @@
 			if (!isReconnecting && terminal) {
 				// Surface the close code so reports of unexpected disconnects
 				// carry the reason (server 1000/1006, proxy 1001, ...) — see #3536.
-				console.warn('Terminal websocket closed', { code: event.code, reason: event.reason, wasClean: event.wasClean });
+				console.warn('Terminal websocket closed', {
+					code: event.code,
+					reason: event.reason,
+					wasClean: event.wasClean,
+					durationMs: openedAt ? Date.now() - openedAt : null
+				});
 				const detail = event.reason ? `${event.code}: ${event.reason}` : `${event.code}`;
 				terminal.writeln(`\r\n\x1b[33m${m.terminal_connection_closed()} (${detail})\x1b[0m`);
 				onDisconnected?.();


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3536

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR propagates WebSocket close reasons through local and edge terminal paths, removes WebSocket compression, and adds terminal-close diagnostics.
- Adds cause-aware container exec shutdown and structured close logging.
- Relays close codes and reasons through direct and edge WebSocket proxies.
- Disables server-side WebSocket compression.
- Adds browser-side close metadata and connection duration logging.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: surface container shell close reaso..."](https://github.com/getarcaneapp/arcane/commit/30e1bb590a34d9aeded744a71d39e8709b3b7b33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59332884)</sub>

**Context used:**

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [API transport, realtime connections, and webhooks](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/api-transport-and-webhooks.md)

<!-- /greptile_comment -->