### PR TITLE
fix(images): show digest-pinned image references

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,14 +23,7 @@
   "tasks.statusbar.default.hide": true,
   "tasks.statusbar.limit": 8,
   "js/ts.tsdk.path": "node_modules/@typescript/native-preview",
-  "yaml.disableSchemaDetection": [
-    "**/.github/workflows/*.yml",
-    "**/.github/workflows/*.yaml",
-    "**/.gitea/workflows/*.yml",
-    "**/.gitea/workflows/*.yaml",
-    "**/.forgejo/workflows/*.yml",
-    "**/.forgejo/workflows/*.yaml"
-  ],
+  "yaml.disableSchemaDetection": [],
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/*"
   }

--- a/backend/internal/dashboard/service.go
+++ b/backend/internal/dashboard/service.go
@@ -216,7 +216,7 @@ func (s *DashboardService) buildSnapshotInternal(ctx context.Context, options Da
 			projectIDByName = map[string]string{}
 		}
 		imageUsageMap := image.BuildVolumeUsageMap(filteredContainers, projectIDByName)
-		imageItems := image.MapDockerImagesToDTOs(dockerImages, imageUsageMap, nil, nil)
+		imageItems := image.MapDockerImagesToDTOs(dockerImages, dockerContainers, imageUsageMap, nil, nil)
 		sort.Slice(imageItems, func(i, j int) bool {
 			if imageItems[i].Size == imageItems[j].Size {
 				return imageItems[i].ID < imageItems[j].ID

--- a/backend/internal/dashboard/service_test.go
+++ b/backend/internal/dashboard/service_test.go
@@ -258,6 +258,46 @@ func TestDashboardService_GetSnapshot_DebugAllGoodOnlyClearsActionItems(t *testi
 	require.Empty(t, snapshot.ActionItems.Items)
 }
 
+func TestDashboardService_GetSnapshot_EnrichesPinnedReferencesInternal(t *testing.T) {
+	db, settingsSvc := setupDashboardServiceTestDB(t)
+
+	pinnedRef := "ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"
+	containers := []dockercontainer.Summary{
+		{
+			ID:      "container-syncthing",
+			Names:   []string{"/syncthing"},
+			Image:   pinnedRef,
+			ImageID: "sha256:image-syncthing",
+			Created: 1800000000,
+			State:   "running",
+			Status:  "Up 1 hour",
+			Labels:  map[string]string{},
+		},
+	}
+	images := []dockerimage.Summary{
+		{
+			ID:          "sha256:image-syncthing",
+			RepoTags:    []string{},
+			RepoDigests: []string{"ghcr.io/syncthing/syncthing@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"},
+			Created:     1720000000,
+			Size:        250,
+		},
+	}
+
+	dockerSvc := newDashboardTestDockerService(t, settingsSvc, containers, images, nil)
+	svc := NewDashboardService(db, dockerSvc, nil, nil, nil, settingsSvc, nil, nil, nil, nil)
+
+	snapshot, err := svc.GetSnapshot(context.Background(), DashboardActionItemsOptions{}, true)
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+
+	require.Len(t, snapshot.Images.Data, 1)
+	assert.Equal(t, "sha256:image-syncthing", snapshot.Images.Data[0].ID)
+	assert.Equal(t, "ghcr.io/syncthing/syncthing", snapshot.Images.Data[0].Repo)
+	assert.Equal(t, "<none>", snapshot.Images.Data[0].Tag)
+	assert.Equal(t, []string{pinnedRef}, snapshot.Images.Data[0].PinnedReferences)
+}
+
 // Test fixtures shared by this package's tests.
 
 // createComposeProjectDirInternal writes a minimal single-service compose project under

--- a/backend/internal/image/image.go
+++ b/backend/internal/image/image.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,8 +73,9 @@ func (s *ImageService) GetImageDetail(ctx context.Context, id string) (*imagetyp
 	}
 
 	var (
-		inspect  image.InspectResponse
-		listSize int64
+		inspect    image.InspectResponse
+		listSize   int64
+		containers []container.Summary
 	)
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -106,6 +108,18 @@ func (s *ImageService) GetImageDetail(ctx context.Context, id string) (*imagetyp
 		return nil
 	})
 
+	g.Go(func() (workerErr error) {
+		defer utils.RecoverToError(&workerErr, "image worker")
+
+		containerList, err := s.dockerService.ListContainers(gctx)
+		if err != nil {
+			slog.DebugContext(gctx, "failed to list containers for image detail pinned references", "id", id, "error", err)
+			return nil
+		}
+		containers = containerList
+		return nil
+	})
+
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
@@ -114,6 +128,10 @@ func (s *ImageService) GetImageDetail(ctx context.Context, id string) (*imagetyp
 	if listSize > 0 {
 		out.Size = listSize
 		out.Descriptor.Size = listSize
+	}
+	if len(containers) > 0 {
+		pinnedRefsMap := collectPinnedReferencesByImageIDInternal(containers)
+		out.PinnedReferences = pinnedRefsMap[inspect.ID]
 	}
 	return &out, nil
 }
@@ -746,7 +764,7 @@ func (s *ImageService) ListImagesPaginated(ctx context.Context, params paginatio
 	usageMap := BuildVolumeUsageMap(containers, projectIDByName)
 	updateMap := buildUpdateMap(updateRecords)
 
-	items := MapDockerImagesToDTOs(dockerImages, usageMap, updateMap, nil)
+	items := MapDockerImagesToDTOs(dockerImages, containers, usageMap, updateMap, nil)
 
 	config := s.getImagePaginationConfig()
 
@@ -1043,24 +1061,72 @@ func buildUpdateInfo(updateRecord *imageupdate.ImageUpdateRecord) *imagetypes.Up
 	}
 }
 
-func MapDockerImagesToDTOs(dockerImages []image.Summary, usageMap map[string][]imagetypes.UsedBy, updateMap map[string]*imageupdate.ImageUpdateRecord, vulnerabilityMap map[string]*vulnerabilitytypes.ScanSummary) []imagetypes.Summary {
+func collectPinnedReferencesByImageIDInternal(containers []container.Summary) map[string][]string {
+	if len(containers) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]map[string]struct{})
+	for _, c := range containers {
+		if c.ImageID == "" || c.Image == "" {
+			continue
+		}
+		trimmed := strings.TrimSpace(c.Image)
+		if trimmed == "" || strings.HasPrefix(trimmed, "sha256:") {
+			continue
+		}
+
+		named, err := ref.ParseNormalizedNamed(trimmed)
+		if err != nil {
+			continue
+		}
+		if _, ok := named.(ref.Digested); !ok {
+			continue
+		}
+
+		if seen[c.ImageID] == nil {
+			seen[c.ImageID] = make(map[string]struct{})
+		}
+		seen[c.ImageID][trimmed] = struct{}{}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	result := make(map[string][]string, len(seen))
+	for imageID, refsMap := range seen {
+		refs := make([]string, 0, len(refsMap))
+		for r := range refsMap {
+			refs = append(refs, r)
+		}
+		sort.Strings(refs)
+		result[imageID] = refs
+	}
+
+	return result
+}
+
+func MapDockerImagesToDTOs(dockerImages []image.Summary, containers []container.Summary, usageMap map[string][]imagetypes.UsedBy, updateMap map[string]*imageupdate.ImageUpdateRecord, vulnerabilityMap map[string]*vulnerabilitytypes.ScanSummary) []imagetypes.Summary {
+	pinnedRefsByImageID := collectPinnedReferencesByImageIDInternal(containers)
 	items := make([]imagetypes.Summary, 0, len(dockerImages))
 	for _, di := range dockerImages {
 		repo, tag := determineRepoAndTag(di)
 
 		usedBy := usageMap[di.ID]
 		imageDto := imagetypes.Summary{
-			ID:          di.ID,
-			Repo:        repo,
-			Tag:         tag,
-			RepoTags:    di.RepoTags,
-			RepoDigests: di.RepoDigests,
-			Created:     di.Created,
-			Size:        di.Size,
-			VirtualSize: di.SharedSize,
-			Labels:      convertLabels(di.Labels),
-			InUse:       len(usedBy) > 0,
-			UsedBy:      usedBy,
+			ID:               di.ID,
+			Repo:             repo,
+			Tag:              tag,
+			RepoTags:         di.RepoTags,
+			RepoDigests:      di.RepoDigests,
+			PinnedReferences: pinnedRefsByImageID[di.ID],
+			Created:          di.Created,
+			Size:             di.Size,
+			VirtualSize:      di.SharedSize,
+			Labels:           convertLabels(di.Labels),
+			InUse:            len(usedBy) > 0,
+			UsedBy:           usedBy,
 		}
 
 		if updateRecord, exists := updateMap[di.ID]; exists {
@@ -1089,6 +1155,9 @@ func (s *ImageService) getImagePaginationConfig() pagination.Config[imagetypes.S
 					return i.RepoTags[0], nil
 				}
 				return "", nil
+			},
+			func(i imagetypes.Summary) (string, error) {
+				return strings.Join(i.PinnedReferences, " "), nil
 			},
 		},
 		SortBindings: []pagination.SortBinding[imagetypes.Summary]{

--- a/backend/internal/image/service_test.go
+++ b/backend/internal/image/service_test.go
@@ -31,9 +31,11 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/docker"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/kv"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	imagetypes "github.com/getarcaneapp/arcane/types/v2/image"
 	"github.com/getarcaneapp/arcane/types/v2/vulnerability"
+	dockercontainer "github.com/moby/moby/api/types/container"
 	dockertypesimage "github.com/moby/moby/api/types/image"
 	dockerregistry "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
@@ -90,6 +92,221 @@ func TestApplyVulnerabilitySummariesToItemsInternal(t *testing.T) {
 
 	assert.Equal(t, summary, items[0].VulnerabilityScan)
 	assert.Nil(t, items[1].VulnerabilityScan)
+}
+
+func TestCollectPinnedReferencesByImageIDInternal(t *testing.T) {
+	containers := []dockercontainer.Summary{
+		{
+			ID:      "c1",
+			ImageID: "sha256:image-pinned-1",
+			Image:   "ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0",
+			State:   "running",
+		},
+		{
+			ID:      "c2",
+			ImageID: "sha256:image-pinned-1",
+			Image:   "ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0",
+			State:   "exited",
+		},
+		{
+			ID:      "c3",
+			ImageID: "sha256:image-pinned-1",
+			Image:   "ghcr.io/syncthing/syncthing:v2@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0",
+			State:   "running",
+		},
+		{
+			ID:      "c4",
+			ImageID: "sha256:image-pinned-2",
+			Image:   "docker.io/library/redis@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			State:   "running",
+		},
+		{
+			ID:      "c5",
+			ImageID: "sha256:image-regular",
+			Image:   "nginx:latest",
+			State:   "running",
+		},
+		{
+			ID:      "c6",
+			ImageID: "sha256:image-hash",
+			Image:   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			State:   "running",
+		},
+		{
+			ID:      "c7",
+			ImageID: "sha256:image-invalid",
+			Image:   "not a valid docker reference ::: 123",
+			State:   "running",
+		},
+	}
+
+	result := collectPinnedReferencesByImageIDInternal(containers)
+	require.NotNil(t, result)
+
+	pins1 := result["sha256:image-pinned-1"]
+	require.Len(t, pins1, 2)
+	assert.Equal(t, []string{
+		"ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0",
+		"ghcr.io/syncthing/syncthing:v2@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0",
+	}, pins1)
+
+	pins2 := result["sha256:image-pinned-2"]
+	require.Len(t, pins2, 1)
+	assert.Equal(t, []string{"docker.io/library/redis@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}, pins2)
+
+	assert.NotContains(t, result, "sha256:image-regular")
+	assert.NotContains(t, result, "sha256:image-hash")
+	assert.NotContains(t, result, "sha256:image-invalid")
+}
+
+func TestMapDockerImagesToDTOs_PopulatesPinnedReferencesInternal(t *testing.T) {
+	pinnedRef := "ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"
+	dockerImages := []dockertypesimage.Summary{
+		{
+			ID:          "sha256:pinned-image",
+			RepoTags:    []string{},
+			RepoDigests: []string{"ghcr.io/syncthing/syncthing@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"},
+			Size:        12345,
+		},
+		{
+			ID:          "sha256:regular-image",
+			RepoTags:    []string{"nginx:alpine"},
+			RepoDigests: []string{"nginx@sha256:abcdef"},
+			Size:        67890,
+		},
+	}
+	containers := []dockercontainer.Summary{
+		{
+			ID:      "c-pinned",
+			ImageID: "sha256:pinned-image",
+			Image:   pinnedRef,
+			Names:   []string{"/syncthing"},
+		},
+		{
+			ID:      "c-regular",
+			ImageID: "sha256:regular-image",
+			Image:   "nginx:alpine",
+			Names:   []string{"/nginx"},
+		},
+	}
+
+	usageMap := BuildVolumeUsageMap(containers, nil)
+	items := MapDockerImagesToDTOs(dockerImages, containers, usageMap, nil, nil)
+
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "sha256:pinned-image", items[0].ID)
+	assert.Equal(t, "ghcr.io/syncthing/syncthing", items[0].Repo)
+	assert.Equal(t, "<none>", items[0].Tag)
+	assert.Empty(t, items[0].RepoTags)
+	assert.Equal(t, []string{pinnedRef}, items[0].PinnedReferences)
+	assert.True(t, items[0].InUse)
+
+	assert.Equal(t, "sha256:regular-image", items[1].ID)
+	assert.Equal(t, "nginx", items[1].Repo)
+	assert.Equal(t, "alpine", items[1].Tag)
+	assert.Equal(t, []string{"nginx:alpine"}, items[1].RepoTags)
+	assert.Nil(t, items[1].PinnedReferences)
+	assert.True(t, items[1].InUse)
+}
+
+func TestImageService_GetImageDetail_EnrichesPinnedReferencesInternal(t *testing.T) {
+	db := setupImageProjectTestDBInternal(t)
+	const pinnedID = "sha256:test-pinned-detail"
+	pinnedRef := "ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/images/json"):
+			_ = json.NewEncoder(w).Encode([]dockertypesimage.Summary{
+				{ID: pinnedID, Size: 2048},
+			})
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			_ = json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:          pinnedID,
+				RepoTags:    []string{},
+				RepoDigests: []string{"ghcr.io/syncthing/syncthing@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"},
+				Size:        2048,
+			})
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			_ = json.NewEncoder(w).Encode([]dockercontainer.Summary{
+				{
+					ID:      "c-pinned-detail",
+					ImageID: pinnedID,
+					Image:   pinnedRef,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	imageSvc := NewImageService(db, &docker.DockerClientService{Client: newTestDockerClientInternal(t, server)}, nil, nil, nil, event.NewEventService(db, nil, nil))
+
+	detail, err := imageSvc.GetImageDetail(context.Background(), pinnedID)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, pinnedID, detail.ID)
+	assert.Equal(t, []string{pinnedRef}, detail.PinnedReferences)
+}
+
+func TestImageService_GetImageDetail_ContainerFailureDoesNotBreakInspectionInternal(t *testing.T) {
+	db := setupImageProjectTestDBInternal(t)
+	const testID = "sha256:test-detail-resilient"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/images/json"):
+			_ = json.NewEncoder(w).Encode([]dockertypesimage.Summary{
+				{ID: testID, Size: 1024},
+			})
+		case strings.Contains(r.URL.Path, "/images/") && strings.HasSuffix(r.URL.Path, "/json"):
+			_ = json.NewEncoder(w).Encode(dockertypesimage.InspectResponse{
+				ID:   testID,
+				Size: 1024,
+			})
+		case strings.HasSuffix(r.URL.Path, "/containers/json"):
+			http.Error(w, "docker daemon error listing containers", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	imageSvc := NewImageService(db, &docker.DockerClientService{Client: newTestDockerClientInternal(t, server)}, nil, nil, nil, event.NewEventService(db, nil, nil))
+
+	detail, err := imageSvc.GetImageDetail(context.Background(), testID)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, testID, detail.ID)
+	assert.Nil(t, detail.PinnedReferences)
+}
+
+func TestImagePaginationConfig_SearchesPinnedReferencesInternal(t *testing.T) {
+	svc := &ImageService{}
+	config := svc.getImagePaginationConfig()
+
+	item := imagetypes.Summary{
+		ID:               "sha256:syncthing",
+		Repo:             "ghcr.io/syncthing/syncthing",
+		Tag:              "<none>",
+		PinnedReferences: []string{"ghcr.io/syncthing/syncthing:2.1.3@sha256:8c8ff37ab6aa8be23b700648a90fa9412e214852e9fd6ea8477c8334792daec0"},
+	}
+
+	res := config.SearchOrderAndPaginate([]imagetypes.Summary{item}, pagination.QueryParams{
+		Search: "8c8ff37",
+		Limit:  10,
+	})
+	require.Len(t, res.Items, 1)
+
+	resTag := config.SearchOrderAndPaginate([]imagetypes.Summary{item}, pagination.QueryParams{
+		Search: "2.1.3",
+		Limit:  10,
+	})
+	require.Len(t, resTag.Items, 1)
 }
 
 func TestImageService_GetUpdateInfoByImageRefs_MatchesCanonicalAndFamiliarRepos(t *testing.T) {

--- a/cli/pkg/images/cmd.go
+++ b/cli/pkg/images/cmd.go
@@ -662,10 +662,11 @@ var ImageRef = cmdutil.ResourceRef[image.DetailSummary, image.Summary]{
 	},
 	Promote: func(match image.Summary) *image.DetailSummary {
 		return &image.DetailSummary{
-			ID:          match.ID,
-			RepoTags:    match.RepoTags,
-			RepoDigests: match.RepoDigests,
-			Size:        match.Size,
+			ID:               match.ID,
+			RepoTags:         match.RepoTags,
+			RepoDigests:      match.RepoDigests,
+			PinnedReferences: match.PinnedReferences,
+			Size:             match.Size,
 		}
 	},
 	IDOf: func(match image.Summary) string { return match.ID },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -807,6 +807,7 @@
   "images_remove_force_label": "Force remove",
   "images_pull_no_tag": "Cannot pull image without repository tag",
   "images_untagged": "Untagged",
+  "images_pinned_references": "Pinned References",
   "images_used_by": "Used By",
   "updates": "Updates",
   "updates_apply_success": "Applied {updated} update(s)",

--- a/frontend/src/lib/types/docker.ts
+++ b/frontend/src/lib/types/docker.ts
@@ -478,6 +478,7 @@ export interface ImageSummaryDto {
 	id: string;
 	repoTags: string[];
 	repoDigests: string[];
+	pinnedReferences?: string[];
 	created: number;
 	size: number;
 	virtualSize: number;
@@ -494,6 +495,9 @@ export interface ImageDetailSummaryDto {
 	id: string;
 	repoTags: string[];
 	repoDigests: string[];
+	pinnedReferences?: string[];
+	repo?: string;
+	tag?: string;
 	parent: string;
 	comment: string;
 	created: string;

--- a/frontend/src/lib/utils/docker.ts
+++ b/frontend/src/lib/utils/docker.ts
@@ -124,18 +124,18 @@ export function isSwarmServiceModeScalable(mode: string): boolean {
 }
 
 export function parseImageRef(imageRef: string): { repo: string; tag: string } {
-	// Handle images like "nginx:latest", "library/nginx:1.0", "ghcr.io/org/image:tag"
-	const lastColon = imageRef.lastIndexOf(':');
+	const namedRef = imageRef.split('@', 1)[0] ?? imageRef;
+	const lastColon = namedRef.lastIndexOf(':');
 	// Check if colon is part of a tag (not a port in registry URL)
-	const hasTag = lastColon > 0 && !imageRef.substring(lastColon).includes('/');
+	const hasTag = lastColon > 0 && !namedRef.substring(lastColon).includes('/');
 
 	if (hasTag) {
 		return {
-			repo: imageRef.substring(0, lastColon),
-			tag: imageRef.substring(lastColon + 1)
+			repo: namedRef.substring(0, lastColon),
+			tag: namedRef.substring(lastColon + 1)
 		};
 	}
-	return { repo: imageRef, tag: 'latest' };
+	return { repo: namedRef, tag: 'latest' };
 }
 
 // --- Project update status display ---

--- a/frontend/src/routes/(app)/images/[imageId]/+page.svelte
+++ b/frontend/src/routes/(app)/images/[imageId]/+page.svelte
@@ -26,9 +26,11 @@
 	import ImageHistoryPanel from './image-history-panel.svelte';
 	import ImageTagDialog from '../components/image-tag-dialog.svelte';
 	import VulnerabilityScanPanel from '#lib/components/vulnerability/vulnerability-scan-panel.svelte';
+	import { CopyButton } from '#lib/components/ui/copy-button';
 	import type { VulnerabilityScanResult } from '#lib/types/environment';
 	import { environmentStore } from '#lib/stores/environment.store.svelte';
 	import { hasPermission } from '#lib/utils/auth';
+	import { parseImageRef } from '#lib/utils/docker';
 	import { toastVulnerabilityScanStatus } from '#lib/utils/vulnerability';
 	import { VolumesIcon, ClockIcon, TagIcon, CpuIcon, ImagesIcon, LayersIcon, ShieldCheckIcon, InspectIcon } from '#lib/icons';
 
@@ -229,9 +231,17 @@
 	const architecture = $derived.by(() => image?.architecture || m.common_na());
 	const osName = $derived.by(() => image?.os || m.common_na());
 	const repoTags = $derived.by(() => image?.repoTags ?? []);
+	const pinnedRefs = $derived.by(() => image?.pinnedReferences ?? []);
 	const envVars = $derived.by(() => image?.config?.env ?? []);
-	const hasTags = $derived.by(() => repoTags.length > 0);
+	const hasTags = $derived.by(() => repoTags.length > 0 && repoTags[0] !== '<none>:<none>');
+	const hasPinnedRefs = $derived.by(() => pinnedRefs.length > 0);
 	const hasEnv = $derived.by(() => envVars.length > 0);
+	const detailTitle = $derived.by((): string => {
+		if (hasTags && repoTags[0]) return repoTags[0];
+		if (hasPinnedRefs && pinnedRefs[0]) return pinnedRefs[0];
+		return shortId;
+	});
+	const pinnedRepository = $derived.by(() => (pinnedRefs[0] ? parseImageRef(pinnedRefs[0]).repo : ''));
 
 	async function handleImageRemove(id: string) {
 		openConfirmDialog({
@@ -329,7 +339,7 @@
 	});
 </script>
 
-<ResourceDetailLayout backUrl="/images" backLabel={m.images()} title={image?.repoTags?.[0] || shortId} {actions}>
+<ResourceDetailLayout backUrl="/images" backLabel={m.images()} title={detailTitle} {actions}>
 	{#if image}
 		{#snippet kvTile(label: string, value: string, opts?: { class?: string })}
 			<KeyValueCard {label} cardClass={opts?.class} valueTitle={value}>
@@ -348,6 +358,27 @@
 						{ icon: CpuIcon, value: `${architecture} · ${osName}` }
 					]}
 				/>
+
+				{#if hasPinnedRefs}
+					<div class="space-y-2">
+						<span class="inline-flex items-center gap-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+							<TagIcon class="size-4" />
+							{m.images_pinned_references()}
+						</span>
+						<div class="flex flex-col gap-2">
+							{#each pinnedRefs as pin (pin)}
+								<div
+									class="flex max-w-2xl items-center justify-between gap-2 rounded-lg border border-border/50 bg-muted/40 p-2.5"
+								>
+									<span class="font-mono text-xs break-all text-foreground select-all" title={m.common_click_to_select()}>
+										{pin}
+									</span>
+									<CopyButton text={pin} size="icon" class="size-7 shrink-0" />
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
 
 				{#if hasTags}
 					<div class="flex flex-wrap items-center gap-2">
@@ -420,7 +451,8 @@
 	<ImageTagDialog
 		bind:open={tagDialogOpen}
 		imageId={image.id}
-		defaultRepository={image.repoTags?.[0]?.split(':')[0] ?? ''}
+		defaultRepository={image.repoTags?.[0]?.split(':')[0] ??
+			(pinnedRepository || (image.repo && image.repo !== '<none>' ? image.repo : ''))}
 		onTagged={() => goto(`/images/${image.id}`, { refreshAll: true })}
 	/>
 {/if}

--- a/frontend/src/routes/(app)/images/[imageId]/+page.ts
+++ b/frontend/src/routes/(app)/images/[imageId]/+page.ts
@@ -1,6 +1,7 @@
 import { imageService } from '#lib/services/image-service.js';
 import { environmentStore } from '#lib/stores/environment.store.svelte';
 import type { ImageDetailSummaryDto } from '#lib/types/docker.js';
+import { parseImageRef } from '#lib/utils/docker';
 import { queryKeys } from '#lib/query/query-keys';
 import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
@@ -28,14 +29,9 @@ export const load: PageLoad = async ({ params, parent }): Promise<ImageDetailDat
 
 		let repo = '<none>';
 		let tag = '<none>';
-		if (image.RepoTags && image.RepoTags.length > 0) {
-			const repoTag = image.RepoTags[0];
-			if (repoTag.includes(':')) {
-				[repo, tag] = repoTag.split(':');
-			} else {
-				repo = repoTag;
-				tag = 'latest';
-			}
+		const rawTags = image.repoTags ?? image.RepoTags;
+		if (rawTags && rawTags.length > 0 && rawTags[0] !== '<none>:<none>') {
+			({ repo, tag } = parseImageRef(rawTags[0]));
 		}
 
 		return {

--- a/frontend/src/routes/(app)/images/image-table.svelte
+++ b/frontend/src/routes/(app)/images/image-table.svelte
@@ -464,6 +464,34 @@
 				<Badge variant="outline" class="text-xs">+{item.repoTags.length - 2}</Badge>
 			{/if}
 		</div>
+	{:else if item.pinnedReferences && item.pinnedReferences.length > 0 && item.pinnedReferences[0]}
+		{@const firstPin = item.pinnedReferences[0]}
+		{@const overflowPins = item.pinnedReferences.slice(1)}
+		<div class="flex max-w-md flex-wrap items-center gap-1.5">
+			<Badge
+				variant="outline"
+				class="h-auto max-w-full font-mono text-xs break-all whitespace-normal select-all"
+				title={m.common_click_to_select()}
+			>
+				{firstPin}
+			</Badge>
+			{#if overflowPins.length > 0}
+				<Tooltip.Provider>
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<Badge variant="outline" class="text-xs">+{overflowPins.length}</Badge>
+						</Tooltip.Trigger>
+						<Tooltip.Content class="pointer-events-auto max-w-sm">
+							<div class="flex flex-col gap-1.5">
+								{#each overflowPins as pin (pin)}
+									<span class="font-mono text-xs break-all select-all">{pin}</span>
+								{/each}
+							</div>
+						</Tooltip.Content>
+					</Tooltip.Root>
+				</Tooltip.Provider>
+			{/if}
+		</div>
 	{:else if item.tag && item.tag !== '<none>'}
 		<Badge variant="outline" class="font-mono text-xs">{item.tag}</Badge>
 	{:else}
@@ -580,6 +608,23 @@
 	</div>
 {/snippet}
 
+{#snippet MobileTagsValue(item: ImageSummaryDto)}
+	{#if item.repoTags && item.repoTags.length > 0 && item.repoTags[0] !== '<none>:<none>'}
+		<span class="font-mono text-xs">{item.repoTags.map((rt) => rt.split(':').pop() || rt).join(', ')}</span>
+	{:else if item.pinnedReferences && item.pinnedReferences.length > 0}
+		<span class="font-mono text-xs break-all whitespace-normal select-all">
+			{item.pinnedReferences[0]}
+			{#if item.pinnedReferences.length > 1}
+				<span class="ml-1 font-sans text-muted-foreground">+{item.pinnedReferences.length - 1}</span>
+			{/if}
+		</span>
+	{:else if item.tag && item.tag !== '<none>'}
+		<span class="font-mono text-xs">{item.tag}</span>
+	{:else}
+		<span class="text-muted-foreground italic">{m.images_untagged()}</span>
+	{/if}
+{/snippet}
+
 {#snippet ImageMobileCardSnippet({
 	item,
 	mobileFieldVisibility
@@ -595,6 +640,9 @@
 		})}
 		title={(item) => {
 			if (item.repo && item.repo !== '<none>') return item.repo;
+			if (item.pinnedReferences && item.pinnedReferences.length > 0 && item.pinnedReferences[0]) {
+				return item.pinnedReferences[0];
+			}
 			return m.images_untagged();
 		}}
 		subtitle={(item) => ((mobileFieldVisibility['id'] ?? false) ? item.id : null)}
@@ -622,12 +670,9 @@
 			},
 			{
 				label: m.common_tags(),
-				getValue: (item: ImageSummaryDto) => {
-					if (item.repoTags && item.repoTags.length > 0 && item.repoTags[0] !== '<none>:<none>') {
-						return item.repoTags.map((rt) => rt.split(':').pop() || rt).join(', ');
-					}
-					return item.tag && item.tag !== '<none>' ? item.tag : m.images_untagged();
-				},
+				getValue: (item: ImageSummaryDto) => item,
+				type: 'component',
+				component: MobileTagsValue,
 				icon: ImagesIcon,
 				iconVariant: 'purple' as const,
 				show: mobileFieldVisibility['repoTags'] ?? true

--- a/tests/spec/images.spec.ts
+++ b/tests/spec/images.spec.ts
@@ -109,6 +109,97 @@ async function fetchAllImagesForUsage(page: Page): Promise<any[]> {
 	return all;
 }
 
+async function mockPinnedImageFlow(page: Page) {
+	const digest = `sha256:${'8c8ff37a'.padEnd(64, '0')}`;
+	const alternateDigest = `sha256:${'9d9aa48b'.padEnd(64, '1')}`;
+	const repository = 'registry.example.com:5000/team/syncthing';
+	const pinnedReference = `${repository}:2.1.3@${digest}`;
+	const alternateReference = `${repository}:stable@${alternateDigest}`;
+	const imageId = `sha256:${'abc123'.padEnd(64, '0')}`;
+	const image = {
+		id: imageId,
+		repoTags: [],
+		repoDigests: [`${repository}@${digest}`],
+		pinnedReferences: [pinnedReference, alternateReference],
+		created: 1_725_000_000,
+		size: 123_456,
+		virtualSize: 123_456,
+		labels: null,
+		inUse: true,
+		usedBy: [{ type: 'container', name: 'syncthing', id: 'container-syncthing' }],
+		repo: repository,
+		tag: '<none>'
+	};
+
+	await page.route('**/api/environments/0/images**', async (route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		if (request.method() !== 'GET') {
+			await route.continue();
+			return;
+		}
+
+		if (url.pathname === ROUTES.apiImages) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: true,
+					data: [image],
+					pagination: {
+						totalPages: 1,
+						totalItems: 1,
+						currentPage: 1,
+						itemsPerPage: 20,
+						grandTotalItems: 1
+					}
+				})
+			});
+			return;
+		}
+
+		if (url.pathname === `${ROUTES.apiImages}/counts`) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: true,
+					data: { imagesInuse: 1, imagesUnused: 0, totalImages: 1, totalImageSize: image.size }
+				})
+			});
+			return;
+		}
+
+		if (decodeURIComponent(url.pathname) === `${ROUTES.apiImages}/${imageId}`) {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: true,
+					data: {
+						...image,
+						created: '2026-09-04T00:00:00Z',
+						comment: '',
+						author: '',
+						config: {},
+						architecture: 'amd64',
+						os: 'linux',
+						graphDriver: { data: null, name: 'overlay2' },
+						rootFs: { type: 'layers', layers: [] },
+						metadata: { lastTagTime: '' },
+						descriptor: { mediaType: '', digest, size: image.size }
+					}
+				})
+			});
+			return;
+		}
+
+		await route.continue();
+	});
+
+	return { imageId, repository, pinnedReference, alternateReference };
+}
+
 let realImages: any[] = [];
 let imageCounts: ImageUsageCounts = {
 	imagesInuse: 0,
@@ -176,6 +267,36 @@ test.describe('Images Page', () => {
 
 		await expect(page.getByRole('table')).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Repository' })).toBeVisible();
+	});
+
+	test('should display full pinned references without enabling tag actions', async ({ page }) => {
+		const { imageId, repository, pinnedReference, alternateReference } =
+			await mockPinnedImageFlow(page);
+		await page.reload();
+
+		const row = page.getByRole('row').filter({
+			has: page.getByRole('link', { name: repository, exact: true })
+		});
+		await expect(row.getByText(pinnedReference, { exact: true })).toBeVisible();
+
+		const overflow = row.getByText('+1', { exact: true });
+		await overflow.hover();
+		await expect(page.getByText(alternateReference, { exact: true })).toBeVisible();
+
+		const menu = await openRowActionsMenu(page, row);
+		await expect(menu.getByRole('menuitem', { name: 'Pull', exact: true })).toBeDisabled();
+		await expect(menu.getByRole('menuitem', { name: 'Patch', exact: true })).toBeDisabled();
+		await page.keyboard.press('Escape');
+
+		await row.getByRole('link', { name: repository, exact: true }).click();
+		await expect
+			.poll(() => decodeURIComponent(new URL(page.url()).pathname))
+			.toBe(`/images/${imageId}`);
+		await expect(page.getByRole('heading', { name: pinnedReference, exact: true })).toBeVisible();
+		await expect(page.getByText('Pinned References', { exact: true })).toBeVisible();
+		await expect(page.getByText(pinnedReference, { exact: true }).last()).toBeVisible();
+		await expect(page.getByText(alternateReference, { exact: true }).last()).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Patch', exact: true })).toHaveCount(0);
 	});
 
 	test('should open the Pull Image dialog', async ({ page }) => {

--- a/types/image/image.go
+++ b/types/image/image.go
@@ -160,6 +160,11 @@ type Summary struct {
 	//
 	// Required: false
 	VulnerabilityScan *vulnerability.ScanSummary `json:"vulnerabilityScan,omitempty"`
+
+	// PinnedReferences contains exact digest-pinned references used by containers.
+	//
+	// Required: false
+	PinnedReferences []string `json:"pinnedReferences,omitempty"`
 }
 
 type AttestationList struct {
@@ -300,6 +305,11 @@ type DetailSummary struct {
 	//
 	// Required: true
 	RepoDigests []string `json:"repoDigests"`
+
+	// PinnedReferences contains exact digest-pinned references used by containers.
+	//
+	// Required: false
+	PinnedReferences []string `json:"pinnedReferences,omitempty"`
 
 	// Comment is a comment associated with the image.
 	//


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3817

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes digest-pinned references gathered from containers in image list and detail responses, then displays and searches those references across the web UI and CLI contracts.
- Adds pinned-reference collection and mapping to image summaries, details, and dashboard snapshots.
- Updates shared Go and TypeScript image contracts.
- Adds desktop, mobile, and detail-page presentation for pinned references.
- Extends backend and browser tests for pinned-image behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-quality issue around ignored JSON encoding errors.

The pinned-reference contract and display paths are consistently wired through the backend and frontend; the remaining concern only reduces diagnostic quality in newly added test fixtures.

**Files Needing Attention:** backend/internal/image/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fimage-ref-pin%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fimage-ref-pin%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233836%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3836&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix%2Fimage-ref-pin%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fimage-ref-pin%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimage%2Fservice_test.go%3A218%0A**JSON%20encoding%20errors%20are%20discarded**%0A%0AThe%20new%20HTTP%20test%20handlers%20discard%20%60json.Encoder.Encode%60%20errors%2C%20so%20an%20encoding%20failure%20can%20produce%20an%20incomplete%20fixture%20response%20while%20hiding%20the%20actual%20cause%20of%20the%20test%20failure.%20Check%20the%20returned%20error%20in%20this%20handler%20and%20the%20other%20newly%20added%20handlers%20using%20the%20same%20pattern.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fimage%2Fservice_test.go%3A218%0A**JSON%20encoding%20errors%20are%20discarded**%0A%0AThe%20new%20HTTP%20test%20handlers%20discard%20%60json.Encoder.Encode%60%20errors%2C%20so%20an%20encoding%20failure%20can%20produce%20an%20incomplete%20fixture%20response%20while%20hiding%20the%20actual%20cause%20of%20the%20test%20failure.%20Check%20the%20returned%20error%20in%20this%20handler%20and%20the%20other%20newly%20added%20handlers%20using%20the%20same%20pattern.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3836&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/image/service_test.go:218
**JSON encoding errors are discarded**

The new HTTP test handlers discard `json.Encoder.Encode` errors, so an encoding failure can produce an incomplete fixture response while hiding the actual cause of the test failure. Check the returned error in this handler and the other newly added handlers using the same pattern.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(images): show digest-pinned image re..."](https://github.com/getarcaneapp/arcane/commit/e95a9e4b4ec23d868b8eca77984d935847094a38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60497084)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (5)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [Images, registries, and image updates](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/image-and-registry-management.md)
- Knowledge Base — [Registry and image update workflows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/registry-and-image-update-workflows.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/web-application.md)
- Knowledge Base — [Command-line interface](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/command-line-interface.md)
</details>


<!-- /greptile_comment -->