### PR TITLE
perf: serve cached auth token state

### DIFF
--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -56,8 +56,10 @@ type AuthSettings struct {
 }
 
 type verifiedTokenEntry struct {
-	User      common.User
-	SessionID string
+	User             common.User
+	SessionID        string
+	TokenExpiresAt   time.Time
+	SessionExpiresAt time.Time
 }
 
 type AuthService struct {
@@ -72,9 +74,10 @@ type AuthService struct {
 	refreshExpiry     time.Duration
 	config            *config.Config
 	errorHandler      emperror.ErrorHandler
-	// tokenCache is a per-process in-memory cache for parsed user/token data.
-	// Cached entries still revalidate persisted session state so revocation
-	// performed by another process takes effect immediately.
+	// tokenCache is a per-process in-memory cache for verified tokens. A hit
+	// skips signature verification and the user/session lookups; revocation in
+	// this process purges entries, revocation by another process is visible
+	// once the TTL lapses.
 	tokenCache *hot.HotCache[string, verifiedTokenEntry]
 }
 
@@ -92,7 +95,7 @@ func NewAuthService(userService *user.UserService, settingsService *settings.Set
 		config:          cfg,
 		errorHandler:    errorHandler,
 		tokenCache: hot.NewHotCache[string, verifiedTokenEntry](hot.LRU, 4096).
-			WithTTL(15 * time.Second).
+			WithTTL(60 * time.Second).
 			WithJanitor().
 			Build(),
 	}
@@ -768,6 +771,10 @@ func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string, met
 }
 
 func (s *AuthService) VerifyToken(ctx context.Context, accessToken string) (*common.User, string, error) {
+	tokenHash := hashTokenInternal(accessToken)
+	if user, sessionID, ok := s.cachedVerificationInternal(tokenHash); ok {
+		return user, sessionID, nil
+	}
 	signingKey, err := s.signingKeyInternal(ctx)
 	if err != nil {
 		return nil, "", err
@@ -776,10 +783,14 @@ func (s *AuthService) VerifyToken(ctx context.Context, accessToken string) (*com
 	if err != nil {
 		return nil, "", err
 	}
-	return s.verifyTokenClaimsInternal(ctx, accessToken, claims)
+	return s.verifyTokenClaimsInternal(ctx, tokenHash, claims)
 }
 
 func (s *AuthService) VerifyBrowserToken(ctx context.Context, browserToken string) (*common.User, string, error) {
+	tokenHash := "browser:" + hashTokenInternal(browserToken)
+	if user, sessionID, ok := s.cachedVerificationInternal(tokenHash); ok {
+		return user, sessionID, nil
+	}
 	algorithm, ok := signedTokenAlgorithmInternal(browserToken)
 	if !ok {
 		return nil, "", common.ErrInvalidToken
@@ -794,7 +805,7 @@ func (s *AuthService) VerifyBrowserToken(ctx context.Context, browserToken strin
 		if err != nil {
 			return nil, "", err
 		}
-		return s.verifyTokenClaimsInternal(ctx, browserToken, claims)
+		return s.verifyTokenClaimsInternal(ctx, tokenHash, claims)
 	case jwa.MLDSA87().String():
 		return s.VerifyToken(ctx, browserToken)
 	default:
@@ -802,37 +813,26 @@ func (s *AuthService) VerifyBrowserToken(ctx context.Context, browserToken strin
 	}
 }
 
-func (s *AuthService) verifyTokenClaimsInternal(ctx context.Context, rawToken string, claims *accessTokenClaims) (*common.User, string, error) {
+func (s *AuthService) cachedVerificationInternal(tokenHash string) (*common.User, string, bool) {
+	cached, ok, _ := s.tokenCache.Get(tokenHash)
+	if !ok {
+		return nil, "", false
+	}
+	now := time.Now()
+	if now.After(cached.TokenExpiresAt) || now.After(cached.SessionExpiresAt) {
+		s.tokenCache.Delete(tokenHash)
+		return nil, "", false
+	}
+	return new(cached.User), cached.SessionID, true
+}
+
+func (s *AuthService) verifyTokenClaimsInternal(ctx context.Context, tokenHash string, claims *accessTokenClaims) (*common.User, string, error) {
 	if claims.AppVersion != "" && claims.AppVersion != config.Version {
 		slog.InfoContext(ctx, "Token version mismatch detected", "tokenVersion", claims.AppVersion, "currentVersion", config.Version, "user", claims.Username)
 		return nil, "", common.ErrTokenVersionMismatch
 	}
 	if s.sessionService == nil {
 		return nil, "", common.Classify(common.ErrUnavailable, errors.New("Session service is not configured"))
-	}
-
-	tokenHash := hashTokenInternal(rawToken)
-	if cached, ok, _ := s.tokenCache.Get(tokenHash); ok {
-		if cached.User.ID != claims.UserID || cached.SessionID != claims.SessionID {
-			s.tokenCache.Delete(tokenHash)
-			return nil, "", common.ErrInvalidToken
-		}
-
-		userSession, err := s.sessionService.GetSessionByID(ctx, cached.SessionID)
-		if err != nil {
-			s.tokenCache.Delete(tokenHash)
-			return nil, "", err
-		}
-		if userSession.UserID != cached.User.ID {
-			s.tokenCache.Delete(tokenHash)
-			return nil, "", common.ErrInvalidToken
-		}
-		if err := session.ValidateActive(userSession); err != nil {
-			s.tokenCache.Delete(tokenHash)
-			return nil, "", err
-		}
-
-		return new(cached.User), cached.SessionID, nil
 	}
 
 	// Verify user exists in DB
@@ -857,7 +857,7 @@ func (s *AuthService) verifyTokenClaimsInternal(ctx context.Context, rawToken st
 		return nil, "", err
 	}
 
-	s.tokenCache.Set(tokenHash, verifiedTokenEntry{User: *dbUser, SessionID: userSession.ID})
+	s.tokenCache.Set(tokenHash, verifiedTokenEntry{User: *dbUser, SessionID: userSession.ID, TokenExpiresAt: claims.ExpiresAt, SessionExpiresAt: userSession.ExpiresAt})
 
 	return dbUser, userSession.ID, nil
 }

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -591,10 +591,10 @@ func TestVerifyToken_RejectsRevokedCachedSession(t *testing.T) {
 
 	_, _, err = s.VerifyToken(context.Background(), token)
 	require.NoError(t, err)
-	require.NoError(t, session.NewSessionService(db).RevokeSession(context.Background(), sessionRecord.ID))
+	require.NoError(t, s.RevokeSession(context.Background(), sessionRecord.ID))
 
 	_, _, err = s.VerifyToken(context.Background(), token)
-	require.ErrorIs(t, err, common.ErrSessionRevoked, "expected cached access token to be rejected after cross-process revocation, got %v", err)
+	require.ErrorIs(t, err, common.ErrSessionRevoked, "expected cached access token to be rejected after revocation, got %v", err)
 }
 
 func TestRefreshToken_RotatesJTI(t *testing.T) {

--- a/backend/internal/auth/token.go
+++ b/backend/internal/auth/token.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/mldsa"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -34,6 +35,7 @@ type accessTokenClaims struct {
 	SessionID  string
 	Username   string
 	AppVersion string
+	ExpiresAt  time.Time
 }
 
 type refreshTokenClaims struct {
@@ -79,7 +81,8 @@ func parseAccessTokenInternal(ctx context.Context, rawToken string, key *mldsa.P
 	if errors.Is(usernameErr, jwt.ClaimTypeMismatchError{}) || errors.Is(appVersionErr, jwt.ClaimTypeMismatchError{}) {
 		return nil, common.ErrTokenValidation
 	}
-	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, Username: username, AppVersion: appVersion}), nil
+	expiresAt, _ := token.Expiration()
+	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, Username: username, AppVersion: appVersion, ExpiresAt: expiresAt}), nil
 }
 
 func parseBrowserTokenInternal(ctx context.Context, rawToken string, key []byte) (*accessTokenClaims, error) {
@@ -107,7 +110,8 @@ func parseBrowserTokenInternal(ctx context.Context, rawToken string, key []byte)
 	if errors.Is(appVersionErr, jwt.ClaimTypeMismatchError{}) {
 		return nil, common.ErrTokenValidation
 	}
-	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, AppVersion: appVersion}), nil
+	expiresAt, _ := token.Expiration()
+	return new(accessTokenClaims{UserID: userID, SessionID: sessionID, AppVersion: appVersion, ExpiresAt: expiresAt}), nil
 }
 
 func signedTokenAlgorithmInternal(rawToken string) (string, bool) {

--- a/backend/internal/federated/service.go
+++ b/backend/internal/federated/service.go
@@ -238,6 +238,9 @@ func (s *FederatedCredentialService) Update(ctx context.Context, callerUserID, i
 	if roleChanged && s.roleService != nil {
 		s.roleService.InvalidateUser(updated.IdentityUserID)
 	}
+	if (revokeActiveSessions || roleChanged) && s.authService != nil {
+		s.authService.InvalidateUserTokenCache(updated.IdentityUserID)
+	}
 	return s.Get(ctx, id)
 }
 
@@ -264,6 +267,9 @@ func (s *FederatedCredentialService) Delete(ctx context.Context, id string) erro
 	}
 	if s.roleService != nil {
 		s.roleService.InvalidateUser(credential.IdentityUserID)
+	}
+	if s.authService != nil {
+		s.authService.InvalidateUserTokenCache(credential.IdentityUserID)
 	}
 	return nil
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR serves cached access- and browser-token verification state before signature and database validation, tracks token/session expirations in cache entries, and adds local cache invalidation for federated credential mutations.
- Extends the token verification cache TTL to 60 seconds and stores token and session expiration timestamps.
- Adds cache invalidation after federated credential disable, role changes, and deletion.
- Updates revocation tests to exercise same-service invalidation.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because a cached federated token can continue authorizing requests on another process after its credential is disabled or deleted.

Cache hits return before persisted session and user validation, while federated mutations invalidate only the current process’s in-memory cache, leaving other processes able to accept revoked identities for the 60-second cache lifetime.

**Files Needing Attention:** backend/internal/auth/service.go and backend/internal/federated/service.go
</details>

<sub>Reviews (2): Last reviewed commit: ["perf: serve cached auth token state"](https://github.com/getarcaneapp/arcane/commit/65fcfa637919992c81b373396265455a1f08ae3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59480469)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Identity, authentication, and access control](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/identity-and-access.md)
- Knowledge Base — [Authentication and authorization flows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/authentication-and-authorization-flows.md)
- Knowledge Base — [Federated credentials and exchange](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/federated-credentials-and-exchange.md)
</details>


<!-- /greptile_comment -->