### PR TITLE
fix: detect missing S3 repositories and pause remote backups

### DIFF
--- a/backend/internal/backup/remote.go
+++ b/backend/internal/backup/remote.go
@@ -1,0 +1,77 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"emperror.dev/errors"
+	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
+	s3domain "github.com/getarcaneapp/arcane/backend/v2/internal/s3"
+	s3util "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/s3"
+	backuptypes "github.com/getarcaneapp/arcane/types/v2/backup"
+)
+
+var ErrRemoteRepositoryMissing = errors.New("S3 backup storage is missing")
+
+const RemoteDisabledMessage = "S3 backup storage is missing. Remote backups were disabled; edit the policy to resume."
+
+// RemoteSnapshotChecker memoizes targeted checks within one response budget.
+// A nil result means the remote copy could not be verified.
+func RemoteSnapshotChecker(ctx context.Context, destinations *s3domain.S3DestinationService, root string) func(string, string) *bool {
+	checked := make(map[string]*backuptypes.RepositoryObservation)
+	deadline := time.Now().Add(10 * time.Second)
+	return func(destinationID, snapshotID string) *bool {
+		if destinations == nil || root == "" || destinationID == "" || snapshotID == "" {
+			return nil
+		}
+		key := destinationID + ":" + snapshotID
+		observation, seen := checked[key]
+		if !seen {
+			checked[key] = nil
+			checkCtx, cancel := context.WithDeadline(ctx, deadline)
+			defer cancel()
+			configuration, err := destinations.Configuration(checkCtx, destinationID)
+			if err != nil {
+				return nil
+			}
+			result, err := s3util.CheckRepository(checkCtx, configuration, root, snapshotID)
+			if err != nil {
+				return nil
+			}
+			observation = &result
+			checked[key] = observation
+		}
+		if observation == nil {
+			return nil
+		}
+		return new(observation.Available && observation.SnapshotAvailable)
+	}
+}
+
+// CheckScheduledRemote permits first-use initialization, but detects lost repositories.
+func CheckScheduledRemote(ctx context.Context, db *database.DB, destinations *s3domain.S3DestinationService, table, destinationID, root string) error {
+	if destinations == nil {
+		return errors.New("S3 destinations are unavailable")
+	}
+	configuration, err := destinations.Configuration(ctx, destinationID)
+	if err != nil {
+		return err
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	result, err := s3util.CheckRepository(checkCtx, configuration, root, "")
+	if err != nil || result.Available {
+		return err
+	}
+	if result.Reason == s3util.RepositoryReasonMissingRepository {
+		var retained int64
+		if err := db.WithContext(ctx).Table(table).Where("s3_destination_id = ? AND COALESCE(remote_snapshot_id, '') <> ''", destinationID).Count(&retained).Error; err != nil {
+			return err
+		}
+		if retained == 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrRemoteRepositoryMissing, result.Reason)
+}

--- a/backend/internal/s3/service_test.go
+++ b/backend/internal/s3/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
+	s3config "github.com/getarcaneapp/arcane/backend/v2/pkg/utils/s3"
 	backuptypes "github.com/getarcaneapp/arcane/types/v2/backup"
 	"github.com/libtnb/sqlite"
 	"github.com/stretchr/testify/require"
@@ -272,6 +273,69 @@ func TestS3DestinationService_TestS3DestinationRoundTrip(t *testing.T) {
 	require.Equal(t, "arcane-backups", persisted.Bucket)
 	require.Equal(t, "production", persisted.Prefix)
 	require.Empty(t, persisted.Region)
+
+	for _, scenario := range []struct {
+		name          string
+		code          string
+		status        int
+		reason        string
+		wantError     bool
+		snapshotError bool
+		configOnly    bool
+	}{
+		{name: "only the requested snapshot is read"},
+		{name: "repository check reads only config", configOnly: true},
+		{name: "confirmed bucket loss", code: "NoSuchBucket", status: http.StatusNotFound, reason: "missing_bucket"},
+		{name: "confirmed repository loss", code: "NoSuchKey", status: http.StatusNotFound, reason: "missing_repository"},
+		{name: "access denied is not deletion", code: "AccessDenied", status: http.StatusForbidden, wantError: true},
+		{name: "generic not found is inconclusive", code: "NotFound", status: http.StatusNotFound, wantError: true},
+		{name: "missing snapshot leaves repository available", code: "NoSuchKey", status: http.StatusNotFound, snapshotError: true},
+		{name: "snapshot access denied is inconclusive", code: "AccessDenied", status: http.StatusForbidden, snapshotError: true, wantError: true},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			snapshotID := strings.Repeat("a", 64)
+			metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				isConfig := r.URL.Path == "/arcane-backups/production/repository/config"
+				isSnapshot := !scenario.configOnly && r.URL.Path == "/arcane-backups/production/repository/snapshots/"+snapshotID
+				if r.Method != http.MethodGet || (!isConfig && !isSnapshot) || r.URL.Query().Get("list-type") != "" {
+					t.Errorf("unexpected metadata request: %s %s", r.Method, r.URL)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if r.Header.Get("Range") != "bytes=0-0" {
+					t.Errorf("metadata request must be limited to one byte")
+				}
+				if scenario.code != "" && (!scenario.snapshotError || !isConfig) {
+					w.Header().Set("Content-Type", "application/xml")
+					w.WriteHeader(scenario.status)
+					_, _ = io.WriteString(w, "<Error><Code>"+scenario.code+"</Code><Message>test response</Message></Error>")
+					return
+				}
+				w.Header().Set("Content-Range", "bytes 0-0/100")
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = io.WriteString(w, "x")
+			}))
+			defer metadataServer.Close()
+			configuration := s3config.Configuration{
+				Name: "Metadata destination", Endpoint: metadataServer.URL, Bucket: "arcane-backups",
+				AccessKeyID: "test-access", SecretAccessKey: "test-secret", Prefix: "production", ForcePathStyle: true,
+			}
+			requestedID := snapshotID
+			if scenario.configOnly {
+				requestedID = ""
+			}
+			observation, checkErr := s3config.CheckRepository(t.Context(), configuration, "repository", requestedID)
+			if scenario.wantError {
+				require.Error(t, checkErr)
+				require.Empty(t, observation.Reason)
+				return
+			}
+			require.NoError(t, checkErr)
+			require.Equal(t, scenario.reason, observation.Reason)
+			require.Equal(t, scenario.reason == "", observation.Available)
+			require.Equal(t, scenario.reason == "" && !scenario.configOnly && !scenario.snapshotError, observation.SnapshotAvailable)
+		})
+	}
 }
 
 func TestListS3DestinationsByIDInternal(t *testing.T) {

--- a/backend/internal/systembackup/service.go
+++ b/backend/internal/systembackup/service.go
@@ -525,10 +525,12 @@ func (s *SystemBackupService) ListBackups(ctx context.Context, params pagination
 			names = available
 		}
 	}
