### PR TITLE
fix(gitops): limit directory sync mutations to managed files

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/stretchr/testify v1.12.1
 	github.com/subosito/gotenv v1.6.0
 	github.com/wneessen/go-mail v0.8.1
-	go.getarcane.app/acfs v0.5.1
+	go.getarcane.app/acfs v0.6.0
 	go.getarcane.app/builds v0.4.1
 	go.getarcane.app/docker/convert v0.3.1
 	go.getarcane.app/kit v0.1.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -734,6 +734,8 @@ github.com/zmb3/spotify/v2 v2.3.1 h1:aEyIPotROM3JJjHMCImFROgnPIUpzVo8wymYSaPSd9w
 github.com/zmb3/spotify/v2 v2.3.1/go.mod h1:+LVh9CafHu7SedyqYmEf12Rd01dIVlEL845yNhksW0E=
 go.getarcane.app/acfs v0.5.1 h1:Rkrzpz8Qh9SVzP2VwpHtLA0clEjBpTA+xmrVuoZ+mMM=
 go.getarcane.app/acfs v0.5.1/go.mod h1:Z+0Gs4LGNjvGMLq+TKv/oGKh29FRbAH6mcVPwY5KhFI=
+go.getarcane.app/acfs v0.6.0 h1:OOoDXmfByGWh9uJcDwtoQdWz1u2huIBhljn4mm1Ifco=
+go.getarcane.app/acfs v0.6.0/go.mod h1:Z+0Gs4LGNjvGMLq+TKv/oGKh29FRbAH6mcVPwY5KhFI=
 go.getarcane.app/builds v0.4.1 h1:R8iEgTf9+NDtI1IEzF2R3Mn+v6AGUqwCMs7CEFpVRZk=
 go.getarcane.app/builds v0.4.1/go.mod h1:vSWYulIelS9m91mPpvaN+orZ4/A20eGGcynP892eMkg=
 go.getarcane.app/docker/convert v0.3.1 h1:VcC2gtTFtGBrHTSBd0RodA0u+aerRAYVJIah7p6BNbE=

--- a/backend/internal/gitops/gitops_sync.go
+++ b/backend/internal/gitops/gitops_sync.go
@@ -34,7 +34,6 @@ import (
 	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
 	swarmtypes "github.com/getarcaneapp/arcane/types/v2/swarm"
 	"go.getarcane.app/acfs"
-	acfstypes "go.getarcane.app/acfs/types"
 	"gorm.io/gorm"
 )
 
@@ -52,6 +51,7 @@ type GitOpsSyncService struct {
 }
 
 const defaultGitSyncTimeout = 5 * time.Minute
+const gitOpsRecoveryMarker = ".recovery-required"
 
 const (
 	defaultMaxSyncFiles        = 500
@@ -85,11 +85,9 @@ type stagedDirectorySync struct {
 	syncedFiles     []string
 	serviceCount    int
 	contentsChanged bool
-	// copySkipped holds project-relative paths that could not be read when the
-	// live project directory was copied into the stage (e.g. foreign-owned
-	// bind-mount data). They are absent from the stage, so promotion must
-	// preserve rather than prune them.
-	copySkipped []string
+	files           []projects.SyncFile
+	oldSyncedFiles  []string
+	gitEnvContent   *string
 }
 
 func validateSyncLimits(maxFiles *int, maxTotalSize, maxBinarySize *int64) error {
@@ -1365,6 +1363,10 @@ func (s *GitOpsSyncService) CleanupLeakedScratchDirsOnStartup(ctx context.Contex
 			continue
 		}
 		scratchPath := filepath.Join(projectsDir, entry.Name)
+		if preserve, err := acfs.Exists(ctx, scratchPath, "/"+gitOpsRecoveryMarker); err != nil || preserve {
+			slog.WarnContext(ctx, "Preserving GitOps recovery directory", "path", scratchPath, "error", err)
+			continue
+		}
 		if rmErr := acfs.RemoveAll(ctx, projectsDir, entry.Path); rmErr != nil {
 			slog.WarnContext(ctx, "Failed to remove leaked GitOps scratch directory on startup", "path", scratchPath, "error", rmErr)
 			continue
@@ -1805,8 +1807,7 @@ func (s *GitOpsSyncService) walkAndParseSyncDirectory(ctx context.Context, sync 
 	return syncFiles, nil
 }
 
-// syncProjectDirectoryInternal runs the new directory-sync path end to end:
-// stage files, validate the staged tree, then create or update the project.
+// syncProjectDirectoryInternal validates and applies the managed directory contents.
 func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sync *projectpkg.GitOpsSync, syncFiles []projects.SyncFile, actor common.User) (*projectpkg.Project, []string, bool, bool, error) {
 	stage, err := s.stageDirectorySyncInternal(ctx, sync, syncFiles)
 	if err != nil {
@@ -1815,7 +1816,9 @@ func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sy
 	}
 	defer func() {
 		if stage != nil && stage.stagePath != "" {
-			_ = acfs.RemoveAll(ctx, stage.projectsDir, stage.stageLogical)
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+			defer cancel()
+			_ = acfs.RemoveAll(cleanupCtx, stage.projectsDir, stage.stageLogical)
 		}
 	}()
 
@@ -1837,122 +1840,79 @@ func (s *GitOpsSyncService) syncProjectDirectoryInternal(ctx context.Context, sy
 	return project, stage.syncedFiles, false, stage.contentsChanged, nil
 }
 
-// stageDirectorySyncInternal builds a temporary project tree that reflects the exact
-// repo layout after sync, including cleanup of files removed from the repo.
+// stageDirectorySyncInternal prepares managed files; only new projects need a scratch tree.
 func (s *GitOpsSyncService) stageDirectorySyncInternal(ctx context.Context, sync *projectpkg.GitOpsSync, syncFiles []projects.SyncFile) (*stagedDirectorySync, error) {
 	projectsDir, err := s.projectService.GetProjectsDirectory(ctx)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to get projects directory")
 	}
+	project, err := s.getDirectorySyncProjectInternal(ctx, sync)
+	if err != nil {
+		return nil, err
+	}
 
-	// The project-root env files are reserved for the three-file override
-	// merge applied below by the Project domain rather than a raw
-	// overwrite — a raw .env write would silently wipe edits made in Arcane
-	// on every sync.
+	syncFiles = slices.Clone(syncFiles)
+	for i := range syncFiles {
+		rel, err := utils.NormalizeRelativePath(syncFiles[i].RelativePath)
+		if err != nil {
+			return nil, errors.WrapIf(err, "invalid synced file path")
+		}
+		syncFiles[i].RelativePath = rel
+	}
+	oldSyncedFiles := parseSyncedFiles(sync.SyncedFiles)
+	for i := range oldSyncedFiles {
+		rel, err := utils.NormalizeRelativePath(oldSyncedFiles[i])
+		if err != nil {
+			return nil, errors.WrapIf(err, "invalid previous synced file path")
+		}
+		oldSyncedFiles[i] = rel
+	}
 	filteredSyncFiles, gitEnvContent := partitionReservedRootEnvFilesInternal(ctx, syncFiles)
+	stage := &stagedDirectorySync{
+		projectsDir:     projectsDir,
+		composeFileName: filepath.Base(sync.ComposePath),
+		project:         project,
+		files:           filteredSyncFiles,
+		oldSyncedFiles:  filterReservedRootEnvFilesInternal(oldSyncedFiles),
+		gitEnvContent:   gitEnvContent,
+		contentsChanged: true,
+	}
+	for _, file := range filteredSyncFiles {
+		stage.syncedFiles = append(stage.syncedFiles, file.RelativePath)
+	}
+	if project != nil {
+		stage.contentsChanged, err = projects.DirectorySyncContentsChanged(ctx, project.Path, stage.files, stage.oldSyncedFiles, stage.composeFileName)
+		return stage, err
+	}
 
-	stageLogical, err := acfs.MkdirTemp(ctx, projectsDir, "/", ".gitops-sync-stage-*")
+	stage.stageLogical, err = acfs.MkdirTemp(ctx, projectsDir, "/", ".gitops-sync-stage-*")
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to create staging directory")
 	}
-	stagePath := filepath.Join(projectsDir, filepath.FromSlash(strings.TrimPrefix(stageLogical, "/")))
-
-	project, err := s.getDirectorySyncProjectInternal(ctx, sync)
-	if err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
+	stage.stagePath = filepath.Join(projectsDir, filepath.FromSlash(strings.TrimPrefix(stage.stageLogical, "/")))
+	prepared := false
+	defer func() {
+		if !prepared {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+			defer cancel()
+			_ = acfs.RemoveAll(cleanupCtx, projectsDir, stage.stageLogical)
+		}
+	}()
+	if err := s.seedStageEnvFromCandidateDirInternal(ctx, sync, projectsDir, stage.stagePath); err != nil {
 		return nil, err
 	}
-
-	var copySkipped []string
-	if project != nil {
-		// Tolerate files Arcane cannot read (e.g. foreign-owned files a container
-		// wrote into the project directory through a relative bind mount). Skipping
-		// them keeps an unrelated unreadable file from aborting the whole sync; the
-		// skipped paths are preserved (not pruned) when the staged tree is mirrored
-		// back over the live project during promotion.
-		staged, stageErr := acfs.CopyDir(ctx, project.Path, stagePath, acfstypes.CopyOptions{TolerateUnreadable: true})
-		copySkipped = staged.Skipped
-		if err = stageErr; err != nil {
-			_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
-			return nil, errors.WrapIf(err, "failed to stage current project files")
-		}
-		if len(copySkipped) > 0 {
-			slog.WarnContext(ctx, "skipped unreadable files while staging project sync; they will be left untouched on promotion", "projectPath", project.Path, "skipped", copySkipped)
-		}
-	} else if err := s.seedStageEnvFromCandidateDirInternal(ctx, sync, projectsDir, stagePath); err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
-		return nil, err
-	}
-
-	syncedFiles := make([]string, len(filteredSyncFiles))
-	for i, file := range filteredSyncFiles {
-		syncedFiles[i] = file.RelativePath
-	}
-
-	// Syncs created before this fix may still have .env recorded as a tracked
-	// file. Drop reserved root env files here too, or CleanupRemovedFiles would
-	// treat .env as removed-by-git and delete the live-copied stage .env before
-	// ApplyGitSyncEnvToDirectory gets a chance to read it for the merge.
-	oldSyncedFiles := filterReservedRootEnvFilesInternal(parseSyncedFiles(sync.SyncedFiles))
-	if len(oldSyncedFiles) > 0 {
-		if err := projects.CleanupRemovedFiles(ctx, projectsDir, stagePath, oldSyncedFiles, syncedFiles); err != nil {
-			_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
-			return nil, errors.WrapIf(err, "failed to clean removed synced files")
-		}
-	}
-
-	composeFileName := filepath.Base(sync.ComposePath)
-	if err := projects.RemoveStaleComposeFiles(ctx, stagePath, composeFileName, syncedFiles); err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
-		return nil, errors.WrapIf(err, "failed to remove stale compose files")
-	}
-
-	contentsChanged := true
-	if project != nil {
-		contentsChanged, err = projects.DirectorySyncContentsChanged(ctx, project.Path, filteredSyncFiles, oldSyncedFiles, composeFileName)
-		if err != nil {
-			_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
-			return nil, errors.WrapIf(err, "failed to compare staged directory changes")
-		}
-	}
-
-	// Write the repo files (excluding reserved root env files, handled below)
-	// after cleanup so validation sees the final on-disk tree exactly as it
-	// will exist in the managed project.
-	if _, err := projects.WriteSyncedDirectory(ctx, projectsDir, stagePath, filteredSyncFiles); err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
+	if _, err := projects.WriteSyncedDirectory(ctx, projectsDir, stage.stagePath, stage.files); err != nil {
 		return nil, errors.WrapIf(err, "failed to write staged sync files")
 	}
