### PR TITLE
perf: route docker deamon calls through singleflight callers

### DIFF
--- a/backend/internal/container/service.go
+++ b/backend/internal/container/service.go
@@ -1446,24 +1446,19 @@ func (s *ContainerService) ListContainersPaginated(
 	includeInternal bool,
 	groupBy string,
 ) (ContainerListResult, error) {
-	var dockerContainers []container.Summary
-	if includeAll {
-		var err error
-		dockerContainers, err = s.dockerService.ListContainers(ctx)
-		if err != nil {
-			return ContainerListResult{}, err
+	dockerContainers, err := s.dockerService.ListContainers(ctx)
+	if err != nil {
+		return ContainerListResult{}, err
+	}
+	if !includeAll {
+		running := make([]container.Summary, 0, len(dockerContainers))
+		for _, dc := range dockerContainers {
+			switch dc.State {
+			case container.StateRunning, container.StatePaused, container.StateRestarting:
+				running = append(running, dc)
+			}
 		}
-	} else {
-		dockerClient, err := s.dockerService.GetClient(ctx)
-		if err != nil {
-			return ContainerListResult{}, errors.WrapIf(err, "failed to connect to Docker")
-		}
-
-		containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
-		if err != nil {
-			return ContainerListResult{}, errors.WrapIf(err, "failed to list Docker containers")
-		}
-		dockerContainers = containerList.Items
+		dockerContainers = running
 	}
 
 	dockerContainers = FilterInternalContainers(dockerContainers, includeInternal)

--- a/backend/internal/docker/service.go
+++ b/backend/internal/docker/service.go
@@ -344,6 +344,13 @@ func listCoalescedInternal[T any](ctx context.Context, group *singleflight.Group
 	}
 }
 
+func (s *DockerClientService) apiTimeoutInternal() time.Duration {
+	if s.settingsService == nil {
+		return timeouts.DefaultDockerAPI
+	}
+	return timeouts.GetDuration(s.settingsService.GetSettingsConfig().DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI)
+}
+
 func (s *DockerClientService) ListContainers(ctx context.Context) ([]container.Summary, error) {
 	return listCoalescedInternal(ctx, &s.containerListFlight, func(ctx context.Context) ([]container.Summary, error) {
 		dockerClient, err := s.GetClient(ctx)
@@ -351,8 +358,7 @@ func (s *DockerClientService) ListContainers(ctx context.Context) ([]container.S
 			return nil, errors.WrapIf(err, "failed to connect to Docker")
 		}
 
-		settings := s.settingsService.GetSettingsConfig()
-		apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+		apiCtx, cancel := context.WithTimeout(ctx, s.apiTimeoutInternal())
 		defer cancel()
 
 		containerList, err := dockerClient.ContainerList(apiCtx, client.ContainerListOptions{All: true})
@@ -370,8 +376,7 @@ func (s *DockerClientService) ListImages(ctx context.Context) ([]image.Summary, 
 			return nil, errors.WrapIf(err, "failed to connect to Docker")
 		}
 
-		settings := s.settingsService.GetSettingsConfig()
-		apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+		apiCtx, cancel := context.WithTimeout(ctx, s.apiTimeoutInternal())
 		defer cancel()
 
 		imageList, err := dockerClient.ImageList(apiCtx, client.ImageListOptions{All: true})
@@ -388,8 +393,7 @@ func (s *DockerClientService) listNetworksInternal(ctx context.Context) ([]netwo
 		return nil, errors.WrapIf(err, "failed to connect to Docker")
 	}
 
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+	apiCtx, cancel := context.WithTimeout(ctx, s.apiTimeoutInternal())
 	defer cancel()
 
 	networkList, err := libarcane.NetworkListWithCompatibility(apiCtx, dockerClient, client.NetworkListOptions{})
@@ -405,8 +409,7 @@ func (s *DockerClientService) listVolumesInternal(ctx context.Context) (*client.
 		return nil, errors.WrapIf(err, "failed to connect to Docker")
 	}
 
-	settings := s.settingsService.GetSettingsConfig()
-	apiCtx, cancel := context.WithTimeout(ctx, timeouts.GetDuration(settings.DockerAPITimeout.AsInt(), timeouts.DefaultDockerAPI))
+	apiCtx, cancel := context.WithTimeout(ctx, s.apiTimeoutInternal())
 	defer cancel()
 
 	volResp, err := dockerClient.VolumeList(apiCtx, client.VolumeListOptions{})

--- a/backend/internal/network/service.go
+++ b/backend/internal/network/service.go
@@ -59,12 +59,12 @@ func (s *NetworkService) GetNetworkTopology(ctx context.Context) (*networktypes.
 		return nil, errors.WrapIf(err, "failed to connect to Docker")
 	}
 
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
+	containers, err := s.dockerService.ListContainers(ctx)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to list containers")
 	}
 
-	containerInfoByID := buildTopologyContainerInfoInternal(containerList.Items)
+	containerInfoByID := buildTopologyContainerInfoInternal(containers)
 
 	networkList, err := libarcane.NetworkListWithCompatibility(ctx, dockerClient, client.NetworkListOptions{})
 	if err != nil {
@@ -354,11 +354,10 @@ func (s *NetworkService) ListNetworksPaginated(ctx context.Context, params pagin
 		return nil, pagination.Response{}, networktypes.UsageCounts{}, errors.WrapIf(err, "failed to connect to Docker")
 	}
 
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
+	containers, err := s.dockerService.ListContainers(ctx)
 	if err != nil {
 		return nil, pagination.Response{}, networktypes.UsageCounts{}, errors.WrapIf(err, "failed to list containers")
 	}
-	containers := containerList.Items
 
 	inUseByID, inUseByName := s.buildNetworkUsageMaps(containers)
 

--- a/backend/internal/port/service.go
+++ b/backend/internal/port/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	containertypes "github.com/getarcaneapp/arcane/types/v2/container"
 	porttypes "github.com/getarcaneapp/arcane/types/v2/port"
-	"github.com/moby/moby/client"
 )
 
 type PortService struct {
@@ -23,18 +22,13 @@ func NewPortService(dockerService *docker.DockerClientService) *PortService {
 }
 
 func (s *PortService) ListPortsPaginated(ctx context.Context, params pagination.QueryParams) ([]porttypes.PortMapping, pagination.Response, error) {
-	dockerClient, err := s.dockerService.GetClient(ctx)
-	if err != nil {
-		return nil, pagination.Response{}, errors.WrapIf(err, "failed to connect to Docker")
-	}
-
-	containerList, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
+	containers, err := s.dockerService.ListContainers(ctx)
 	if err != nil {
 		return nil, pagination.Response{}, errors.WrapIf(err, "failed to list containers")
 	}
 
 	items := make([]porttypes.PortMapping, 0)
-	for _, rawContainer := range containerList.Items {
+	for _, rawContainer := range containers {
 		summary := containertypes.NewSummary(rawContainer)
 		containerName := primaryContainerNameInternal(summary.Names, summary.ID)
 		for _, port := range summary.Ports {

--- a/backend/internal/volume/listing.go
+++ b/backend/internal/volume/listing.go
@@ -103,14 +103,14 @@ func enrichVolumesWithUsageDataInternal(volumes []volume.Volume, usageVolumes []
 	return result
 }
 
-func buildVolumeContainerMapInternal(ctx context.Context, dockerClient *client.Client) (map[string][]string, error) {
-	containers, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: true})
+func (s *VolumeService) buildVolumeContainerMapInternal(ctx context.Context) (map[string][]string, error) {
+	containers, err := s.dockerService.ListContainers(ctx)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to list containers")
 	}
 
 	volumeContainerMap := make(map[string][]string)
-	for _, c := range containers.Items {
+	for _, c := range containers {
 		for _, m := range c.Mounts {
 			if m.Type == mount.TypeVolume && m.Name != "" {
 				volumeContainerMap[m.Name] = append(volumeContainerMap[m.Name], c.ID)
@@ -386,7 +386,7 @@ func (s *VolumeService) ListVolumesPaginated(ctx context.Context, params paginat
 	}(apiCtx)
 
 	go func(ctx context.Context) {
-		containerMap, err := buildVolumeContainerMapInternal(ctx, dockerClient)
+		containerMap, err := s.buildVolumeContainerMapInternal(ctx)
 		containerChan <- containerMapResult{containerMap: containerMap, err: err}
 	}(apiCtx)
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR routes container-list operations for container, network, port, and volume views through the existing singleflight-backed Docker service, allowing concurrent requests to share one daemon response. It also centralizes Docker API timeout resolution and preserves per-caller cancellation while filtering or transforming the shared result without mutation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect remains after checking caller reachability, shared-result handling, and timeout behavior.

Current consumers treat coalesced Docker summaries as immutable, the only behaviorally different running-only branch is unreachable from existing callers, and timeout extraction preserves the prior bounded operation.
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: route docker deamon calls through ..."](https://github.com/getarcaneapp/arcane/commit/7c4e5c5007cbeadd581a2d6d36bc53aa607f8c19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59486895)</sub>

<!-- /greptile_comment -->