### PR TITLE
fix: surface per-container auto-update outcomes in the job output

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.3
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.111.0
+	github.com/aws/smithy-go v1.28.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coder/websocket v1.8.15
 	github.com/compose-spec/compose-go/v2 v2.15.0
@@ -57,6 +58,7 @@ require (
 	github.com/project-copacetic/copacetic v0.15.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/hot v0.13.1
+	github.com/samber/lo v1.53.0
 	github.com/samber/mo v1.17.0
 	github.com/samber/slog-echo/v2 v2.1.0
 	github.com/shirou/gopsutil/v4 v4.26.8
@@ -72,7 +74,7 @@ require (
 	go.getarcane.app/streams v0.4.3
 	go.getarcane.app/sys/cgroup v0.2.3
 	go.getarcane.app/sys/crypto v0.2.1
-	go.getarcane.app/updater v0.9.1
+	go.getarcane.app/updater v0.9.2
 	go.uber.org/fx v1.24.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/crypto v0.56.0
@@ -120,7 +122,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.49.0 // indirect
-	github.com/aws/smithy-go v1.28.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
@@ -249,7 +250,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/go-singleflightx v0.3.2 // indirect
-	github.com/samber/lo v1.53.0 // indirect
 	github.com/samber/oops v1.18.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.11.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -746,8 +746,8 @@ go.getarcane.app/sys/cgroup v0.2.3 h1:+eGLUC+3Ct+BNcPBQwC/g/psDOzjWN2vUr6KhKyNWg
 go.getarcane.app/sys/cgroup v0.2.3/go.mod h1:1ksFb/psBkQlOsS9D6OFydd9Evpb0mCoJzyCyb9RoL8=
 go.getarcane.app/sys/crypto v0.2.1 h1:A2HFmCRnDAj4/gl96apUifmw95verB5HCaPyNsHSAl8=
 go.getarcane.app/sys/crypto v0.2.1/go.mod h1:bA7dHfhnUCXl06+RxBJjwtoLR01J9WSZft6yoVnW4jE=
-go.getarcane.app/updater v0.9.1 h1:kQsBIKRAEsCv1xgt7BMClStuNDj8JB2TrjY4djhgTa4=
-go.getarcane.app/updater v0.9.1/go.mod h1:rMRAzw2KX5S8Ptjs4HAoN7inIHqxdSFsCHcrQWWK+vw=
+go.getarcane.app/updater v0.9.2 h1:a+1J9q64OXqrzz29DFdToZvj70ujumaZmFlU1Lo79Z8=
+go.getarcane.app/updater v0.9.2/go.mod h1:rMRAzw2KX5S8Ptjs4HAoN7inIHqxdSFsCHcrQWWK+vw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/backend/internal/updater/recovery.go
+++ b/backend/internal/updater/recovery.go
@@ -2,10 +2,14 @@ package updater
 
 import (
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 
 	"emperror.dev/errors"
+	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/scheduler/jobcontext"
+	activitytypes "github.com/getarcaneapp/arcane/types/v2/activity"
 	schedulertypes "github.com/getarcaneapp/arcane/types/v2/scheduler"
 	arcaneupdater "github.com/getarcaneapp/arcane/types/v2/updater"
 	"go.getarcane.app/updater"
@@ -25,16 +29,38 @@ func (s *UpdaterService) RecordUpdateRun(ctx context.Context, result updater.Res
 	if s != nil && s.deps.DB != nil {
 		recordErr = s.recordRunInternal(ctx, resourceResultFromModuleInternal(result))
 	}
+	name := strings.TrimSpace(result.ResourceName)
+	if name == "" {
+		name = result.ResourceID
+	}
+	message := name + ": " + string(result.Status)
+	level := activitytypes.MessageLevelInfo
 	status := schedulertypes.NeedsAttention
 	switch result.Status {
 	case updater.StatusUpdated, updater.StatusRestarted, updater.StatusUpToDate:
 		status = schedulertypes.Succeeded
+		if result.Status != updater.StatusUpToDate && result.OldImage != "" && result.NewImage != "" && result.OldImage != result.NewImage {
+			message += " (" + result.OldImage + " -> " + result.NewImage + ")"
+		}
 	case updater.StatusSkipped:
 		status = schedulertypes.Skipped
 	case updater.StatusChecked, updater.StatusUpdateAvailable:
 		status = schedulertypes.NeedsAttention
 	case updater.StatusFailed:
 		status = schedulertypes.Failed
+		level = activitytypes.MessageLevelError
+	}
+	if reason := strings.TrimSpace(result.Error); reason != "" {
+		if level == activitytypes.MessageLevelError {
+			message = name + ": " + reason
+		} else {
+			message += " (" + reason + ")"
+		}
+	}
+	if activityID := activityIDFromContextInternal(ctx); activityID != "" && s != nil && s.deps.Activity != nil {
+		if _, appendErr := s.deps.Activity.AppendMessage(ctx, activityID, activitylib.AppendMessageRequest{Level: level, Message: message, Step: "Applying updates"}); appendErr != nil {
+			slog.DebugContext(ctx, "failed to append update result activity message", "activityId", activityID, "resource", name, "error", appendErr)
+		}
 	}
 	progressErr := jobcontext.Progress(ctx, schedulertypes.TargetOutcome{ID: result.ResourceID, ResourceType: string(result.ResourceType), Status: status, Message: result.Error, ActivityID: activityIDFromContextInternal(ctx)})
 	err := errors.Combine(recordErr, progressErr)

--- a/backend/internal/updater/service_test.go
+++ b/backend/internal/updater/service_test.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
 
+	"github.com/getarcaneapp/arcane/backend/v2/internal/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/common"
+	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
+	activitytypes "github.com/getarcaneapp/arcane/types/v2/activity"
 
 	"bytes"
 	"context"
@@ -673,6 +676,60 @@ func TestUpdaterService_RecordUpdateRunAdapterInternal(t *testing.T) {
 	err = svc.RecordUpdateRun(ctx, updater.ResourceResult{ResourceID: "failed-container", ResourceType: updater.ResourceTypeContainer, Status: updater.StatusFailed})
 	require.ErrorContains(t, err, "progress unavailable")
 	require.ErrorContains(t, progress.err, "progress unavailable")
+}
+
+func TestUpdaterService_RecordUpdateRunAppendsActivityMessageInternal(t *testing.T) {
+	ctx := context.Background()
+	db := setupProjectTestDBInternal(t)
+	require.NoError(t, db.AutoMigrate(&AutoUpdateRecord{}, &activity.Activity{}, &activity.ActivityMessage{}))
+	activityService := activity.NewActivityService(db, nil)
+	svc, svcErr := NewUpdaterService(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, activityService)
+	require.NoError(t, svcErr)
+
+	for _, tt := range []struct {
+		name        string
+		result      updater.ResourceResult
+		wantLevel   activitytypes.MessageLevel
+		wantMessage string
+	}{
+		{
+			name:        "failed with reason",
+			result:      updater.ResourceResult{ResourceID: "c1", ResourceName: "sonarr", ResourceType: updater.ResourceTypeContainer, Status: updater.StatusFailed, Error: "pull failed: unexpected EOF"},
+			wantLevel:   activitytypes.MessageLevelError,
+			wantMessage: "sonarr: pull failed: unexpected EOF",
+		},
+		{
+			name:        "failed without reason falls back to status",
+			result:      updater.ResourceResult{ResourceID: "c2", ResourceName: "dozzle", ResourceType: updater.ResourceTypeContainer, Status: updater.StatusFailed},
+			wantLevel:   activitytypes.MessageLevelError,
+			wantMessage: "dozzle: failed",
+		},
+		{
+			name:        "updated includes image change",
+			result:      updater.ResourceResult{ResourceID: "c3", ResourceName: "maintainerr", ResourceType: updater.ResourceTypeContainer, Status: updater.StatusUpdated, OldImage: "sha256:old", NewImage: "ghcr.io/maintainerr/maintainerr:latest"},
+			wantLevel:   activitytypes.MessageLevelInfo,
+			wantMessage: "maintainerr: updated (sha256:old -> ghcr.io/maintainerr/maintainerr:latest)",
+		},
+		{
+			name:        "skipped unnamed uses resource id and reason",
+			result:      updater.ResourceResult{ResourceID: "arcane-id", ResourceType: updater.ResourceTypeContainer, Status: updater.StatusSkipped, Error: "container excluded by settings"},
+			wantLevel:   activitytypes.MessageLevelInfo,
+			wantMessage: "arcane-id: skipped (container excluded by settings)",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			started, err := activityService.StartActivity(ctx, activitylib.StartRequest{EnvironmentID: "0", Type: activitytypes.TypeAutoUpdate})
+			require.NoError(t, err)
+
+			require.NoError(t, svc.RecordUpdateRun(contextWithActivityIDInternal(ctx, started.ID), tt.result))
+
+			detail, err := activityService.GetActivityDetail(ctx, "0", started.ID, 10)
+			require.NoError(t, err)
+			require.Len(t, detail.Messages, 1)
+			assert.Equal(t, tt.wantLevel, detail.Messages[0].Level)
+			assert.Equal(t, tt.wantMessage, detail.Messages[0].Message)
+		})
+	}
 }
 
 func TestUpdaterService_ApplyPending_ProjectFailureDoesNotBlockOtherProjectsInternal(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3870

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->




<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces individual updater outcomes in the associated activity, including error reasons and image transitions, and updates the updater module dependency.
- Appends informational or error-level activity messages for each updater resource result.
- Falls back to the resource ID when a display name is unavailable.
- Adds table-driven coverage for failed, updated, skipped, and unnamed outcomes.
- Updates `go.getarcane.app/updater` from v0.9.1 to v0.9.2.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the previously missing activity-output coverage now added.

The follow-up correctly preserves a status-based fallback for failed results without an error reason, trims error text, and adds isolated table-driven subtests for the principal output variants. The previous activity-output testing finding is fully fixed, and no new actionable failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: surface per-container auto-update o..."](https://github.com/getarcaneapp/arcane/commit/3366eccb860ce19b11081bbac646d59a18f05951) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61454159)</sub>

**Context used:**

- Knowledge Base — [API services and request lifecycle](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/api-services.md)

<!-- /greptile_comment -->