### PR TITLE
perf(projects): validate metadata cache by file mtime and resolve in parallel

### DIFF
--- a/backend/internal/project/project.go
+++ b/backend/internal/project/project.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/registry"
 
@@ -59,9 +58,9 @@ type ProjectService struct {
 	parsedCompose *parsedComposeCacheInternal
 	// metaCache holds per-project icon/URL metadata, keyed by project ID. Deriving
 	// it costs a full compose load (interpolation plus .env reads) and, for GitOps
-	// projects, a gitops_syncs lookup — per project, on every list request. Mirrors
-	// ContainerService.iconMetaCache.
-	metaCache *hot.HotCache[string, projects.ArcaneComposeMetadata]
+	// projects, a gitops_syncs lookup — per project, on every list request.
+	// Entries are validated by compose/include/env file mtimes rather than a TTL.
+	metaCache *hot.HotCache[string, projectMetadataEntryInternal]
 }
 
 // EnsureGitOpsProjectLinked persists the bidirectional GitOps/project binding
@@ -194,14 +193,12 @@ func (s *ProjectService) CreateGitOpsManagedProject(ctx context.Context, sync *G
 // projectMetadataEnvInternal carries the inputs ParseArcaneComposeMetadata needs
 // beyond the project itself. Resolving them costs a settings clone and a stat
 // syscall each, so list paths resolve once and reuse across every project.
+const maxConcurrentComposeReads = 8
+
 type projectMetadataEnvInternal struct {
 	projectsDirectory string
 	autoInjectEnv     bool
 }
-
-// projectMetadataTTL bounds how stale cached compose metadata can be. It matches
-// containerIconMetadataTTL so icons resolved from either service agree.
-const projectMetadataTTL = 5 * time.Second
 
 type registryCredentialsProviderInternal func(context.Context) ([]containerregistry.Credential, error)
 
@@ -217,10 +214,7 @@ func NewProjectService(db *database.DB, settingsService *settings.SettingsServic
 		containerRegistryService: containerRegistryService,
 		config:                   cfg,
 		parsedCompose:            newParsedComposeCacheInternal(),
-		metaCache: hot.NewHotCache[string, projects.ArcaneComposeMetadata](hot.LRU, 1024).
-			WithTTL(projectMetadataTTL).
-			WithJanitor().
-			Build(),
+		metaCache:                hot.NewHotCache[string, projectMetadataEntryInternal](hot.LRU, 1024).Build(),
 	}
 }
 

--- a/backend/internal/project/project_compose_cache.go
+++ b/backend/internal/project/project_compose_cache.go
@@ -49,6 +49,12 @@ type composeCacheEntry struct {
 	project   *composetypes.Project
 }
 
+type projectMetadataEntryInternal struct {
+	composeCacheEntry
+
+	meta projects.ArcaneComposeMetadata
+}
+
 func newParsedComposeCacheInternal() *parsedComposeCacheInternal {
 	return &parsedComposeCacheInternal{entries: hot.NewHotCache[string, composeCacheEntry](hot.LRU, 2048).Build()}
 }
