### PR TITLE
perf: bound scheduled scans, skip unchanged images, stop remounting on navigation

### DIFF
--- a/backend/internal/vulnerability/model.go
+++ b/backend/internal/vulnerability/model.go
@@ -49,6 +49,8 @@ type VulnerabilityScanRecord struct {
 	// scan time so image patching can query it without parsing the JSON blob.
 	// NULL on records written before the column existed.
 	FixableCount *int `json:"fixableCount,omitempty" gorm:"column:fixable_count" sortable:"true"`
+
+	ScanPolicy string `json:"-" gorm:"column:scan_policy"`
 }
 
 func (v *VulnerabilityScanRecord) TableName() string {

--- a/backend/internal/vulnerability/vulnerability_scan.go
+++ b/backend/internal/vulnerability/vulnerability_scan.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	activitytypes "github.com/getarcaneapp/arcane/types/v2/activity"
@@ -18,8 +20,8 @@ import (
 	"emperror.dev/errors"
 
 	imagetypes "github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/client"
 	"github.com/samber/mo"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/notification"
@@ -356,7 +358,20 @@ func (s *VulnerabilityService) completeVulnerabilityScanActivityInternal(ctx con
 	}
 }
 
+const scheduledScanMaxAge = 7 * 24 * time.Hour
+
+func (s *VulnerabilityService) scanPolicyInternal() string {
+	serverURL, _ := s.getTrivyServerConfig()
+	return fmt.Sprintf("ignoreUnfixed=%t;server=%s", s.getTrivyIgnoreUnfixed(), serverURL)
+}
+
+type scheduledScanTargetInternal struct {
+	imageID   string
+	imageName string
+}
+
 type scheduledScanNotificationSummary struct {
+	mu                sync.Mutex
 	totalFixable      int
 	imagesWithFixable int
 	severityCounts    map[string]int
@@ -397,20 +412,25 @@ func scheduledScanImageTargetInternal(img imagetypes.Summary) (imageID, imageNam
 
 func (s *VulnerabilityService) runScheduledImageScanInternal(
 	ctx context.Context,
-	containerID, imageName, imageID, scannerVersion string,
+	containerPool chan string,
+	imageName, imageID, scannerVersion string,
 ) (*vulnerability.ScanResult, int64, error) {
 	startTime := time.Now()
-	_, releaseSlot, slotErr := s.acquireTrivyScanSlotInternal(ctx)
+	slotID, releaseSlot, slotErr := s.acquireTrivyScanSlotInternal(ctx)
 	if slotErr != nil {
 		return nil, 0, slotErr
 	}
+	defer releaseSlot()
 
-	var result *vulnerability.ScanResult
-	var scanErr error
-	func() {
-		defer releaseSlot()
-		result, scanErr = s.execTrivyScanInContainer(ctx, containerID, imageName, imageID, scannerVersion)
-	}()
+	var containerID string
+	select {
+	case containerID = <-containerPool:
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	}
+	defer func() { containerPool <- containerID }()
+
+	result, scanErr := s.execTrivyScanInContainer(ctx, containerID, imageName, imageID, scannerVersion, slotID)
 
 	return result, time.Since(startTime).Milliseconds(), scanErr
 }
@@ -461,6 +481,8 @@ func (s *VulnerabilityService) collectScheduledFixableSummaryInternal(
 		return
 	}
 
+	summary.mu.Lock()
+	defer summary.mu.Unlock()
 	summary.imagesWithFixable++
 	for i := range fixableVulns {
 		v := fixableVulns[i]
@@ -516,45 +538,121 @@ func (s *VulnerabilityService) sendScheduledVulnerabilitySummaryInternal(
 // container is created and reused for every image via docker exec, which avoids
 // the overhead of creating/destroying a container per scan. The caller-supplied
 // user is recorded in the event log.
-func (s *VulnerabilityService) ScanAllImages(ctx context.Context, envID string, user common.User) (scanned, failed int, err error) {
-	dockerClient, err := s.dockerService.GetClient(ctx)
-	if err != nil {
-		return 0, 0, errors.WrapIf(err, "failed to connect to Docker")
-	}
-
-	imageList, err := dockerClient.ImageList(ctx, client.ImageListOptions{})
+func (s *VulnerabilityService) ScanAllImages(ctx context.Context, envID string, user common.User, force bool) (scanned, failed int, err error) {
+	images, err := s.dockerService.ListImages(ctx)
 	if err != nil {
 		return 0, 0, errors.WrapIf(err, "failed to list images")
 	}
-	images := imageList.Items
 
-	containerID, cleanup, err := s.setupTrivyBatchContainer(ctx)
+	targets := make([]scheduledScanTargetInternal, 0, len(images))
+	for _, img := range images {
+		imageID, imageName, shouldScan := scheduledScanImageTargetInternal(img)
+		if shouldScan {
+			targets = append(targets, scheduledScanTargetInternal{imageID: imageID, imageName: imageName})
+		}
+	}
+
+	scannerVersion := s.GetTrivyVersion(ctx)
+	if !force {
+		targets, err = s.skipRecentlyScannedTargetsInternal(ctx, targets, scannerVersion)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	if len(targets) == 0 {
+		return 0, 0, nil
+	}
+
+	concurrency := s.getTrivyConcurrentScanContainersInternal()
+	containerIDs, cleanup, err := s.setupTrivyBatchContainersInternal(ctx, concurrency)
 	if err != nil {
 		return 0, 0, err
 	}
 	defer cleanup()
 
-	scannerVersion := s.GetTrivyVersion(ctx)
+	containerPool := make(chan string, len(containerIDs))
+	for _, containerID := range containerIDs {
+		containerPool <- containerID
+	}
+
 	notificationSummary := newScheduledScanNotificationSummary()
+	var scannedCount, failedCount atomic.Int64
 
-	for _, img := range images {
-		if ctx.Err() != nil {
-			return scanned, failed, ctx.Err()
-		}
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+	for _, target := range targets {
+		g.Go(func() (workerErr error) {
+			defer utils.RecoverToError(&workerErr, "scheduled vulnerability scan worker", "imageId", target.imageID)
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			switch s.scanSingleImage(gctx, containerPool, target.imageID, target.imageName, scannerVersion, envID, user, notificationSummary) {
+			case scanStatusSuccess:
+				scannedCount.Add(1)
+			case scanStatusFailed:
+				failedCount.Add(1)
+			}
+			return nil
+		})
+	}
 
-		switch s.scanSingleImage(ctx, containerID, img, scannerVersion, envID, user, notificationSummary) {
-		case scanStatusSuccess:
-			scanned++
-		case scanStatusFailed:
-			failed++
-		case scanStatusSkipped:
-			// no-op
-		}
+	err = g.Wait()
+	scanned, failed = int(scannedCount.Load()), int(failedCount.Load())
+	if err != nil {
+		return scanned, failed, err
 	}
 
 	s.sendScheduledVulnerabilitySummaryInternal(ctx, scanned, notificationSummary)
 
 	return scanned, failed, nil
+}
+
+func (s *VulnerabilityService) skipRecentlyScannedTargetsInternal(ctx context.Context, targets []scheduledScanTargetInternal, scannerVersion string) ([]scheduledScanTargetInternal, error) {
+	if len(targets) == 0 {
+		return targets, nil
+	}
+
+	ids := make([]string, 0, len(targets))
+	for _, target := range targets {
+		ids = append(ids, target.imageID)
+	}
+
+	var records []VulnerabilityScanRecord
+	if err := s.db.WithContext(ctx).
+		Select("id", "image_name", "status", "scan_time", "scanner_version", "scan_policy").
+		Where("id IN ?", ids).
+		Find(&records).Error; err != nil {
+		return nil, errors.WrapIf(err, "failed to load existing scan records")
+	}
+
+	cutoff := time.Now().Add(-scheduledScanMaxAge)
+	policy := s.scanPolicyInternal()
+	recent := make(map[string]VulnerabilityScanRecord, len(records))
+	for _, record := range records {
+		if record.Status == string(vulnerability.ScanStatusCompleted) && record.ScannerVersion == scannerVersion && record.ScanPolicy == policy && record.ScanTime.After(cutoff) {
+			recent[record.ID] = record
+		}
+	}
+
+	remaining := make([]scheduledScanTargetInternal, 0, len(targets))
+	for _, target := range targets {
+		record, ok := recent[target.imageID]
+		if !ok {
+			remaining = append(remaining, target)
+			continue
+		}
+		if record.ImageName != target.imageName {
+			if err := s.db.WithContext(ctx).Model(&VulnerabilityScanRecord{}).Where("id = ?", target.imageID).Update("image_name", target.imageName).Error; err != nil {
+				slog.WarnContext(ctx, "failed to refresh scan record image name", "imageId", target.imageID, "error", err)
+			}
+		}
+	}
+
+	if skipped := len(targets) - len(remaining); skipped > 0 {
+		slog.InfoContext(ctx, "scheduled vulnerability scan: skipping recently scanned images", "skipped", skipped, "maxAge", scheduledScanMaxAge.String())
+	}
+
+	return remaining, nil
 }
 
 func (s *VulnerabilityService) fixedVulnerabilitiesForNotifications(

--- a/backend/internal/vulnerability/vulnerability_store.go
+++ b/backend/internal/vulnerability/vulnerability_store.go
@@ -410,6 +410,7 @@ func (s *VulnerabilityService) saveScanResult(ctx context.Context, result *vulne
 		Vulnerabilities: vulnJSON,
 		Error:           errPtr,
 		ScannerVersion:  result.ScannerVersion,
+		ScanPolicy:      s.scanPolicyInternal(),
 	}
 	fixable := 0
 	for i := range result.Vulnerabilities {

--- a/backend/internal/vulnerability/vulnerability_trivy.go
+++ b/backend/internal/vulnerability/vulnerability_trivy.go
@@ -15,7 +15,6 @@ import (
 	"emperror.dev/errors"
 
 	containertypes "github.com/moby/moby/api/types/container"
-	imagetypes "github.com/moby/moby/api/types/image"
 	mounttypes "github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
 	"github.com/samber/mo"
@@ -125,20 +124,19 @@ func (s *VulnerabilityService) buildTrivyRegistryConfigInternal(ctx context.Cont
 type scanResultStatus int
 
 const (
-	scanStatusSkipped scanResultStatus = iota
-	scanStatusSuccess
+	scanStatusSuccess scanResultStatus = iota
 	scanStatusFailed
 )
 
-func (s *VulnerabilityService) setupTrivyBatchContainer(ctx context.Context) (string, func(), error) {
+func (s *VulnerabilityService) setupTrivyBatchContainersInternal(ctx context.Context, count int) ([]string, func(), error) {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
-		return "", nil, errors.WrapIf(err, "failed to connect to Docker")
+		return nil, nil, errors.WrapIf(err, "failed to connect to Docker")
 	}
 
 	trivyImage, err := s.ensureTrivyImageInternal(ctx)
 	if err != nil {
-		return "", nil, errors.WrapIf(err, "trivy scanner not available")
+		return nil, nil, errors.WrapIf(err, "trivy scanner not available")
 	}
 
 	serverURL, _ := s.getTrivyServerConfig()
@@ -146,38 +144,39 @@ func (s *VulnerabilityService) setupTrivyBatchContainer(ctx context.Context) (st
 	if serverURL == "" {
 		cacheVolume, err = s.ensureTrivyCacheVolumeInternal(ctx)
 		if err != nil {
-			return "", nil, errors.WrapIf(err, "failed to ensure trivy cache volume")
+			return nil, nil, errors.WrapIf(err, "failed to ensure trivy cache volume")
 		}
 	}
 
-	containerID, err := s.createBatchTrivyContainer(ctx, trivyImage, cacheVolume)
-	if err != nil {
-		return "", nil, errors.WrapIf(err, "failed to create batch trivy container")
-	}
-
+	containerIDs := make([]string, 0, max(count, 1))
 	cleanup := func() {
-		vuln.RemoveContainer(ctx, dockerClient, containerID, "failed to remove batch trivy container")
+		for _, containerID := range containerIDs {
+			vuln.RemoveContainer(ctx, dockerClient, containerID, "failed to remove batch trivy container")
+		}
 	}
 
-	return containerID, cleanup, nil
+	for range max(count, 1) {
+		containerID, createErr := s.createBatchTrivyContainer(ctx, trivyImage, cacheVolume)
+		if createErr != nil {
+			cleanup()
+			return nil, nil, errors.WrapIf(createErr, "failed to create batch trivy container")
+		}
+		containerIDs = append(containerIDs, containerID)
+	}
+
+	return containerIDs, cleanup, nil
 }
 
 func (s *VulnerabilityService) scanSingleImage(
 	ctx context.Context,
-	containerID string,
-	img imagetypes.Summary,
-	scannerVersion, envID string,
+	containerPool chan string,
+	imageID, imageName, scannerVersion, envID string,
 	user common.User,
 	notificationSummary *scheduledScanNotificationSummary,
 ) scanResultStatus {
-	imageID, imageName, shouldScan := scheduledScanImageTargetInternal(img)
-	if !shouldScan {
-		return scanStatusSkipped
-	}
-
 	slog.InfoContext(ctx, "scheduled vulnerability scan: scanning image", "image", imageName, "imageId", imageID)
 
-	result, duration, scanErr := s.runScheduledImageScanInternal(ctx, containerID, imageName, imageID, scannerVersion)
+	result, duration, scanErr := s.runScheduledImageScanInternal(ctx, containerPool, imageName, imageID, scannerVersion)
 	if scanErr != nil {
 		s.saveScheduledFailedScanInternal(ctx, envID, imageID, imageName, user, duration, scanErr)
 		return scanStatusFailed
@@ -238,7 +237,7 @@ func (s *VulnerabilityService) createBatchTrivyContainer(ctx context.Context, tr
 
 // execTrivyScanInContainer runs a trivy scan for a single image inside an
 // already-running container via docker exec.
-func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, containerID, imageName, imageID, scannerVersion string) (*vulnerability.ScanResult, error) {
+func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, containerID, imageName, imageID, scannerVersion string, slotID int) (*vulnerability.ScanResult, error) {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to connect to Docker")
@@ -264,6 +263,9 @@ func (s *VulnerabilityService) execTrivyScanInContainer(ctx context.Context, con
 	execCmd := make([]string, 0, 16)
 	execCmd = append(execCmd, "trivy", "image", "--format", "json", "--quiet", "--output", outputPath, "--timeout", trivyTimeout)
 	execCmd = append(execCmd, vuln.ScanSourceArgs(serverURL)...)
+	if serverURL == "" {
+		execCmd = append(execCmd, "--cache-dir", s.getTrivySingleScanCacheDirForSlotInternal(slotID))
+	}
 	execCmd = append(execCmd, vuln.IgnoreUnfixedArgs(s.getTrivyIgnoreUnfixed())...)
 	execCmd = append(execCmd, imageName)
 

--- a/backend/pkg/scheduler/vulnerability_scan_job.go
+++ b/backend/pkg/scheduler/vulnerability_scan_job.go
@@ -76,7 +76,7 @@ func (j *VulnerabilityScanJob) Run(ctx context.Context) {
 		slog.InfoContext(ctx, "cleaned up orphaned vulnerability scan records", "deleted", deleted)
 	}
 
-	scanned, failed, err := j.vulnerabilityService.ScanAllImages(ctx, types.LocalDockerEnvironmentID, vulnerabilityScanSystemUser)
+	scanned, failed, err := j.vulnerabilityService.ScanAllImages(ctx, types.LocalDockerEnvironmentID, vulnerabilityScanSystemUser, false)
 	if err != nil {
 		slog.ErrorContext(ctx, "scheduled vulnerability scan failed", "error", err)
 		return

--- a/backend/resources/migrations/postgres/079_add_vulnerability_scan_policy.sql
+++ b/backend/resources/migrations/postgres/079_add_vulnerability_scan_policy.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE vulnerability_scans ADD COLUMN scan_policy TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE vulnerability_scans DROP COLUMN scan_policy;

--- a/backend/resources/migrations/sqlite/079_add_vulnerability_scan_policy.sql
+++ b/backend/resources/migrations/sqlite/079_add_vulnerability_scan_policy.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE vulnerability_scans ADD COLUMN scan_policy TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE vulnerability_scans DROP COLUMN scan_policy;

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -125,7 +125,7 @@
 					)
 				: 'h-full p-3 sm:p-5'}
 		>
-			{#key page.url.pathname}
+			{#key user?.id}
 				{@render children()}
 			{/key}
 		</section>

--- a/frontend/src/routes/(app)/containers/+page.svelte
+++ b/frontend/src/routes/(app)/containers/+page.svelte
@@ -20,9 +20,9 @@
 
 	let { data } = $props();
 
-	let requestOptions = $state(untrack(() => data.containerRequestOptions));
+	let requestOptions = $derived(data.containerRequestOptions);
 	let selectedIds = $state<string[]>([]);
-	let containers = $state(untrack(() => data.containers));
+	let containers = $derived(data.containers);
 	const envId = $derived(environmentStore.selected?.id || '0');
 	let displayedEnvId = $state<string | null>(untrack(() => (data.envId === envId ? data.envId : null)));
 	let isRefreshing = $state(false);

--- a/frontend/src/routes/(app)/customize/git-repositories/+page.svelte
+++ b/frontend/src/routes/(app)/customize/git-repositories/+page.svelte
@@ -7,17 +7,16 @@
 	import { tryCatch } from '#lib/utils/api';
 	import { m } from '#lib/paraglide/messages';
 	import { gitRepositoryService } from '#lib/services/git-repository-service';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton } from '#lib/layouts/index.js';
 	import { hasPermission } from '#lib/utils/auth';
 
 	let { data } = $props();
 
-	let repositories = $state(untrack(() => data.repositories));
+	let repositories = $derived(data.repositories);
 	let selectedIds = $state<string[]>([]);
 	let isRepositoryDialogOpen = $state(false);
 	let repositoryToEdit = $state<GitRepository | null>(null);
-	let requestOptions = $state(untrack(() => data.repositoryRequestOptions));
+	let requestOptions = $derived(data.repositoryRequestOptions);
 
 	let isLoading = $state({
 		create: false,

--- a/frontend/src/routes/(app)/customize/registries/+page.svelte
+++ b/frontend/src/routes/(app)/customize/registries/+page.svelte
@@ -10,19 +10,18 @@
 	import { m } from '#lib/paraglide/messages';
 	import { containerRegistryService } from '#lib/services/container-registry-service';
 	import { queryKeys } from '#lib/query/query-keys';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton } from '#lib/layouts/index.js';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { hasPermission } from '#lib/utils/auth';
 
 	let { data } = $props();
 
-	let registries = $state(untrack(() => data.registries));
+	let registries = $derived(data.registries);
 	let selectedIds = $state<string[]>([]);
 	let isRegistryDialogOpen = $state(false);
 	let isInfoDialogOpen = $state(false);
 	let registryToEdit = $state<ContainerRegistry | null>(null);
-	let requestOptions = $state(untrack(() => data.registryRequestOptions));
+	let requestOptions = $derived(data.registryRequestOptions);
 	const pullUsageQuery = createQuery(() => ({
 		queryKey: queryKeys.containerRegistries.pullUsage(),
 		queryFn: () => containerRegistryService.getPullUsage(),

--- a/frontend/src/routes/(app)/customize/templates/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/+page.svelte
@@ -10,7 +10,6 @@
 	import TemplateGallery from './components/template-gallery.svelte';
 	import RegistryManager from './components/RegistryManager.svelte';
 	import type { TemplateRegistry } from '#lib/types/swarm';
-	import { untrack } from 'svelte';
 	import type { SearchPaginationSortRequest } from '#lib/types/shared';
 	import { RegistryIcon, TemplateIcon, FolderOpenIcon } from '#lib/icons';
 	import { hasPermission } from '#lib/utils/auth';
@@ -18,9 +17,9 @@
 
 	let { data } = $props();
 
-	let templates = $state(untrack(() => data.templates));
-	let registries = $state<TemplateRegistry[]>(untrack(() => data.registries));
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.templateRequestOptions));
+	let templates = $derived(data.templates);
+	let registries = $derived<TemplateRegistry[]>(data.registries);
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.templateRequestOptions);
 	const tabItems: TabItem[] = [
 		{
 			value: 'browse',

--- a/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/customize/templates/[id]/+page.svelte
@@ -11,7 +11,6 @@
 	import { m } from '#lib/paraglide/messages.js';
 	import { templateService } from '#lib/services/template-service';
 	import { openConfirmDialog } from '#lib/components/confirm-dialog';
-	import { untrack } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { createForm } from '#lib/utils/settings';
 	import { formatDateTimeShort } from '#lib/utils/formatting';
@@ -58,10 +57,10 @@
 	// Form schema for custom template editing
 	const formSchema = createNamedTemplateSchema();
 
-	let originalName = $state(untrack(() => template.name));
-	let originalDescription = $state(untrack(() => template.description ?? ''));
-	let originalCompose = $state(untrack(() => data.templateData.content));
-	let originalEnv = $state(untrack(() => data.templateData.envContent));
+	let originalName = $derived(template.name);
+	let originalDescription = $derived(template.description ?? '');
+	let originalCompose = $derived(data.templateData.content);
+	let originalEnv = $derived(data.templateData.envContent);
 
 	let formData = $derived({
 		name: originalName,

--- a/frontend/src/routes/(app)/customize/variables/+page.svelte
+++ b/frontend/src/routes/(app)/customize/variables/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton } from '#lib/layouts/index.js';
 	import { openConfirmDialog } from '#lib/components/confirm-dialog';
 	import VariableFormSheet from '#lib/components/sheets/variable-form-sheet.svelte';
@@ -22,7 +21,7 @@
 
 	let { data } = $props();
 
-	let variables = $state(untrack(() => data.variables));
+	let variables = $derived(data.variables);
 	let isSheetOpen = $state(false);
 	let variableToEdit = $state<GlobalVariable | null>(null);
 	let isSubmitting = $state(false);

--- a/frontend/src/routes/(app)/environments/+page.svelte
+++ b/frontend/src/routes/(app)/environments/+page.svelte
@@ -6,7 +6,6 @@
 	import EnvironmentTable from './environment-table.svelte';
 	import { m } from '#lib/paraglide/messages';
 	import { environmentManagementService } from '#lib/services/env-mgmt-service';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton } from '#lib/layouts/index.js';
 	import { environmentStore } from '#lib/stores/environment.store.svelte';
 	import { simpleRefresh } from '#lib/utils/api';
@@ -17,9 +16,9 @@
 
 	let { data } = $props();
 
-	let environments = $state(untrack(() => data.environments));
+	let environments = $derived(data.environments);
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state(untrack(() => data.environmentRequestOptions));
+	let requestOptions = $derived(data.environmentRequestOptions);
 	let showEnvironmentSheet = $state(false);
 	let showUpdateAllDialog = $state(false);
 	let isLoading = $state({ refresh: false, creating: false, deleting: false });

--- a/frontend/src/routes/(app)/environments/[id]/gitops/+page.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/+page.svelte
@@ -12,7 +12,6 @@
 	import { extractApiErrorMessage, handleApiResultWithCallbacks, tryCatch } from '#lib/utils/api';
 	import { m } from '#lib/paraglide/messages';
 	import { gitOpsSyncService } from '#lib/services/gitops-sync-service';
-	import { untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '#lib/layouts/index.js';
@@ -21,12 +20,12 @@
 
 	let { data } = $props();
 
-	let syncs = $state(untrack(() => data.syncs));
+	let syncs = $derived(data.syncs);
 	let selectedIds = $state<string[]>([]);
 	let isSyncDialogOpen = $state(false);
 	let isImportDialogOpen = $state(false);
 	let syncToEdit = $state<GitOpsSync | null>(null);
-	let syncRequestOptions = $state(untrack(() => data.syncRequestOptions));
+	let syncRequestOptions = $derived(data.syncRequestOptions);
 	let environmentId = $derived(data.environmentId);
 
 	let isLoading = $state({

--- a/frontend/src/routes/(app)/events/+page.svelte
+++ b/frontend/src/routes/(app)/events/+page.svelte
@@ -3,7 +3,6 @@
 	import { m } from '#lib/paraglide/messages';
 	import { eventService } from '#lib/services/event-service';
 	import { queryKeys } from '#lib/query/query-keys';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type ActionButton, type StatCardConfig } from '#lib/layouts/index.js';
 	import { createQuery, keepPreviousData } from '@tanstack/svelte-query';
 	import { AlertIcon, CheckIcon, CloseIcon, EventsIcon, InfoIcon } from '#lib/icons';
@@ -12,9 +11,9 @@
 
 	let { data } = $props();
 
-	let events = $state(untrack(() => data.events));
+	let events = $derived(data.events);
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state(untrack(() => data.eventRequestOptions));
+	let requestOptions = $derived(data.eventRequestOptions);
 	let isDeleting = $state(false);
 
 	const eventsQuery = createQuery(() => ({

--- a/frontend/src/routes/(app)/images/+page.svelte
+++ b/frontend/src/routes/(app)/images/+page.svelte
@@ -27,8 +27,8 @@
 	let { data } = $props();
 	const queryClient = useQueryClient();
 
-	let images = $state(untrack(() => data.images));
-	let requestOptions = $state(untrack(() => data.imageRequestOptions));
+	let images = $derived(data.images);
+	let requestOptions = $derived(data.imageRequestOptions);
 	let selectedIds = $state<string[]>([]);
 	let isPullDialogOpen = $state(false);
 	let isRegistrySearchDialogOpen = $state(false);

--- a/frontend/src/routes/(app)/networks/ports/+page.svelte
+++ b/frontend/src/routes/(app)/networks/ports/+page.svelte
@@ -10,7 +10,7 @@
 
 	let { data } = $props();
 
-	let requestOptions = $state(untrack(() => data.portRequestOptions));
+	let requestOptions = $derived(data.portRequestOptions);
 	let selectedIds = $state<string[]>([]);
 
 	const envId = $derived(environmentStore.selected?.id || '0');

--- a/frontend/src/routes/(app)/security/+page.svelte
+++ b/frontend/src/routes/(app)/security/+page.svelte
@@ -7,7 +7,7 @@
 	import { useEnvironmentRefresh } from '#lib/hooks/use-environment-refresh.svelte';
 	import type { EnvironmentVulnerabilitySummary, VulnerabilityWithImage } from '#lib/types/environment';
 	import type { Paginated, SearchPaginationSortRequest } from '#lib/types/shared';
-	import { onMount, untrack } from 'svelte';
+	import { onMount } from 'svelte';
 	import SecurityVulnerabilityTable from './security-vulnerability-table.svelte';
 	import SecurityPatchTable from './security-patch-table.svelte';
 	import type { ImagePatchTargetDto } from '#lib/types/docker';
@@ -23,11 +23,11 @@
 
 	let { data } = $props();
 
-	let summary = $state<EnvironmentVulnerabilitySummary>(untrack(() => data.summary));
+	let summary = $derived<EnvironmentVulnerabilitySummary>(data.summary);
 	type VulnerabilityRow = VulnerabilityWithImage & { id: string };
 
-	let vulnerabilities = $state<Paginated<VulnerabilityRow>>(untrack(() => data.vulnerabilities));
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.vulnerabilityRequestOptions));
+	let vulnerabilities = $derived<Paginated<VulnerabilityRow>>(data.vulnerabilities);
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.vulnerabilityRequestOptions);
 	let showIgnored = $state(false);
 
 	function withIgnoredFilter(options: SearchPaginationSortRequest, show: boolean): SearchPaginationSortRequest {
@@ -68,7 +68,7 @@
 		data: [],
 		pagination: { totalPages: 0, totalItems: 0, currentPage: 1, itemsPerPage: 20 }
 	});
-	let patchRequestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.patchRequestOptions));
+	let patchRequestOptions = $derived<SearchPaginationSortRequest>(data.patchRequestOptions);
 	async function loadPatches() {
 		try {
 			const response = await imageService.listPatchTargets(patchRequestOptions);

--- a/frontend/src/routes/(app)/settings/api-keys/+page.svelte
+++ b/frontend/src/routes/(app)/settings/api-keys/+page.svelte
@@ -12,14 +12,13 @@
 	import { ArcaneButton } from '#lib/components/arcane-button/index.js';
 	import { Snippet } from '#lib/components/ui/snippet/index.js';
 	import * as m from '#lib/paraglide/messages.js';
-	import { untrack } from 'svelte';
 	import { ApiKeyIcon } from '#lib/icons';
 
 	let { data } = $props();
 
-	let apiKeys = $state(untrack(() => data.apiKeys));
+	let apiKeys = $derived(data.apiKeys);
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.apiKeyRequestOptions));
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.apiKeyRequestOptions);
 
 	let isDialogOpen = $state({
 		create: false,

--- a/frontend/src/routes/(app)/settings/authentication/+page.svelte
+++ b/frontend/src/routes/(app)/settings/authentication/+page.svelte
@@ -28,7 +28,6 @@
 	import { oidcMappingService } from '#lib/services/oidc-mapping-service';
 	import { handleApiResultWithCallbacks } from '#lib/utils/api';
 	import { tryCatch } from '#lib/utils/api';
-	import { untrack } from 'svelte';
 	import IfPermitted from '#lib/components/if-permitted.svelte';
 	import { mergeProps } from 'bits-ui';
 	import { useUrlTab } from '#lib/hooks/use-url-tab.svelte';
@@ -65,7 +64,7 @@
 
 	// OIDC role mappings — co-located with the OIDC settings so admins
 	// configure the groups claim and the mappings that read it in one place.
-	let oidcMappings: OidcRoleMapping[] = $state(untrack(() => data.oidcMappings ?? []));
+	let oidcMappings: OidcRoleMapping[] = $derived(data.oidcMappings ?? []);
 	let mappingSheetOpen = $state(false);
 	let editingMapping: OidcRoleMapping | null = $state(null);
 	let mappingSaving = $state(false);

--- a/frontend/src/routes/(app)/settings/backups/+page.svelte
+++ b/frontend/src/routes/(app)/settings/backups/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
 	import settingsStore from '#lib/stores/config-store';
@@ -37,11 +36,11 @@
 
 	let { data } = $props();
 	const queryClient = useQueryClient();
-	let backups = $state(untrack(() => data.backups));
-	let policyCollection = $state(untrack(() => data.policyCollection));
-	let systemVolumePolicyCollection = $state(untrack(() => data.systemVolumePolicyCollection));
+	let backups = $derived(data.backups);
+	let policyCollection = $derived(data.policyCollection);
+	let systemVolumePolicyCollection = $derived(data.systemVolumePolicyCollection);
 	let systemVolumeOptions = $state<SystemVolumeBackupOption[]>([]);
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.requestOptions));
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.requestOptions);
 	let scheduleOpen = $state(false);
 	let scheduleType = $state<'system' | 'volume'>('system');
 	let editingScheduleId = $state<string | undefined>();

--- a/frontend/src/routes/(app)/settings/backups/s3/+page.svelte
+++ b/frontend/src/routes/(app)/settings/backups/s3/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import settingsStore from '#lib/stores/config-store';
 	import { SettingsPageLayout, type SettingsActionButton } from '#lib/layouts';
@@ -13,8 +12,8 @@
 	import S3DestinationTable from './s3-destination-table.svelte';
 
 	let { data } = $props();
-	let destinations = $state(untrack(() => data.destinations));
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.requestOptions));
+	let destinations = $derived(data.destinations);
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.requestOptions);
 	let selected = $state<S3Destination | null>(null);
 	let dialogOpen = $state(false);
 	let saving = $state(false);

--- a/frontend/src/routes/(app)/settings/roles/+page.svelte
+++ b/frontend/src/routes/(app)/settings/roles/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { ShieldAlertIcon } from '#lib/icons';
 	import { goto } from '$app/navigation';
-	import { untrack } from 'svelte';
 	import RolesTable from './roles-table.svelte';
 	import type { SearchPaginationSortRequest } from '#lib/types/shared';
 	import { m } from '#lib/paraglide/messages';
@@ -13,9 +12,9 @@
 
 	const isAdmin = $derived(userStore.isGlobalAdmin());
 
-	let roles = $state(untrack(() => data.roles));
+	let roles = $derived(data.roles);
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.rolesRequestOptions));
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.rolesRequestOptions);
 
 	async function refreshRoles() {
 		roles = await roleService.getRoles(requestOptions);

--- a/frontend/src/routes/(app)/settings/users/+page.svelte
+++ b/frontend/src/routes/(app)/settings/users/+page.svelte
@@ -15,7 +15,6 @@
 	import { settingsService } from '#lib/services/settings-service';
 	import userStore from '#lib/stores/user-store';
 	import settingsStore from '#lib/stores/config-store';
-	import { untrack } from 'svelte';
 	import { SettingsPageLayout, type SettingsActionButton } from '#lib/layouts/index.js';
 	import SettingsRow from '#lib/components/settings/settings-row.svelte';
 	import { Switch } from '#lib/components/ui/switch/index.js';
@@ -23,9 +22,9 @@
 
 	let { data } = $props();
 
-	let users = $state(untrack(() => data.users));
+	let users = $derived(data.users);
 	let selectedIds = $state<string[]>([]);
-	let requestOptions = $state<SearchPaginationSortRequest>(untrack(() => data.userRequestOptions));
+	let requestOptions = $derived<SearchPaginationSortRequest>(data.userRequestOptions);
 
 	let isDialogOpen = $state({
 		create: false,

--- a/frontend/src/routes/(app)/settings/webhooks/+page.svelte
+++ b/frontend/src/routes/(app)/settings/webhooks/+page.svelte
@@ -10,13 +10,12 @@
 	import * as ResponsiveDialog from '#lib/components/ui/responsive-dialog/index.js';
 	import { ArcaneButton } from '#lib/components/arcane-button/index.js';
 	import { Snippet } from '#lib/components/ui/snippet/index.js';
-	import { untrack } from 'svelte';
 	import { GlobeIcon } from '#lib/icons';
 	import * as m from '#lib/paraglide/messages.js';
 
 	let { data } = $props();
 
-	let webhooks = $state<Webhook[]>(untrack(() => data.webhooks));
+	let webhooks = $derived<Webhook[]>(data.webhooks);
 
 	let isDialogOpen = $state({
 		create: false,

--- a/frontend/src/routes/(app)/swarm/nodes/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/nodes/+page.svelte
@@ -3,7 +3,6 @@
 	import { AlertTriangleIcon, UsersIcon } from '#lib/icons';
 	import { m } from '#lib/paraglide/messages';
 	import { swarmService } from '#lib/services/swarm-service';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type StatCardConfig } from '#lib/layouts/index.js';
 	import { useEnvironmentRefresh } from '#lib/hooks/use-environment-refresh.svelte';
 	import { simpleRefresh } from '#lib/utils/api';
@@ -14,8 +13,8 @@
 
 	let { data } = $props();
 
-	let nodes = $state(untrack(() => data.nodes));
-	let requestOptions = $state(untrack(() => data.requestOptions));
+	let nodes = $derived(data.nodes);
+	let requestOptions = $derived(data.requestOptions);
 	let isLoading = $state({ refresh: false });
 	let reconciledEnvironmentId = $state<string | null>(null);
 	const currentEnvironmentId = $derived(environmentStore.selected?.id ?? null);

--- a/frontend/src/routes/(app)/swarm/services/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/services/+page.svelte
@@ -3,7 +3,6 @@
 	import { m } from '#lib/paraglide/messages';
 	import { swarmService } from '#lib/services/swarm-service';
 	import { toast } from 'svelte-sonner';
-	import { untrack } from 'svelte';
 	import { tryCatch } from '#lib/utils/api';
 	import { handleApiResultWithCallbacks } from '#lib/utils/api';
 	import { ResourcePageLayout, type StatCardConfig } from '#lib/layouts/index.js';
@@ -18,8 +17,8 @@
 
 	let { data } = $props();
 
-	let services = $state(untrack(() => data.services));
-	let requestOptions = $state(untrack(() => data.requestOptions));
+	let services = $derived(data.services);
+	let requestOptions = $derived(data.requestOptions);
 	let isLoading = $state({ refresh: false, creating: false });
 	let showCreateDialog = $state(false);
 

--- a/frontend/src/routes/(app)/swarm/stacks/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/stacks/+page.svelte
@@ -2,7 +2,6 @@
 	import { LayersIcon } from '#lib/icons';
 	import { m } from '#lib/paraglide/messages';
 	import { swarmService } from '#lib/services/swarm-service';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type StatCardConfig } from '#lib/layouts/index.js';
 	import { useEnvironmentRefresh } from '#lib/hooks/use-environment-refresh.svelte';
 	import { simpleRefresh } from '#lib/utils/api';
@@ -14,8 +13,8 @@
 
 	let { data } = $props();
 
-	let stacks = $state(untrack(() => data.stacks));
-	let requestOptions = $state(untrack(() => data.requestOptions));
+	let stacks = $derived(data.stacks);
+	let requestOptions = $derived(data.requestOptions);
 	let isLoading = $state({ refresh: false });
 
 	async function refresh() {

--- a/frontend/src/routes/(app)/swarm/stacks/[name]/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/stacks/[name]/+page.svelte
@@ -15,7 +15,6 @@
 	import { handleApiResultWithCallbacks } from '#lib/utils/api';
 	import { tryCatch } from '#lib/utils/api';
 	import { onMount } from 'svelte';
-	import { untrack } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { openConfirmDialog } from '#lib/components/confirm-dialog';
 	import SwarmServicesTable from '../../services/services-table.svelte';
@@ -27,11 +26,13 @@
 
 	let { data } = $props();
 
-	let stack = $state(untrack(() => data.stack));
-	let services = $state(untrack(() => data.services));
-	let tasks = $state(untrack(() => data.tasks));
-	let source = $state<SwarmStackSource | null>(untrack(() => data.source));
-	let sourceState = $state<'loading' | 'available' | 'missing' | 'forbidden' | 'error'>(untrack(() => data.sourceState));
+	let stack = $derived(data.stack);
+	let services = $derived(data.services);
+	let tasks = $derived(data.tasks);
+	let source = $derived<SwarmStackSource | null>(data.source);
+	let sourceState = $derived<'loading' | 'available' | 'missing' | 'forbidden' | 'error'>(data.sourceState);
+	let servicesRequestOptions = $derived(data.servicesRequestOptions);
+	let tasksRequestOptions = $derived(data.tasksRequestOptions);
 
 	let selectedSourceFile = $state('compose');
 	let openSourceTabs = $state<string[]>(['compose']);
@@ -69,8 +70,6 @@
 			selectedSourceFile = remaining[Math.min(Math.max(index - 1, 0), remaining.length - 1)] ?? 'compose';
 		}
 	}
-	let servicesRequestOptions = $state(untrack(() => data.servicesRequestOptions));
-	let tasksRequestOptions = $state(untrack(() => data.tasksRequestOptions));
 	type StackTab = 'services' | 'tasks' | 'source';
 	let isLoading = $state({ refresh: false, remove: false });
 

--- a/frontend/src/routes/(app)/swarm/tasks/+page.svelte
+++ b/frontend/src/routes/(app)/swarm/tasks/+page.svelte
@@ -2,7 +2,6 @@
 	import { JobsIcon } from '#lib/icons';
 	import { m } from '#lib/paraglide/messages';
 	import { swarmService } from '#lib/services/swarm-service';
-	import { untrack } from 'svelte';
 	import { ResourcePageLayout, type StatCardConfig } from '#lib/layouts/index.js';
 	import { useEnvironmentRefresh } from '#lib/hooks/use-environment-refresh.svelte';
 	import { simpleRefresh } from '#lib/utils/api';
@@ -11,9 +10,9 @@
 
 	let { data } = $props();
 
-	let tasks = $state(untrack(() => data.tasks));
-	let requestOptions = $state(untrack(() => data.requestOptions));
-	let nodeId = $state(untrack(() => data.nodeId ?? ''));
+	let tasks = $derived(data.tasks);
+	let requestOptions = $derived(data.requestOptions);
+	let nodeId = $derived(data.nodeId ?? '');
 	let isLoading = $state({ refresh: false });
 
 	async function fetchTasks(options: typeof requestOptions) {

--- a/frontend/src/routes/(app)/updates/+page.svelte
+++ b/frontend/src/routes/(app)/updates/+page.svelte
@@ -59,8 +59,8 @@
 
 	let containerSnapshot = $state<{ envId: string; value: ContainersPaginatedResponse } | null>(null);
 	let projectSnapshot = $state<{ envId: string; value: Paginated<Project> } | null>(null);
-	let containerRequestOptions = $state(untrack(() => data.containerRequestOptions as ContainerListRequestOptions));
-	let projectRequestOptions = $state(untrack(() => data.projectRequestOptions as SearchPaginationSortRequest));
+	let containerRequestOptions = $derived(data.containerRequestOptions as ContainerListRequestOptions);
+	let projectRequestOptions = $derived(data.projectRequestOptions as SearchPaginationSortRequest);
 	const envId = $derived(environmentStore.selected?.id || '0');
 
 	const containersQuery = createQuery(() => ({

--- a/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
+++ b/frontend/src/routes/(app)/volumes/[volumeName]/+page.svelte
@@ -22,7 +22,6 @@
 	import { handleApiResultWithCallbacks } from '#lib/utils/api';
 	import { ArcaneButton } from '#lib/components/arcane-button/index.js';
 	import { m } from '#lib/paraglide/messages';
-	import { untrack } from 'svelte';
 	import { volumeService } from '#lib/services/volume-service.js';
 	import { volumeWorkspaceService } from '#lib/services/volume-workspace-service';
 	import { type DetailAction } from '#lib/layouts';
@@ -70,8 +69,8 @@
 	import { volumeWorkspaceReadOnlyMessage } from '../components/volume-workspace-utils';
 
 	let { data } = $props();
-	let volume = $state(untrack(() => data.volume));
-	let containersDetailed = $state<{ id: string; name: string }[]>(untrack(() => data.containersDetailed ?? []));
+	let volume = $derived(data.volume);
+	let containersDetailed = $derived<{ id: string; name: string }[]>(data.containersDetailed ?? []);
 
 	const backupVolumeName = $derived.by(() => $settingsStore?.backupVolumeName || 'arcane-backups');
 	const isBackupVolume = $derived(volume?.name === backupVolumeName);


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->








<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR bounds scheduled vulnerability scans with a worker and container pool, skips recent scans only when scanner inputs match, and preserves Svelte route components across navigation.
- Adds persisted vulnerability scan-policy metadata and seven-day freshness checks.
- Allocates one reusable Trivy container per configured scheduled-scan worker.
- Replaces route-data snapshots with reactive derivations so preserved pages receive updated data.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["perf: bound scheduled scans, skip unchan..."](https://github.com/getarcaneapp/arcane/commit/203c777b6a688962f6c95c5f76c199b023b79a8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59659749)</sub>

<!-- /greptile_comment -->