### PR TITLE
fix: refactor image digest inspection logic

### DIFF
--- a/backend/internal/registry/service.go
+++ b/backend/internal/registry/service.go
@@ -913,72 +913,24 @@ func (s *ContainerRegistryService) InspectImageDigest(ctx context.Context, image
 	return lastResult, nil
 }
 
-func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx context.Context, normalizedRef, registryHost string, externalCreds []containerregistry.Credential) (*containerregistry.DigestResult, error) {
-	dockerClient, err := s.getDockerClientInternal(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Use stored credentials up front for any registry that has them. Anonymous
-	// requests share a per-registry quota with every other unauthenticated client,
-	// so an anonymous first attempt is rate limited for reasons unrelated to us.
-	if credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds); credErr == nil && len(credentials) > 0 {
-		result, credentialErr := s.inspectImageDigestWithCredentialsInternal(ctx, dockerClient, normalizedRef, registryHost, credentials, nil)
-		// Docker Hub anonymous quotas are too small to be worth a retry; elsewhere a
-		// stale credential must not break public images that resolve anonymously.
-		if credentialErr == nil || isDockerHubRegistryInternal(registryHost) {
-			return result, credentialErr
-		}
-		slog.DebugContext(ctx, "credentialed distribution inspect failed, retrying anonymously",
-			"registry", registryHost,
-			"imageRef", normalizedRef,
-			"error", credentialErr.Error())
-	}
-
-	inspectResult, err := dockerClient.DistributionInspect(ctx, normalizedRef, client.DistributionInspectOptions{})
-	if err == nil {
-		digestValue, normalizeErr := digest.Normalize(inspectResult.Descriptor.Digest.String())
-		if normalizeErr != nil {
-			return nil, errors.WrapIff(normalizeErr, "distribution inspect returned invalid digest for %s", normalizedRef)
-		}
-		return &containerregistry.DigestResult{
-			Digest:       digestValue,
-			AuthMethod:   "anonymous",
-			AuthRegistry: registryHost,
-		}, nil
-	}
-	if !isUnauthorizedRegistryErrorInternal(err) {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, errors.
-			WrapIff(err, "distribution inspect failed for %s", normalizedRef)
-	}
-
-	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
-	if credErr != nil {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, errors.
-			WrapIf(stderrors.Join(err, credErr), "distribution inspect: anonymous access unauthorized; credential lookup failed")
-	}
-
-	return s.inspectImageDigestWithCredentialsInternal(ctx, dockerClient, normalizedRef, registryHost, credentials, err)
-}
-
-func (s *ContainerRegistryService) inspectImageDigestWithCredentialsInternal(ctx context.Context, dockerClient RegistryDaemonClient, normalizedRef, registryHost string, credentials []resolvedRegistryCredential, previousErr error) (*containerregistry.DigestResult, error) {
-	lastErr := previousErr
+// iterateCredentialsInternal tries each credential in order using fetchFunc.
+// On success it returns a complete DigestResult. On non-auth errors it returns
+// early with credential metadata. On exhaustion it returns a partial result
+// with the last error.
+func iterateCredentialsInternal(
+	ctx context.Context,
+	credentials []resolvedRegistryCredential,
+	registryHost string,
+	fetchFunc func(ctx context.Context, cred *resolvedRegistryCredential) (string, error),
+	errorContext string,
+	errorDetail string,
+) (*containerregistry.DigestResult, error) {
+	var lastErr error
 	var lastCred resolvedRegistryCredential
 	for _, credential := range credentials {
 		lastCred = credential
-		authHeader, encodeErr := utilsregistry.EncodeAuthHeader(credential.Username, credential.Token, credential.ServerAddress)
-		if encodeErr != nil {
-			return nil, errors.WrapIff(encodeErr, "encode registry auth header for %s", registryHost)
-		}
-
-		inspectResult, err := dockerClient.DistributionInspect(ctx, normalizedRef, client.DistributionInspectOptions{
-			EncodedRegistryAuth: authHeader,
-		})
+		digestValue, err := fetchFunc(ctx, &credential)
 		if err == nil {
-			digestValue, normalizeErr := digest.Normalize(inspectResult.Descriptor.Digest.String())
-			if normalizeErr != nil {
-				return nil, errors.WrapIff(normalizeErr, "distribution inspect returned invalid digest for %s", normalizedRef)
-			}
 			return &containerregistry.DigestResult{
 				Digest:         digestValue,
 				AuthMethod:     "credential",
@@ -994,7 +946,7 @@ func (s *ContainerRegistryService) inspectImageDigestWithCredentialsInternal(ctx
 				AuthUsername:   credential.Username,
 				AuthRegistry:   registryHost,
 				UsedCredential: true,
-			}, errors.WrapIff(err, "distribution inspect failed for %s with credentials", normalizedRef)
+			}, errors.WrapIff(err, "%s failed for %s with credentials", errorContext, errorDetail)
 		}
 	}
 
@@ -1005,58 +957,86 @@ func (s *ContainerRegistryService) inspectImageDigestWithCredentialsInternal(ctx
 		partial.UsedCredential = true
 	}
 	if lastErr == nil {
-		return partial, errors.Errorf("distribution inspect failed for %s: no credentials available", normalizedRef)
+		return partial, errors.Errorf("%s failed for %s: no credentials available", errorContext, errorDetail)
 	}
-	return partial, errors.WrapIff(lastErr, "distribution inspect failed for %s", normalizedRef)
+	return partial, errors.WrapIff(lastErr, "%s failed for %s", errorContext, errorDetail)
+}
+
+// inspectImageDigestWithFallbackInternal tries stored credentials first, then
+// falls back to anonymous access. For non-DockerHub registries, non-auth errors
+// from the credentialed attempt are returned immediately so the outer retry loop
+// retries the credential attempt instead of burning the shared anonymous quota.
+func (s *ContainerRegistryService) inspectImageDigestWithFallbackInternal(
+	ctx context.Context,
+	registryHost string,
+	externalCreds []containerregistry.Credential,
+	fetchFunc func(ctx context.Context, credentials *resolvedRegistryCredential) (string, error),
+	errorContext string,
+	errorDetail string,
+) (*containerregistry.DigestResult, error) {
+	// Use stored credentials up front for any registry that has them. Anonymous
+	// requests share a per-registry quota with every other unauthenticated client,
+	// so an anonymous first attempt is rate limited for reasons unrelated to us.
+	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
+	if credErr == nil && len(credentials) > 0 {
+		result, err := iterateCredentialsInternal(ctx, credentials, registryHost, fetchFunc, errorContext, errorDetail)
+		if err == nil {
+			return result, nil
+		}
+		if isDockerHubRegistryInternal(registryHost) {
+			// Docker Hub anonymous quotas are too small to be worth a retry; elsewhere a
+			// stale credential must not break public images that resolve anonymously.
+			return result, err
+		}
+		if !isUnauthorizedRegistryErrorInternal(err) {
+			// Non-auth errors (e.g. rate limits) on non-DockerHub must not fall
+			// back to anonymous — the retry loop will retry the credential
+			// attempt instead of burning the shared anonymous quota.
+			return result, err
+		}
+		slog.DebugContext(ctx, "credentialed "+errorContext+" failed, retrying anonymously",
+			"registry", registryHost,
+			"error", err.Error())
+	}
+
+	result, err := fetchFunc(ctx, nil)
+	if err == nil {
+		return &containerregistry.DigestResult{Digest: result, AuthMethod: "anonymous", AuthRegistry: registryHost}, nil
+	}
+	err = errors.WrapIff(err, "%s failed for %s", errorContext, errorDetail)
+	if !isUnauthorizedRegistryErrorInternal(err) {
+		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
+	}
+	if credErr != nil {
+		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost},
+			errors.WrapIff(stderrors.Join(err, credErr), "%s: anonymous access unauthorized; credential lookup failed", errorContext)
+	}
+	return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
+}
+
+func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx context.Context, normalizedRef, registryHost string, externalCreds []containerregistry.Credential) (*containerregistry.DigestResult, error) {
+	dockerClient, err := s.getDockerClientInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.inspectImageDigestWithFallbackInternal(ctx, registryHost, externalCreds,
+		func(ctx context.Context, cred *resolvedRegistryCredential) (string, error) {
+			return s.fetchDigestFromDaemonInternal(ctx, dockerClient, registryHost, normalizedRef, cred)
+		},
+		"distribution inspect",
+		normalizedRef,
+	)
 }
 
 func (s *ContainerRegistryService) inspectImageDigestViaRegistryInternal(ctx context.Context, registryHost, repository, tag string, externalCreds []containerregistry.Credential) (*containerregistry.DigestResult, error) {
-	digestValue, err := s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, nil)
-	if err == nil {
-		return &containerregistry.DigestResult{
-			Digest:       digestValue,
-			AuthMethod:   "anonymous",
-			AuthRegistry: registryHost,
-		}, nil
-	}
-	if !isUnauthorizedRegistryErrorInternal(err) {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, errors.
-			WrapIff(err, "registry manifest inspect failed for %s/%s:%s", registryHost, repository, tag)
-	}
-
-	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
-	if credErr != nil {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, errors.
-			WrapIf(stderrors.Join(err, credErr), "registry manifest inspect: anonymous access unauthorized; credential lookup failed")
-	}
-
-	lastErr := err
-	var lastCred resolvedRegistryCredential
-	for _, credential := range credentials {
-		lastCred = credential
-
-		digestValue, err = s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, &credential)
-		if err == nil {
-			return &containerregistry.DigestResult{
-				Digest:         digestValue,
-				AuthMethod:     "credential",
-				AuthUsername:   credential.Username,
-				AuthRegistry:   registryHost,
-				UsedCredential: true,
-			}, nil
-		}
-
-		lastErr = err
-	}
-
-	partial := &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}
-	if lastCred.Username != "" {
-		partial.AuthMethod = "credential"
-		partial.AuthUsername = lastCred.Username
-		partial.UsedCredential = true
-	}
-
-	return partial, errors.WrapIff(lastErr, "registry manifest inspect failed for %s/%s:%s", registryHost, repository, tag)
+	return s.inspectImageDigestWithFallbackInternal(ctx, registryHost, externalCreds,
+		func(ctx context.Context, cred *resolvedRegistryCredential) (string, error) {
+			return s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, cred)
+		},
+		"registry manifest inspect",
+		registryHost+"/"+repository+":"+tag,
+	)
 }
 
 func (s *ContainerRegistryService) getDockerClientInternal(ctx context.Context) (RegistryDaemonClient, error) {
@@ -1476,6 +1456,27 @@ func isDistributionFallbackEligibleInternal(err error) bool {
 	return strings.Contains(errLower, "context deadline exceeded") ||
 		strings.Contains(errLower, "client.timeout exceeded") ||
 		strings.Contains(errLower, "i/o timeout")
+}
+
+func (s *ContainerRegistryService) fetchDigestFromDaemonInternal(ctx context.Context, dockerClient RegistryDaemonClient, registryHost, normalizedRef string, credential *resolvedRegistryCredential) (string, error) {
+	var inspectOptions client.DistributionInspectOptions
+	if credential != nil {
+		authHeader, err := utilsregistry.EncodeAuthHeader(credential.Username, credential.Token, credential.ServerAddress)
+		if err != nil {
+			return "", errors.WrapIff(err, "encode registry auth header for %s", registryHost)
+		}
+		inspectOptions.EncodedRegistryAuth = authHeader
+	}
+
+	inspectResult, err := dockerClient.DistributionInspect(ctx, normalizedRef, inspectOptions)
+	if err != nil {
+		return "", err
+	}
+	digestValue, err := digest.Normalize(inspectResult.Descriptor.Digest.String())
+	if err != nil {
+		return "", errors.WrapIff(err, "distribution inspect returned invalid digest for %s", normalizedRef)
+	}
+	return digestValue, nil
 }
 
 func (s *ContainerRegistryService) fetchDigestFromRegistryInternal(ctx context.Context, registryHost, repository, tag string, credential *resolvedRegistryCredential) (string, error) {

--- a/backend/internal/registry/service.go
+++ b/backend/internal/registry/service.go
@@ -913,106 +913,7 @@ func (s *ContainerRegistryService) InspectImageDigest(ctx context.Context, image
 	return lastResult, nil
 }
 
-// iterateCredentialsInternal tries each credential in order using fetchFunc.
-// On success it returns a complete DigestResult. On non-auth errors it returns
-// early with credential metadata. On exhaustion it returns a partial result
-// with the last error.
-func iterateCredentialsInternal(
-	ctx context.Context,
-	credentials []resolvedRegistryCredential,
-	registryHost string,
-	fetchFunc func(ctx context.Context, cred *resolvedRegistryCredential) (string, error),
-	errorContext string,
-	errorDetail string,
-) (*containerregistry.DigestResult, error) {
-	var lastErr error
-	var lastCred resolvedRegistryCredential
-	for _, credential := range credentials {
-		lastCred = credential
-		digestValue, err := fetchFunc(ctx, &credential)
-		if err == nil {
-			return &containerregistry.DigestResult{
-				Digest:         digestValue,
-				AuthMethod:     "credential",
-				AuthUsername:   credential.Username,
-				AuthRegistry:   registryHost,
-				UsedCredential: true,
-			}, nil
-		}
-		lastErr = err
-		if !isUnauthorizedRegistryErrorInternal(err) {
-			return &containerregistry.DigestResult{
-				AuthMethod:     "credential",
-				AuthUsername:   credential.Username,
-				AuthRegistry:   registryHost,
-				UsedCredential: true,
-			}, errors.WrapIff(err, "%s failed for %s with credentials", errorContext, errorDetail)
-		}
-	}
-
-	partial := &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}
-	if lastCred.Username != "" {
-		partial.AuthMethod = "credential"
-		partial.AuthUsername = lastCred.Username
-		partial.UsedCredential = true
-	}
-	if lastErr == nil {
-		return partial, errors.Errorf("%s failed for %s: no credentials available", errorContext, errorDetail)
-	}
-	return partial, errors.WrapIff(lastErr, "%s failed for %s", errorContext, errorDetail)
-}
-
-// inspectImageDigestWithFallbackInternal tries stored credentials first, then
-// falls back to anonymous access. For non-DockerHub registries, non-auth errors
-// from the credentialed attempt are returned immediately so the outer retry loop
-// retries the credential attempt instead of burning the shared anonymous quota.
-func (s *ContainerRegistryService) inspectImageDigestWithFallbackInternal(
-	ctx context.Context,
-	registryHost string,
-	externalCreds []containerregistry.Credential,
-	fetchFunc func(ctx context.Context, credentials *resolvedRegistryCredential) (string, error),
-	errorContext string,
-	errorDetail string,
-) (*containerregistry.DigestResult, error) {
-	// Use stored credentials up front for any registry that has them. Anonymous
-	// requests share a per-registry quota with every other unauthenticated client,
-	// so an anonymous first attempt is rate limited for reasons unrelated to us.
-	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
-	if credErr == nil && len(credentials) > 0 {
-		result, err := iterateCredentialsInternal(ctx, credentials, registryHost, fetchFunc, errorContext, errorDetail)
-		if err == nil {
-			return result, nil
-		}
-		if isDockerHubRegistryInternal(registryHost) {
-			// Docker Hub anonymous quotas are too small to be worth a retry; elsewhere a
-			// stale credential must not break public images that resolve anonymously.
-			return result, err
-		}
-		if !isUnauthorizedRegistryErrorInternal(err) {
-			// Non-auth errors (e.g. rate limits) on non-DockerHub must not fall
-			// back to anonymous — the retry loop will retry the credential
-			// attempt instead of burning the shared anonymous quota.
-			return result, err
-		}
-		slog.DebugContext(ctx, "credentialed "+errorContext+" failed, retrying anonymously",
-			"registry", registryHost,
-			"error", err.Error())
-	}
-
-	result, err := fetchFunc(ctx, nil)
-	if err == nil {
-		return &containerregistry.DigestResult{Digest: result, AuthMethod: "anonymous", AuthRegistry: registryHost}, nil
-	}
-	err = errors.WrapIff(err, "%s failed for %s", errorContext, errorDetail)
-	if !isUnauthorizedRegistryErrorInternal(err) {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
-	}
-	if credErr != nil {
-		return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost},
-			errors.WrapIff(stderrors.Join(err, credErr), "%s: anonymous access unauthorized; credential lookup failed", errorContext)
-	}
-	return &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}, err
-}
+type digestFetchFunc func(ctx context.Context, credential *resolvedRegistryCredential) (string, error)
 
 func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx context.Context, normalizedRef, registryHost string, externalCreds []containerregistry.Credential) (*containerregistry.DigestResult, error) {
 	dockerClient, err := s.getDockerClientInternal(ctx)
@@ -1020,23 +921,58 @@ func (s *ContainerRegistryService) inspectImageDigestViaDaemonInternal(ctx conte
 		return nil, err
 	}
 
-	return s.inspectImageDigestWithFallbackInternal(ctx, registryHost, externalCreds,
-		func(ctx context.Context, cred *resolvedRegistryCredential) (string, error) {
-			return s.fetchDigestFromDaemonInternal(ctx, dockerClient, registryHost, normalizedRef, cred)
-		},
-		"distribution inspect",
-		normalizedRef,
-	)
+	return s.inspectImageDigestWithCredentialsInternal(ctx, registryHost, "distribution inspect of "+normalizedRef, externalCreds,
+		func(ctx context.Context, credential *resolvedRegistryCredential) (string, error) {
+			return s.fetchDigestFromDaemonInternal(ctx, dockerClient, registryHost, normalizedRef, credential)
+		})
 }
 
 func (s *ContainerRegistryService) inspectImageDigestViaRegistryInternal(ctx context.Context, registryHost, repository, tag string, externalCreds []containerregistry.Credential) (*containerregistry.DigestResult, error) {
-	return s.inspectImageDigestWithFallbackInternal(ctx, registryHost, externalCreds,
-		func(ctx context.Context, cred *resolvedRegistryCredential) (string, error) {
-			return s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, cred)
-		},
-		"registry manifest inspect",
-		registryHost+"/"+repository+":"+tag,
-	)
+	return s.inspectImageDigestWithCredentialsInternal(ctx, registryHost, "registry manifest inspect of "+registryHost+"/"+repository+":"+tag, externalCreds,
+		func(ctx context.Context, credential *resolvedRegistryCredential) (string, error) {
+			return s.fetchDigestFromRegistryInternal(ctx, registryHost, repository, tag, credential)
+		})
+}
+
+// Stored credentials go first: anonymous requests share a per-registry quota with every other unauthenticated client.
+func (s *ContainerRegistryService) inspectImageDigestWithCredentialsInternal(ctx context.Context, registryHost, operation string, externalCreds []containerregistry.Credential, fetch digestFetchFunc) (*containerregistry.DigestResult, error) {
+	credentials, credErr := s.getMatchingRegistryCredentialsInternal(ctx, registryHost, externalCreds)
+
+	var lastErr error
+	var lastResult *containerregistry.DigestResult
+	for _, credential := range credentials {
+		lastResult = &containerregistry.DigestResult{AuthMethod: "credential", AuthUsername: credential.Username, AuthRegistry: registryHost, UsedCredential: true}
+		digestValue, err := fetch(ctx, &credential)
+		if err == nil {
+			lastResult.Digest = digestValue
+			return lastResult, nil
+		}
+		lastErr = err
+		if !isUnauthorizedRegistryErrorInternal(err) {
+			return lastResult, errors.WrapIff(err, "%s failed with credentials", operation)
+		}
+	}
+	if lastErr != nil {
+		// Docker Hub anonymous quotas are too small to be worth a retry; elsewhere a stale credential must not break public images.
+		if isDockerHubRegistryInternal(registryHost) {
+			return lastResult, errors.WrapIff(lastErr, "%s failed", operation)
+		}
+		slog.DebugContext(ctx, "credentialed digest lookup failed, retrying anonymously",
+			"registry", registryHost,
+			"operation", operation,
+			"error", lastErr.Error())
+	}
+
+	result := &containerregistry.DigestResult{AuthMethod: "anonymous", AuthRegistry: registryHost}
+	digestValue, err := fetch(ctx, nil)
+	if err == nil {
+		result.Digest = digestValue
+		return result, nil
+	}
+	if credErr != nil && isUnauthorizedRegistryErrorInternal(err) {
+		return result, errors.WrapIff(stderrors.Join(err, credErr), "%s: anonymous access unauthorized; credential lookup failed", operation)
+	}
+	return result, errors.WrapIff(err, "%s failed", operation)
 }
 
 func (s *ContainerRegistryService) getDockerClientInternal(ctx context.Context) (RegistryDaemonClient, error) {

--- a/backend/internal/registry/service_test.go
+++ b/backend/internal/registry/service_test.go
@@ -939,9 +939,7 @@ func TestContainerRegistryService_InspectImageDigest_FallsBackToAnonymousWhenSto
 	assert.False(t, result.UsedCredential)
 }
 