-
-	// Route the project-root .env through the same three-file override merge
-	// single-file git sync uses: git is source-of-truth, edits made in Arcane
-	// become an override that wins, and new git-introduced keys still flow in.
-	preEnvContent, postEnvContent, err := s.projectService.ApplyGitSyncEnvToDirectory(ctx, stagePath, projectsDir, gitEnvContent)
-	if err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
+	if _, _, err := s.projectService.ApplyGitSyncEnvToDirectory(ctx, stage.stagePath, projectsDir, gitEnvContent); err != nil {
 		return nil, err
 	}
-	if project != nil && envContentChangedInternal(preEnvContent, postEnvContent) {
-		contentsChanged = true
-	}
-
-	serviceCount, err := s.projectService.ValidateComposeDirectory(ctx, sync.ProjectName, stagePath, composeFileName)
+	stage.serviceCount, err = s.projectService.ValidateComposeDirectory(ctx, sync.ProjectName, stage.stagePath, stage.composeFileName)
 	if err != nil {
-		_ = acfs.RemoveAll(ctx, projectsDir, stageLogical)
 		return nil, errors.WrapIf(err, "invalid compose file")
 	}
-
-	return &stagedDirectorySync{
-		stagePath:       stagePath,
-		stageLogical:    stageLogical,
-		projectsDir:     projectsDir,
-		composeFileName: composeFileName,
-		project:         project,
-		syncedFiles:     syncedFiles,
-		serviceCount:    serviceCount,
-		contentsChanged: contentsChanged,
-		copySkipped:     copySkipped,
-	}, nil
+	prepared = true
+	return stage, nil
 }
 
 // isReservedRootEnvFileInternal reports whether relPath is one of the
@@ -2375,83 +2335,90 @@ func (s *GitOpsSyncService) createDirectorySyncProjectInternal(ctx context.Conte
 	return project, nil
 }
 
