### PR TITLE
fix: keep first-login password dialog open and clear the flag on admin password change

### DIFF
--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -276,6 +276,7 @@ func (h *UserHandler) UpdateUser(ctx context.Context, input *UpdateUserInput) (*
 			return nil, huma.Error500InternalServerError("Failed to hash password")
 		}
 		userModel.PasswordHash = hashedPassword
+		userModel.RequiresPasswordChange = false
 	}
 
 	updatedUser, err := h.userService.UpdateUser(ctx, userModel, callerPerms)

--- a/backend/resources/migrations/postgres/080_drop_legacy_require_password_change.sql
+++ b/backend/resources/migrations/postgres/080_drop_legacy_require_password_change.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users DROP COLUMN IF EXISTS require_password_change;
+
+-- +goose Down
+ALTER TABLE users ADD COLUMN IF NOT EXISTS require_password_change BOOLEAN NOT NULL DEFAULT false;

--- a/backend/resources/migrations/sqlite/080_drop_legacy_require_password_change.sql
+++ b/backend/resources/migrations/sqlite/080_drop_legacy_require_password_change.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users DROP COLUMN require_password_change;
+
+-- +goose Down
+ALTER TABLE users ADD COLUMN require_password_change BOOLEAN NOT NULL DEFAULT 0;

--- a/frontend/src/lib/components/dialogs/first-login-password-dialog.svelte
+++ b/frontend/src/lib/components/dialogs/first-login-password-dialog.svelte
@@ -59,14 +59,10 @@
 
 <ResponsiveDialog
 	{open}
-	onOpenChange={(isOpen) => {
-		if (!isOpen) {
-			open = true;
-		}
-	}}
+	dismissible={false}
 	title={m.first_login_title()}
 	description={m.first_login_description()}
-	contentClass="sm:max-w-[425px] [&>button]:hidden"
+	contentClass="sm:max-w-[425px]"
 >
 	<form
 		onsubmit={(e) => {

--- a/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.svelte
+++ b/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.svelte
@@ -19,12 +19,14 @@
 		class: className,
 		contentClass,
 		showCloseButton = true,
+		dismissible = true,
 		variant = 'dialog'
 	}: ResponsiveDialogProps = $props();
 
 	const isDesktop = new MediaQuery('(min-width: 768px)');
 
 	function handleOpenChange(newOpen: boolean) {
+		if (!newOpen && !dismissible) return;
 		open = newOpen;
 		onOpenChange?.(newOpen);
 	}
@@ -46,7 +48,11 @@
 					{@render trigger()}
 				</Sheet.Trigger>
 			{/if}
-			<Sheet.Content class={cn('flex flex-col overflow-hidden p-0', contentClass)}>
+			<Sheet.Content
+				class={cn('flex flex-col overflow-hidden p-0', contentClass)}
+				interactOutsideBehavior={dismissible ? 'close' : 'ignore'}
+				escapeKeydownBehavior={dismissible ? 'close' : 'ignore'}
+			>
 				{#if title || description}
 					<Sheet.Header class="shrink-0 px-6 pt-6">
 						{#if title}
@@ -81,7 +87,9 @@
 					'max-h-[calc(100vh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto]! overflow-hidden p-0!',
 					contentClass ?? 'sm:max-w-[425px]'
 				)}
-				{showCloseButton}
+				showCloseButton={showCloseButton && dismissible}
+				interactOutsideBehavior={dismissible ? 'close' : 'ignore'}
+				escapeKeydownBehavior={dismissible ? 'close' : 'ignore'}
 			>
 				{#if title || description}
 					<Dialog.Header class="shrink-0 px-6 pt-6">
@@ -105,7 +113,7 @@
 		</Dialog.Root>
 	{/if}
 {:else}
-	<Drawer.Root {open} onOpenChange={handleOpenChange}>
+	<Drawer.Root {open} {dismissible} onOpenChange={handleOpenChange}>
 		{#if trigger}
 			<Drawer.Trigger>
 				{@render trigger()}

--- a/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.type.ts
+++ b/frontend/src/lib/components/ui/responsive-dialog/responsive-dialog.type.ts
@@ -59,6 +59,12 @@ export interface ResponsiveDialogProps {
 	showCloseButton?: boolean;
 
 	/**
+	 * Whether the dialog can be closed by outside click, Escape, or the close button
+	 * @default true
+	 */
+	dismissible?: boolean;
+
+	/**
 	 * The variant of the dialog on desktop
 	 * @default 'dialog'
 	 */

--- a/frontend/src/lib/types/auth.ts
+++ b/frontend/src/lib/types/auth.ts
@@ -227,7 +227,6 @@ export type AuthenticationResponse = {
 	user?: User;
 	mfa?: MFAChallenge;
 	error?: string;
-	requirePasswordChange?: boolean;
 };
 
 export type Passkey = {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3827

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps the first-login password dialog open until password replacement succeeds and consistently clears the password-change requirement when an administrator updates a password.

- Adds a shared `dismissible` option across responsive dialog, sheet, and drawer presentations.
- Removes the obsolete top-level authentication-response password-change field.
- Drops the unused singular `require_password_change` database column for PostgreSQL and SQLite.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The password-change flag remains available through the user response consumed by the dialog, all affected password update paths consistently clear it, and the migration removes only an unused legacy column present in supported schema histories.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep first-login password dialog op..."](https://github.com/getarcaneapp/arcane/commit/2b353390a5bcf655302c590f18dee9384c07b02c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59736868)</sub>

<!-- /greptile_comment -->