-// A rate-limited credentialed attempt must not fall back to anonymous, because
-// the anonymous path shares the same per-registry quota and would just burn
-// another request against a quota that is already exhausted.
+// A rate-limited credential must not fall back to anonymous: both paths share the per-registry quota.
 func TestContainerRegistryService_InspectImageDigest_DoesNotFallBackToAnonymousOnCredentialRateLimit(t *testing.T) {
 	db := setupContainerRegistryTestDBInternal(t)
 	createTestPullRegistryInternal(t, db, "ghcr.io", "ghcr-user", "ghcr-token")
@@ -967,8 +965,7 @@ func TestContainerRegistryService_InspectImageDigest_DoesNotFallBackToAnonymousO
 	assert.True(t, result.UsedCredential)
 }
 
-// The direct-HTTP fallback must not burn an anonymous request (and its shared
-// per-registry quota) when a stored credential can resolve the digest.
+// The direct-HTTP fallback must not spend an anonymous request when a stored credential resolves the digest.
 func TestContainerRegistryService_InspectImageDigest_FallbackUsesStoredCredentialsBeforeAnonymous(t *testing.T) {
 	db := setupContainerRegistryTestDBInternal(t)
 	createTestPullRegistryInternal(t, db, "ghcr.io", "ghcr-user", "ghcr-token")
@@ -1156,8 +1153,7 @@ func TestContainerRegistryService_InspectImageDigest_RetriesStoredCredentialsAft
 	result, err := svc.InspectImageDigest(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
 	require.NoError(t, err)
 	assert.Equal(t, wantDigest, result.Digest)
-	// Stored credentials are tried up front; only after they are rejected does
-	// the lookup retry anonymously, which succeeds for a public image.
+	// Stored credentials go first; only after rejection does the lookup retry anonymously.
 	require.Len(t, authHeaders, 4)
 	assert.Equal(t, "Basic c3RvcmVkLXVzZXI6c3RvcmVkLXRva2Vu", authHeaders[0])
 	assert.Equal(t, "Bearer credential-token", authHeaders[1])

--- a/backend/internal/registry/service_test.go
+++ b/backend/internal/registry/service_test.go
@@ -2,7 +2,9 @@ package registry
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -937,6 +939,74 @@ func TestContainerRegistryService_InspectImageDigest_FallsBackToAnonymousWhenSto
 	assert.False(t, result.UsedCredential)
 }
 
+// A rate-limited credentialed attempt must not fall back to anonymous, because
+// the anonymous path shares the same per-registry quota and would just burn
+// another request against a quota that is already exhausted.
+func TestContainerRegistryService_InspectImageDigest_DoesNotFallBackToAnonymousOnCredentialRateLimit(t *testing.T) {
+	db := setupContainerRegistryTestDBInternal(t)
+	createTestPullRegistryInternal(t, db, "ghcr.io", "ghcr-user", "ghcr-token")
+
+	var anonymousCalls int
+	svc := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				if options.EncodedRegistryAuth == "" {
+					anonymousCalls++
+				}
+				return client.DistributionInspectResult{}, errors.New(
+					"Error response from daemon: toomanyrequests: retry-after: 1.246809ms, allowed: 44000/minute")
+			},
+		}, nil
+	}, nil)
+
+	result, err := svc.InspectImageDigest(context.Background(), "ghcr.io/getarcaneapp/agent:latest", nil)
+	require.Error(t, err)
+	assert.Zero(t, anonymousCalls, "must not burn anonymous quota when the credential itself is rate limited")
+	require.NotNil(t, result)
+	assert.Equal(t, "credential", result.AuthMethod)
+	assert.True(t, result.UsedCredential)
+}
+
+// The direct-HTTP fallback must not burn an anonymous request (and its shared
+// per-registry quota) when a stored credential can resolve the digest.
+func TestContainerRegistryService_InspectImageDigest_FallbackUsesStoredCredentialsBeforeAnonymous(t *testing.T) {
+	db := setupContainerRegistryTestDBInternal(t)
+	createTestPullRegistryInternal(t, db, "ghcr.io", "ghcr-user", "ghcr-token")
+	wantDigest := digest.FromString("fallback-stored-credentials").String()
+
+	var anonymousCalls int
+	svc := NewContainerRegistryService(db, func(context.Context) (RegistryDaemonClient, error) {
+		return &fakeRegistryDaemonClient{
+			distributionInspectFn: func(ctx context.Context, imageRef string, options client.DistributionInspectOptions) (client.DistributionInspectResult, error) {
+				return client.DistributionInspectResult{}, errors.New("Error response from daemon: Not Found")
+			},
+		}, nil
+	}, nil)
+	svc.distributionHTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			authorization := req.Header.Get("Authorization")
+			if authorization == "" {
+				anonymousCalls++
+				return nil, errors.New("unexpected anonymous registry request")
+			}
+			assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("ghcr-user:ghcr-token")), authorization)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Docker-Content-Digest": []string{wantDigest}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+	}
+
+	result, err := svc.InspectImageDigest(context.Background(), "ghcr.io/getarcaneapp/agent:latest", nil)
+	require.NoError(t, err)
+	assert.Zero(t, anonymousCalls)
+	assert.Equal(t, wantDigest, result.Digest)
+	assert.Equal(t, "credential", result.AuthMethod)
+	assert.Equal(t, "ghcr-user", result.AuthUsername)
+	assert.True(t, result.UsedCredential)
+}
+
 func TestContainerRegistryService_InspectImageDigest_FallsBackWhenDistributionNotFound(t *testing.T) {
 	wantDigest := digest.FromString("fallback-not-found").String()
 
@@ -1028,6 +1098,9 @@ func TestContainerRegistryService_InspectImageDigest_RetriesStoredCredentialsAft
 			case 2:
 				w.WriteHeader(http.StatusForbidden)
 			case 3:
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenURL+`",service="registry.example.com"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			case 4:
 				w.Header().Set("Docker-Content-Digest", wantDigest)
 				w.WriteHeader(http.StatusOK)
 			default:
@@ -1083,13 +1156,15 @@ func TestContainerRegistryService_InspectImageDigest_RetriesStoredCredentialsAft
 	result, err := svc.InspectImageDigest(context.Background(), serverURL.Host+"/team/app:1.2.3", nil)
 	require.NoError(t, err)
 	assert.Equal(t, wantDigest, result.Digest)
-	assert.Equal(t, "credential", result.AuthMethod)
-	assert.Equal(t, "stored-user", result.AuthUsername)
-	assert.True(t, result.UsedCredential)
-	require.Len(t, authHeaders, 3)
-	assert.Empty(t, authHeaders[0])
-	assert.Equal(t, "Bearer anonymous-token", authHeaders[1])
-	assert.Equal(t, "Basic c3RvcmVkLXVzZXI6c3RvcmVkLXRva2Vu", authHeaders[2])
+	// Stored credentials are tried up front; only after they are rejected does
+	// the lookup retry anonymously, which succeeds for a public image.
+	require.Len(t, authHeaders, 4)
+	assert.Equal(t, "Basic c3RvcmVkLXVzZXI6c3RvcmVkLXRva2Vu", authHeaders[0])
+	assert.Equal(t, "Bearer credential-token", authHeaders[1])
+	assert.Empty(t, authHeaders[2])
+	assert.Equal(t, "Bearer anonymous-token", authHeaders[3])
+	assert.Equal(t, "anonymous", result.AuthMethod)
+	assert.False(t, result.UsedCredential)
 }
 
 func TestContainerRegistryService_InspectImageDigest_DoesNotFallbackOnTLSFailure(t *testing.T) {


### PR DESCRIPTION
## Summary

#3639 made a change that made docker registry checks done through the docker daemon use credentials before falling back to anonymous checks, but didn't properly account for _non-auth_ errors from that credentialed check. It also left the direct-http fallback path alone and didn't attempt a similar fix for it to use credentials first.

## What This PR Implements

Alleviates intermittent `toomanyrequests` rate-limit failures during image update checks by ensuring stored registry credentials are always tried before falling back to anonymous, and by preventing the code from burning additional anonymous quota when a credentialed attempt hits a non-auth error (e.g. rate limit). It's still possible to hit this error when the image update / auto update jobs are set to run on-the-hour, but this PR fixes some issues making the problem worse.

Two issues making the failures worse:
1. **Direct-HTTP fallback was anonymous-first.** When the daemon's `DistributionInspect` returned a non-recoverable error (e.g. 404, distribution disabled), the fallback path made an anonymous HEAD request to the registry. If that anonymous request hit the shared per-registry quota, it returned immediately without ever consulting stored credentials.
2. **Daemon path fell back to anonymous on non-auth errors.** When the credentialed `DistributionInspect` returned a non-auth error like `toomanyrequests`, the code dropped the credentialed result and tried anonymously — burning the same shared quota rather than letting the outer retry loop retry the credentialed attempt.

## Changes Made

- **`backend/internal/registry/service.go`**:
  - Refactor the logic used by `inspectImageDigestViaDaemonInternal` and `inspectImageDigestViaRegistryInternal` so all logic is shared between them save for the method used to actually fetch a digest with a credential
  - Both methods (daemon and HTTP fallback via registry):
    - Tries stored credentials up front, before any anonymous request
    - On a non-auth error from the credentialed attempt (e.g. 429), returns the error to the caller so the outer `InspectImageDigest` retry loop retries the credentialed path with backoff, instead of falling through to anonymous
    - Falls back to anonymous only when the credentialed attempt is unauthorized (401/403) and the registry is not Docker Hub
    - Docker Hub behavior is preserved: always returns immediately without anonymous fallback

- **`backend/internal/registry/service_test.go`**:
  - Updated credentialed-first ordering assertions
  - Added `..._DoesNotFallBackToAnonymousOnCredentialRateLimit` — verifies the credentialed 429 path returns immediately and never makes an anonymous request
  - Added `..._FallbackUsesStoredCredentialsBeforeAnonymous` — verifies the direct-HTTP fallback never burns an anonymous request when a credential is available

## Testing Done

- New tests verify: credentialed-first ordering on both paths, credentialed 429 never falls back to anonymous
- I ran a build of the manager with this change in my personal homelab for a few days

## AI Tool Used (if applicable)

AI (various models via pi) was used to help me understand the codebase, find the issue(s), and to do the initial fixes. I reviewed all changes and hand edited a lot of it to clean it up and consolidate it.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consolidates daemon and direct-registry digest inspection behind shared credential iteration and fallback logic.
- Tries matching stored credentials before anonymous registry access.
- Returns credentialed rate-limit and other non-authentication errors for outer retry rather than spending anonymous quota.
- Adds coverage for credentialed rate limits and credential-first direct-HTTP fallback behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking request to restructure the new tests as table-driven subtests.

The shared credential-first implementation retains the intended retry and fallback behavior, and no concrete runtime defect remains beyond the maintainability issue in the newly added tests.

**Files Needing Attention:** backend/internal/registry/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix-rate-limit-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-rate-limit-retry%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233826%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3826&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix-rate-limit-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-rate-limit-retry%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fregistry%2Fservice_test.go%3A943%0A**Standalone%20credential%20fallback%20tests**%0A%0AThe%20new%20credential%20rate-limit%20test%20and%20the%20related%20direct-HTTP%20fallback%20test%20at%20line%20968%20duplicate%20closely%20related%20registry%20setup%20and%20assertions%20instead%20of%20using%20the%20repository-required%20table-driven%20subtests%2C%20making%20additional%20credential%20and%20fallback%20cases%20more%20costly%20to%20add%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fregistry%2Fservice_test.go%3A943%0A**Standalone%20credential%20fallback%20tests**%0A%0AThe%20new%20credential%20rate-limit%20test%20and%20the%20related%20direct-HTTP%20fallback%20test%20at%20line%20968%20duplicate%20closely%20related%20registry%20setup%20and%20assertions%20instead%20of%20using%20the%20repository-required%20table-driven%20subtests%2C%20making%20additional%20credential%20and%20fallback%20cases%20more%20costly%20to%20add%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fregistry%2Fservice_test.go%3A943%0A**Standalone%20credential%20fallback%20tests**%0A%0AThe%20new%20credential%20rate-limit%20test%20and%20the%20related%20direct-HTTP%20fallback%20test%20at%20line%20968%20duplicate%20closely%20related%20registry%20setup%20and%20assertions%20instead%20of%20using%20the%20repository-required%20table-driven%20subtests%2C%20making%20additional%20credential%20and%20fallback%20cases%20more%20costly%20to%20add%20and%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/registry/service_test.go:943
**Standalone credential fallback tests**

The new credential rate-limit test and the related direct-HTTP fallback test at line 968 duplicate closely related registry setup and assertions instead of using the repository-required table-driven subtests, making additional credential and fallback cases more costly to add and maintain.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: refactor image inspection logic"](https://github.com/getarcaneapp/arcane/commit/dbde5f7be699090440f5e6547cbe1ad0e30ac48c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59633366)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Images, registries, and image updates](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/image-and-registry-management.md)
- Knowledge Base — [Registry and image update workflows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/registry-and-image-update-workflows.md)
</details>


<!-- /greptile_comment -->