### PR TITLE
fix(environments): surface sync failures and track manual sync as an activity

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -418,7 +418,7 @@ func registerHandlersInternal(api huma.API, deps HandlerDeps, handlerAppCtx hand
 	deps.Event.RegisterRoutes(api)
 	deps.Activity.RegisterRoutes(api)
 	oidc.RegisterOidc(api, deps.Auth.Service(), deps.Passkey, deps.Oidc, deps.Role.Service(), deps.User.Service(), cfg)
-	deps.Environment.RegisterRoutes(api)
+	deps.Environment.RegisterRoutes(api, handlerAppCtx)
 	deps.ContainerRegistry.RegisterRoutes(api)
 	deps.Template.RegisterRoutes(api)
 	deps.Variable.RegisterRoutes(api, cfg)

--- a/backend/internal/di/providers.go
+++ b/backend/internal/di/providers.go
@@ -84,12 +84,13 @@ func provideActivityServiceInternal(module *activity.Module) *activity.ActivityS
 	return module.Service()
 }
 
-func provideEnvironmentModuleInternal(service *environment.EnvironmentService, settingsService *settings.SettingsService, apiKey *apikey.ApiKeyService, eventService *event.EventService, cfg *config.Config) *environment.Module {
+func provideEnvironmentModuleInternal(service *environment.EnvironmentService, settingsService *settings.SettingsService, apiKey *apikey.ApiKeyService, eventService *event.EventService, cfg *config.Config, activityService *activity.ActivityService) *environment.Module {
 	return environment.New(service, environment.Dependencies{
 		Settings: settingsService,
 		ApiKey:   apiKey,
 		Event:    eventService,
 		Config:   cfg,
+		Activity: activityService,
 	})
 }
 

--- a/backend/internal/environment/environment.go
+++ b/backend/internal/environment/environment.go
@@ -14,14 +14,17 @@ import (
 	"emperror.dev/errors"
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/apikey"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/docker"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
+	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/remenv"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/scheduler/entityjobs"
 	httputils "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/httpx"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/validation"
+	activitytypes "github.com/getarcaneapp/arcane/types/v2/activity"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
 	"go.getarcane.app/sys/crypto"
 	"gorm.io/gorm"
@@ -480,4 +483,43 @@ func (s *EnvironmentService) GetEnabledRegistryCredentials(ctx context.Context) 
 	}
 
 	return creds, nil
+}
+
+// SyncResourcesToEnvironment tracks a manual sync and attempts every resource group.
+func (s *EnvironmentService) SyncResourcesToEnvironment(ctx context.Context, environmentID string, user *common.User, activityService activitylib.Service) (string, error) {
+	return activitylib.RunHandlerActivity(ctx, activityService, activitylib.HandlerOptions{
+		EnvironmentID:  environmentID,
+		Type:           activitytypes.TypeResourceAction,
+		ResourceType:   "environment",
+		ResourceID:     environmentID,
+		ResourceName:   environmentID,
+		User:           user,
+		Step:           "Syncing environment",
+		Message:        "Syncing container registries, S3 destinations, and git repositories",
+		SuccessMessage: "Environment synced successfully",
+		Metadata:       database.JSON{"action": "sync_environment"},
+	}, func(ctx context.Context) error {
+		var failedGroups []string
+
+		if err := s.SyncRegistriesToEnvironment(ctx, environmentID); err != nil {
+			slog.WarnContext(ctx, "Failed to sync registries", "environmentID", environmentID, "error", err.Error())
+			failedGroups = append(failedGroups, "container registries")
+		}
+
+		if err := s.SyncS3DestinationsToEnvironment(ctx, environmentID); err != nil {
+			slog.WarnContext(ctx, "Failed to sync S3 destinations", "environmentID", environmentID, "error", err.Error())
+			failedGroups = append(failedGroups, "S3 destinations")
+		}
+
+		if err := s.SyncRepositoriesToEnvironment(ctx, environmentID); err != nil {
+			slog.WarnContext(ctx, "Failed to sync git repositories", "environmentID", environmentID, "error", err.Error())
+			failedGroups = append(failedGroups, "git repositories")
+		}
+
+		if len(failedGroups) > 0 {
+			return errors.New("Failed to sync " + strings.Join(failedGroups, ", ") + ". Other resource groups may have synced successfully. Check the manager logs, correct the failed sync, and retry.")
+		}
+
+		return nil
+	})
 }

