### PR TITLE
fix(scheduler): skip overlapping cron job runs

### DIFF
--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"sync"
 	"time"
 
 	"emperror.dev/errors"
@@ -29,6 +30,7 @@ type schedulerStateInternal struct {
 	runners     map[string]*actors.Runner
 	entryIDs    map[string]cron.EntryID
 	schedules   map[string]string
+	runLocks    map[string]*sync.Mutex
 	stopping    bool
 }
 
@@ -72,6 +74,7 @@ func NewJobScheduler(ctx context.Context, runtime *actors.Runtime, location *tim
 		runners:     make(map[string]*actors.Runner),
 		entryIDs:    make(map[string]cron.EntryID),
 		schedules:   make(map[string]string),
+		runLocks:    make(map[string]*sync.Mutex),
 	}
 	state, err := actors.NewState(ctx, runtime, "scheduler", "control-plane", 3, initial, func(value schedulerStateInternal) schedulerStateInternal {
 		value.jobs = slices.Clone(value.jobs)
@@ -81,6 +84,7 @@ func NewJobScheduler(ctx context.Context, runtime *actors.Runtime, location *tim
 		value.runners = maps.Clone(value.runners)
 		value.entryIDs = maps.Clone(value.entryIDs)
 		value.schedules = maps.Clone(value.schedules)
+		value.runLocks = maps.Clone(value.runLocks)
 		return value
 	})
 	if err != nil {
@@ -345,7 +349,12 @@ func (js *jobSchedulerInternal) upsertJobInternal(ctx context.Context, state *sc
 		delete(state.entryIDs, jobName)
 	}
 	if shouldSchedule {
-		entryID, nextRun = js.addCronEntryInternal(job, schedule, parsedSchedule)
+		runLock, ok := state.runLocks[jobName]
+		if !ok {
+			runLock = &sync.Mutex{}
+			state.runLocks[jobName] = runLock
+		}
+		entryID, nextRun = js.addCronEntryInternal(job, schedule, parsedSchedule, runLock)
 		state.entryIDs[jobName] = entryID
 	}
 	state.jobsByID[jobName] = job
@@ -360,8 +369,13 @@ func (js *jobSchedulerInternal) upsertJobInternal(ctx context.Context, state *sc
 	return nil
 }
 
-func (js *jobSchedulerInternal) addCronEntryInternal(job schedulertypes.Job, schedule string, parsedSchedule cron.Schedule) (cron.EntryID, *time.Time) {
+func (js *jobSchedulerInternal) addCronEntryInternal(job schedulertypes.Job, schedule string, parsedSchedule cron.Schedule, runLock *sync.Mutex) (cron.EntryID, *time.Time) {
 	entryID := js.cron.Schedule(parsedSchedule, cron.FuncJob(func() {
+		if !runLock.TryLock() {
+			slog.WarnContext(js.context, "Job skipped; previous run still in progress", "name", job.Name(), "schedule", schedule)
+			return
+		}
+		defer runLock.Unlock()
 		defer utils.RecoverToError(nil, "scheduled job", "name", job.Name(), "schedule", schedule)
 		slog.InfoContext(js.context, "Job starting", "name", job.Name(), "schedule", schedule)
 		job.Run(js.context)


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This change introduces persistent per-job mutexes so replacement cron entries share overlap state and skip an invocation while the preceding invocation is still running.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(scheduler): skip overlapping cron jo..."](https://github.com/getarcaneapp/arcane/commit/51cf6bb6a1049a01596a5933ddb2508de6938dea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59473716)</sub>

<!-- /greptile_comment -->