+	remoteAvailable := backup.RemoteSnapshotChecker(ctx, s.s3Destinations, "arcane-system-recovery")
 	result := make([]backuptypes.SystemBackupRun, len(runs))
 	for i := range runs {
 		runs[i].S3DestinationName = names[runs[i].S3DestinationID].Name
 		result[i] = runs[i].ToDTO()
+		result[i].RemoteAvailable = remoteAvailable(runs[i].S3DestinationID, runs[i].RemoteSnapshotID)
 	}
 	return result, response, nil
 }
@@ -1084,18 +1086,18 @@ func (s *SystemBackupService) DeleteBackup(ctx context.Context, id, recoveryKey 
 	if err != nil {
 		return err
 	}
-	return s.deleteRunsInternal(ctx, []*SystemBackupRun{run}, recoveryKey)
+	return s.deleteRunsInternal(ctx, []*SystemBackupRun{run}, recoveryKey, true)
 }
 
 // deleteRunsInternal forgets snapshots grouped by repository under the caller's run lease.
-func (s *SystemBackupService) deleteRunsInternal(ctx context.Context, runs []*SystemBackupRun, recoveryKey string) error {
+func (s *SystemBackupService) deleteRunsInternal(ctx context.Context, runs []*SystemBackupRun, recoveryKey string, includeRemote bool) error {
 	var localRuns []*SystemBackupRun
 	remoteGroups := make(map[string][]*SystemBackupRun)
 	for _, run := range runs {
 		if run.LocalSnapshotID != "" {
 			localRuns = append(localRuns, run)
 		}
-		if run.RemoteSnapshotID != "" {
+		if includeRemote && run.RemoteSnapshotID != "" {
 			remoteGroups[run.S3DestinationID] = append(remoteGroups[run.S3DestinationID], run)
 		}
 	}
@@ -1123,7 +1125,6 @@ func (s *SystemBackupService) deleteRunsInternal(ctx context.Context, runs []*Sy
 			}
 			continue
 		}
-		run.Error = deleteErr.Error()
 		if saveErr := s.db.WithContext(ctx).Save(run).Error; saveErr != nil {
 			deleteErr = errors.Combine(deleteErr, saveErr)
 		}
@@ -1579,13 +1580,20 @@ func (s *SystemBackupService) runScheduledBackupInternal(ctx context.Context, po
 		outcome := jobcontext.ConfirmedTarget(previous, policy.ID)
 		if outcome.Status == schedulertypes.Succeeded {
 			if policy.RetentionCount > 0 {
-				if err := s.applyRetentionInternal(ctx, policy.ID, policy.RetentionCount); err != nil {
+				if err := s.applyRetentionInternal(ctx, policy.ID, policy.RetentionCount, policy.S3Enabled); err != nil {
 					outcome.Status = schedulertypes.Partial
 					return outcome, err
 				}
 			}
 			return outcome, nil
 		}
+	}
+	remoteDisabled, checkErr := s.disableMissingS3Internal(ctx, policy)
+	if checkErr != nil {
+		return schedulertypes.Outcome{}, checkErr
+	}
+	if remoteDisabled && !policy.LocalEnabled {
+		return schedulertypes.Outcome{Status: schedulertypes.NeedsAttention, Message: backup.RemoteDisabledMessage}, nil
 	}
 	var run *SystemBackupRun
 	activityID, runErr := activitylib.RunHandlerActivity(ctx, s.activityService, activitylib.HandlerOptions{
@@ -1611,12 +1619,15 @@ func (s *SystemBackupService) runScheduledBackupInternal(ctx context.Context, po
 		return schedulertypes.Outcome{ActivityID: activityID}, runErr
 	}
 	if policy.RetentionCount > 0 {
-		if retentionErr := s.applyRetentionInternal(ctx, policy.ID, policy.RetentionCount); retentionErr != nil {
+		if retentionErr := s.applyRetentionInternal(ctx, policy.ID, policy.RetentionCount, policy.S3Enabled); retentionErr != nil {
 			slog.ErrorContext(ctx, "System backup retention failed", "policyId", policy.ID, "error", retentionErr)
 			return schedulertypes.Outcome{Status: schedulertypes.Partial, ActivityID: activityID, Message: "Backup completed but retention failed"}, retentionErr
 		}
 	}
 	slog.InfoContext(ctx, "Scheduled Arcane system backup completed", "backupId", run.ID, "policyId", policy.ID)
+	if remoteDisabled {
+		return schedulertypes.Outcome{Status: schedulertypes.Partial, ActivityID: activityID, Message: backup.RemoteDisabledMessage}, nil
+	}
 	return schedulertypes.Outcome{Status: schedulertypes.Succeeded, ActivityID: activityID}, nil
 }
 
@@ -1648,7 +1659,7 @@ func (s *SystemBackupService) rescheduleSystemBackupPolicyInternal(ctx context.C
 					return outcome, err
 				}
 				if current != nil && current.RetentionCount > 0 {
-					if err := s.applyRetentionInternal(ctx, policyID, current.RetentionCount); err != nil {
+					if err := s.applyRetentionInternal(ctx, policyID, current.RetentionCount, current.S3Enabled); err != nil {
 						outcome.Status = schedulertypes.Partial
 						outcome.Message = "Backup completed but retention failed"
 						return outcome, err
@@ -1682,7 +1693,7 @@ func (s *SystemBackupService) RegisterBackupJobOnStartup(ctx context.Context) {
 	slog.InfoContext(ctx, "Registered backup schedules", "systemPolicies", len(policies), "volumePolicies", volumePolicyCount)
 }
 
-func (s *SystemBackupService) applyRetentionInternal(ctx context.Context, policyID string, keep int) error {
+func (s *SystemBackupService) applyRetentionInternal(ctx context.Context, policyID string, keep int, includeRemote bool) error {
 	expired, err := backup.ExpiredRunIDs(ctx, s.db, "system_backup_runs", policyID, keep)
 	if err != nil || len(expired) == 0 {
 		return err
@@ -1699,5 +1710,32 @@ func (s *SystemBackupService) applyRetentionInternal(ctx context.Context, policy
 	if err := s.db.WithContext(ctx).Where("id IN ?", expired).Find(&runs).Error; err != nil {
 		return err
 	}
-	return s.deleteRunsInternal(ctx, runs, "")
+	return s.deleteRunsInternal(ctx, runs, "", includeRemote)
+}
+
+func (s *SystemBackupService) disableMissingS3Internal(ctx context.Context, policy *SystemBackupPolicy) (bool, error) {
+	if !policy.S3Enabled {
+		return false, nil
+	}
+	err := backup.CheckScheduledRemote(ctx, s.db, s.s3Destinations, "system_backup_runs", policy.S3DestinationID, "arcane-system-recovery")
+	if !errors.Is(err, backup.ErrRemoteRepositoryMissing) {
+		return false, nil
+	}
+	column := "enabled"
+	if policy.LocalEnabled {
+		column = "s3_enabled"
+	}
+	result := s.db.WithContext(ctx).Model(&SystemBackupPolicy{}).
+		Where("id = ? AND s3_destination_id = ? AND enabled = ? AND s3_enabled = ? AND local_enabled = ?", policy.ID, policy.S3DestinationID, true, true, policy.LocalEnabled).
+		Update(column, false)
+	if result.Error != nil || result.RowsAffected == 0 {
+		return false, result.Error
+	}
+	if policy.LocalEnabled {
+		policy.S3Enabled = false
+	} else {
+		policy.Enabled = false
+	}
+	s.rescheduleSystemBackupPolicyInternal(ctx, policy)
+	return true, nil
 }

--- a/backend/internal/systembackup/service_test.go
+++ b/backend/internal/systembackup/service_test.go
@@ -2,6 +2,8 @@ package systembackup
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"testing"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/config"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	recoverytypes "github.com/getarcaneapp/arcane/backend/v2/internal/recovery"
+	s3domain "github.com/getarcaneapp/arcane/backend/v2/internal/s3"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/scheduler/entityjobs"
 	backuptypes "github.com/getarcaneapp/arcane/types/v2/backup"
 	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
@@ -113,6 +116,33 @@ func TestSystemBackupPoliciesRegisterIndependentJobs(t *testing.T) {
 	require.Equal(t, firstID, collection.Policies[0].ID)
 	require.Equal(t, 9, collection.Policies[0].RetentionCount)
 	require.Len(t, scheduler.jobs, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("<Error><Code>NoSuchBucket</Code></Error>"))
+	}))
+	defer server.Close()
+	require.NoError(t, gormDB.AutoMigrate(&s3domain.S3Destination{}))
+	service.s3Destinations = s3domain.NewS3DestinationService(service.db)
+	destination, err := service.s3Destinations.CreateS3Destination(t.Context(), backuptypes.CreateS3Destination{
+		Name: "Missing storage", Endpoint: server.URL, Bucket: "backups", AccessKeyID: "test", SecretAccessKey: "test", ForcePathStyle: true,
+	})
+	require.NoError(t, err)
+	for _, local := range []bool{false, true} {
+		policy := &SystemBackupPolicy{Enabled: true, LocalEnabled: local, S3Enabled: true, S3DestinationID: destination.ID, Schedule: "0 0 2 * * *"}
+		require.NoError(t, gormDB.Create(policy).Error)
+		require.NoError(t, gormDB.Model(policy).Update("local_enabled", local).Error)
+		service.rescheduleSystemBackupPolicyInternal(t.Context(), policy)
+		disabled, err := service.disableMissingS3Internal(t.Context(), policy)
+		require.NoError(t, err)
+		require.True(t, disabled)
+		require.NoError(t, gormDB.First(policy, "id = ?", policy.ID).Error)
+		require.Equal(t, local, policy.Enabled)
+		require.Equal(t, !local, policy.S3Enabled)
+		require.Equal(t, local, scheduler.HasJob(service.jobs.JobName(policy.ID)))
+	}
+
 }
 
 func TestSystemBackupPolicyRequiresConfiguredRecoveryKeyWhenEnabled(t *testing.T) {

--- a/backend/internal/systembackup/system_volume.go
+++ b/backend/internal/systembackup/system_volume.go
@@ -154,13 +154,7 @@ func (s *SystemBackupService) UpdateSystemVolumeBackupConfig(ctx context.Context
 			*policy = normalized
 			return nil
 		},
-		Persist: func(ctx context.Context, policies []backuptypes.SystemVolumeBackupPolicy) error {
-			encoded, encodeErr := json.Marshal(backuptypes.SystemVolumeBackupPolicyCollection{Policies: policies})
-			if encodeErr != nil {
-				return fmt.Errorf("encode policies: %w", encodeErr)
-			}
-			return s.settingsService.UpdateSetting(ctx, systemVolumeBackupConfigKey, string(encoded))
-		},
+		Persist: s.saveSystemVolumeBackupPoliciesInternal,
 		Unregister: func(ctx context.Context, policyID string) {
 			s.jobs.Unregister(ctx, systemVolumeBackupJobPrefix+policyID)
 		},
@@ -385,6 +379,13 @@ func (s *SystemBackupService) runScheduledSystemVolumeBackupInternal(ctx context
 	if policy == nil || !policy.Enabled {
 		return schedulertypes.Outcome{Status: schedulertypes.Skipped}, nil
 	}
+	remoteDisabled, checkErr := s.disableMissingVolumeS3Internal(ctx, policy)
+	if checkErr != nil {
+		return schedulertypes.Outcome{}, checkErr
+	}
+	if remoteDisabled && !policy.LocalEnabled {
+		return schedulertypes.Outcome{Status: schedulertypes.NeedsAttention, Message: backup.RemoteDisabledMessage}, nil
+	}
 	result, err := s.runSystemVolumeBackupsInternal(ctx, backuptypes.RunSystemVolumeBackupsRequest{PolicyID: policyID}, volume.VolumeBackupTriggerScheduled)
 	if errors.Is(err, ErrSystemBackupAlreadyRunning) {
 		slog.InfoContext(ctx, "Scheduled system-managed volume backups skipped; a system backup is running", "policyId", policyID)
@@ -396,7 +397,10 @@ func (s *SystemBackupService) runScheduledSystemVolumeBackupInternal(ctx context
 	}
 	slog.InfoContext(ctx, "Scheduled system-managed volume backups completed", "policyId", policyID, "matched", result.Matched, "succeeded", result.Succeeded, "failed", result.Failed, "skipped", result.Skipped)
 	outcome := schedulertypes.Outcome{Status: schedulertypes.Succeeded}
-	if result.Failed > 0 {
+	if remoteDisabled {
+		outcome.Message = backup.RemoteDisabledMessage
+	}
+	if result.Failed > 0 || remoteDisabled {
 		outcome.Status = schedulertypes.Partial
 	}
 	for _, failure := range result.Failures {
@@ -453,6 +457,20 @@ func (s *SystemBackupService) ListBackupHistory(ctx context.Context, params pagi
 		return nil, pagination.Response{}, fmt.Errorf("list backup history: %w", err)
 	}
 	decorateHistoryDestinationsInternal(ctx, s.s3Destinations, history)
+	systemAvailable := backup.RemoteSnapshotChecker(ctx, s.s3Destinations, "arcane-system-recovery")
+	volumeRoot := ""
+	if s.settingsService != nil {
+		volumeRoot = "arcane-volume-backups/" + s.settingsService.GetSettingsConfig().InstanceID.Value
+	}
+	volumeAvailable := backup.RemoteSnapshotChecker(ctx, s.s3Destinations, volumeRoot)
+	for i := range history {
+		check := systemAvailable
+		if history[i].ResourceType == "volume" {
+			check = volumeAvailable
+		}
+		history[i].RemoteAvailable = check(history[i].S3DestinationID, history[i].RemoteSnapshotID)
+	}
+
 	page.GrandTotalItems = page.TotalItems
 	return history, page, nil
 }
@@ -468,4 +486,48 @@ func decorateHistoryDestinationsInternal(ctx context.Context, service *s3domain.
 	for i := range history {
 		history[i].S3DestinationName = destinations[history[i].S3DestinationID].Name
 	}
+}
+
+func (s *SystemBackupService) saveSystemVolumeBackupPoliciesInternal(ctx context.Context, policies []backuptypes.SystemVolumeBackupPolicy) error {
+	encoded, err := json.Marshal(backuptypes.SystemVolumeBackupPolicyCollection{Policies: policies})
+	if err != nil {
+		return fmt.Errorf("encode policies: %w", err)
+	}
+	return s.settingsService.UpdateSetting(ctx, systemVolumeBackupConfigKey, string(encoded))
+}
+
+func (s *SystemBackupService) disableMissingVolumeS3Internal(ctx context.Context, policy *backuptypes.SystemVolumeBackupPolicy) (bool, error) {
+	if !policy.S3Enabled {
+		return false, nil
+	}
+	root := "arcane-volume-backups/" + s.settingsService.GetSettingsConfig().InstanceID.Value
+	err := backup.CheckScheduledRemote(ctx, s.db, s.s3Destinations, "volume_backups", policy.S3DestinationID, root)
+	if !errors.Is(err, backup.ErrRemoteRepositoryMissing) {
+		return false, nil
+	}
+	collection, err := s.loadSystemVolumeBackupPoliciesInternal()
+	if err != nil {
+		return false, err
+	}
+	for i := range collection.Policies {
+		current := &collection.Policies[i]
+		if current.ID != policy.ID {
+			continue
+		}
+		if current.S3DestinationID != policy.S3DestinationID || current.S3Enabled != policy.S3Enabled || current.Enabled != policy.Enabled || current.LocalEnabled != policy.LocalEnabled {
+			return false, nil
+		}
+		if current.LocalEnabled {
+			current.S3Enabled = false
+		} else {
+			current.Enabled = false
+		}
+		if err := s.saveSystemVolumeBackupPoliciesInternal(ctx, collection.Policies); err != nil {
+			return false, err
+		}
+		*policy = *current
+		s.rescheduleSystemVolumeBackupInternal(ctx, policy)
+		return true, nil
+	}
+	return false, nil
 }

--- a/backend/internal/volume/backup.go
+++ b/backend/internal/volume/backup.go
@@ -382,8 +382,14 @@ func (s *VolumeService) ListBackupsPaginated(ctx context.Context, volumeName str
 			}
 		}
 	}
+	root := ""
+	if s.settingsService != nil {
+		root = "arcane-volume-backups/" + s.settingsService.GetSettingsConfig().InstanceID.Value
+	}
+	remoteAvailable := backup.RemoteSnapshotChecker(ctx, s.s3Destinations, root)
 	for i := range backups {
 		backups[i].Type = volumeBackupManagementTypeInternal(backups[i].PolicyID)
+		backups[i].RemoteAvailable = remoteAvailable(backups[i].S3DestinationID, backups[i].RemoteSnapshotID)
 	}
 
 	return backups, pagination.BuildResponse(totalItems, totalItems, params), nil
@@ -738,7 +744,7 @@ func (s *VolumeService) executeBackupInternal(ctx context.Context, entry *Volume
 	// and the deferred status-save would otherwise mark it failed and hide it
 	// from ExpiredRunIDs forever.
 	if trigger != VolumeBackupTriggerSafety && plan.policy != nil && plan.policy.RetentionCount > 0 {
-		if retentionErr := s.applyVolumeBackupRetentionInternal(ctx, plan.policy.ID, plan.policy.RetentionCount); retentionErr != nil {
+		if retentionErr := s.applyVolumeBackupRetentionInternal(ctx, plan.policy.ID, plan.policy.RetentionCount, plan.s3Enabled); retentionErr != nil {
 			slog.ErrorContext(ctx, "Volume backup retention failed", "volume", volumeName, "policy", plan.policy.ID, "error", retentionErr)
 		}
 	}
@@ -843,11 +849,11 @@ func (s *VolumeService) deleteBackupInternal(ctx context.Context, backupID strin
 	if entry.Format == VolumeBackupFormatArchive {
 		return s.deleteArchiveBackupInternal(ctx, &entry, user)
 	}
-	return s.deleteRusticBackupsInternal(ctx, []*VolumeBackup{&entry}, user)
+	return s.deleteRusticBackupsInternal(ctx, []*VolumeBackup{&entry}, user, true)
 }
 
 // deleteRusticBackupsInternal forgets snapshots grouped by repository so each repository is pruned once.
-func (s *VolumeService) deleteRusticBackupsInternal(ctx context.Context, entries []*VolumeBackup, user *common.User) error {
+func (s *VolumeService) deleteRusticBackupsInternal(ctx context.Context, entries []*VolumeBackup, user *common.User, includeRemote bool) error {
 	dockerClient, err := s.dockerService.GetClient(ctx)
 	if err != nil {
 		return err
@@ -858,7 +864,7 @@ func (s *VolumeService) deleteRusticBackupsInternal(ctx context.Context, entries
 		if entry.LocalSnapshotID != "" {
 			localEntries = append(localEntries, entry)
 		}
-		if entry.RemoteSnapshotID != "" {
+		if includeRemote && entry.RemoteSnapshotID != "" {
 			remoteGroups[entry.S3DestinationID] = append(remoteGroups[entry.S3DestinationID], entry)
 		}
 	}
@@ -883,7 +889,6 @@ func (s *VolumeService) deleteRusticBackupsInternal(ctx context.Context, entries
 		default:
 			entry.Destination = volumetypes.BackupDestinationS3
 		}
-		entry.Error = deleteErr.Error()
 		if saveErr := s.db.WithContext(ctx).Save(entry).Error; saveErr != nil {
 			deleteErr = errors.Combine(deleteErr, saveErr)
 		}
@@ -1766,7 +1771,7 @@ func (s *VolumeService) UpdateBackupPolicies(ctx context.Context, volumeName str
 	return s.GetBackupPolicies(ctx, volumeName)
 }
 
-func (s *VolumeService) applyVolumeBackupRetentionInternal(ctx context.Context, policyID string, retentionCount int) error {
+func (s *VolumeService) applyVolumeBackupRetentionInternal(ctx context.Context, policyID string, retentionCount int, includeRemote bool) error {
 	expired, err := backup.ExpiredRunIDs(ctx, s.db, "volume_backups", policyID, retentionCount)
 	if err != nil || len(expired) == 0 {
 		return err
@@ -1775,7 +1780,7 @@ func (s *VolumeService) applyVolumeBackupRetentionInternal(ctx context.Context, 
 	if err := s.db.WithContext(ctx).Where("id IN ?", expired).Find(&entries).Error; err != nil {
 		return err
 	}
-	return s.deleteRusticBackupsInternal(ctx, entries, nil)
+	return s.deleteRusticBackupsInternal(ctx, entries, nil, includeRemote)
 }
 
 func (s *VolumeService) runScheduledBackupInternal(ctx context.Context, policyID string) (schedulertypes.Outcome, error) {
@@ -1791,6 +1796,13 @@ func (s *VolumeService) runScheduledBackupInternal(ctx context.Context, policyID
 		if outcome.Status == schedulertypes.Succeeded {
 			return outcome, nil
 		}
+	}
+	remoteDisabled, checkErr := s.disableMissingS3Internal(ctx, &policy)
+	if checkErr != nil {
+		return schedulertypes.Outcome{}, checkErr
+	}
+	if remoteDisabled && !policy.LocalEnabled {
+		return schedulertypes.Outcome{Status: schedulertypes.NeedsAttention, Message: backup.RemoteDisabledMessage}, nil
 	}
 	var entry *VolumeBackup
 	activityID, err := activitylib.RunHandlerActivity(ctx, s.activityService, activitylib.HandlerOptions{
@@ -1828,6 +1840,9 @@ func (s *VolumeService) runScheduledBackupInternal(ctx context.Context, policyID
 		return schedulertypes.Outcome{}, err
 	}
 	slog.InfoContext(ctx, "Scheduled volume backup completed", "volume", policy.VolumeName, "backup_id", entry.ID, "remote_snapshot_id", entry.RemoteSnapshotID)
+	if remoteDisabled {
+		return schedulertypes.Outcome{Status: schedulertypes.Partial, ActivityID: activityID, Message: backup.RemoteDisabledMessage}, nil
+	}
 	return schedulertypes.Outcome{Status: schedulertypes.Succeeded, ActivityID: activityID}, nil
 }
 
@@ -1883,4 +1898,31 @@ func (s *VolumeService) removeVolumeBackupPolicyInternal(ctx context.Context, vo
 	if err := s.db.WithContext(ctx).Where("volume_name = ?", volumeName).Delete(&VolumeBackupPolicy{}).Error; err != nil {
 		slog.WarnContext(ctx, "Failed to delete volume backup policy", "volume", volumeName, "error", err)
 	}
+}
+
+func (s *VolumeService) disableMissingS3Internal(ctx context.Context, policy *VolumeBackupPolicy) (bool, error) {
+	if !policy.S3Enabled {
+		return false, nil
+	}
+	err := backup.CheckScheduledRemote(ctx, s.db, s.s3Destinations, "volume_backups", policy.S3DestinationID, "arcane-volume-backups/"+s.settingsService.GetSettingsConfig().InstanceID.Value)
+	if !errors.Is(err, backup.ErrRemoteRepositoryMissing) {
+		return false, nil
+	}
+	column := "enabled"
+	if policy.LocalEnabled {
+		column = "s3_enabled"
+	}
+	result := s.db.WithContext(ctx).Model(&VolumeBackupPolicy{}).
+		Where("id = ? AND s3_destination_id = ? AND enabled = ? AND s3_enabled = ? AND local_enabled = ?", policy.ID, policy.S3DestinationID, true, true, policy.LocalEnabled).
+		Update(column, false)
+	if result.Error != nil || result.RowsAffected == 0 {
+		return false, result.Error
+	}
+	if policy.LocalEnabled {
+		policy.S3Enabled = false
+	} else {
+		policy.Enabled = false
+	}
+	s.rescheduleVolumeBackupPolicyInternal(ctx, policy)
+	return true, nil
 }

--- a/backend/internal/volume/model.go
+++ b/backend/internal/volume/model.go
@@ -49,6 +49,7 @@ type VolumeBackup struct {
 	Error             string                     `json:"error,omitempty" gorm:"column:error;type:text"`
 	ActivityID        *string                    `json:"activityId,omitempty" gorm:"-"`
 	Type              backuptypes.ManagementType `json:"type" gorm:"-"`
+	RemoteAvailable   *bool                      `json:"remoteAvailable,omitempty" gorm:"-"`
 }
 
 func (*VolumeBackup) TableName() string {
@@ -57,6 +58,7 @@ func (*VolumeBackup) TableName() string {
 
 func (b *VolumeBackup) ToDTO() volume.BackupEntry {
 	return volume.BackupEntry{
+		RemoteAvailable:   b.RemoteAvailable,
 		ActivityID:        b.ActivityID,
 		ID:                b.ID,
 		VolumeName:        b.VolumeName,

--- a/backend/internal/volume/service_test.go
+++ b/backend/internal/volume/service_test.go
@@ -719,7 +719,7 @@ func TestVolumeBackupPolicy_RetentionIgnoresFailedRuns(t *testing.T) {
 	}).Error)
 
 	service := &VolumeService{db: &database.DB{DB: gormDB}}
-	require.NoError(t, service.applyVolumeBackupRetentionInternal(context.Background(), policyID, 1))
+	require.NoError(t, service.applyVolumeBackupRetentionInternal(context.Background(), policyID, 1, true))
 
 	var backups []VolumeBackup
 	require.NoError(t, gormDB.Order("created_at ASC").Find(&backups).Error)

--- a/backend/pkg/utils/s3/s3.go
+++ b/backend/pkg/utils/s3/s3.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 
 	"emperror.dev/errors"
@@ -18,7 +19,14 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	backuptypes "github.com/getarcaneapp/arcane/types/v2/backup"
 	"github.com/google/uuid"
+)
+
+const (
+	RepositoryReasonMissingBucket     = "missing_bucket"
+	RepositoryReasonMissingRepository = "missing_repository"
 )
 
 const connectionTestPayload = "arcane-s3-connection-test"
@@ -198,6 +206,61 @@ func TestConnection(ctx context.Context, configuration Configuration) (err error
 	}
 	deleted = true
 	return nil
+}
+
+// CheckRepository reads only the config and, when supplied, one snapshot object.
+func CheckRepository(ctx context.Context, configuration Configuration, root, snapshotID string) (backuptypes.RepositoryObservation, error) {
+	configuration = configuration.Normalized()
+	if err := configuration.Validate(true); err != nil {
+		return backuptypes.RepositoryObservation{}, err
+	}
+	client, err := newClientInternal(ctx, configuration)
+	if err != nil {
+		return backuptypes.RepositoryObservation{}, fmt.Errorf("failed to configure S3 repository check: %w", err)
+	}
+	configKey := path.Join(configuration.Prefix, root, "config")
+	if err := checkBackupObjectInternal(ctx, client, configuration.Bucket, configKey); err != nil {
+		if isMissingResourceInternal(err, "NoSuchBucket") {
+			return backuptypes.RepositoryObservation{Reason: RepositoryReasonMissingBucket}, nil
+		}
+		if isMissingResourceInternal(err, "NoSuchKey") {
+			return backuptypes.RepositoryObservation{Reason: RepositoryReasonMissingRepository}, nil
+		}
+		return backuptypes.RepositoryObservation{}, err
+	}
+	result := backuptypes.RepositoryObservation{Available: true}
+	if snapshotID == "" {
+		return result, nil
+	}
+	snapshotKey := path.Join(configuration.Prefix, root, "snapshots", snapshotID)
+	if err := checkBackupObjectInternal(ctx, client, configuration.Bucket, snapshotKey); err != nil {
+		if isMissingResourceInternal(err, "NoSuchKey") {
+			return result, nil
+		}
+		if isMissingResourceInternal(err, "NoSuchBucket") {
+			return backuptypes.RepositoryObservation{Reason: RepositoryReasonMissingBucket}, nil
+		}
+		return backuptypes.RepositoryObservation{}, err
+	}
+	result.SnapshotAvailable = true
+	return result, nil
+}
+
+// A one-byte GET preserves the named S3 errors that generic HEAD responses omit.
+func checkBackupObjectInternal(ctx context.Context, client *awss3.Client, bucket, key string) error {
+	object, err := client.GetObject(ctx, &awss3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String(key), Range: aws.String("bytes=0-0")})
+	if err != nil {
+		return err
+	}
+	return object.Body.Close()
+}
+
+func isMissingResourceInternal(err error, codes ...string) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return slices.Contains(codes, apiErr.ErrorCode())
 }
 
 func newClientInternal(ctx context.Context, configuration Configuration) (*awss3.Client, error) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3272,6 +3272,7 @@
   "backups_trigger_scheduled": "Scheduled",
   "backups_trigger_safety": "Pre-restore safety",
   "backups_destination_s3": "S3",
+  "backups_remote_unavailable": "Remote copy unavailable",
   "backups_destination_local_s3": "Local + S3",
   "s3_destinations_title": "S3 Destinations",
   "s3_destinations_description": "Create and manage reusable S3-compatible storage destinations for Arcane and volume backups.",

--- a/frontend/src/lib/components/arcane-table/cells/backup-destination-cell.svelte
+++ b/frontend/src/lib/components/arcane-table/cells/backup-destination-cell.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+	import * as m from '#lib/paraglide/messages.js';
 	import { Badge } from '#lib/components/ui/badge/index.js';
 	import type { BackupRun } from '#lib/types/backup.js';
 	import { backupDestinationLabel, backupDestinationName } from '#lib/utils/backups.js';
 
-	let { item }: { item: Pick<BackupRun, 'destination' | 's3DestinationId' | 's3DestinationName'> } = $props();
+	let { item }: { item: Pick<BackupRun, 'destination' | 's3DestinationId' | 's3DestinationName' | 'remoteAvailable'> } = $props();
 </script>
 
 <div class="flex items-center gap-2">
 	<Badge variant={item.destination === 'local' ? 'gray' : 'blue'}>{backupDestinationLabel(item.destination)}</Badge>
 	{#if item.destination !== 'local' && backupDestinationName(item)}
 		<span class="max-w-48 truncate text-xs text-muted-foreground">{backupDestinationName(item)}</span>
+	{/if}
+	{#if item.remoteAvailable === false}
+		<span class="text-xs text-destructive">{m.backups_remote_unavailable()}</span>
 	{/if}
 </div>

--- a/frontend/src/lib/types/backup.ts
+++ b/frontend/src/lib/types/backup.ts
@@ -6,6 +6,7 @@ export type BackupTrigger = 'manual' | 'scheduled' | 'safety';
 export type BackupManagementType = 'system' | 'volume';
 
 export type BackupRun = {
+	remoteAvailable?: boolean;
 	activityId?: string;
 	id: string;
 	size: number;

--- a/types/backup/repository.go
+++ b/types/backup/repository.go
@@ -1,0 +1,8 @@
+package backup
+
+// RepositoryObservation describes a read-only S3 metadata check.
+type RepositoryObservation struct {
+	Available         bool
+	Reason            string
+	SnapshotAvailable bool
+}

--- a/types/backup/system_backup.go
+++ b/types/backup/system_backup.go
@@ -11,6 +11,7 @@ const (
 )
 
 type SystemBackupRun struct {
+	RemoteAvailable   *bool                   `json:"remoteAvailable,omitempty"`
 	ActivityID        string                  `json:"activityId,omitempty"`
 	ID                string                  `json:"id"`
 	Size              int64                   `json:"size"`

--- a/types/backup/system_volume_backup.go
+++ b/types/backup/system_volume_backup.go
@@ -96,6 +96,7 @@ type SystemVolumeBackupRunResult struct {
 
 // HistoryEntry is a common view over Arcane recovery and volume backup records.
 type HistoryEntry struct {
+	RemoteAvailable   *bool                   `json:"remoteAvailable,omitempty" gorm:"-"`
 	ID                string                  `json:"id" sortable:"true"`
 	Size              int64                   `json:"size" sortable:"true"`
 	CreatedAt         time.Time               `json:"createdAt" sortable:"true"`

--- a/types/volume/backup.go
+++ b/types/volume/backup.go
@@ -28,6 +28,7 @@ const (
 )
 
 type BackupEntry struct {
+	RemoteAvailable   *bool                 `json:"remoteAvailable,omitempty"`
 	ActivityID        *string               `json:"activityId,omitempty"`
 	ID                string                `json:"id" doc:"Unique identifier of the backup"`
 	VolumeName        string                `json:"volumeName" doc:"Name of the volume"`


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3768

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR detects missing S3 backup repositories, disables affected remote schedules while preserving local backups, and exposes per-snapshot remote availability without scanning entire repositories.
- Adds bounded, targeted S3 metadata checks for repository configuration and individual snapshots.
- Updates system, system-volume, and regular volume backup scheduling and retention behavior when remote storage disappears.
- Adds API fields and translated UI messaging for unavailable remote copies.
- Resolves the previous contradictory backup-error display and full-repository scanning concerns.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The functional changes appear safe, but the explicit repository requirement to handle Go errors must be satisfied before merging.

The prior contradictory-error and full-scan findings are resolved, and no new functional or security failure remains; the only accepted issue is that new HTTP test fixtures silently discard response-write errors contrary to a mandatory repository rule.

**Files Needing Attention:** backend/internal/s3/service_test.go, backend/internal/systembackup/service_test.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_detect_missing_s3_repositories_and_pause_remote_backups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_detect_missing_s3_repositories_and_pause_remote_backups%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233869%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3869&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_detect_missing_s3_repositories_and_pause_remote_backups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_detect_missing_s3_repositories_and_pause_remote_backups%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fs3%2Fservice_test.go%3A311%0A**Response%20errors%20are%20ignored**%0A%0AThe%20new%20HTTP%20test%20discards%20the%20error%20returned%20by%20%60io.WriteString%60.%20The%20other%20new%20response%20writes%20in%20this%20test%20and%20%60backend%2Finternal%2Fsystembackup%2Fservice_test.go%60%20do%20the%20same.%20This%20violates%20the%20repository%20directive%20to%20handle%20errors%20rather%20than%20assign%20them%20to%20%60_%60%2C%20and%20a%20failed%20test-server%20response%20could%20lead%20to%20misleading%20assertions.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3869&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fs3%2Fservice_test.go%3A311%0A**Response%20errors%20are%20ignored**%0A%0AThe%20new%20HTTP%20test%20discards%20the%20error%20returned%20by%20%60io.WriteString%60.%20The%20other%20new%20response%20writes%20in%20this%20test%20and%20%60backend%2Finternal%2Fsystembackup%2Fservice_test.go%60%20do%20the%20same.%20This%20violates%20the%20repository%20directive%20to%20handle%20errors%20rather%20than%20assign%20them%20to%20%60_%60%2C%20and%20a%20failed%20test-server%20response%20could%20lead%20to%20misleading%20assertions.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3869&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/s3/service_test.go:311
**Response errors are ignored**

The new HTTP test discards the error returned by `io.WriteString`. The other new response writes in this test and `backend/internal/systembackup/service_test.go` do the same. This violates the repository directive to handle errors rather than assign them to `_`, and a failed test-server response could lead to misleading assertions. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: detect missing S3 repositories and ..."](https://github.com/getarcaneapp/arcane/commit/20103e63a37435f8eeb91a89476c1d9baceeacf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61408260)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - # Golang Pro  Senior Go developer with deep expert... ([source](https://app.greptile.com/ofkm/-/custom-context?memory=214b40a8-9695-4738-986d-5949b5d65ff1))

<!-- /greptile_comment -->