### PR TITLE
perf: lookup copa targets by digest vs db queries

### DIFF
--- a/backend/internal/imagepatch/imagepatch.go
+++ b/backend/internal/imagepatch/imagepatch.go
@@ -540,9 +540,29 @@ func (s *ImagePatchService) ListPatchTargets(ctx context.Context, envID string, 
 		return nil, pagination.Response{}, errors.WrapIf(err, "failed to list patch targets")
 	}
 
+	if len(scans) == 0 {
+		return []imagepatch.PatchTarget{}, paginationResp, nil
+	}
+
 	// Best-effort: mark images without a registry source so the UI can explain
 	// why they cannot be patched.
-	dockerClient, dockerErr := s.dockerService.GetClient(ctx)
+	repoDigestsByID := map[string][]string{}
+	if images, err := s.dockerService.ListImages(ctx); err == nil {
+		for i := range images {
+			repoDigestsByID[images[i].ID] = images[i].RepoDigests
+		}
+	} else {
+		slog.WarnContext(ctx, "failed to list images for patch targets", "error", err)
+	}
+
+	imageIDs := make([]string, 0, len(scans))
+	for i := range scans {
+		imageIDs = append(imageIDs, scans[i].ID)
+	}
+	lastPatchByImageID, lastPatchScanByImageID, err := s.latestPatchesByImageInternal(ctx, envID, imageIDs)
+	if err != nil {
+		return nil, pagination.Response{}, err
+	}
 
 	targets := make([]imagepatch.PatchTarget, 0, len(scans))
 	for i := range scans {
@@ -554,20 +574,20 @@ func (s *ImagePatchService) ListPatchTargets(ctx context.Context, envID string, 
 			TotalCount:   scan.TotalCount,
 			ScanTime:     scan.ScanTime,
 		}
-		if dockerErr == nil {
-			if inspect, err := dockerClient.ImageInspect(ctx, scan.ID); err == nil {
-				target.LocalOnly = len(inspect.RepoDigests) == 0
+		if digests, ok := repoDigestsByID[scan.ID]; ok {
+			target.LocalOnly = true
+			for _, digest := range digests {
+				if digest != "<none>@<none>" {
+					target.LocalOnly = false
+					break
+				}
 			}
 		}
 
-		var lastPatch ImagePatchRecord
-		if err := s.db.WithContext(ctx).
-			Where("environment_id = ? AND original_image_id = ?", envID, scan.ID).
-			Order("created_at DESC").
-			First(&lastPatch).Error; err == nil {
+		if lastPatch, ok := lastPatchByImageID[scan.ID]; ok {
 			dto := lastPatch.ToDto()
 			target.LastPatch = &dto
-			target.LastPatchScan = s.patchedImageScanSummaryInternal(ctx, &lastPatch)
+			target.LastPatchScan = lastPatchScanByImageID[scan.ID]
 		}
 
 		targets = append(targets, target)
@@ -576,30 +596,72 @@ func (s *ImagePatchService) ListPatchTargets(ctx context.Context, envID string, 
 	return targets, paginationResp, nil
 }
 
-// patchedImageScanSummaryInternal looks up the scan of a completed patch's
-// output image so the original's row can show whether the patch worked.
-func (s *ImagePatchService) patchedImageScanSummaryInternal(ctx context.Context, lastPatch *ImagePatchRecord) *imagepatch.PatchScanSummary {
-	if lastPatch.Status != string(imagepatch.PatchStatusCompleted) {
-		return nil
+// latestPatchesByImageInternal loads the most recent patch run per original
+// image in two batched queries, plus the scan of each completed patch's output
+// image so the original's row can show whether the patch worked.
+func (s *ImagePatchService) latestPatchesByImageInternal(ctx context.Context, envID string, imageIDs []string) (map[string]*ImagePatchRecord, map[string]*imagepatch.PatchScanSummary, error) {
+	var patchRows []ImagePatchRecord
+	if err := s.db.WithContext(ctx).
+		Where("environment_id = ? AND original_image_id IN ?", envID, imageIDs).
+		Order("original_image_id, created_at DESC, id").
+		Find(&patchRows).Error; err != nil {
+		return nil, nil, errors.WrapIf(err, "failed to load latest image patches")
 	}
-	names := []string{lastPatch.PatchedRef}
-	if named, err := reference.ParseNormalizedNamed(lastPatch.PatchedRef); err == nil {
-		names = append(names, reference.FamiliarString(named))
+	lastPatchByImageID := make(map[string]*ImagePatchRecord, len(imageIDs))
+	patchedNamesByImageID := make(map[string][]string, len(imageIDs))
+	var patchedNames []string
+	for i := range patchRows {
+		row := &patchRows[i]
+		if _, seen := lastPatchByImageID[row.OriginalImageID]; seen {
+			continue
+		}
+		lastPatchByImageID[row.OriginalImageID] = row
+		if row.Status != string(imagepatch.PatchStatusCompleted) {
+			continue
+		}
+		names := []string{row.PatchedRef}
+		if named, err := reference.ParseNormalizedNamed(row.PatchedRef); err == nil {
+			names = append(names, reference.FamiliarString(named))
+		}
+		patchedNamesByImageID[row.OriginalImageID] = names
+		patchedNames = append(patchedNames, names...)
 	}
 
-	var scan vulnerability.VulnerabilityScanRecord
+	lastPatchScanByImageID := make(map[string]*imagepatch.PatchScanSummary, len(patchedNamesByImageID))
+	if len(patchedNames) == 0 {
+		return lastPatchByImageID, lastPatchScanByImageID, nil
+	}
+	var patchScans []vulnerability.VulnerabilityScanRecord
 	if err := s.db.WithContext(ctx).
-		Where("image_name IN ?", names).
+		Select("image_name", "status", "fixable_count", "total_count", "scan_time").
+		Where("image_name IN ?", patchedNames).
 		Order("scan_time DESC").
-		First(&scan).Error; err != nil {
-		return nil
+		Find(&patchScans).Error; err != nil {
+		return nil, nil, errors.WrapIf(err, "failed to load patched image scans")
 	}
-	return &imagepatch.PatchScanSummary{
-		Status:       scan.Status,
-		FixableCount: mo.PointerToOption(scan.FixableCount).OrEmpty(),
-		TotalCount:   scan.TotalCount,
-		ScanTime:     scan.ScanTime,
+	latestScanByName := make(map[string]*vulnerability.VulnerabilityScanRecord, len(patchScans))
+	for i := range patchScans {
+		if _, seen := latestScanByName[patchScans[i].ImageName]; !seen {
+			latestScanByName[patchScans[i].ImageName] = &patchScans[i]
+		}
 	}
+	for imageID, names := range patchedNamesByImageID {
+		var latest *vulnerability.VulnerabilityScanRecord
+		for _, name := range names {
+			if candidate, ok := latestScanByName[name]; ok && (latest == nil || candidate.ScanTime.After(latest.ScanTime)) {
+				latest = candidate
+			}
+		}
+		if latest != nil {
+			lastPatchScanByImageID[imageID] = &imagepatch.PatchScanSummary{
+				Status:       latest.Status,
+				FixableCount: mo.PointerToOption(latest.FixableCount).OrEmpty(),
+				TotalCount:   latest.TotalCount,
+				ScanTime:     latest.ScanTime,
+			}
+		}
+	}
+	return lastPatchByImageID, lastPatchScanByImageID, nil
 }
 
 // PatchFlaggedImages patches every image whose latest completed vulnerability


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces patch-target lookup overhead by replacing per-image Docker inspections and database queries with batched image, patch-history, and verification-scan lookups.

- Returns early when no patchable scans exist.
- Maps Docker repository digests by image ID to determine local-only targets.
- Loads latest patch records and patched-image scan summaries in batches.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking inconsistency in its new database error wrapping.

The batched lookup paths retain the existing patch-target behavior, and the only accepted concern is that two newly added error returns do not use the repository-required wrapping convention.

**Files Needing Attention:** backend/internal/imagepatch/imagepatch.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22perf_lookup_copa_targets_by_digest_vs_db_queries%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf_lookup_copa_targets_by_digest_vs_db_queries%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233821%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3821&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22perf_lookup_copa_targets_by_digest_vs_db_queries%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf_lookup_copa_targets_by_digest_vs_db_queries%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimagepatch%2Fimagepatch.go%3A608-609%0A**Inconsistent%20database%20error%20wrapping**%0A%0AThe%20new%20database%20error%20paths%20use%20%60errors.WrapIf%60%20instead%20of%20the%20repository-required%20%60fmt.Errorf%60%20with%20%60%25w%60%2C%20making%20error%20propagation%20inconsistent%20with%20maintained%20Go%20code.%20The%20same%20pattern%20also%20occurs%20in%20the%20patched-scan%20query.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3821&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimagepatch%2Fimagepatch.go%3A608-609%0A**Inconsistent%20database%20error%20wrapping**%0A%0AThe%20new%20database%20error%20paths%20use%20%60errors.WrapIf%60%20instead%20of%20the%20repository-required%20%60fmt.Errorf%60%20with%20%60%25w%60%2C%20making%20error%20propagation%20inconsistent%20with%20maintained%20Go%20code.%20The%20same%20pattern%20also%20occurs%20in%20the%20patched-scan%20query.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3821&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/imagepatch/imagepatch.go:608-609
**Inconsistent database error wrapping**

The new database error paths use `errors.WrapIf` instead of the repository-required `fmt.Errorf` with `%w`, making error propagation inconsistent with maintained Go code. The same pattern also occurs in the patched-scan query.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: lookup copa targets by digest vs d..."](https://github.com/getarcaneapp/arcane/commit/7c7e3e6cb697670f238d8282cc886955a4f1edf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59544496)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Security and vulnerability management](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/security-and-vulnerability-management.md)
- Knowledge Base — [Vulnerability scanning and image patching](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/vulnerability-scanning-and-image-patching.md)
</details>


<!-- /greptile_comment -->