@@ -98,6 +104,15 @@ func (c *composeNameCacheInternal) replace(byName map[string]string) {
 	c.mu.Lock()
 	c.byName = byName
 	c.mu.Unlock()
+}
+
+func (s *ProjectService) invalidateProjectCachesInternal(projectID string) {
+	if s.parsedCompose != nil {
+		s.parsedCompose.invalidate(projectID)
+	}
+	if s.metaCache != nil {
+		s.metaCache.Delete(projectID)
+	}
 }
 
 func (c *parsedComposeCacheInternal) invalidate(projectID string) {
@@ -251,7 +266,7 @@ func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, pr
 	}
 
 	if cached, ok := s.parsedCompose.entries.Peek(proj.ID); ok {
-		if validComposeCacheEntryInternal(cached) {
+		if cached.project != nil && validComposeCacheEntryInternal(cached) {
 			return cached.project, nil
 		}
 		s.parsedCompose.entries.Delete(proj.ID)
@@ -267,32 +282,18 @@ func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, pr
 			return nil, err
 		}
 
-		entry := composeCacheEntry{
-			composePath:   composePath,
-			includeMtimes: make(map[string]time.Time),
-			envMtimes:     collectEnvMtimesInternal(proj, getProjectsDirectoryOrDefaultInternal(ctx, cfg), composeProject),
-			project:       composeProject,
-		}
-		// os.Stat rather than acfs here and below: see
-		// validComposeCacheEntryInternal — these paths may resolve outside the
-		// project directory (#3556).
-		if info, statErr := os.Stat(composePath); statErr == nil {
-			entry.composeMtime = info.ModTime()
-		} else {
-			return nil, errors.WrapIf(statErr, "stat compose file")
-		}
+		var composeFiles, composeEnvFiles []string
 		if composeProject != nil {
-			for _, composeFile := range composeProject.ComposeFiles {
-				if composeFile == "" || composeFile == composePath {
-					continue
-				}
-				info, statErr := os.Stat(composeFile)
-				if statErr != nil {
-					return nil, errors.WrapIff(statErr, "stat compose include %s", composeFile)
-				}
-				entry.includeMtimes[composeFile] = info.ModTime()
+			composeFiles = composeProject.ComposeFiles
+			if envOpts, err := projects.ParseComposeEnvOptions(composeProject.WorkingDir, projects.EnvMap(composeProject.Environment)); err == nil {
+				composeEnvFiles = envOpts.EnvFiles
 			}
 		}
+		entry, err := newComposeCacheEntryInternal(proj, getProjectsDirectoryOrDefaultInternal(ctx, cfg), composePath, composeFiles, composeEnvFiles)
+		if err != nil {
+			return nil, err
+		}
+		entry.project = composeProject
 
 		return map[string]composeCacheEntry{proj.ID: entry}, nil
 	})
@@ -306,32 +307,52 @@ func (s *ProjectService) getCachedComposeProjectInternal(ctx context.Context, pr
 	return entry.project, nil
 }
 