--- a/backend/internal/environment/environment_proxy.go
+++ b/backend/internal/environment/environment_proxy.go
@@ -6,6 +6,7 @@ import (
 
 	"context"
 	"encoding/json/v2"
+	"fmt"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -336,7 +337,7 @@ func doRemoteEnvironmentTunnelRequestInternal(
 // SyncRegistriesToEnvironment syncs all registries from this manager to a remote environment
 func (s *EnvironmentService) SyncRegistriesToEnvironment(ctx context.Context, environmentID string) error {
 	return s.fanOutSyncToEnvironment(ctx, environmentID, "registries", "/api/container-registries/sync",
-		func(ctx context.Context, reg registry.ContainerRegistry) (containerregistry.Sync, bool, error) {
+		func(reg registry.ContainerRegistry) (containerregistry.Sync, bool, error) {
 			registryType, typeErr := registry.NormalizeRegistryType(reg.RegistryType)
 			if typeErr != nil {
 				return containerregistry.Sync{}, false, errors.WrapIff(typeErr, "normalize registry type for sync %s", reg.ID)
@@ -357,8 +358,7 @@ func (s *EnvironmentService) SyncRegistriesToEnvironment(ctx context.Context, en
 			if registryType == registry.RegistryTypeECR {
 				decryptedSecret, err := crypto.Decrypt(reg.AWSSecretAccessKey)
 				if err != nil {
-					slog.WarnContext(ctx, "Failed to decrypt ECR secret for sync", "registryID", reg.ID, "registryURL", reg.URL, "error", err.Error())
-					return containerregistry.Sync{}, false, nil
+					return containerregistry.Sync{}, false, fmt.Errorf("failed to decrypt ECR secret for registry %s for sync: %w", reg.ID, err)
 				}
 
 				syncItem.AWSAccessKeyID = reg.AWSAccessKeyID
@@ -367,8 +367,7 @@ func (s *EnvironmentService) SyncRegistriesToEnvironment(ctx context.Context, en
 			} else {
 				decryptedToken, err := crypto.Decrypt(reg.Token)
 				if err != nil {
-					slog.WarnContext(ctx, "Failed to decrypt registry token for sync", "registryID", reg.ID, "registryURL", reg.URL, "error", err.Error())
-					return containerregistry.Sync{}, false, nil
+					return containerregistry.Sync{}, false, fmt.Errorf("failed to decrypt token for registry %s for sync: %w", reg.ID, err)
 				}
 
 				syncItem.Username = reg.Username
@@ -386,7 +385,7 @@ func (s *EnvironmentService) SyncRegistriesToEnvironment(ctx context.Context, en
 // SyncS3DestinationsToEnvironment sends manager-owned destinations to one remote environment.
 func (s *EnvironmentService) SyncS3DestinationsToEnvironment(ctx context.Context, environmentID string) error {
 	return s.fanOutSyncToEnvironment(ctx, environmentID, "S3 destinations", "/api/backups/s3/sync",
-		func(_ context.Context, destination s3domain.S3Destination) (backuptypes.S3DestinationSync, bool, error) {
+		func(destination s3domain.S3Destination) (backuptypes.S3DestinationSync, bool, error) {
 			secret, err := crypto.Decrypt(destination.SecretAccessKey)
 			if err != nil {
 				return backuptypes.S3DestinationSync{}, false, errors.WrapIff(err, "failed to decrypt S3 destination %s for sync", destination.ID)
@@ -402,7 +401,7 @@ func (s *EnvironmentService) SyncS3DestinationsToEnvironment(ctx context.Context
 // SyncRepositoriesToEnvironment syncs all git repositories from this manager to a remote environment
 func (s *EnvironmentService) SyncRepositoriesToEnvironment(ctx context.Context, environmentID string) error {
 	return s.fanOutSyncToEnvironment(ctx, environmentID, "git repositories", "/api/git-repositories/sync",
-		func(ctx context.Context, repo gitrepo.GitRepository) (gitops.RepositorySync, bool, error) {
+		func(repo gitrepo.GitRepository) (gitops.RepositorySync, bool, error) {
 			item := gitops.RepositorySync{
 				ID:          repo.ID,
 				Name:        repo.Name,
@@ -420,8 +419,7 @@ func (s *EnvironmentService) SyncRepositoriesToEnvironment(ctx context.Context, 
 			if repo.Token != "" {
 				decryptedToken, err := crypto.Decrypt(repo.Token)
 				if err != nil {
-					slog.WarnContext(ctx, "Failed to decrypt repository token for sync", "repositoryID", repo.ID, "repositoryName", repo.Name, "error", err.Error())
-					return gitops.RepositorySync{}, false, nil
+					return gitops.RepositorySync{}, false, fmt.Errorf("failed to decrypt token for repository %s for sync: %w", repo.ID, err)
 				}
 				item.Token = decryptedToken
 			}
@@ -429,8 +427,7 @@ func (s *EnvironmentService) SyncRepositoriesToEnvironment(ctx context.Context, 
 			if repo.SSHKey != "" {
 				decryptedSSHKey, err := crypto.Decrypt(repo.SSHKey)
 				if err != nil {
-					slog.WarnContext(ctx, "Failed to decrypt repository SSH key for sync", "repositoryID", repo.ID, "repositoryName", repo.Name, "error", err.Error())
-					return gitops.RepositorySync{}, false, nil
+					return gitops.RepositorySync{}, false, fmt.Errorf("failed to decrypt SSH key for repository %s for sync: %w", repo.ID, err)
 				}
 				item.SSHKey = decryptedSSHKey
 			}
@@ -445,15 +442,14 @@ func (s *EnvironmentService) SyncRepositoriesToEnvironment(ctx context.Context, 
 
 // fanOutSyncToEnvironment pushes every row of Model held by this
 // manager to one remote environment. toSyncItem maps a row to its wire form and
-// reports whether to keep it — rows whose credentials fail to decrypt are
-// skipped rather than failing the whole batch — and wrap builds the request
-// envelope the target endpoint expects.
+// reports whether to keep it. Mapping errors abort before sending the snapshot.
+// wrap builds the request envelope the target endpoint expects.
 func (s *EnvironmentService) fanOutSyncToEnvironment[Model any, Item any, Request any](
 	ctx context.Context,
 	environmentID string,
 	kind string,
 	path string,
-	toSyncItem func(context.Context, Model) (Item, bool, error),
+	toSyncItem func(Model) (Item, bool, error),
 	wrap func([]Item) Request,
 ) error {
 	target, err := s.resolveRemoteEnvironmentTargetInternal(ctx, environmentID)
@@ -470,7 +466,7 @@ func (s *EnvironmentService) fanOutSyncToEnvironment[Model any, Item any, Reques
 
 	syncItems := make([]Item, 0, len(records))
 	for _, record := range records {
-		item, keep, err := toSyncItem(ctx, record)
+		item, keep, err := toSyncItem(record)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/environment/environment_sync_test.go
+++ b/backend/internal/environment/environment_sync_test.go
@@ -1,0 +1,172 @@
+package environment_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/getarcaneapp/arcane/backend/v2/internal/activity"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/environment"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/gitrepo"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/registry"
+	s3domain "github.com/getarcaneapp/arcane/backend/v2/internal/s3"
+	activitytypes "github.com/getarcaneapp/arcane/types/v2/activity"
+	"github.com/getarcaneapp/arcane/types/v2/gitops"
+	"github.com/libtnb/sqlite"
+	"github.com/stretchr/testify/require"
+	"go.getarcane.app/sys/crypto"
+	"gorm.io/gorm"
+)
+
+func setupSyncDBInternal(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "sync.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&environment.Environment{}, &registry.ContainerRegistry{}, &gitrepo.GitRepository{}, &s3domain.S3Destination{}, &activity.Activity{}, &activity.ActivityMessage{}))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	crypto.InitEncryption(&crypto.Config{EncryptionKey: "test-encryption-key-for-testing-32bytes-min", Environment: "test"})
+	return &database.DB{DB: db}
+}
+
+func TestSyncResourcesToEnvironmentOutcomes(t *testing.T) {
+	paths := []string{"/api/container-registries/sync", "/api/backups/s3/sync", "/api/git-repositories/sync"}
+	cases := []struct {
+		name     string
+		failures map[string]string
+		groups   string
+	}{
+		{name: "success"},
+		{name: "registry failure", failures: map[string]string{paths[0]: "status"}, groups: "container registries"},
+		{name: "S3 failure", failures: map[string]string{paths[1]: "status"}, groups: "S3 destinations"},
+		{name: "repository failure", failures: map[string]string{paths[2]: "status"}, groups: "git repositories"},
+		{name: "multiple failures", failures: map[string]string{paths[0]: "status", paths[2]: "status"}, groups: "container registries, git repositories"},
+		{name: "all fail", failures: map[string]string{paths[0]: "status", paths[1]: "status", paths[2]: "status"}, groups: "container registries, S3 destinations, git repositories"},
+		{name: "malformed response", failures: map[string]string{paths[0]: "malformed"}, groups: "container registries"},
+		{name: "agent reports failure", failures: map[string]string{paths[0]: "false"}, groups: "container registries"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupSyncDBInternal(t)
+			var mu sync.Mutex
+			var calls []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				calls = append(calls, r.URL.Path)
+				mu.Unlock()
+				switch tc.failures[r.URL.Path] {
+				case "status":
+					http.Error(w, "private-agent-response", http.StatusUnauthorized)
+				case "malformed":
+					_, _ = w.Write([]byte("private-agent-response"))
+				case "false":
+					_, _ = w.Write([]byte(`{"success":false,"data":{"message":"private-agent-response"}}`))
+				default:
+					_, _ = w.Write([]byte(`{"success":true}`))
+				}
+			}))
+			defer server.Close()
+			require.NoError(t, db.Create(&environment.Environment{BaseModel: database.BaseModel{ID: "remote"}, Name: "Remote", ApiUrl: server.URL, AccessToken: new("agent-token"), Enabled: true}).Error)
+			service := environment.NewEnvironmentService(db, server.Client(), nil, nil, nil, nil)
+			activityService := activity.NewActivityService(db, nil)
+			id, err := service.SyncResourcesToEnvironment(t.Context(), "remote", &common.User{ID: "operator", Username: "operator"}, activityService)
+			require.NotEmpty(t, id)
+			var recorded activity.Activity
+			require.NoError(t, db.First(&recorded, "id = ?", id).Error)
+			require.NotNil(t, recorded.EndedAt)
+			require.NotNil(t, recorded.DurationMs)
+			require.Equal(t, "remote", recorded.EnvironmentID)
+			if tc.groups == "" {
+				require.NoError(t, err)
+				require.Equal(t, activitytypes.StatusSuccess, recorded.Status)
+				require.Equal(t, "Environment synced successfully", recorded.LatestMessage)
+				require.Nil(t, recorded.Error)
+			} else {
+				require.EqualError(t, err, "Failed to sync "+tc.groups+". Other resource groups may have synced successfully. Check the manager logs, correct the failed sync, and retry.")
+				require.Equal(t, activitytypes.StatusFailed, recorded.Status)
+				require.NotNil(t, recorded.Error)
+				require.Equal(t, err.Error(), *recorded.Error)
+				require.Equal(t, err.Error(), recorded.LatestMessage)
+				require.NotContains(t, err.Error(), "private-agent-response")
+				require.NotContains(t, err.Error(), "agent-token")
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			require.Equal(t, paths, calls)
+		})
+	}
+}
+
+func TestSyncCredentialDecryptionAbortsSnapshot(t *testing.T) {
+	for _, kind := range []string{"registry token", "ECR secret", "repository token", "repository SSH key", "S3 secret"} {
+		t.Run(kind, func(t *testing.T) {
+			db := setupSyncDBInternal(t)
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				_, _ = w.Write([]byte(`{"success":true}`))
+			}))
+			defer server.Close()
+			require.NoError(t, db.Create(&environment.Environment{BaseModel: database.BaseModel{ID: "remote"}, ApiUrl: server.URL, AccessToken: new("agent-token")}).Error)
+			service := environment.NewEnvironmentService(db, server.Client(), nil, nil, nil, nil)
+			var syncResource func(context.Context, string) error
+			switch kind {
+			case "registry token", "ECR secret":
+				row := registry.ContainerRegistry{BaseModel: database.BaseModel{ID: "bad-credential"}, URL: "registry.example.com", RegistryType: registry.RegistryTypeGeneric, Token: "invalid-ciphertext"}
+				if kind == "ECR secret" {
+					row.RegistryType = registry.RegistryTypeECR
+					row.AWSSecretAccessKey = "invalid-ciphertext"
+				}
+				require.NoError(t, db.Create(&row).Error)
+				syncResource = service.SyncRegistriesToEnvironment
+			case "repository token", "repository SSH key":
+				row := gitrepo.GitRepository{BaseModel: database.BaseModel{ID: "bad-credential"}, Name: "Repository", URL: "https://example.com/repo.git"}
+				if kind == "repository token" {
+					row.Token = "invalid-ciphertext"
+				} else {
+					row.SSHKey = "invalid-ciphertext"
+				}
+				require.NoError(t, db.Create(&row).Error)
+				syncResource = service.SyncRepositoriesToEnvironment
+			case "S3 secret":
+				require.NoError(t, db.Create(&s3domain.S3Destination{BaseModel: database.BaseModel{ID: "bad-credential"}, Name: "Backup", SecretAccessKey: "invalid-ciphertext"}).Error)
+				syncResource = service.SyncS3DestinationsToEnvironment
+			}
+			err := syncResource(t.Context(), "remote")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "bad-credential")
+			require.NotNil(t, errors.Unwrap(err))
+			require.Zero(t, calls.Load(), "an incomplete snapshot must never reach the agent")
+		})
+	}
+}
+
+func TestSyncRepositoriesPreservesEmptyCredentials(t *testing.T) {
+	db := setupSyncDBInternal(t)
+	require.NoError(t, db.Create(&gitrepo.GitRepository{BaseModel: database.BaseModel{ID: "public-repo"}, Name: "Public", URL: "https://example.com/public.git", AuthType: "none"}).Error)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload gitops.RepositorySyncRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if rows := payload.Repositories; len(rows) != 1 || rows[0].ID != "public-repo" {
+			t.Errorf("missing public repository: %v", payload)
+		}
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer server.Close()
+	require.NoError(t, db.Create(&environment.Environment{BaseModel: database.BaseModel{ID: "remote"}, ApiUrl: server.URL, AccessToken: new("token")}).Error)
+	service := environment.NewEnvironmentService(db, server.Client(), nil, nil, nil, nil)
+	require.NoError(t, service.SyncRepositoriesToEnvironment(t.Context(), "remote"))
+}

--- a/backend/internal/environment/handler.go
+++ b/backend/internal/environment/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/middleware"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
+	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/handlerutil"
@@ -35,6 +36,7 @@ import (
 	"github.com/getarcaneapp/arcane/types/v2/base"
 	"github.com/getarcaneapp/arcane/types/v2/environment"
 	"github.com/getarcaneapp/arcane/types/v2/version"
+	"github.com/samber/mo"
 	"go.getarcane.app/streams/agg"
 )
 
@@ -56,6 +58,8 @@ type EnvironmentHandler struct {
 	eventService       *event.EventService
 	cfg                *config.Config
 	streamHub          *agg.Hub[[]environment.Environment]
+	activityService    activitylib.Service
+	appCtx             context.Context
 }
 
 // ============================================================================
@@ -146,7 +150,7 @@ type DownloadEnvironmentMTLSFileInput struct {
 // ============================================================================
 
 // NewHandler builds the environment HTTP handler and its stream producer.
-func NewHandler(environmentService *EnvironmentService, settingsService *settings.SettingsService, apiKeyService *apikey.ApiKeyService, eventService *event.EventService, cfg *config.Config) *EnvironmentHandler {
+func NewHandler(environmentService *EnvironmentService, settingsService *settings.SettingsService, apiKeyService *apikey.ApiKeyService, eventService *event.EventService, cfg *config.Config, activityService activitylib.Service) *EnvironmentHandler {
 	return &EnvironmentHandler{
 		environmentService: environmentService,
 		settingsService:    settingsService,
@@ -154,6 +158,7 @@ func NewHandler(environmentService *EnvironmentService, settingsService *setting
 		eventService:       eventService,
 		cfg:                cfg,
 		streamHub:          agg.NewHub[[]environment.Environment](),
+		activityService:    activityService,
 	}
 }
 
@@ -252,7 +257,7 @@ func RegisterEnvironments(api huma.API, h *EnvironmentHandler) {
 		Method:      "POST",
 		Path:        "/environments/{id}/sync",
 		Summary:     "Sync environment",
-		Description: "Sync container registries and git repositories to a remote environment",
+		Description: "Sync container registries, S3 destinations, and git repositories to a remote environment. Returns an error if any resource group fails; other groups may still sync successfully.",
 		Tags:        []string{"Environments"},
 		Security:    handlerutil.DefaultOperationSecurity(),
 	}, authz.PermEnvironmentsSync, h.SyncEnvironment)
@@ -862,25 +867,23 @@ func (h *EnvironmentHandler) PairAgent(ctx context.Context, input *PairAgentInpu
 
 // SyncEnvironment syncs manager-owned resources to an environment.
 func (h *EnvironmentHandler) SyncEnvironment(ctx context.Context, input *SyncEnvironmentInput) (*handlerutil.Out[base.MessageResponse], error) {
-	// Sync registries
-	if err := h.environmentService.SyncRegistriesToEnvironment(ctx, input.ID); err != nil {
-		slog.WarnContext(ctx, "Failed to sync registries", "environmentID", input.ID, "error", err.Error())
+	user, err := handlerutil.RequireUser(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := h.environmentService.SyncS3DestinationsToEnvironment(ctx, input.ID); err != nil {
-		slog.WarnContext(ctx, "Failed to sync S3 destinations", "environmentID", input.ID, "error", err.Error())
-	}
-
-	// Sync git repositories
-	if err := h.environmentService.SyncRepositoriesToEnvironment(ctx, input.ID); err != nil {
-		slog.WarnContext(ctx, "Failed to sync git repositories", "environmentID", input.ID, "error", err.Error())
+	runtimeCtx := utils.ActivityRuntimeContext(ctx, h.appCtx)
+	activityID, err := h.environmentService.SyncResourcesToEnvironment(runtimeCtx, input.ID, user, h.activityService)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(err.Error())
 	}
 
 	return &handlerutil.Out[base.MessageResponse]{
 		Body: base.ApiResponse[base.MessageResponse]{
 			Success: true,
 			Data: base.MessageResponse{
-				Message: "Environment synced successfully",
+				Message:    "Environment synced successfully",
+				ActivityID: mo.EmptyableToOption(strings.TrimSpace(activityID)).ToPointer(),
 			},
 		},
 	}, nil

--- a/backend/internal/environment/module.go
+++ b/backend/internal/environment/module.go
@@ -9,6 +9,8 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
+	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/handlerutil"
 )
 
 type Dependencies struct {
@@ -16,6 +18,7 @@ type Dependencies struct {
 	ApiKey   *apikey.ApiKeyService
 	Event    *event.EventService
 	Config   *config.Config
+	Activity activitylib.Service
 }
 
 type Module struct {
@@ -26,7 +29,7 @@ type Module struct {
 func New(service *EnvironmentService, deps Dependencies) *Module {
 	return &Module{
 		service: service,
-		handler: NewHandler(service, deps.Settings, deps.ApiKey, deps.Event, deps.Config),
+		handler: NewHandler(service, deps.Settings, deps.ApiKey, deps.Event, deps.Config, deps.Activity),
 	}
 }
 
@@ -44,10 +47,11 @@ func (m *Module) Handler() *EnvironmentHandler {
 	return m.handler
 }
 
-func (m *Module) RegisterRoutes(api huma.API) {
+func (m *Module) RegisterRoutes(api huma.API, appCtx handlerutil.ActivityAppContext) {
 	if m == nil {
-		RegisterEnvironments(api, NewHandler(nil, nil, nil, nil, nil))
+		RegisterEnvironments(api, NewHandler(nil, nil, nil, nil, nil, nil))
 		return
 	}
+	m.handler.appCtx = appCtx.Context()
 	RegisterEnvironments(api, m.handler)
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3852

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes manual environment synchronization report resource-group failures, records each manual sync as an activity, and prevents credential-decryption failures from sending incomplete snapshots.

- Wires the activity service and application lifecycle context into environment routes.
- Attempts registry, S3 destination, and repository synchronization independently and aggregates failures.
- Propagates repository and registry credential-decryption errors.
- Adds table-driven coverage for sync outcomes, activity completion, and aborted snapshots.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The functional changes appear sound, but the explicit repository requirement to handle response-write errors in the new tests must be satisfied before merging.

Credential failures now abort incomplete snapshots, resource-group failures are surfaced and recorded, and the added table-driven tests fully address the previously outstanding coverage finding. The remaining issue is that several new HTTP test handlers explicitly discard `w.Write` errors contrary to the repository’s Go requirements.

**Files Needing Attention:** backend/internal/environment/environment_sync_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_environments_surface_sync_failures_and_track_manual_sync_as_an_activity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_environments_surface_sync_failures_and_track_manual_sync_as_an_activity%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233854%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3854&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_environments_surface_sync_failures_and_track_manual_sync_as_an_activity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_environments_surface_sync_failures_and_track_manual_sync_as_an_activity%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fenvironment%2Fenvironment_sync_test.go%3A70-74%0A**Response%20Errors%20Are%20Ignored**%0A%0AThe%20new%20HTTP%20test%20handlers%20discard%20errors%20from%20%60w.Write%60%20here%20and%20at%20lines%20116%20and%20166.%20This%20violates%20the%20repository%20directive%20to%20handle%20errors%20explicitly%20and%20can%20let%20a%20failed%20response%20write%20produce%20misleading%20test%20results.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3854&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fenvironment%2Fenvironment_sync_test.go%3A70-74%0A**Response%20Errors%20Are%20Ignored**%0A%0AThe%20new%20HTTP%20test%20handlers%20discard%20errors%20from%20%60w.Write%60%20here%20and%20at%20lines%20116%20and%20166.%20This%20violates%20the%20repository%20directive%20to%20handle%20errors%20explicitly%20and%20can%20let%20a%20failed%20response%20write%20produce%20misleading%20test%20results.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3854&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/environment/environment_sync_test.go:70-74
**Response Errors Are Ignored**

The new HTTP test handlers discard errors from `w.Write` here and at lines 116 and 166. This violates the repository directive to handle errors explicitly and can let a failed response write produce misleading test results. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(environments): surface sync failures..."](https://github.com/getarcaneapp/arcane/commit/c79085d566bcfae429228a620482a51522f4e0b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60794587)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))
- Knowledge Base — [API services and request lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/api-services.md)
- Knowledge Base — [Containers, environments, and workloads](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/workload-management.md)
- Knowledge Base — [Container and environment lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/container-and-environment-lifecycle.md)
</details>


<!-- /greptile_comment -->