-// updateDirectorySyncProjectInternal mirrors a validated staged tree into the
-// existing project path in place so running containers keep their bind-mount
-// inodes; a temporary backup copy allows rollback if promotion fails.
-func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Context, sync *projectpkg.GitOpsSync, stage *stagedDirectorySync) (*projectpkg.Project, error) {
+// updateDirectorySyncProjectInternal applies and validates only managed paths in the live project context.
+func (s *GitOpsSyncService) updateDirectorySyncProjectInternal(ctx context.Context, sync *projectpkg.GitOpsSync, stage *stagedDirectorySync) (updated *projectpkg.Project, retErr error) {
 	project := stage.project
 	projectPath := filepath.Clean(project.Path)
-	backupPath := ""
-	existed := true
-
-	// The project directory is the confinement root for the mirror below and may
-	// itself be a symlink, so it is probed and bootstrapped through os.
-	if info, err := os.Stat(projectPath); err == nil {
-		if !info.IsDir() {
-			return nil, errors.Errorf("project path is not a directory: %s", projectPath)
+	// Existing imported roots may themselves be symlinks.
+	if _, err := acfs.Stat(ctx, projectPath, "/", false); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, errors.WrapIf(err, "failed to inspect project directory")
 		}
-	} else if errors.Is(err, os.ErrNotExist) {
-		existed = false
-		if err := os.MkdirAll(projectPath, 0o755); err != nil {
-			return nil, errors.WrapIf(err, "failed to recreate project directory")
-		}
-	} else {
-		return nil, errors.WrapIf(err, "failed to inspect current project directory")
-	}
-
-	var backupSkipped []string
-	if existed {
-		projectsDir, err := s.projectService.GetProjectsDirectory(ctx)
+		logicalPath, err := acfs.LogicalPath(stage.projectsDir, projectPath)
 		if err != nil {
-			return nil, errors.WrapIf(err, "failed to get projects directory")
+			return nil, err
 		}
-		backupLogical, tempErr := acfs.MkdirTemp(ctx, projectsDir, "/", ".gitops-backup-*")
-		if tempErr != nil {
-			return nil, errors.WrapIf(tempErr, "failed to create backup directory")
-		}
-		backupPath = filepath.Join(projectsDir, filepath.FromSlash(strings.TrimPrefix(backupLogical, "/")))
-		defer func() { _ = acfs.RemoveAll(ctx, projectsDir, backupLogical) }()
-		// Tolerate unreadable files (e.g. foreign-owned bind-mount data) so an
-		// unrelated file can't block the backup; the skipped paths are absent from
-		// the backup and must be preserved, not pruned, when restoring.
-		backedUp, backupErr := acfs.CopyDir(ctx, projectPath, backupPath, acfstypes.CopyOptions{TolerateUnreadable: true})
-		backupSkipped = backedUp.Skipped
-		if err = backupErr; err != nil {
-			return nil, errors.WrapIf(err, "failed to back up current project directory")
-		}
-		if len(backupSkipped) > 0 {
-			slog.WarnContext(ctx, "skipped unreadable files while backing up project for sync; they will be left untouched on rollback", "projectPath", projectPath, "skipped", backupSkipped)
+		if err := acfs.MkdirAll(ctx, stage.projectsDir, logicalPath, 0o755); err != nil {
+			return nil, errors.WrapIf(err, "failed to prepare project directory")
 		}
 	}
-
-	restore := func() {
-		var restoreErr error
-		if existed {
-			restoreErr = acfs.MirrorDir(ctx, backupPath, projectPath, acfstypes.MirrorOptions{Preserve: backupSkipped})
-		} else {
-			restoreErr = acfs.RemoveAll(ctx, filepath.Dir(projectPath), "/"+filepath.Base(projectPath))
+	staleFiles, err := projects.StaleComposeFiles(ctx, projectPath, stage.composeFileName, stage.syncedFiles)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to identify stale compose files")
+	}
+	removedFiles := append(slices.Clone(stage.oldSyncedFiles), staleFiles...)
+	scope := projects.ProjectUpdateBackupScope{
+		Paths: append(slices.Clone(stage.syncedFiles), removedFiles...),
+	}
+	scope.Paths = append(scope.Paths, projects.EffectiveEnvFileName, projects.GitSourceEnvFileName, projects.OverrideEnvFileName)
+	backupLogical, err := acfs.MkdirTemp(ctx, stage.projectsDir, "/", ".gitops-backup-*")
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to create backup directory")
+	}
+	backupPath := filepath.Join(stage.projectsDir, filepath.FromSlash(strings.TrimPrefix(backupLogical, "/")))
+	var backup *projects.ProjectUpdateBackup
+	mutated := false
+	defer func() {
+		recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+		defer cancel()
+		if retErr != nil && mutated {
+			if restoreErr := projects.RestoreProjectUpdateBackup(recoveryCtx, projectPath, backup); restoreErr != nil {
+				retErr = errors.Combine(retErr, errors.WrapIff(restoreErr, "failed to restore project; recovery backup retained at %s", backupPath))
+				return
+			}
 		}
-		if restoreErr != nil {
-			slog.ErrorContext(ctx, "Failed to restore project directory after sync promotion failure; directory may be in a mixed state", "projectPath", projectPath, "backupPath", backupPath, "error", restoreErr)
+		if cleanupErr := acfs.RemoveAll(recoveryCtx, stage.projectsDir, backupLogical); cleanupErr != nil {
+			slog.WarnContext(recoveryCtx, "Failed to remove GitOps backup", "path", backupPath, "error", cleanupErr)
+		}
+	}()
+	if err := acfs.Mkdir(ctx, backupPath, "/files", 0o700); err != nil {
+		return nil, errors.WrapIf(err, "failed to prepare backup contents directory")
+	}
+	backup, err = projects.BackupProjectUpdateScope(ctx, projectPath, filepath.Join(backupPath, "files"), scope)
+	if err != nil {
+		return nil, errors.WrapIf(err, "failed to back up managed project files")
+	}
+	for _, skipped := range backup.Skipped {
+		if !isReservedRootEnvFileInternal(filepath.ToSlash(skipped)) {
+			return nil, errors.Errorf("cannot safely replace managed path %s: backup was unreadable", skipped)
 		}
 	}
-
-	// Preserve files skipped while staging: they remain in the live project but are
-	// absent from the stage, so a plain mirror would prune them.
-	if err := acfs.MirrorDir(ctx, stage.stagePath, projectPath, acfstypes.MirrorOptions{Preserve: stage.copySkipped}); err != nil {
-		restore()
-		return nil, errors.WrapIf(err, "failed to promote staged project directory")
+	if err := acfs.Write(ctx, backupPath, "/"+gitOpsRecoveryMarker, []byte(projectPath+"\n"), acfs.WriteOptions{Mode: 0o600}); err != nil {
+		return nil, errors.WrapIf(err, "failed to mark recovery backup")
 	}
-
+	mutated = true
+	if err := projects.CleanupRemovedFiles(ctx, stage.projectsDir, projectPath, removedFiles, stage.syncedFiles); err != nil {
+		return nil, errors.WrapIf(err, "failed to remove old synced files")
+	}
+	if _, err := projects.WriteSyncedDirectory(ctx, stage.projectsDir, projectPath, stage.files); err != nil {
+		return nil, errors.WrapIf(err, "failed to write synced files")
+	}
+	before, after, err := s.projectService.ApplyGitSyncEnvToDirectory(ctx, projectPath, stage.projectsDir, stage.gitEnvContent)
+	if err != nil {
+		return nil, err
+	}
+	stage.contentsChanged = stage.contentsChanged || len(staleFiles) > 0 || envContentChangedInternal(before, after)
+	stage.serviceCount, err = s.projectService.ValidateComposeDirectory(ctx, sync.ProjectName, projectPath, stage.composeFileName)
+	if err != nil {
+		return nil, errors.WrapIf(err, "invalid compose file")
+	}
 	if err := s.db.WithContext(ctx).Model(&projectpkg.Project{}).Where("id = ?", project.ID).Updates(map[string]any{
 		"service_count":     stage.serviceCount,
 		"gitops_managed_by": sync.ID,
 		"updated_at":        time.Now(),
 	}).Error; err != nil {
-		restore()
 		return nil, errors.WrapIf(err, "failed to update project metadata after directory sync")
 	}
-
 	return project, nil
 }
 

--- a/backend/internal/gitops/service_test.go
+++ b/backend/internal/gitops/service_test.go
@@ -380,6 +380,9 @@ func TestGitOpsSyncService_CleanupLeakedScratchDirsOnStartup_RemovesOrphans(t *t
 	}
 	realProject := mkdir("app")
 	require.NoError(t, os.WriteFile(filepath.Join(realProject, "compose.yaml"), []byte("services: {}\n"), 0o644))
+	preservedBackup := mkdir(".gitops-backup-preserved")
+	require.NoError(t, os.WriteFile(filepath.Join(preservedBackup, ".recovery-required"), []byte("interrupted update\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(preservedBackup, "compose.yaml"), []byte("services: {}\n"), 0o644))
 
 	require.NoError(t, svc.CleanupLeakedScratchDirsOnStartup(ctx))
 
@@ -389,6 +392,8 @@ func TestGitOpsSyncService_CleanupLeakedScratchDirsOnStartup_RemovesOrphans(t *t
 	}
 	_, err := os.Stat(realProject)
 	assert.NoError(t, err, "real project dir must be kept")
+	assert.FileExists(t, filepath.Join(preservedBackup, ".recovery-required"))
+	assert.FileExists(t, filepath.Join(preservedBackup, "compose.yaml"))
 }
 
 // TestGitOpsSyncService_CleanupLeakedCloneDirsOnStartup_RemovesAll verifies the
@@ -668,6 +673,41 @@ services:
 	featureBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "nested", "feature.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(featureBytes), "worker:")
+
+	sync.SyncedFiles = marshalSyncedFiles(syncedFiles)
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "keep.txt"), []byte("application wrote new data\n"), 0o644))
+	keepInfo, err := os.Stat(filepath.Join(projectPath, "keep.txt"))
+	require.NoError(t, err)
+	_, repeatedFiles, created, changed, err := svc.syncProjectDirectoryInternal(ctx, sync, syncFiles, common.User{})
+	require.NoError(t, err)
+	require.False(t, created)
+	require.False(t, changed)
+	require.ElementsMatch(t, syncedFiles, repeatedFiles)
+	currentKeepInfo, err := os.Stat(filepath.Join(projectPath, "keep.txt"))
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(keepInfo, currentKeepInfo))
+	assert.Equal(t, keepInfo.ModTime(), currentKeepInfo.ModTime())
+
+	// A rejected replacement must restore both overwritten and removed managed files.
+	_, _, _, _, err = svc.syncProjectDirectoryInternal(ctx, sync, []projects.SyncFile{
+		{RelativePath: "docker-compose.yaml", Content: []byte("services: [\n")},
+		{RelativePath: "new/config.txt", Content: []byte("must be rolled back\n")},
+	}, common.User{})
+	require.Error(t, err)
+	restoredCompose, err := os.ReadFile(filepath.Join(projectPath, "docker-compose.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, syncFiles[0].Content, restoredCompose)
+	restoredFeature, err := os.ReadFile(filepath.Join(projectPath, "nested", "feature.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, featureBytes, restoredFeature)
+	assert.NoFileExists(t, filepath.Join(projectPath, "new", "config.txt"))
+	keepBytes, err = os.ReadFile(filepath.Join(projectPath, "keep.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "application wrote new data\n", string(keepBytes))
+	currentKeepInfo, err = os.Stat(filepath.Join(projectPath, "keep.txt"))
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(keepInfo, currentKeepInfo))
+	assert.Equal(t, keepInfo.ModTime(), currentKeepInfo.ModTime())
 }
 
 // TestGitOpsSyncService_SyncProjectDirectory_PreservesEnvOverrideAndAddsNewGitKey
@@ -1105,8 +1145,11 @@ func TestProjectsRemoveStaleComposeFiles_RemovesStaleCustomComposeFiles(t *testi
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "sonarr.yaml"), []byte("services:\n  app:\n    image: nginx:alpine\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "values.yaml"), []byte("replicaCount: 2\nimage:\n  tag: latest\n"), 0o644))
 
-	err := projects.RemoveStaleComposeFiles(t.Context(), projectPath, "sonarr.yaml", []string{"sonarr.yaml"})
+	stale, err := projects.StaleComposeFiles(t.Context(), projectPath, "sonarr.yaml", []string{"sonarr.yaml"})
 	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"radarr.yaml"}, stale)
+	require.FileExists(t, filepath.Join(projectPath, "radarr.yaml"))
+	require.NoError(t, projects.CleanupRemovedFiles(t.Context(), projectPath, projectPath, stale, []string{"sonarr.yaml"}))
 
 	_, statErr := os.Stat(filepath.Join(projectPath, "radarr.yaml"))
 	require.ErrorIs(t, statErr, os.ErrNotExist)

--- a/backend/internal/gitops/service_unix_test.go
+++ b/backend/internal/gitops/service_unix_test.go
@@ -44,6 +44,12 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesUnreadableBindMountData
 	require.NoError(t, os.WriteFile(secretPath, []byte("supersecret"), 0o644))
 	require.NoError(t, os.Chmod(secretPath, 0o000))
 	t.Cleanup(func() { _ = os.Chmod(secretPath, 0o644) })
+	readablePath := filepath.Join(projectPath, "data", "state.db")
+	require.NoError(t, os.WriteFile(readablePath, []byte("application data"), 0o640))
+	readableInfo, err := os.Stat(readablePath)
+	require.NoError(t, err)
+	linkPath := filepath.Join(projectPath, "data", "state-link")
+	require.NoError(t, os.Symlink("state.db", linkPath))
 
 	project := &projectpkg.Project{
 		ID:      "proj-unreadable-bindmount",
@@ -95,4 +101,15 @@ func TestGitOpsSyncService_SyncProjectDirectory_PreservesUnreadableBindMountData
 	composeBytes, err := os.ReadFile(filepath.Join(updatedProject.Path, "docker-compose.yaml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(composeBytes), "nginx:1.27-alpine")
+	readableBytes, err := os.ReadFile(readablePath)
+	require.NoError(t, err)
+	assert.Equal(t, "application data", string(readableBytes))
+	currentReadableInfo, err := os.Stat(readablePath)
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(readableInfo, currentReadableInfo))
+	assert.Equal(t, readableInfo.ModTime(), currentReadableInfo.ModTime())
+	assert.Equal(t, readableInfo.Mode(), currentReadableInfo.Mode())
+	linkTarget, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "state.db", linkTarget)
 }

--- a/backend/internal/imagepatch/imagepatch.go
+++ b/backend/internal/imagepatch/imagepatch.go
@@ -427,7 +427,7 @@ func (s *ImagePatchService) writeRegistryAuthConfigInternal(ctx context.Context)
 	if err != nil {
 		return
 	}
-	if err := acfs.WriteFile(ctx, configDir, "/config.json", payload, 0o600); err != nil {
+	if err := acfs.Write(ctx, configDir, "/config.json", payload, acfs.WriteOptions{Mode: 0o600}); err != nil {
 		slog.WarnContext(ctx, "failed to write docker config for image patching", "path", configDir, "error", err)
 	}
 }

--- a/backend/internal/template/service.go
+++ b/backend/internal/template/service.go
@@ -426,7 +426,7 @@ func (s *TemplateService) SaveComposeTemplate(ctx context.Context, content strin
 	if err != nil {
 		return errors.WrapIf(err, "failed to get templates directory")
 	}
-	return acfs.WriteFile(ctx, baseDir, "/.compose.template", []byte(content), utils.FilePerm)
+	return acfs.Write(ctx, baseDir, "/.compose.template", []byte(content), acfs.WriteOptions{Mode: utils.FilePerm})
 }
 
 func (s *TemplateService) GetEnvTemplate(ctx context.Context) string {
@@ -443,7 +443,7 @@ func (s *TemplateService) SaveEnvTemplate(ctx context.Context, content string) e
 	if err != nil {
 		return errors.WrapIf(err, "failed to get templates directory")
 	}
-	return acfs.WriteFile(ctx, baseDir, "/.env.template", []byte(content), utils.FilePerm)
+	return acfs.Write(ctx, baseDir, "/.env.template", []byte(content), acfs.WriteOptions{Mode: utils.FilePerm})
 }
 
 func (s *TemplateService) GetRegistries(ctx context.Context) ([]TemplateRegistry, error) {

--- a/backend/internal/upload/upload.go
+++ b/backend/internal/upload/upload.go
@@ -110,7 +110,7 @@ func (s *UploadService) CreateSession(ctx context.Context, kind string, request 
 		ReceivedChunks: []int{},
 		CreatedAt:      time.Now().UTC(),
 	}
-	if err := acfs.WriteFile(ctx, s.root, path.Join(sessionDir, sessionDataFilename), nil, 0o600); err != nil {
+	if err := acfs.Write(ctx, s.root, path.Join(sessionDir, sessionDataFilename), nil, acfs.WriteOptions{Mode: 0o600}); err != nil {
 		_ = acfs.RemoveAll(ctx, s.root, sessionDir)
 		return nil, fmt.Errorf("create upload session data file: %w", err)
 	}
@@ -154,7 +154,7 @@ func (s *UploadService) writeMetaInternal(ctx context.Context, session *uploadty
 	if err != nil {
 		return fmt.Errorf("encode upload session metadata: %w", err)
 	}
-	if err := acfs.WriteFile(ctx, s.root, path.Join("/", session.ID, sessionMetaFilename), payload, 0o600); err != nil {
+	if err := acfs.Write(ctx, s.root, path.Join("/", session.ID, sessionMetaFilename), payload, acfs.WriteOptions{Mode: 0o600}); err != nil {
 		return fmt.Errorf("write upload session metadata: %w", err)
 	}
 	return nil

--- a/backend/internal/variable/variable.go
+++ b/backend/internal/variable/variable.go
@@ -559,7 +559,7 @@ func (s *VariableService) WriteLocalEnvFile(ctx context.Context, vars []env.Vari
 		_, _ = fmt.Fprintf(&builder, "%s=%s\n", key, value)
 	}
 
-	if err := acfs.WriteFile(ctx, projectsDirectory, "/"+projects.GlobalEnvFileName, []byte(builder.String()), utils.FilePerm); err != nil {
+	if err := acfs.Write(ctx, projectsDirectory, "/"+projects.GlobalEnvFileName, []byte(builder.String()), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 		return errors.WrapIf(err, "failed to write global variables file")
 	}
 

--- a/backend/pkg/libarcane/edge/tls.go
+++ b/backend/pkg/libarcane/edge/tls.go
@@ -322,7 +322,7 @@ func EnsureAgentMTLSAssets(ctx context.Context, cfg *Config) error {
 		needsEnrollment, reason := agentMTLSAssetsNeedEnrollmentInternal(certPath, keyPath, time.Now())
 		if !needsEnrollment {
 			if !fileExistsInternal(filepath.Join(assetsDir, generatedMTLSEnrolledName)) {
-				if err := acfs.WriteFile(ctx, assetsDir, "/"+generatedMTLSEnrolledName, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o600); err != nil {
+				if err := acfs.Write(ctx, assetsDir, "/"+generatedMTLSEnrolledName, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), acfs.WriteOptions{Mode: 0o600}); err != nil {
 					return errors.WrapIf(err, "failed to write edge mTLS enrollment marker")
 				}
 			}
@@ -396,7 +396,7 @@ func enrollAgentMTLSAssetsInternal(ctx context.Context, cfg *Config, assetsDir, 
 		if strings.TrimSpace(file.Permissions) == "0600" {
 			perm = 0o600
 		}
-		if err := acfs.WriteFile(ctx, assetsDir, "/"+filepath.Base(file.Name), []byte(file.Content), perm); err != nil {
+		if err := acfs.Write(ctx, assetsDir, "/"+filepath.Base(file.Name), []byte(file.Content), acfs.WriteOptions{Mode: perm}); err != nil {
 			return errors.WrapIff(err, "failed to write edge mTLS asset %s", file.Name)
 		}
 	}
@@ -404,7 +404,7 @@ func enrollAgentMTLSAssetsInternal(ctx context.Context, cfg *Config, assetsDir, 
 	if needsEnrollment {
 		return errors.Errorf("edge mTLS enrollment wrote unusable assets: %s", reason)
 	}
-	if err := acfs.WriteFile(ctx, assetsDir, "/"+generatedMTLSEnrolledName, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o600); err != nil {
+	if err := acfs.Write(ctx, assetsDir, "/"+generatedMTLSEnrolledName, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), acfs.WriteOptions{Mode: 0o600}); err != nil {
 		return errors.WrapIf(err, "failed to write edge mTLS enrollment marker")
 	}
 

--- a/backend/pkg/projects/fs_backup.go
+++ b/backend/pkg/projects/fs_backup.go
@@ -10,7 +10,6 @@ import (
 
 	"emperror.dev/errors"
 	"go.getarcane.app/acfs"
-	"go.getarcane.app/acfs/atomic"
 	acfstypes "go.getarcane.app/acfs/types"
 )
 
@@ -32,7 +31,6 @@ type ProjectUpdateBackupScope struct {
 
 type projectUpdateEnvSymlinkBackup struct {
 	relativePath string
-	linkTarget   string
 	resolvedPath string
 }
 
@@ -44,14 +42,15 @@ func (s ProjectUpdateBackupScope) IsEmpty() bool {
 // RestoreProjectUpdateBackup can put the project directory back without
 // touching anything outside the update's scope.
 type ProjectUpdateBackup struct {
-	BackupDir     string
-	TopLevelFiles bool
-	FileEntries   []string    // regular file contents copied into BackupDir
-	DirEntries    []string    // directories copied recursively
-	AbsentEntries []string    // did not exist at backup time -> removed on restore
-	RenamedDirs   [][2]string // undone via inverse rename on restore
-	Skipped       []string    // unreadable, skipped; preserved on restore
-	envSymlink    *projectUpdateEnvSymlinkBackup
+	BackupDir        string
+	TopLevelFiles    bool
+	FileEntries      []string    // regular file contents copied into BackupDir
+	DirEntries       []string    // directories copied recursively
+	AbsentEntries    []string    // did not exist at backup time -> removed on restore
+	RenamedDirs      [][2]string // undone via inverse rename on restore
+	Skipped          []string    // unreadable, skipped; preserved on restore
+	envSymlink       *projectUpdateEnvSymlinkBackup
+	absentParentDirs []string
 }
 
 // BackupProjectUpdateScope copies the parts of projectDir named by scope into
@@ -59,22 +58,14 @@ type ProjectUpdateBackup struct {
 // unrelated foreign-owned file cannot block a save, matching the tolerant
 // semantics of the old whole-directory backup.
 //
-// The backup/restore engine stays on os.Root rather than acfs: restoring a
-// project .env means recreating its symlink (which may point outside the
-// project directory), and acfs deliberately refuses symlink mutation.
+// External .env targets are resolved explicitly; other operations remain
+// confined to their project or backup directory.
 func BackupProjectUpdateScope(ctx context.Context, projectDir, backupDir string, scope ProjectUpdateBackupScope) (*ProjectUpdateBackup, error) {
-	projRoot, err := os.OpenRoot(projectDir)
-	if err != nil {
-		return nil, errors.WrapIf(err, "open project directory")
+	for _, directory := range []string{projectDir, backupDir} {
+		if _, err := acfs.Stat(ctx, directory, "/", false); err != nil {
+			return nil, errors.WrapIff(err, "open backup directory %s", directory)
+		}
 	}
-	defer func() { _ = projRoot.Close() }()
-
-	backupRoot, err := os.OpenRoot(backupDir)
-	if err != nil {
-		return nil, errors.WrapIf(err, "open backup directory")
-	}
-	defer func() { _ = backupRoot.Close() }()
-
 	backup := &ProjectUpdateBackup{
 		BackupDir:     backupDir,
 		TopLevelFiles: scope.TopLevelFiles,
@@ -82,18 +73,26 @@ func BackupProjectUpdateScope(ctx context.Context, projectDir, backupDir string,
 	}
 
 	if scope.TopLevelFiles {
-		if err := backupTopLevelFilesInternal(projRoot, backupRoot, backup); err != nil {
+		if err := backupTopLevelFilesInternal(ctx, projectDir, backupDir, backup); err != nil {
 			return nil, err
 		}
 	}
 
 	for _, rel := range normalizeScopePathsInternal(scope.Paths) {
-		if err := backupScopePathInternal(ctx, projRoot, backupRoot, projectDir, backupDir, rel, backup); err != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if backupPathCoveredInternal(backup, rel) {
+			continue
+		}
+		if err := backupScopePathInternal(ctx, projectDir, backupDir, rel, backup); err != nil {
 			return nil, err
 		}
 	}
 
 	dedupeCoveredBackupEntriesInternal(backup)
+	slices.Sort(backup.absentParentDirs)
+	backup.absentParentDirs = slices.Compact(backup.absentParentDirs)
 	slices.Sort(backup.Skipped)
 	return backup, nil
 }
@@ -111,20 +110,20 @@ func normalizeScopePathsInternal(paths []string) []string {
 	return slices.Compact(normalized)
 }
 
-func backupTopLevelFilesInternal(projRoot, backupRoot *os.Root, backup *ProjectUpdateBackup) error {
-	entries, err := os.ReadDir(projRoot.Name())
+func backupTopLevelFilesInternal(ctx context.Context, projectDir, backupDir string, backup *ProjectUpdateBackup) error {
+	entries, err := acfs.List(ctx, projectDir, "/")
 	if err != nil {
 		return errors.WrapIf(err, "read project directory")
 	}
 	for _, entry := range entries {
-		name := entry.Name()
+		name := entry.Name
 		switch {
-		case entry.Type().IsRegular():
-			if err := copyBackupFileInternal(projRoot, backupRoot, name, backup); err != nil {
+		case os.FileMode(entry.UnixMode).IsRegular():
+			if err := copyBackupFileInternal(ctx, projectDir, backupDir, name, backup); err != nil {
 				return err
 			}
-		case name == EffectiveEnvFileName && entry.Type()&os.ModeSymlink != 0:
-			if err := copyBackupEnvSymlinkInternal(projRoot, backupRoot, name, backup); err != nil {
+		case name == EffectiveEnvFileName && entry.IsSymlink:
+			if err := copyBackupEnvSymlinkInternal(ctx, projectDir, backupDir, name, backup); err != nil {
 				return err
 			}
 		}
@@ -132,16 +131,15 @@ func backupTopLevelFilesInternal(projRoot, backupRoot *os.Root, backup *ProjectU
 	return nil
 }
 
-func backupScopePathInternal(ctx context.Context, projRoot, backupRoot *os.Root, projectDir, backupDir, rel string, backup *ProjectUpdateBackup) error {
-	info, err := projRoot.Lstat(rel)
+func backupScopePathInternal(ctx context.Context, projectDir, backupDir, rel string, backup *ProjectUpdateBackup) error {
+	info, err := acfs.Stat(ctx, projectDir, "/"+rel, false)
 	if errors.Is(err, os.ErrNotExist) {
-		// Record the shallowest nonexistent ancestor so MkdirAll debris from a
-		// failed create is removed on restore too.
-		absent, absentErr := shallowestAbsentAncestorInternal(projRoot, rel)
+		parents, absentErr := absentParentDirectoriesInternal(ctx, projectDir, rel)
 		if absentErr != nil {
 			return absentErr
 		}
-		backup.AbsentEntries = append(backup.AbsentEntries, absent)
+		backup.AbsentEntries = append(backup.AbsentEntries, rel)
+		backup.absentParentDirs = append(backup.absentParentDirs, parents...)
 		return nil
 	}
 	if err != nil {
@@ -149,9 +147,9 @@ func backupScopePathInternal(ctx context.Context, projRoot, backupRoot *os.Root,
 	}
 
 	switch {
-	case info.IsDir():
+	case info.IsDirectory:
 		destDir := filepath.Join(backupDir, filepath.FromSlash(rel))
-		if err := os.MkdirAll(destDir, 0o755); err != nil {
+		if err := acfs.MkdirAll(ctx, backupDir, "/"+rel, 0o755); err != nil {
 			return errors.WrapIf(err, "create backup directory")
 		}
 		copied, err := acfs.CopyDir(ctx, filepath.Join(projectDir, filepath.FromSlash(rel)), destDir, acfstypes.CopyOptions{TolerateUnreadable: true})
@@ -161,38 +159,71 @@ func backupScopePathInternal(ctx context.Context, projRoot, backupRoot *os.Root,
 		for _, sub := range copied.Skipped {
 			backup.Skipped = append(backup.Skipped, path.Join(rel, filepath.ToSlash(sub)))
 		}
+		if err := recordBackupSymlinksInternal(ctx, projectDir, rel, backup); err != nil {
+			return errors.WrapIff(err, "inspect project directory symlinks %s", rel)
+		}
 		backup.DirEntries = append(backup.DirEntries, rel)
-	case info.Mode().IsRegular():
-		if err := copyBackupFileInternal(projRoot, backupRoot, rel, backup); err != nil {
+	case os.FileMode(info.UnixMode).IsRegular():
+		if err := copyBackupFileInternal(ctx, projectDir, backupDir, rel, backup); err != nil {
 			return err
 		}
+	case rel == EffectiveEnvFileName && info.IsSymlink:
+		return copyBackupEnvSymlinkInternal(ctx, projectDir, backupDir, rel, backup)
 	default:
-		// Symlinks and other special files: the apply operations reject them
-		// before mutating anything, so there is nothing to back up.
+		return errors.Errorf("cannot back up non-regular project path %s", rel)
 	}
 	return nil
 }
 
-func shallowestAbsentAncestorInternal(projRoot *os.Root, rel string) (string, error) {
-	current := ""
-	for segment := range strings.SplitSeq(rel, "/") {
-		current = path.Join(current, segment)
-		if _, err := projRoot.Lstat(current); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return current, nil
-			}
-			return "", errors.WrapIff(err, "inspect project path %s", current)
+func absentParentDirectoriesInternal(ctx context.Context, projectDir, rel string) ([]string, error) {
+	var parents []string
+	for current := path.Dir(rel); current != "."; current = path.Dir(current) {
+		if _, err := acfs.Stat(ctx, projectDir, "/"+current, false); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, errors.WrapIff(err, "inspect project path %s", current)
 		}
+		parents = append(parents, current)
 	}
-	return rel, nil
+	return parents, nil
 }
 
-func copyBackupFileInternal(projRoot, backupRoot *os.Root, rel string, backup *ProjectUpdateBackup) error {
-	info, err := projRoot.Lstat(rel)
+func recordBackupSymlinksInternal(ctx context.Context, projectDir, rel string, backup *ProjectUpdateBackup) error {
+	err := acfs.ListEach(ctx, projectDir, "/"+rel, func(entry acfstypes.Entry) error {
+		current := strings.TrimPrefix(entry.Path, "/")
+		if entry.IsSymlink {
+			backup.Skipped = append(backup.Skipped, current)
+			return nil
+		}
+		if entry.IsDirectory {
+			return recordBackupSymlinksInternal(ctx, projectDir, current, backup)
+		}
+		return nil
+	})
+	if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
+		backup.Skipped = append(backup.Skipped, rel)
+		return nil
+	}
+	return err
+}
+
+func backupPathCoveredInternal(backup *ProjectUpdateBackup, rel string) bool {
+	for _, entries := range [][]string{backup.FileEntries, backup.DirEntries, backup.AbsentEntries, backup.Skipped} {
+		for _, entry := range entries {
+			if rel == entry || strings.HasPrefix(rel, entry+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func copyBackupFileInternal(ctx context.Context, projectDir, backupDir, rel string, backup *ProjectUpdateBackup) error {
+	info, err := acfs.Stat(ctx, projectDir, "/"+rel, false)
 	if err != nil {
 		return errors.WrapIff(err, "inspect project file %s", rel)
 	}
-	content, err := projRoot.ReadFile(rel)
+	content, err := acfs.ReadFile(ctx, projectDir, "/"+rel)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			backup.Skipped = append(backup.Skipped, rel)
@@ -201,29 +232,20 @@ func copyBackupFileInternal(projRoot, backupRoot *os.Root, rel string, backup *P
 		return errors.WrapIff(err, "read project file %s", rel)
 	}
 	if dir := path.Dir(rel); dir != "." {
-		if err := backupRoot.MkdirAll(dir, 0o755); err != nil {
+		if err := acfs.MkdirAll(ctx, backupDir, "/"+dir, 0o755); err != nil {
 			return errors.WrapIf(err, "create backup directory")
 		}
 	}
-	if err := atomic.WriteFile(filepath.Join(backupRoot.Name(), filepath.FromSlash(rel)), content, info.Mode().Perm()); err != nil {
+	if err := acfs.Write(ctx, backupDir, "/"+rel, content, acfs.WriteOptions{Mode: os.FileMode(info.UnixMode).Perm()}); err != nil {
 		return errors.WrapIff(err, "write backup file %s", rel)
 	}
 	backup.FileEntries = append(backup.FileEntries, rel)
 	return nil
 }
 
-func copyBackupEnvSymlinkInternal(projRoot, backupRoot *os.Root, rel string, backup *ProjectUpdateBackup) error {
-	envPath := filepath.Join(projRoot.Name(), filepath.FromSlash(rel))
-	linkTarget, err := os.Readlink(envPath)
-	if err != nil {
-		if errors.Is(err, os.ErrPermission) {
-			backup.Skipped = append(backup.Skipped, rel)
-			return nil
-		}
-		return errors.WrapIff(err, "read project env symlink %s", rel)
-	}
-
-	resolvedPath, perm, isSymlink, err := resolveEnvFileWriteTargetInternal(envPath)
+func copyBackupEnvSymlinkInternal(ctx context.Context, projectDir, backupDir, rel string, backup *ProjectUpdateBackup) error {
+	envPath := filepath.Join(projectDir, filepath.FromSlash(rel))
+	resolvedPath, perm, isSymlink, err := resolveEnvFileWriteTargetInternal(ctx, envPath)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			backup.Skipped = append(backup.Skipped, rel)
@@ -235,7 +257,7 @@ func copyBackupEnvSymlinkInternal(projRoot, backupRoot *os.Root, rel string, bac
 		return errors.Errorf("project env file %s is no longer a symlink", rel)
 	}
 
-	content, err := os.ReadFile(resolvedPath)
+	content, err := acfs.ReadFile(ctx, filepath.Dir(resolvedPath), "/"+filepath.Base(resolvedPath))
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			backup.Skipped = append(backup.Skipped, rel)
@@ -243,14 +265,13 @@ func copyBackupEnvSymlinkInternal(projRoot, backupRoot *os.Root, rel string, bac
 		}
 		return errors.WrapIff(err, "read project env symlink target %s", rel)
 	}
-	if err := atomic.WriteFile(filepath.Join(backupRoot.Name(), filepath.FromSlash(rel)), content, perm); err != nil {
+	if err := acfs.Write(ctx, backupDir, "/"+rel, content, acfs.WriteOptions{Mode: perm}); err != nil {
 		return errors.WrapIff(err, "write backup file %s", rel)
 	}
 
 	backup.FileEntries = append(backup.FileEntries, rel)
 	backup.envSymlink = &projectUpdateEnvSymlinkBackup{
 		relativePath: rel,
-		linkTarget:   linkTarget,
 		resolvedPath: filepath.Clean(resolvedPath),
 	}
 	return nil
@@ -278,21 +299,33 @@ func dedupeCoveredBackupEntriesInternal(backup *ProjectUpdateBackup) {
 // state captured in backup. Files are restored in place (preserving inodes so
 // container bind mounts stay valid) and out-of-scope files are never touched.
 func RestoreProjectUpdateBackup(ctx context.Context, projectDir string, backup *ProjectUpdateBackup) error {
-	projRoot, err := os.OpenRoot(projectDir)
-	if err != nil {
-		return errors.WrapIf(err, "open project directory")
+	for _, directory := range []string{projectDir, backup.BackupDir} {
+		if _, err := acfs.Stat(ctx, directory, "/", false); err != nil {
+			return errors.WrapIff(err, "open restore directory %s", directory)
+		}
 	}
-	defer func() { _ = projRoot.Close() }()
-
 	// 1. Undo directory renames, then 2. remove debris the failed update
 	// created at paths that did not exist.
-	if err := undoRenamedDirsAndDebrisInternal(projRoot, backup); err != nil {
+	if err := undoRenamedDirsAndDebrisInternal(ctx, projectDir, backup); err != nil {
 		return err
 	}
 
 	// 3. Mirror backed-up directories back in place.
 	for _, rel := range backup.DirEntries {
-		if err := projRoot.MkdirAll(rel, 0o755); err != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if live, err := acfs.Stat(ctx, projectDir, "/"+rel, false); err == nil && !live.IsDirectory {
+			if live.IsSymlink {
+				return errors.Errorf("refusing to restore project directory %s: destination is a symlink", rel)
+			}
+			if err := acfs.Remove(ctx, projectDir, "/"+rel); err != nil {
+				return errors.WrapIff(err, "remove conflicting file %s", rel)
+			}
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.WrapIff(err, "inspect project directory %s", rel)
+		}
+		if err := acfs.MkdirAll(ctx, projectDir, "/"+rel, 0o755); err != nil {
 			return errors.WrapIff(err, "recreate project directory %s", rel)
 		}
 		preserve := skippedUnderInternal(backup.Skipped, rel)
@@ -303,15 +336,9 @@ func RestoreProjectUpdateBackup(ctx context.Context, projectDir string, backup *
 		}
 	}
 
-	backupRoot, err := os.OpenRoot(backup.BackupDir)
-	if err != nil {
-		return errors.WrapIf(err, "open backup directory")
-	}
-	defer func() { _ = backupRoot.Close() }()
-
 	// 4. Restore individual files in place.
 	for _, rel := range backup.FileEntries {
-		if err := restoreBackupFileInternal(backupRoot, projRoot, backup, rel); err != nil {
+		if err := restoreBackupFileInternal(ctx, projectDir, backup, rel); err != nil {
 			return err
 		}
 	}
@@ -321,7 +348,7 @@ func RestoreProjectUpdateBackup(ctx context.Context, projectDir string, backup *
 	// then copy every top-level backup file back. Top-level directories and
 	// symlinks are never touched.
 	if backup.TopLevelFiles {
-		if err := restoreTopLevelFilesInternal(backupRoot, projRoot, backup); err != nil {
+		if err := restoreTopLevelFilesInternal(ctx, projectDir, backup); err != nil {
 			return err
 		}
 	}
@@ -332,14 +359,17 @@ func RestoreProjectUpdateBackup(ctx context.Context, projectDir string, backup *
 // undoRenamedDirsAndDebrisInternal reverses directory renames with an inverse
 // rename (no copy involved), then removes debris the failed update created at
 // paths that were absent at backup time.
-func undoRenamedDirsAndDebrisInternal(projRoot *os.Root, backup *ProjectUpdateBackup) error {
+func undoRenamedDirsAndDebrisInternal(ctx context.Context, projectDir string, backup *ProjectUpdateBackup) error {
 	handledAbsent := make(map[string]bool)
 	for _, pair := range backup.RenamedDirs {
 		src, dest := pair[0], pair[1]
-		if _, err := projRoot.Lstat(dest); err != nil {
+		if _, err := acfs.Stat(ctx, projectDir, "/"+dest, false); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return errors.WrapIff(err, "inspect renamed path %s", dest)
+			}
 			continue
 		}
-		if _, err := projRoot.Lstat(src); err == nil {
+		if _, err := acfs.Stat(ctx, projectDir, "/"+src, false); err == nil {
 			// The failed batch recreated something at src (e.g. rename a -> b
 			// then create_folder a). Clear it only when the backup covers src —
 			// debris at an absent path or a directory we hold a full copy of —
@@ -348,12 +378,14 @@ func undoRenamedDirsAndDebrisInternal(projRoot *os.Root, backup *ProjectUpdateBa
 			if !slices.Contains(backup.DirEntries, src) && !slices.Contains(backup.AbsentEntries, src) {
 				continue
 			}
-			if err := projRoot.RemoveAll(src); err != nil {
+			if err := acfs.RemoveAll(ctx, projectDir, "/"+src); err != nil {
 				return errors.WrapIff(err, "remove recreated path %s", src)
 			}
 			handledAbsent[src] = true
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return errors.WrapIff(err, "inspect rename source %s", src)
 		}
-		if err := projRoot.Rename(dest, src); err != nil {
+		if err := acfs.Rename(ctx, projectDir, "/"+dest, "/"+src); err != nil {
 			return errors.WrapIff(err, "undo rename of %s", src)
 		}
 	}
@@ -364,8 +396,28 @@ func undoRenamedDirsAndDebrisInternal(projRoot *os.Root, backup *ProjectUpdateBa
 			// the original directory at this path — do not delete it again.
 			continue
 		}
-		if err := projRoot.RemoveAll(rel); err != nil {
+		if err := acfs.RemoveAll(ctx, projectDir, "/"+rel); err != nil {
 			return errors.WrapIff(err, "remove created path %s", rel)
+		}
+	}
+	return cleanupCreatedParentsInternal(ctx, projectDir, backup.absentParentDirs)
+}
+
+func cleanupCreatedParentsInternal(ctx context.Context, projectDir string, parents []string) error {
+	// Only remove empty ancestors; applications may have created siblings.
+	for _, rel := range slices.Backward(parents) {
+		info, err := acfs.Stat(ctx, projectDir, "/"+rel, false)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return errors.WrapIff(err, "inspect created parent directory %s", rel)
+		}
+		if !info.IsDirectory {
+			continue
+		}
+		if err := acfs.Remove(ctx, projectDir, "/"+rel); err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, acfs.ErrNotEmpty) {
+			return errors.WrapIff(err, "remove empty created parent directory %s", rel)
 		}
 	}
 	return nil
@@ -382,55 +434,45 @@ func skippedUnderInternal(skipped []string, rel string) []string {
 	return under
 }
 
-func restoreBackupFileInternal(backupRoot, projRoot *os.Root, backup *ProjectUpdateBackup, rel string) error {
-	info, err := backupRoot.Lstat(rel)
+func restoreBackupFileInternal(ctx context.Context, projectDir string, backup *ProjectUpdateBackup, rel string) error {
+	info, err := acfs.Stat(ctx, backup.BackupDir, "/"+rel, false)
 	if err != nil {
 		return errors.WrapIff(err, "inspect backup file %s", rel)
 	}
-	content, err := backupRoot.ReadFile(rel)
+	content, err := acfs.ReadFile(ctx, backup.BackupDir, "/"+rel)
 	if err != nil {
 		return errors.WrapIff(err, "read backup file %s", rel)
 	}
 	if backup.envSymlink != nil && backup.envSymlink.relativePath == rel {
-		return restoreBackupEnvSymlinkInternal(projRoot, backup.envSymlink, content, info.Mode().Perm())
+		return restoreBackupEnvSymlinkInternal(ctx, projectDir, backup.envSymlink, content, os.FileMode(info.UnixMode).Perm())
 	}
-	if live, err := projRoot.Lstat(rel); err == nil && live.IsDir() {
-		if err := projRoot.RemoveAll(rel); err != nil {
+	if live, err := acfs.Stat(ctx, projectDir, "/"+rel, false); err == nil && live.IsDirectory {
+		if err := acfs.RemoveAll(ctx, projectDir, "/"+rel); err != nil {
 			return errors.WrapIff(err, "remove conflicting directory %s", rel)
 		}
 	}
 	if dir := path.Dir(rel); dir != "." {
-		if err := projRoot.MkdirAll(dir, 0o755); err != nil {
+		if err := acfs.MkdirAll(ctx, projectDir, "/"+dir, 0o755); err != nil {
 			return errors.WrapIff(err, "recreate parent directory of %s", rel)
 		}
 	}
-	// Atomic write: a crash mid-restore leaves either the failed-update
-	// content or the fully restored file, never a torn write.
-	if err := atomic.WriteFile(filepath.Join(projRoot.Name(), filepath.FromSlash(rel)), content, info.Mode().Perm()); err != nil {
+	if err := acfs.Write(ctx, projectDir, "/"+rel, content, acfs.WriteOptions{Mode: os.FileMode(info.UnixMode).Perm(), InPlace: true}); err != nil {
 		return errors.WrapIff(err, "restore project file %s", rel)
 	}
 	return nil
 }
 
-func restoreBackupEnvSymlinkInternal(projRoot *os.Root, envBackup *projectUpdateEnvSymlinkBackup, content []byte, perm os.FileMode) error {
-	envPath := filepath.Join(projRoot.Name(), filepath.FromSlash(envBackup.relativePath))
-	info, err := os.Lstat(envPath)
+func restoreBackupEnvSymlinkInternal(ctx context.Context, projectDir string, envBackup *projectUpdateEnvSymlinkBackup, content []byte, perm os.FileMode) error {
+	info, err := acfs.Stat(ctx, projectDir, "/"+envBackup.relativePath, false)
 	if err != nil {
 		return errors.WrapIf(err, "inspect project env symlink during restore")
 	}
-	if info.Mode()&os.ModeSymlink == 0 {
+	if !info.IsSymlink {
 		return errors.Errorf("refusing to restore project env file %s: destination is no longer a symlink", envBackup.relativePath)
 	}
 
-	linkTarget, err := os.Readlink(envPath)
-	if err != nil {
-		return errors.WrapIf(err, "read project env symlink during restore")
-	}
-	if linkTarget != envBackup.linkTarget {
-		return errors.Errorf("refusing to restore project env file %s: symlink target changed", envBackup.relativePath)
-	}
-
-	resolvedPath, _, isSymlink, err := resolveEnvFileWriteTargetInternal(envPath)
+	envPath := filepath.Join(projectDir, filepath.FromSlash(envBackup.relativePath))
+	resolvedPath, _, isSymlink, err := resolveEnvFileWriteTargetInternal(ctx, envPath)
 	if err != nil {
 		return errors.WrapIf(err, "resolve project env symlink during restore")
 	}
@@ -438,21 +480,21 @@ func restoreBackupEnvSymlinkInternal(projRoot *os.Root, envBackup *projectUpdate
 		return errors.Errorf("refusing to restore project env file %s: resolved symlink target changed", envBackup.relativePath)
 	}
 
-	if err := atomic.WriteFile(resolvedPath, content, perm); err != nil {
+	if err := acfs.Write(ctx, filepath.Dir(resolvedPath), "/"+filepath.Base(resolvedPath), content, acfs.WriteOptions{Mode: perm, InPlace: true}); err != nil {
 		return errors.WrapIff(err, "restore project env symlink target %s", envBackup.relativePath)
 	}
 	return nil
 }
 
-func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, backup *ProjectUpdateBackup) error {
-	backupEntries, err := os.ReadDir(backupRoot.Name())
+func restoreTopLevelFilesInternal(ctx context.Context, projectDir string, backup *ProjectUpdateBackup) error {
+	backupEntries, err := acfs.List(ctx, backup.BackupDir, "/")
 	if err != nil {
 		return errors.WrapIf(err, "read backup directory")
 	}
 	inBackup := make(map[string]bool, len(backupEntries))
 	for _, entry := range backupEntries {
-		if entry.Type().IsRegular() {
-			inBackup[entry.Name()] = true
+		if os.FileMode(entry.UnixMode).IsRegular() {
+			inBackup[entry.Name] = true
 		}
 	}
 	skippedTopLevel := make(map[string]bool)
@@ -462,27 +504,27 @@ func restoreTopLevelFilesInternal(backupRoot, projRoot *os.Root, backup *Project
 		}
 	}
 
-	liveEntries, err := os.ReadDir(projRoot.Name())
+	liveEntries, err := acfs.List(ctx, projectDir, "/")
 	if err != nil {
 		return errors.WrapIf(err, "read project directory")
 	}
 	for _, entry := range liveEntries {
-		name := entry.Name()
-		if !entry.Type().IsRegular() || inBackup[name] || skippedTopLevel[name] {
+		name := entry.Name
+		if !os.FileMode(entry.UnixMode).IsRegular() || inBackup[name] || skippedTopLevel[name] {
 			continue
 		}
-		if err := projRoot.Remove(name); err != nil {
+		if err := acfs.Remove(ctx, projectDir, "/"+name); err != nil {
 			return errors.WrapIff(err, "prune created file %s", name)
 		}
 	}
 
-	// backupEntries is sorted by os.ReadDir, so restoration order is
+	// ACFS returns entries in name order, so restoration order is
 	// deterministic and mirrors the backup order.
 	for _, entry := range backupEntries {
-		if !entry.Type().IsRegular() {
+		if !os.FileMode(entry.UnixMode).IsRegular() {
 			continue
 		}
-		if err := restoreBackupFileInternal(backupRoot, projRoot, backup, entry.Name()); err != nil {
+		if err := restoreBackupFileInternal(ctx, projectDir, backup, entry.Name); err != nil {
 			return err
 		}
 	}

--- a/backend/pkg/projects/fs_backup_test.go
+++ b/backend/pkg/projects/fs_backup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.getarcane.app/acfs"
 )
 
 func TestRestoreProjectUpdateBackup_UndoesRenameWhenSourceWasRecreated(t *testing.T) {
@@ -15,10 +16,19 @@ func TestRestoreProjectUpdateBackup_UndoesRenameWhenSourceWasRecreated(t *testin
 	projectDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "a", "keep.txt"), []byte("keep\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "file-transition"), []byte("original file\n"), 0o640))
+	require.NoError(t, os.Mkdir(filepath.Join(projectDir, "dir-transition"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "dir-transition", "keep.txt"), []byte("original directory\n"), 0o644))
+	configPath := filepath.Join(projectDir, "config.txt")
+	require.NoError(t, os.WriteFile(configPath, []byte("original config\n"), 0o640))
+	require.NoError(t, os.Chmod(configPath, 0o640))
+	originalConfig, err := os.Stat(configPath)
+	require.NoError(t, err)
 
 	// Batch: rename a -> b, create_folder a, then a later change fails.
 	scope := ProjectUpdateBackupScope{
-		Paths:       []string{"a"},
+		Paths: []string{"a", "file-transition", "file-transition/child.txt", "dir-transition", "config.txt",
+			"new-parent/deep/managed.txt", "empty-parent/deep/managed.txt"},
 		RenamedDirs: [][2]string{{"a", "b"}},
 	}
 	backup, err := BackupProjectUpdateScope(t.Context(), projectDir, t.TempDir(), scope)
@@ -26,11 +36,43 @@ func TestRestoreProjectUpdateBackup_UndoesRenameWhenSourceWasRecreated(t *testin
 
 	require.NoError(t, os.Rename(filepath.Join(projectDir, "a"), filepath.Join(projectDir, "b")))
 	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, "a"), 0o755))
+	require.NoError(t, os.Remove(filepath.Join(projectDir, "file-transition")))
+	require.NoError(t, os.Mkdir(filepath.Join(projectDir, "file-transition"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "file-transition", "child.txt"), []byte("new child\n"), 0o644))
+	require.NoError(t, os.RemoveAll(filepath.Join(projectDir, "dir-transition")))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "dir-transition"), []byte("replacement file\n"), 0o644))
+	require.NoError(t, os.WriteFile(configPath, []byte("changed config\n"), 0o640))
+	require.NoError(t, os.Chmod(configPath, 0o600))
+	for _, parent := range []string{"new-parent", "empty-parent"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(projectDir, parent, "deep"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, parent, "deep", "managed.txt"), []byte("managed\n"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "new-parent", "deep", "app-data.txt"), []byte("unrelated\n"), 0o644))
 
 	require.NoError(t, RestoreProjectUpdateBackup(t.Context(), projectDir, backup))
 
 	require.NoDirExists(t, filepath.Join(projectDir, "b"))
 	require.FileExists(t, filepath.Join(projectDir, "a", "keep.txt"))
+	fileContent, err := os.ReadFile(filepath.Join(projectDir, "file-transition"))
+	require.NoError(t, err)
+	require.Equal(t, "original file\n", string(fileContent))
+	dirContent, err := os.ReadFile(filepath.Join(projectDir, "dir-transition", "keep.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "original directory\n", string(dirContent))
+	configContent, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "original config\n", string(configContent))
+	restoredConfig, err := os.Stat(configPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(originalConfig, restoredConfig))
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o640), restoredConfig.Mode().Perm())
+	}
+	require.NoFileExists(t, filepath.Join(projectDir, "new-parent", "deep", "managed.txt"))
+	appContent, err := os.ReadFile(filepath.Join(projectDir, "new-parent", "deep", "app-data.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "unrelated\n", string(appContent))
+	require.NoDirExists(t, filepath.Join(projectDir, "empty-parent"))
 }
 
 func TestRestoreProjectUpdateBackup_RestoresExternalEnvSymlinkTarget(t *testing.T) {
@@ -48,12 +90,17 @@ func TestRestoreProjectUpdateBackup_RestoresExternalEnvSymlinkTarget(t *testing.
 	originalLinkTarget, err := os.Readlink(envPath)
 	require.NoError(t, err)
 
-	backup, err := BackupProjectUpdateScope(t.Context(), projectDir, t.TempDir(), ProjectUpdateBackupScope{TopLevelFiles: true})
+	backup, err := BackupProjectUpdateScope(t.Context(), projectDir, t.TempDir(), ProjectUpdateBackupScope{Paths: []string{EffectiveEnvFileName}})
 	require.NoError(t, err)
 	require.NotNil(t, backup.envSymlink)
 
 	require.NoError(t, WriteProjectFile(t.Context(), projectDir, projectDir, ".env", "VALUE=updated\n"))
+	targetBeforeRestore, err := os.Stat(targetPath)
+	require.NoError(t, err)
 	require.NoError(t, RestoreProjectUpdateBackup(t.Context(), projectDir, backup))
+	targetAfterRestore, err := os.Stat(targetPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(targetBeforeRestore, targetAfterRestore))
 
 	restoredContent, err := os.ReadFile(targetPath)
 	require.NoError(t, err)
@@ -103,4 +150,16 @@ func TestRestoreProjectUpdateBackup_RejectsRetargetedEnvSymlink(t *testing.T) {
 	currentLinkTarget, readlinkErr := os.Readlink(envPath)
 	require.NoError(t, readlinkErr)
 	require.Equal(t, newTarget, currentLinkTarget)
+
+	configPath := filepath.Join(projectDir, "config.txt")
+	require.NoError(t, os.WriteFile(configPath, []byte("original config\n"), 0o600))
+	configBackup, err := BackupProjectUpdateScope(t.Context(), projectDir, t.TempDir(), ProjectUpdateBackupScope{Paths: []string{"config.txt"}})
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(configPath))
+	require.NoError(t, os.Symlink(newTarget, configPath))
+	err = RestoreProjectUpdateBackup(t.Context(), projectDir, configBackup)
+	require.ErrorIs(t, err, acfs.ErrSymlink)
+	newContent, readErr = os.ReadFile(newTarget)
+	require.NoError(t, readErr)
+	require.Equal(t, "VALUE=untouched\n", string(newContent))
 }

--- a/backend/pkg/projects/fs_templates.go
+++ b/backend/pkg/projects/fs_templates.go
@@ -104,7 +104,7 @@ func EnsureDefaultTemplates(ctx context.Context, configuredTemplatesDir string) 
 	if exists, err := acfs.Exists(ctx, templatesDir, "/.compose.template"); err != nil {
 		return errors.WrapIf(err, "write default compose template")
 	} else if !exists {
-		if err := acfs.WriteFile(ctx, templatesDir, "/.compose.template", []byte(getDefaultComposeTemplate()), utils.FilePerm); err != nil {
+		if err := acfs.Write(ctx, templatesDir, "/.compose.template", []byte(getDefaultComposeTemplate()), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 			return errors.WrapIf(err, "write default compose template")
 		}
 	}
@@ -113,7 +113,7 @@ func EnsureDefaultTemplates(ctx context.Context, configuredTemplatesDir string) 
 	if exists, err := acfs.Exists(ctx, templatesDir, "/.swarm-stack.template"); err != nil {
 		return errors.WrapIf(err, "write default swarm stack template")
 	} else if !exists {
-		if err := acfs.WriteFile(ctx, templatesDir, "/.swarm-stack.template", []byte(DefaultSwarmStackTemplate()), utils.FilePerm); err != nil {
+		if err := acfs.Write(ctx, templatesDir, "/.swarm-stack.template", []byte(DefaultSwarmStackTemplate()), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 			return errors.WrapIf(err, "write default swarm stack template")
 		}
 	}
@@ -122,7 +122,7 @@ func EnsureDefaultTemplates(ctx context.Context, configuredTemplatesDir string) 
 	if exists, err := acfs.Exists(ctx, templatesDir, "/.swarm-stack.env.template"); err != nil {
 		return errors.WrapIf(err, "write default swarm stack env template")
 	} else if !exists {
-		if err := acfs.WriteFile(ctx, templatesDir, "/.swarm-stack.env.template", []byte(DefaultSwarmStackEnvTemplate()), utils.FilePerm); err != nil {
+		if err := acfs.Write(ctx, templatesDir, "/.swarm-stack.env.template", []byte(DefaultSwarmStackEnvTemplate()), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 			return errors.WrapIf(err, "write default swarm stack env template")
 		}
 	}
@@ -131,7 +131,7 @@ func EnsureDefaultTemplates(ctx context.Context, configuredTemplatesDir string) 
 	if exists, err := acfs.Exists(ctx, templatesDir, "/.env.template"); err != nil {
 		return errors.WrapIf(err, "write default env template")
 	} else if !exists {
-		if err := acfs.WriteFile(ctx, templatesDir, "/.env.template", []byte(getDefaultEnvTemplate()), utils.FilePerm); err != nil {
+		if err := acfs.Write(ctx, templatesDir, "/.env.template", []byte(getDefaultEnvTemplate()), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 			return errors.WrapIf(err, "write default env template")
 		}
 	}

--- a/backend/pkg/projects/fs_util.go
+++ b/backend/pkg/projects/fs_util.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 
 	"emperror.dev/errors"
 
@@ -184,12 +185,15 @@ func syncedProjectFileMatchesInternal(ctx context.Context, projectPath string, f
 	logicalPath := "/" + filepath.ToSlash(file.RelativePath)
 	entry, err := acfs.Stat(ctx, projectPath, logicalPath, false)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) || errors.Is(err, acfs.ErrNotDirectory) {
 			return false, nil
 		}
 		return false, err
 	}
 	if entry.IsDirectory {
+		return false, nil
+	}
+	if (os.FileMode(entry.UnixMode)&0o111 != 0) != file.Executable {
 		return false, nil
 	}
 
@@ -273,56 +277,37 @@ func DirectorySyncContentsChanged(ctx context.Context, projectPath string, syncF
 	return false, nil
 }
 
-func RemoveStaleComposeFiles(ctx context.Context, projectPath, composeFileName string, syncedFiles []string) error {
+// StaleComposeFiles identifies Compose files a sync replaces before the caller backs them up.
+func StaleComposeFiles(ctx context.Context, projectPath, composeFileName string, syncedFiles []string) ([]string, error) {
 	syncedFileSet := make(map[string]struct{}, len(syncedFiles))
 	for _, file := range syncedFiles {
 		syncedFileSet[file] = struct{}{}
 	}
-
-	for _, candidate := range ComposeFileCandidates() {
-		if candidate == composeFileName {
-			continue
-		}
-		if _, exists := syncedFileSet[candidate]; exists {
-			continue
-		}
-		if err := acfs.Remove(ctx, projectPath, "/"+candidate); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-	}
-
 	entries, err := acfs.List(ctx, projectPath, "/")
 	if err != nil {
-		return err
+		return nil, err
 	}
-
+	var staleFiles []string
 	for _, entry := range entries {
-		if entry.IsDirectory {
-			continue
-		}
-
 		name := entry.Name
-		if name == composeFileName {
+		if entry.IsDirectory || entry.IsSymlink || name == composeFileName {
 			continue
 		}
 		if _, exists := syncedFileSet[name]; exists {
 			continue
 		}
-		if slices.Contains(ComposeFileCandidates(), name) || !IsProjectFile(name) {
-			continue
+		if !slices.Contains(ComposeFileCandidates(), name) {
+			if !IsProjectFile(name) {
+				continue
+			}
+			hasComposeRootKeys, err := HasComposeRootKeysInFile(filepath.Join(projectPath, name))
+			if err != nil || !hasComposeRootKeys {
+				continue
+			}
 		}
-
-		hasComposeRootKeys, rootKeysErr := HasComposeRootKeysInFile(filepath.Join(projectPath, name))
-		if rootKeysErr != nil || !hasComposeRootKeys {
-			continue
-		}
-
-		if err := acfs.Remove(ctx, projectPath, entry.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
+		staleFiles = append(staleFiles, name)
 	}
-
-	return nil
+	return staleFiles, nil
 }
 
 // CreateUniqueDir creates a unique directory within the allowed projectsRoot,

--- a/backend/pkg/projects/fs_writer.go
+++ b/backend/pkg/projects/fs_writer.go
@@ -72,7 +72,7 @@ func WriteComposeFile(ctx context.Context, projectsRoot, dirPath, content string
 		composeFileName = filepath.Base(existingFile)
 	}
 
-	if err := acfs.WriteFile(ctx, dirPath, "/"+composeFileName, []byte(content), utils.FilePerm); err != nil {
+	if err := acfs.Write(ctx, dirPath, "/"+composeFileName, []byte(content), acfs.WriteOptions{Mode: utils.FilePerm}); err != nil {
 		return errors.WrapIf(err, "failed to write compose file")
 	}
 
@@ -88,12 +88,20 @@ func WriteProjectFile(ctx context.Context, projectsRoot, dirPath, fileName, cont
 		return errors.Errorf("invalid project file name %q", fileName)
 	}
 
-	if err := os.MkdirAll(dirPath, utils.DirPerm); err != nil {
-		return errors.WrapIf(err, "failed to create directory")
+	logicalDir, err := acfs.LogicalPath(projectsRoot, dirPath)
+	if err != nil {
+		return err
+	}
+	if _, err := acfs.Stat(ctx, dirPath, "/", false); errors.Is(err, fs.ErrNotExist) {
+		if err := acfs.MkdirAll(ctx, projectsRoot, logicalDir, utils.DirPerm); err != nil {
+			return errors.WrapIf(err, "failed to create directory")
+		}
+	} else if err != nil {
+		return errors.WrapIf(err, "failed to inspect project directory")
 	}
 
 	if fileName == EffectiveEnvFileName {
-		written, err := writeEnvThroughSymlinkInternal(filepath.Join(dirPath, fileName), content)
+		written, err := writeEnvThroughSymlinkInternal(ctx, filepath.Join(dirPath, fileName), content)
 		if err != nil {
 			return errors.WrapIff(err, "failed to write project file %s", fileName)
 		}
@@ -123,64 +131,64 @@ func WriteProjectFile(ctx context.Context, projectsRoot, dirPath, fileName, cont
 		}
 	}
 
-	if err := acfs.WriteFile(ctx, dirPath, logicalPath, []byte(content), utils.FilePerm); err != nil {
+	perm := utils.FilePerm
+	if statErr == nil {
+		perm = os.FileMode(entry.UnixMode).Perm()
+	}
+	if err := acfs.Write(ctx, dirPath, logicalPath, []byte(content), acfs.WriteOptions{Mode: perm, InPlace: true}); err != nil {
 		return errors.WrapIff(err, "failed to write project file %s", fileName)
 	}
 
 	return nil
 }
 
-// writeEnvThroughSymlinkInternal writes content through a project .env that is
-// a symbolic link and reports whether it did.
-//
-// The link target is allowed to live outside the projects root by design, so
-// the write goes to the resolved absolute path rather than through the
-// root-confined API; tightening that is the same class of regression as the
-// includes handling in #3556. The resolved target is always a regular file.
-func writeEnvThroughSymlinkInternal(envPath, content string) (bool, error) {
-	resolvedPath, resolvedPerm, isSymlink, err := resolveEnvFileWriteTargetInternal(envPath)
+// writeEnvThroughSymlinkInternal honors explicitly configured external .env targets.
+func writeEnvThroughSymlinkInternal(ctx context.Context, envPath, content string) (bool, error) {
+	resolvedPath, resolvedPerm, isSymlink, err := resolveEnvFileWriteTargetInternal(ctx, envPath)
 	if err != nil {
 		return false, errors.WrapIf(err, "resolve write target")
 	}
 	if !isSymlink {
 		return false, nil
 	}
-
-	existingContent, readErr := os.ReadFile(resolvedPath)
-	if readErr == nil && string(existingContent) == content {
-		return true, nil
-	}
-	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-		return true, errors.WrapIf(readErr, "read existing content")
-	}
-	return true, atomic.WriteFile(resolvedPath, []byte(content), resolvedPerm)
+	return true, acfs.Write(ctx, filepath.Dir(resolvedPath), "/"+filepath.Base(resolvedPath), []byte(content), acfs.WriteOptions{Mode: resolvedPerm, InPlace: true})
 }
 
-func resolveEnvFileWriteTargetInternal(envPath string) (writePath string, perm os.FileMode, isSymlink bool, err error) {
-	info, err := os.Lstat(envPath)
+func resolveEnvFileWriteTargetInternal(ctx context.Context, envPath string) (writePath string, perm os.FileMode, isSymlink bool, err error) {
+	info, err := acfs.Stat(ctx, filepath.Dir(envPath), "/"+filepath.Base(envPath), false)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return envPath, utils.FilePerm, false, nil
 		}
 		return "", 0, false, errors.WrapIf(err, "inspect env file")
 	}
-	if info.Mode()&os.ModeSymlink == 0 {
+	if !info.IsSymlink {
 		return envPath, utils.FilePerm, false, nil
 	}
 
-	resolvedPath, err := filepath.EvalSymlinks(envPath)
+	// External .env targets are supported; other project paths stay project-confined.
+	absPath, err := filepath.Abs(envPath)
+	if err != nil {
+		return "", 0, false, err
+	}
+	volumeRoot := filepath.VolumeName(absPath) + string(filepath.Separator)
+	logicalPath, err := acfs.LogicalPath(volumeRoot, absPath)
+	if err != nil {
+		return "", 0, false, err
+	}
+	resolvedEntry, err := acfs.Stat(ctx, volumeRoot, logicalPath, true)
 	if err != nil {
 		return "", 0, false, errors.WrapIf(err, "resolve env file symlink")
 	}
-	targetInfo, err := os.Stat(resolvedPath)
+	resolvedPath := filepath.Join(volumeRoot, filepath.FromSlash(strings.TrimPrefix(resolvedEntry.Path, "/")))
+	targetInfo, err := acfs.Stat(ctx, filepath.Dir(resolvedPath), "/"+filepath.Base(resolvedPath), false)
 	if err != nil {
 		return "", 0, false, errors.WrapIf(err, "inspect env file symlink target")
 	}
-	if !targetInfo.Mode().IsRegular() {
+	if !os.FileMode(targetInfo.UnixMode).IsRegular() {
 		return "", 0, false, errors.Errorf("env file symlink target is not a regular file: %s", resolvedPath)
 	}
-
-	return resolvedPath, targetInfo.Mode().Perm(), true, nil
+	return resolvedPath, os.FileMode(targetInfo.UnixMode).Perm(), true, nil
 }
 
 func RemoveProjectFile(ctx context.Context, projectsRoot, dirPath, fileName string) error {
@@ -338,14 +346,19 @@ type SyncFile struct {
 // It validates all paths are within the project directory and creates
 // subdirectories as needed. Returns the list of written file paths.
 func WriteSyncedDirectory(ctx context.Context, projectsRoot, projectPath string, files []SyncFile) ([]string, error) {
-	if _, err := acfs.LogicalPath(projectsRoot, projectPath); err != nil {
+	logicalDir, err := acfs.LogicalPath(projectsRoot, projectPath)
+	if err != nil {
 		return nil, errors.WrapIf(err, "project path is outside projects root")
 	}
 
 	// The project directory is the confinement root for every write below, so
 	// it has to exist before acfs can open it.
-	if err := os.MkdirAll(projectPath, utils.DirPerm); err != nil {
-		return nil, errors.WrapIf(err, "failed to create project directory")
+	if _, err := acfs.Stat(ctx, projectPath, "/", false); errors.Is(err, fs.ErrNotExist) {
+		if err := acfs.MkdirAll(ctx, projectsRoot, logicalDir, utils.DirPerm); err != nil {
+			return nil, errors.WrapIf(err, "failed to create project directory")
+		}
+	} else if err != nil {
+		return nil, errors.WrapIf(err, "failed to inspect project directory")
 	}
 
 	writtenPaths := make([]string, 0, len(files))
@@ -373,10 +386,13 @@ func WriteSyncedDirectory(ctx context.Context, projectsRoot, projectPath string,
 		// Write the file. Honor the source's executable bit so scripts arrive
 		// runnable for lifecycle hooks and similar consumers.
 		perm := utils.FilePerm
-		if file.Executable {
-			perm = 0o755
+		if statErr == nil && !entry.IsDirectory {
+			perm = os.FileMode(entry.UnixMode).Perm() &^ 0o111
 		}
-		if err := acfs.WriteFile(ctx, projectPath, logicalPath, file.Content, perm); err != nil {
+		if file.Executable {
+			perm |= 0o111
+		}
+		if err := acfs.Write(ctx, projectPath, logicalPath, file.Content, acfs.WriteOptions{Mode: perm, InPlace: true}); err != nil {
 			return nil, errors.WrapIff(err, "failed to write file %s", file.RelativePath)
 		}
 

--- a/backend/pkg/projects/includes.go
+++ b/backend/pkg/projects/includes.go
@@ -90,7 +90,7 @@ func (l *MissingIncludeStubLoader) Load(ctx context.Context, filePath string) (s
 	if err := acfs.MkdirAll(ctx, l.tempDir, path.Dir(stubLogical), 0o755); err != nil {
 		return "", errors.WrapIf(err, "create validation include directory")
 	}
-	if err := acfs.WriteFile(ctx, l.tempDir, stubLogical, []byte("services: {}\n"), 0o600); err != nil {
+	if err := acfs.Write(ctx, l.tempDir, stubLogical, []byte("services: {}\n"), acfs.WriteOptions{Mode: 0o600}); err != nil {
 		return "", errors.WrapIf(err, "write validation include stub")
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes GitOps directory synchronization to mutate and back up only managed paths, preserving unrelated application files and adding scoped rollback behavior.
- Upgrades `acfs` and migrates filesystem writes to its newer API.
- Adds managed-path backup and restoration helpers.
- Preserves recovery-marked backup directories during startup cleanup.
- Expands tests for unmanaged files, unreadable data, symlinks, and rollback.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The PR does not appear safe to merge because unmanaged Compose files can still be deleted, invalid files can become live before validation, and interrupted updates are not automatically recovered.

Three unresolved correctness failures remain from the previous review: stale Compose discovery can still select unmanaged user files for deletion; existing projects are still mutated before Compose validation, exposing rejected contents temporarily; and startup preserves recovery-marked backups without applying them, leaving interrupted updates partially applied. The newly introduced cleanup paths also violate the repository’s explicit error-handling requirement by silently discarding cleanup failures.

**Files Needing Attention:** backend/internal/gitops/gitops_sync.go, backend/pkg/projects/fs_util.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_gitops_limit_directory_sync_mutations_to_managed_files%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_gitops_limit_directory_sync_mutations_to_managed_files%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233849%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3849&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_gitops_limit_directory_sync_mutations_to_managed_files%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_gitops_limit_directory_sync_mutations_to_managed_files%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fgitops%2Fgitops_sync.go%3A1821%0A**Cleanup%20Errors%20Are%20Ignored**%0A%0AThe%20new%20scratch-directory%20cleanup%20paths%20discard%20errors%20from%20%60acfs.RemoveAll%60%20without%20justification%20or%20logging.%20This%20violates%20the%20repository%20directive%20requiring%20errors%20to%20be%20handled%20explicitly%20and%20%60_%60%20assignments%20to%20be%20avoided%20unless%20justified.%20A%20failed%20cleanup%20can%20leave%20staging%20data%20behind%20with%20no%20diagnostic%3B%20the%20same%20pattern%20also%20occurs%20near%20line%201898.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fgitops%2Fgitops_sync.go%3A1821%0A**Cleanup%20Errors%20Are%20Ignored**%0A%0AThe%20new%20scratch-directory%20cleanup%20paths%20discard%20errors%20from%20%60acfs.RemoveAll%60%20without%20justification%20or%20logging.%20This%20violates%20the%20repository%20directive%20requiring%20errors%20to%20be%20handled%20explicitly%20and%20%60_%60%20assignments%20to%20be%20avoided%20unless%20justified.%20A%20failed%20cleanup%20can%20leave%20staging%20data%20behind%20with%20no%20diagnostic%3B%20the%20same%20pattern%20also%20occurs%20near%20line%201898.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3849&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/gitops/gitops_sync.go:1821
**Cleanup Errors Are Ignored**

The new scratch-directory cleanup paths discard errors from `acfs.RemoveAll` without justification or logging. This violates the repository directive requiring errors to be handled explicitly and `_` assignments to be avoided unless justified. A failed cleanup can leave staging data behind with no diagnostic; the same pattern also occurs near line 1898. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(gitops): limit directory sync mutati..."](https://github.com/getarcaneapp/arcane/commit/5f18ce996e23df5700c53f45b9dc024b3d0a87f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60678919)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->