-// collectEnvMtimesInternal records the mtimes of every env file that influences
-// compose-file selection or interpolation for a project: the project .env, the
-// global .env.global, and any COMPOSE_ENV_FILES entries. A file that does not
-// exist is recorded as a zero time so its later appearance invalidates too.
-func collectEnvMtimesInternal(proj *Project, projectsDirectory string, composeProject *composetypes.Project) map[string]time.Time {
-	paths := []string{
-		filepath.Join(proj.Path, projects.EffectiveEnvFileName),
-		filepath.Join(projectsDirectory, projects.GlobalEnvFileName),
+// newComposeCacheEntryInternal snapshots the mtimes of every file a compose
+// load consumed: the root, every other merged config file (COMPOSE_FILE
+// entries, an auto-loaded override, includes), and the env files that select
+// and interpolate them (.env, .env.global, COMPOSE_ENV_FILES entries). An env
+// file that does not exist is recorded as a zero time so its later appearance
+// invalidates too. os.Stat rather than acfs throughout: see
+// validComposeCacheEntryInternal.
+func newComposeCacheEntryInternal(proj *Project, projectsDirectory, composePath string, composeFiles, composeEnvFiles []string) (composeCacheEntry, error) {
+	entry := composeCacheEntry{
+		composePath:   composePath,
+		includeMtimes: make(map[string]time.Time, len(composeFiles)),
+		envMtimes:     make(map[string]time.Time, 2+len(composeEnvFiles)),
 	}
-	if composeProject != nil {
-		if envOpts, err := projects.ParseComposeEnvOptions(composeProject.WorkingDir, projects.EnvMap(composeProject.Environment)); err == nil {
-			paths = append(paths, envOpts.EnvFiles...)
+	info, err := os.Stat(composePath)
+	if err != nil {
+		return composeCacheEntry{}, errors.WrapIf(err, "stat compose file")
+	}
+	entry.composeMtime = info.ModTime()
+
+	rootPath, err := filepath.Abs(composePath)
+	if err != nil {
+		rootPath = composePath
+	}
+	for _, composeFile := range composeFiles {
+		if composeFile == "" || composeFile == composePath || composeFile == rootPath {
+			continue
 		}
+		info, err := os.Stat(composeFile)
+		if err != nil {
+			return composeCacheEntry{}, errors.WrapIff(err, "stat compose file %s", composeFile)
+		}
+		entry.includeMtimes[composeFile] = info.ModTime()
 	}
 
-	mtimes := make(map[string]time.Time, len(paths))
-	for _, p := range paths {
-		// os.Stat rather than acfs: env files may be symlinks resolving outside
-		// any confinement root (a supported setup).
-		if info, err := os.Stat(p); err == nil {
-			mtimes[p] = info.ModTime()
+	envPaths := append([]string{
+		filepath.Join(proj.Path, projects.EffectiveEnvFileName),
+		filepath.Join(projectsDirectory, projects.GlobalEnvFileName),
+	}, composeEnvFiles...)
+	for _, envPath := range envPaths {
+		if info, err := os.Stat(envPath); err == nil {
+			entry.envMtimes[envPath] = info.ModTime()
 		} else {
-			mtimes[p] = time.Time{}
+			entry.envMtimes[envPath] = time.Time{}
 		}
 	}
-	return mtimes
+	return entry, nil
 }
 
 // The compose file and its includes are absolute paths compose-go resolved, and
@@ -339,7 +360,7 @@ func collectEnvMtimesInternal(proj *Project, projectsDirectory string, composePr
 // the project (#3556). These invalidation probes therefore stay on os.Stat
 // rather than a root-confined stat, which would reject those layouts.
 func validComposeCacheEntryInternal(entry composeCacheEntry) bool {
-	if entry.project == nil || entry.composePath == "" {
+	if entry.composePath == "" {
 		return false
 	}
 

--- a/backend/internal/project/project_details.go
+++ b/backend/internal/project/project_details.go
@@ -458,7 +458,6 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	allImageRefs := make([]string, 0)
 	cfg := s.settingsService.GetSettingsOrDefaults(ctx)
 
-	const maxConcurrentComposeReads = 8
 	type imageRefsResult struct {
 		projectID string
 		refs      []string

--- a/backend/internal/project/project_lifecycle.go
+++ b/backend/internal/project/project_lifecycle.go
@@ -552,7 +552,7 @@ func (s *ProjectService) DestroyProject(ctx context.Context, projectID string, r
 			}
 		}
 	}
-	s.parsedCompose.invalidate(projectID)
+	s.invalidateProjectCachesInternal(projectID)
 
 	metadata := database.JSON{"action": "destroy", "projectID": projectID, "projectName": proj.Name, "removeFiles": removeFiles, "removeVolumes": removeVolumes}
 	s.logProjectEventInternal(ctx, event.EventTypeProjectDelete, projectID, proj.Name, user, metadata, "could not log project destroy action")

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -16,6 +16,7 @@ import (
 	dockerutil "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/iconcatalog"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
 	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
@@ -25,6 +26,7 @@ import (
 	"github.com/samber/mo"
 	"go.getarcane.app/sys/cgroup"
 	"go.getarcane.app/updater/labels"
+	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 )
 
@@ -800,6 +802,7 @@ func (s *ProjectService) fetchProjectStatusConcurrently(ctx context.Context, pro
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to list global compose containers", "error", err)
 		// Fallback: return basic info with unknown status
+		metas := s.resolveProjectMetadataConcurrentlyInternal(ctx, projectsList, metaEnv)
 		results := make([]project.Details, len(projectsList))
 		for i, p := range projectsList {
 			_ = mapper.MapStruct(p, &results[i])
@@ -809,9 +812,8 @@ func (s *ProjectService) fetchProjectStatusConcurrently(ctx context.Context, pro
 			results[i].RelativePath = getProjectRelativePathInternal(projectsDir, p.Path)
 			results[i].GitOpsManagedBy = p.GitOpsManagedBy
 			results[i].HasBuildDirective = p.BuildImageRefsJSON != nil && len(projects.ParseImageRefsJSON(*p.BuildImageRefsJSON)) > 0
-			meta := s.ProjectMetadata(ctx, p, metaEnv)
-			applyResolvedProjectIconInternal(&results[i], iconcatalog.Resolve(IconCatalogForContext(ctx), meta.ProjectIcon))
-			results[i].URLs = meta.ProjectURLS
+			applyResolvedProjectIconInternal(&results[i], iconcatalog.Resolve(IconCatalogForContext(ctx), metas[i].ProjectIcon))
+			results[i].URLs = metas[i].ProjectURLS
 			results[i].Status = string(ProjectStatusUnknown)
 		}
 		return results
@@ -821,16 +823,34 @@ func (s *ProjectService) fetchProjectStatusConcurrently(ctx context.Context, pro
 	containersByProject := groupComposeContainersByProjectInternal(containers)
 
 	// 3. Map to DTOs
+	metas := s.resolveProjectMetadataConcurrentlyInternal(ctx, projectsList, metaEnv)
 	results := make([]project.Details, len(projectsList))
 	currentContainerID, currentContainerErr := cgroup.CurrentContainerID()
 	for i, p := range projectsList {
-		results[i] = s.mapProjectToDto(ctx, projectsDir, p, containersByProject, currentContainerID, currentContainerErr, metaEnv)
+		results[i] = s.mapProjectToDto(ctx, projectsDir, p, containersByProject, currentContainerID, currentContainerErr, metas[i])
 	}
 
 	return results
 }
 
-func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string, p Project, containersByProject map[string][]container.Summary, currentContainerID string, currentContainerErr error, metaEnv *projectMetadataEnvInternal) project.Details {
+func (s *ProjectService) resolveProjectMetadataConcurrentlyInternal(ctx context.Context, projectsList []Project, metaEnv *projectMetadataEnvInternal) []projects.ArcaneComposeMetadata {
+	metas := make([]projects.ArcaneComposeMetadata, len(projectsList))
+	var g errgroup.Group
+	g.SetLimit(maxConcurrentComposeReads)
+	for i := range projectsList {
+		g.Go(func() (workerErr error) {
+			defer utils.RecoverToError(&workerErr, "project metadata worker", "projectID", projectsList[i].ID)
+			metas[i] = s.ProjectMetadata(ctx, projectsList[i], metaEnv)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		slog.WarnContext(ctx, "project metadata resolution failed", "error", err)
+	}
+	return metas
+}
+
+func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string, p Project, containersByProject map[string][]container.Summary, currentContainerID string, currentContainerErr error, meta projects.ArcaneComposeMetadata) project.Details {
 	var resp project.Details
 	_ = mapper.MapStruct(p, &resp)
 
@@ -842,7 +862,6 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 	resp.RelativePath = getProjectRelativePathInternal(projectsDir, p.Path)
 	resp.GitOpsManagedBy = p.GitOpsManagedBy
 	resp.HasBuildDirective = p.BuildImageRefsJSON != nil && len(projects.ParseImageRefsJSON(*p.BuildImageRefsJSON)) > 0
-	meta := s.ProjectMetadata(ctx, p, metaEnv)
 	applyResolvedProjectIconInternal(&resp, iconcatalog.Resolve(IconCatalogForContext(ctx), meta.ProjectIcon))
 	resp.URLs = meta.ProjectURLS
 
@@ -954,17 +973,22 @@ func (s *ProjectService) mapProjectToDto(ctx context.Context, projectsDir string
 }
 
 // ProjectMetadata resolves a project's icon sets and service URLs.
-// Results are cached for projectMetadataTTL because deriving them is expensive
-// (compose load with interpolation and .env reads, plus a gitops_syncs query for
-// GitOps-managed projects) and every project row on the list page needs it.
+// Results are cached until any compose file the parse merged (root, COMPOSE_FILE
+// entries, override, includes) or any env file it read changes on disk,
+// because deriving them is expensive (compose load with
+// interpolation and .env reads, plus a gitops_syncs query for GitOps-managed
+// projects) and every project row on the list page needs it.
 //
 // env may be nil, in which case the projects directory and autoInjectEnv setting
 // are resolved here; callers iterating over many projects should resolve them
 // once and pass them in.
 func (s *ProjectService) ProjectMetadata(ctx context.Context, p Project, env *projectMetadataEnvInternal) projects.ArcaneComposeMetadata {
 	if s.metaCache != nil && p.ID != "" {
-		if meta, ok, _ := s.metaCache.Get(p.ID); ok {
-			return meta
+		if entry, ok, _ := s.metaCache.Get(p.ID); ok {
+			if validComposeCacheEntryInternal(entry.composeCacheEntry) {
+				return entry.meta
+			}
+			s.metaCache.Delete(p.ID)
 		}
 	}
 
@@ -992,9 +1016,14 @@ func (s *ProjectService) ProjectMetadata(ctx context.Context, p Project, env *pr
 		return empty
 	}
 
-	if s.metaCache != nil && p.ID != "" {
-		s.metaCache.Set(p.ID, meta)
+	if s.metaCache == nil || p.ID == "" {
+		return meta
 	}
+	entry, err := newComposeCacheEntryInternal(&p, env.projectsDirectory, composeFile, meta.ComposeFiles, meta.EnvFiles)
+	if err != nil {
+		return meta
+	}
+	s.metaCache.Set(p.ID, projectMetadataEntryInternal{composeCacheEntry: entry, meta: meta})
 
 	return meta
 }

--- a/backend/internal/project/project_sync.go
+++ b/backend/internal/project/project_sync.go
@@ -37,7 +37,7 @@ func (s *ProjectService) refreshProjectImageRefsInternal(ctx context.Context, pr
 		return
 	}
 
-	s.parsedCompose.invalidate(proj.ID)
+	s.invalidateProjectCachesInternal(proj.ID)
 	refs, buildRefs, err := s.getProjectImageRefsFromComposeInternal(ctx, *proj, nil)
 	if err != nil {
 		if dbErr := s.db.WithContext(ctx).
@@ -84,7 +84,7 @@ func (s *ProjectService) HandleProjectFilesChanged(ctx context.Context, paths []
 		return
 	}
 	for i := range affected {
-		s.parsedCompose.invalidate(affected[i].ID)
+		s.invalidateProjectCachesInternal(affected[i].ID)
 		s.refreshProjectImageRefsInternal(ctx, &affected[i])
 		if err := s.reconcileComposeTagsForProjectInternal(ctx, &affected[i]); err != nil {
 			slog.WarnContext(ctx, "failed to reconcile Compose project tags after file change", "projectID", affected[i].ID, "error", err)

--- a/backend/internal/project/service_test.go
+++ b/backend/internal/project/service_test.go
@@ -4194,7 +4194,7 @@ func TestProjectService_MapProjectToDto_SetsRedeployDisabledFromRuntimeServices(
 						Labels: tt.labels,
 					},
 				},
-			}, tt.currentContainerID, tt.currentErr, nil)
+			}, tt.currentContainerID, tt.currentErr, projects.ArcaneComposeMetadata{})
 
 			require.Equal(t, tt.wantProject, details.RedeployDisabled)
 			require.Len(t, details.RuntimeServices, 1)
@@ -7362,7 +7362,7 @@ func TestProjectService_MapProjectToDto_SeedsHasBuildDirectiveFromPersistedRefs(
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Project{ID: tt.name, Name: tt.name, Path: t.TempDir(), UpdatedAt: &now, BuildImageRefsJSON: tt.buildImageRefsJSON}
-			assert.Equal(t, tt.want, svc.mapProjectToDto(ctx, metaEnv.projectsDirectory, p, nil, "", nil, metaEnv).HasBuildDirective)
+			assert.Equal(t, tt.want, svc.mapProjectToDto(ctx, metaEnv.projectsDirectory, p, nil, "", nil, svc.ProjectMetadata(ctx, p, metaEnv)).HasBuildDirective)
 		})
 	}
 }

--- a/backend/pkg/projects/custom_labels.go
+++ b/backend/pkg/projects/custom_labels.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"emperror.dev/errors"
@@ -49,6 +50,10 @@ type ArcaneComposeMetadata struct {
 	ProjectTagsAuthoritative bool
 	// ServiceIconSets maps service names to their fallback, light, and dark icon values.
 	ServiceIconSets map[string]IconSet
+	// ComposeFiles lists every compose file the metadata was parsed from: the root, COMPOSE_FILE entries, an auto-loaded override, and includes.
+	ComposeFiles []string
+	// EnvFiles lists every env file the parse read: the .env beside each parsed compose file plus resolved COMPOSE_ENV_FILES entries.
+	EnvFiles []string
 }
 
 // ParseArcaneComposeMetadata reads a Docker Compose file and extracts Arcane-specific metadata.
@@ -59,18 +64,41 @@ func ParseArcaneComposeMetadata(ctx context.Context, composeFilePath, projectsDi
 	}
 
 	workdir := filepath.Dir(composeFilePath)
+	var envMap map[string]string
 	if strings.TrimSpace(projectsDirectory) == "" {
-		envMap := loadComposeEnvironment(workdir)
-		return parseArcaneComposeMetadataFromFileInternal(ctx, composeFilePath, envMap, map[string]struct{}{})
+		envMap = loadComposeEnvironment(workdir)
+	} else {
+		envLoader := NewEnvLoader(projectsDirectory, workdir, autoInjectEnv)
+		loaded, _, err := envLoader.LoadEnvironment(ctx)
+		if err != nil {
+			return emptyArcaneComposeMetadataInternal(), errors.WrapIf(err, "load project environment")
+		}
+		envMap = loaded
 	}
 
-	envLoader := NewEnvLoader(projectsDirectory, workdir, autoInjectEnv)
-	envMap, _, err := envLoader.LoadEnvironment(ctx)
+	visited := map[string]struct{}{}
+	meta, err := parseArcaneComposeMetadataFromFileInternal(ctx, composeFilePath, envMap, visited)
 	if err != nil {
-		return emptyArcaneComposeMetadataInternal(), errors.WrapIf(err, "load project environment")
+		return meta, err
 	}
+	meta.ComposeFiles = utils.UniqueNonEmptyStrings(append(meta.ComposeFiles, slices.Collect(maps.Keys(visited))...))
+	slices.Sort(meta.ComposeFiles)
+	meta.EnvFiles = utils.UniqueNonEmptyStrings(append(meta.EnvFiles, resolveComposeEnvFilesInternal(workdir, envMap)...))
+	return meta, nil
+}
 
-	return parseArcaneComposeMetadataFromFileInternal(ctx, composeFilePath, envMap, map[string]struct{}{})
+// resolveComposeEnvFilesInternal resolves the COMPOSE_ENV_FILES entries env
+// declares against workdir, skipping entries that escape it, mirroring what
+// EnvLoader merges for that directory.
+func resolveComposeEnvFilesInternal(workdir string, env EnvMap) []string {
+	entries := ComposeEnvFileEntriesFromEnv(env)
+	resolved := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if path, err := ResolvePathWithinDir(workdir, entry); err == nil {
+			resolved = append(resolved, path)
+		}
+	}
+	return resolved
 }
 
 func parseArcaneComposeMetadataFromFileInternal(ctx context.Context, composeFilePath string, envMap map[string]string, visited map[string]struct{}) (ArcaneComposeMetadata, error) {
@@ -90,7 +118,7 @@ func parseArcaneComposeMetadataFromFileInternal(ctx context.Context, composeFile
 	visited[absPath] = struct{}{}
 
 	workdir := filepath.Dir(absPath)
-	mergedEnv := mergeEnvFromDotEnv(envMap, workdir)
+	mergedEnv, siblingEnv := mergeEnvFromDotEnv(envMap, workdir)
 
 	project, err := loadComposeProjectForMetadataFromFileInternal(ctx, absPath, mergedEnv)
 	if err != nil {
@@ -98,6 +126,12 @@ func parseArcaneComposeMetadataFromFileInternal(ctx context.Context, composeFile
 	}
 
 	meta = extractArcaneComposeMetadata(project)
+	if project != nil {
+		meta.ComposeFiles = slices.Clone(project.ComposeFiles)
+	}
+	// The nested load's EnvLoader reads the sibling .env and the COMPOSE_ENV_FILES
+	// it declares, even where the inherited environment overrides those values.
+	meta.EnvFiles = append([]string{filepath.Join(workdir, EffectiveEnvFileName)}, resolveComposeEnvFilesInternal(workdir, siblingEnv)...)
 
 	includePaths, err := parseIncludePaths(absPath)
 	if err != nil {
@@ -248,6 +282,8 @@ func mergeArcaneComposeMetadata(target *ArcaneComposeMetadata, source ArcaneComp
 	target.ProjectURLS = utils.UniqueNonEmptyStrings(append(target.ProjectURLS, source.ProjectURLS...))
 	target.ProjectTags = mergeComposeTagsInternal(target.ProjectTags, source.ProjectTags)
 	target.ProjectTagsAuthoritative = target.ProjectTagsAuthoritative && source.ProjectTagsAuthoritative
+	target.ComposeFiles = append(target.ComposeFiles, source.ComposeFiles...)
+	target.EnvFiles = append(target.EnvFiles, source.EnvFiles...)
 
 	if target.ServiceIconSets == nil {
 		target.ServiceIconSets = map[string]IconSet{}
@@ -319,11 +355,13 @@ func loadComposeEnvironment(workdir string) map[string]string {
 	return envMap
 }
 
-func mergeEnvFromDotEnv(envMap map[string]string, workdir string) map[string]string {
+// mergeEnvFromDotEnv layers workdir's .env under envMap (existing keys win) and
+// also returns the .env values on their own.
+func mergeEnvFromDotEnv(envMap map[string]string, workdir string) (map[string]string, EnvMap) {
 	merged := make(map[string]string, len(envMap)+1)
 	maps.Copy(merged, envMap)
 	if workdir == "" {
-		return merged
+		return merged, nil
 	}
 
 	if absWorkdir, err := filepath.Abs(workdir); err == nil {
@@ -337,12 +375,12 @@ func mergeEnvFromDotEnv(envMap map[string]string, workdir string) map[string]str
 	// confinement root (a supported setup).
 	info, err := os.Stat(envPath)
 	if err != nil || info.IsDir() {
-		return merged
+		return merged, nil
 	}
 
 	fileEnv, err := ParseProjectEnvFile(envPath, merged)
 	if err != nil {
-		return merged
+		return merged, nil
 	}
 
 	for k, v := range fileEnv {
@@ -351,7 +389,7 @@ func mergeEnvFromDotEnv(envMap map[string]string, workdir string) map[string]str
 		}
 	}
 
-	return merged
+	return merged, fileEnv
 }
 
 func parseIncludePaths(composeFilePath string) ([]string, error) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->








<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the project metadata cache TTL with Compose and environment file mtime validation and resolves project metadata concurrently.
- Adds reusable mtime snapshots for Compose, include, and environment dependencies.
- Tracks metadata parser inputs across recursive Compose files.
- Invalidates metadata alongside parsed Compose caches during project lifecycle and synchronization changes.
- Parallelizes metadata resolution with a bounded worker group.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because metadata loaded from nested COMPOSE_ENV_FILES declared by .env.global can remain stale indefinitely.

Nested EnvLoader instances consume globally declared COMPOSE_ENV_FILES relative to their own working directories, but those resolved files are absent from the metadata cache dependency set.

**Files Needing Attention:** backend/pkg/projects/custom_labels.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22perf_projects_validate_metadata_cache_by_file_mtime_and_resolve_in_parallel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf_projects_validate_metadata_cache_by_file_mtime_and_resolve_in_parallel%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233823%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3823&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22perf_projects_validate_metadata_cache_by_file_mtime_and_resolve_in_parallel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf_projects_validate_metadata_cache_by_file_mtime_and_resolve_in_parallel%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fcustom_labels.go%3A132-134%0A**Nested%20global%20env%20files%20stay%20stale**%0A%0AWhen%20%60.env.global%60%20declares%20a%20relative%20%60COMPOSE_ENV_FILES%60%20entry%20for%20an%20included%20Compose%20file%2C%20the%20nested%20loader%20reads%20that%20file%20relative%20to%20the%20include%20directory%2C%20but%20dependency%20collection%20records%20entries%20only%20from%20%60siblingEnv%60.%20Editing%20the%20nested%20env%20file%20therefore%20does%20not%20invalidate%20the%20metadata%20cache%2C%20leaving%20project%20icons%2C%20URLs%2C%20or%20tags%20stale%20indefinitely.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Fpkg%2Fprojects%2Fcustom_labels.go%3A132-134%0A**Nested%20global%20env%20files%20stay%20stale**%0A%0AWhen%20%60.env.global%60%20declares%20a%20relative%20%60COMPOSE_ENV_FILES%60%20entry%20for%20an%20included%20Compose%20file%2C%20the%20nested%20loader%20reads%20that%20file%20relative%20to%20the%20include%20directory%2C%20but%20dependency%20collection%20records%20entries%20only%20from%20%60siblingEnv%60.%20Editing%20the%20nested%20env%20file%20therefore%20does%20not%20invalidate%20the%20metadata%20cache%2C%20leaving%20project%20icons%2C%20URLs%2C%20or%20tags%20stale%20indefinitely.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3823&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/pkg/projects/custom_labels.go:132-134
**Nested global env files stay stale**

When `.env.global` declares a relative `COMPOSE_ENV_FILES` entry for an included Compose file, the nested loader reads that file relative to the include directory, but dependency collection records entries only from `siblingEnv`. Editing the nested env file therefore does not invalidate the metadata cache, leaving project icons, URLs, or tags stale indefinitely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["perf(projects): validate metadata cache ..."](https://github.com/getarcaneapp/arcane/commit/57645695f366d5ab49d9fd3f062c7dd81ae567ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59557293)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->