### PR TITLE
perf: shared one stream producer across all clients

### DIFF
--- a/backend/internal/container/service.go
+++ b/backend/internal/container/service.go
@@ -1453,8 +1453,7 @@ func (s *ContainerService) ListContainersPaginated(
 	if !includeAll {
 		running := make([]container.Summary, 0, len(dockerContainers))
 		for _, dc := range dockerContainers {
-			switch dc.State {
-			case container.StateRunning, container.StatePaused, container.StateRestarting:
+			if dc.State == container.StateRunning || dc.State == container.StatePaused || dc.State == container.StateRestarting {
 				running = append(running, dc)
 			}
 		}

--- a/backend/internal/environment/handler.go
+++ b/backend/internal/environment/handler.go
@@ -43,8 +43,9 @@ const localDockerEnvironmentID = "0"
 const (
 	// Only covers poll-mode TTL expiry; tunnel and health-check changes arrive
 	// on the service's runtime-change signal instead.
-	environmentStreamPollInterval = 5 * time.Second
-	environmentStreamRefreshFloor = 30 * time.Second
+	environmentStreamPollInterval   = 5 * time.Second
+	environmentStreamRefreshFloor   = 30 * time.Second
+	environmentStreamHubKeyInternal = "environments"
 )
 
 // EnvironmentHandler handles environment management endpoints.
@@ -54,6 +55,7 @@ type EnvironmentHandler struct {
 	apiKeyService      *apikey.ApiKeyService
 	eventService       *event.EventService
 	cfg                *config.Config
+	streamHub          *agg.Hub[[]environment.Environment]
 }
 
 // ============================================================================
@@ -151,6 +153,7 @@ func NewHandler(environmentService *EnvironmentService, settingsService *setting
 		apiKeyService:      apiKeyService,
 		eventService:       eventService,
 		cfg:                cfg,
+		streamHub:          agg.NewHub[[]environment.Environment](),
 	}
 }
 
@@ -383,17 +386,14 @@ func accessibleEnvironmentIDsInternal(ps *authz.PermissionSet) []string {
 	return ids
 }
 
-// visibleEnvironmentsForInternal returns the environments the caller may see,
-// with the manager's runtime overlay already applied. It reuses the same access
-// rules as ListEnvironments so the stream and the REST list can never disagree
-// about which environments a caller has.
-func (h *EnvironmentHandler) visibleEnvironmentsForInternal(ctx context.Context, ps *authz.PermissionSet) ([]environment.Environment, error) {
-	envs, err := h.environmentService.ListVisibleEnvironments(ctx)
-	if err != nil {
-		return nil, err
-	}
+// visibleEnvironmentsForInternal filters the shared environment snapshot down
+// to what the caller may see. It reuses the same access rules as
+// ListEnvironments so the stream and the REST list can never disagree about
+// which environments a caller has. The input slice is shared across stream
+// subscribers and must not be mutated.
+func visibleEnvironmentsForInternal(envs []environment.Environment, ps *authz.PermissionSet) []environment.Environment {
 	if environmentListerSeesAllInternal(ps) {
-		return envs, nil
+		return envs
 	}
 
 	allowed := make(map[string]struct{}, len(ps.PerEnv))
@@ -401,13 +401,13 @@ func (h *EnvironmentHandler) visibleEnvironmentsForInternal(ctx context.Context,
 		allowed[envID] = struct{}{}
 	}
 
-	filtered := envs[:0]
+	filtered := make([]environment.Environment, 0, len(allowed))
 	for _, env := range envs {
 		if _, ok := allowed[env.ID]; ok {
 			filtered = append(filtered, env)
 		}
 	}
-	return filtered, nil
+	return filtered
 }
 
 // fingerprintEnvironmentsInternal hashes every field of the visible environment
@@ -450,23 +450,12 @@ func fingerprintEnvironmentsInternal(envs []environment.Environment) uint64 {
 }
 
 func (h *EnvironmentHandler) RunStreamProducer(ctx context.Context, ps *authz.PermissionSet, events chan<- environment.StreamEvent) {
-	changes, unsubscribe := h.environmentService.SubscribeRuntimeChanges()
-	defer unsubscribe()
-
 	var lastFingerprint uint64
 	var haveFingerprint bool
 	var lastSentAt time.Time
 
-	send := func() bool {
-		envs, err := h.visibleEnvironmentsForInternal(ctx, ps)
-		if err != nil {
-			// A failed read must not end the stream; the next tick retries.
-			if ctx.Err() == nil {
-				slog.WarnContext(ctx, "environment stream failed to list environments", "error", err)
-			}
-			return ctx.Err() == nil
-		}
-
+	h.streamHub.Subscribe(ctx, environmentStreamHubKeyInternal, h.runEnvironmentStreamListerInternal, func(all []environment.Environment) bool {
+		envs := visibleEnvironmentsForInternal(all, ps)
 		fingerprint := fingerprintEnvironmentsInternal(envs)
 		// Re-send unchanged state on a floor so relative timestamps in the UI
 		// ("last seen 2 minutes ago") keep advancing.
@@ -482,11 +471,26 @@ func (h *EnvironmentHandler) RunStreamProducer(ctx context.Context, ps *authz.Pe
 			Environments: envs,
 			Timestamp:    time.Now(),
 		})
+	})
+}
+
+func (h *EnvironmentHandler) runEnvironmentStreamListerInternal(ctx context.Context, publish func([]environment.Environment)) {
+	changes, unsubscribe := h.environmentService.SubscribeRuntimeChanges()
+	defer unsubscribe()
+
+	list := func() {
+		envs, err := h.environmentService.ListVisibleEnvironments(ctx)
+		if err != nil {
+			// A failed read must not end the stream; the next tick retries.
+			if ctx.Err() == nil {
+				slog.WarnContext(ctx, "environment stream failed to list environments", "error", err)
+			}
+			return
+		}
+		publish(envs)
 	}
 
-	if !send() {
-		return
-	}
+	list()
 
 	ticker := time.NewTicker(environmentStreamPollInterval)
 	defer ticker.Stop()
@@ -496,13 +500,9 @@ func (h *EnvironmentHandler) RunStreamProducer(ctx context.Context, ps *authz.Pe
 		case <-ctx.Done():
 			return
 		case <-changes:
-			if !send() {
-				return
-			}
+			list()
 		case <-ticker.C:
-			if !send() {
-				return
-			}
+			list()
 		}
 	}
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates environment-stream polling into one shared producer while retaining per-client authorization filtering and refresh behavior.
- Adds a shared `agg.Hub` to the environment handler, with snapshot replay and latest-wins delivery for subscribers.
- Moves environment listing and runtime-change polling into a single producer.
- Preserves per-subscriber permission filtering, fingerprinting, and periodic unchanged-state refreshes.
- Simplifies the equivalent running-container state filter.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with shared-producer lifecycle, replay, isolation, and authorization filtering preserved.

The hub retains the latest snapshot for new subscribers, isolates slow consumers through per-subscriber mailboxes, keeps the producer alive until the final subscriber disconnects, and filters the shared snapshot using each client’s permission set before emission.
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: shared one stream producer across ..."](https://github.com/getarcaneapp/arcane/commit/d83d186a90461b9fe005241cb495788f9e25831a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59491616)</sub>

**Context used:**

- Knowledge Base — [Containers, environments, and workloads](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/workload-management.md)
- Knowledge Base — [Container and environment lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-and-environment-lifecycle.md)

<!-- /greptile_comment -->