### PR TITLE
feat: support hidden containers via labels and Compose metadata

### DIFF
--- a/backend/internal/container/handler.go
+++ b/backend/internal/container/handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/authz"
 	dockerutils "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
-	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	activitylib "github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/activity"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
@@ -61,6 +60,7 @@ type ListContainersInput struct {
 	Limit           int    `query:"limit" default:"20" doc:"Limit"`
 	GroupBy         string `query:"groupBy" doc:"Optional grouping mode (for example: project)"`
 	IncludeInternal bool   `query:"includeInternal" default:"false" doc:"Include internal containers"`
+	IncludeHidden   bool   `query:"includeHidden" default:"false" doc:"Include hidden containers"`
 	Updates         string `query:"updates" doc:"Filter by update status (has_update, up_to_date, error, unknown)"`
 	Standalone      string `query:"standalone" doc:"Filter standalone containers only (true/false)"`
 	Label           string `query:"label" doc:"Filter by label key or key=value"`
@@ -73,6 +73,7 @@ type ListContainersOutput struct {
 type GetContainerStatusCountsInput struct {
 	EnvironmentID   string `path:"id" doc:"Environment ID"`
 	IncludeInternal bool   `query:"includeInternal" default:"false" doc:"Include internal containers"`
+	IncludeHidden   bool   `query:"includeHidden" default:"false" doc:"Include hidden containers"`
 }
 
 type CreateContainerInput struct {
@@ -318,7 +319,7 @@ func (h *ContainerHandler) ListContainers(ctx context.Context, input *ListContai
 		params.Filters["label"] = input.Label
 	}
 
-	result, err := h.containerService.ListContainersPaginated(ctx, params, true, input.IncludeInternal, input.GroupBy)
+	result, err := h.containerService.ListContainersPaginated(ctx, params, true, input.IncludeInternal, input.IncludeHidden, input.GroupBy)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(errors.WithMessage(err, "Failed to list containers").Error())
 	}
@@ -340,16 +341,7 @@ func (h *ContainerHandler) GetContainerStatusCounts(ctx context.Context, input *
 		return nil, huma.Error500InternalServerError(errors.WithMessage(err, "Failed to get container counts").Error())
 	}
 
-	if !input.IncludeInternal {
-		filtered := make([]dockercontainer.Summary, 0, len(containers))
-		for _, c := range containers {
-			if libarcane.IsInternalContainer(c.Labels) {
-				continue
-			}
-			filtered = append(filtered, c)
-		}
-		containers = filtered
-	}
+	containers = FilterExcludedContainers(containers, input.IncludeInternal, input.IncludeHidden)
 
 	running, stopped := 0, 0
 	for _, c := range containers {

--- a/backend/internal/container/service.go
+++ b/backend/internal/container/service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/iconcatalog"
 	containertypes "github.com/getarcaneapp/arcane/types/v2/container"
 	"github.com/getarcaneapp/arcane/types/v2/containerregistry"
@@ -1422,6 +1423,7 @@ func (s *ContainerService) ListContainersPaginated(
 	params pagination.QueryParams,
 	includeAll bool,
 	includeInternal bool,
+	includeHidden bool,
 	groupBy string,
 ) (ContainerListResult, error) {
 	dockerContainers, err := s.dockerService.ListContainers(ctx)
@@ -1438,7 +1440,7 @@ func (s *ContainerService) ListContainersPaginated(
 		dockerContainers = running
 	}
 
-	dockerContainers = FilterInternalContainers(dockerContainers, includeInternal)
+	dockerContainers = FilterExcludedContainers(dockerContainers, includeInternal, includeHidden)
 	updateInfoMap := s.getUpdateInfoMapInternal(ctx, dockerContainers)
 	currentContainerID, currentContainerErr := cgroup.CurrentContainerID()
 	items := s.BuildSummaries(dockerContainers, updateInfoMap, currentContainerID, currentContainerErr)
@@ -1575,14 +1577,17 @@ func getContainerProjectNameInternal(container containertypes.Summary) string {
 	return projectName
 }
 
-func FilterInternalContainers(containers []container.Summary, includeInternal bool) []container.Summary {
-	if includeInternal {
+// FilterExcludedContainers removes internal and hidden containers unless their corresponding inclusion flags are enabled.
+func FilterExcludedContainers(containers []container.Summary, includeInternal, includeHidden bool) []container.Summary {
+	if includeInternal && includeHidden {
 		return containers
 	}
 
 	filtered := make([]container.Summary, 0, len(containers))
 	for _, dc := range containers {
-		if libarcane.IsInternalContainer(dc.Labels) {
+		internal, _ := utils.ParseBool(dc.Labels[libarcane.InternalResourceLabel])
+		hidden, _ := utils.ParseBool(dc.Labels[libarcane.HiddenResourceLabel])
+		if (!includeInternal && internal) || (!includeHidden && hidden) {
 			continue
 		}
 		filtered = append(filtered, dc)
@@ -1648,6 +1653,7 @@ func (s *ContainerService) BuildSummaries(containers []container.Summary, update
 			summary.UpdateInfo = info
 		}
 		summary.RedeployDisabled = labels.ShouldDisableArcaneServerRedeploy(summary.Labels, summary.ID, currentContainerID, currentContainerErr)
+		summary.Hidden, _ = utils.ParseBool(dc.Labels[libarcane.HiddenResourceLabel])
 		items = append(items, summary)
 	}
 	return items
@@ -1905,14 +1911,8 @@ func (s *ContainerService) buildContainerFilterAccessors() []pagination.FilterAc
 			Key: "standalone",
 			Fn: func(c containertypes.Summary, filterValue string) bool {
 				isStandalone := dockerutils.ComposeProjectLabel(c.Labels) == ""
-				switch filterValue {
-				case "true", "1":
-					return isStandalone
-				case "false", "0":
-					return !isStandalone
-				default:
-					return true
-				}
+				value, valid := utils.ParseBool(filterValue)
+				return !valid || isStandalone == value
 			},
 		},
 		{

--- a/backend/internal/dashboard/service.go
+++ b/backend/internal/dashboard/service.go
@@ -174,7 +174,8 @@ func (s *DashboardService) buildSnapshotInternal(ctx context.Context, options Da
 	dockerContainers := dockerSnapshot.Containers
 	dockerImages := dockerSnapshot.Images
 
-	filteredContainers := container.FilterInternalContainers(dockerContainers, false)
+	filteredContainers := container.FilterExcludedContainers(dockerContainers, false, false)
+	imageConsumers := container.FilterExcludedContainers(dockerContainers, false, true)
 
 	containerCounts := containertypes.StatusCounts{TotalContainers: len(filteredContainers)}
 	for _, c := range filteredContainers {
@@ -213,11 +214,11 @@ func (s *DashboardService) buildSnapshotInternal(ctx context.Context, options Da
 
 		var projectIDByName map[string]string
 		if s.imageService != nil {
-			projectIDByName = s.imageService.BuildProjectIDMap(ctx, filteredContainers)
+			projectIDByName = s.imageService.BuildProjectIDMap(ctx, imageConsumers)
 		} else {
 			projectIDByName = map[string]string{}
 		}
-		imageUsageMap := image.BuildVolumeUsageMap(filteredContainers, projectIDByName)
+		imageUsageMap := image.BuildVolumeUsageMap(imageConsumers, projectIDByName)
 		imageItems := image.MapDockerImagesToDTOs(dockerImages, dockerContainers, imageUsageMap, nil, nil)
 		sort.Slice(imageItems, func(i, j int) bool {
 			if imageItems[i].Size == imageItems[j].Size {
@@ -228,7 +229,7 @@ func (s *DashboardService) buildSnapshotInternal(ctx context.Context, options Da
 		imagePage = imageItems[:min(dashboardSnapshotPreloadLimit, len(imageItems))]
 	}
 
-	imageUsageCounts := docker.CountImageUsage(dockerImages, filteredContainers)
+	imageUsageCounts := docker.CountImageUsage(dockerImages, imageConsumers)
 
 	// Uses the unfiltered container list so a volume mounted only by an internal
 	// container still counts as in use, matching the volumes page.
@@ -386,13 +387,14 @@ func (s *DashboardService) getPendingResourceUpdatesCountInternal(ctx context.Co
 		return 0, nil
 	}
 
-	filteredContainers := container.FilterInternalContainers(allContainers, false)
+	filteredContainers := container.FilterExcludedContainers(allContainers, false, false)
 	standaloneContainers := filterStandaloneDockerContainersInternal(filteredContainers)
 	containerCount, err := s.getPendingContainerUpdatesCountInternal(ctx, standaloneContainers)
 	if err != nil {
 		return 0, err
 	}
 
+	// Keep hidden service identities so project counting can exclude their Compose and cached image records.
 	projectCount, err := s.getPendingProjectUpdatesCountInternal(ctx, allContainers)
 	if err != nil {
 		return 0, err

--- a/backend/internal/environment/environment_listing.go
+++ b/backend/internal/environment/environment_listing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/edge"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
 	"github.com/getarcaneapp/arcane/types/v2/environment"
 )
@@ -147,14 +148,8 @@ func (s *EnvironmentService) listEnvironmentsPaginatedWithRuntimeFiltersInternal
 			{
 				Key: "enabled",
 				Fn: func(item environment.Environment, filterValue string) bool {
-					switch strings.ToLower(strings.TrimSpace(filterValue)) {
-					case "true", "1":
-						return item.Enabled
-					case "false", "0":
-						return !item.Enabled
-					default:
-						return true
-					}
+					value, valid := utils.ParseBool(filterValue)
+					return !valid || item.Enabled == value
 				},
 			},
 			{

--- a/backend/internal/image/handler.go
+++ b/backend/internal/image/handler.go
@@ -733,10 +733,10 @@ func resolvePruneImageModeInternal(input *PruneImagesInput) string {
 
 	if vals, ok := input.Body.Filters["dangling"]; ok {
 		for _, value := range vals {
-			switch value {
-			case "true", "1":
-				return "dangling"
-			case "false", "0":
+			if dangling, valid := utils.ParseBool(value); valid {
+				if dangling {
+					return "dangling"
+				}
 				return "all"
 			}
 		}

--- a/backend/internal/image/image.go
+++ b/backend/internal/image/image.go
@@ -1277,13 +1277,10 @@ func (s *ImageService) getImagePaginationConfig() pagination.Config[imagetypes.S
 						return i.UpdateInfo != nil && i.UpdateInfo.Error != ""
 					case "unknown":
 						return i.UpdateInfo == nil
-					// Legacy boolean support
-					case "true":
-						return i.UpdateInfo != nil && i.UpdateInfo.HasUpdate
-					case "false":
-						return i.UpdateInfo == nil || !i.UpdateInfo.HasUpdate
 					default:
-						return true
+						value, valid := utils.ParseBool(filterValue)
+						hasUpdate := i.UpdateInfo != nil && i.UpdateInfo.HasUpdate
+						return !valid || hasUpdate == value
 					}
 				},
 			},

--- a/backend/internal/project/project_details.go
+++ b/backend/internal/project/project_details.go
@@ -22,6 +22,7 @@ import (
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	dockerutil "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/iconcatalog"
@@ -454,13 +455,46 @@ func (s *ProjectService) enrichProjectUpdateInfoInternal(ctx context.Context, re
 	resp.UpdateInfo = BuildUpdateInfoSummary(imageRefs, mergeProjectContainerUpdateInfoInternal(updateInfoByRef, resp.RuntimeServices, scoped))
 }
 
+func excludeHiddenRuntimeServicesInternal(details []project.Details) (map[string]map[string]bool, map[string]map[string]bool) {
+	hiddenServicesByProjectID := make(map[string]map[string]bool)
+	hiddenRefsByProjectID := make(map[string]map[string]bool)
+	for i := range details {
+		hiddenServices := make(map[string]bool)
+		hiddenRefs := make(map[string]bool)
+		visibleServices := make([]project.RuntimeService, 0, len(details[i].RuntimeServices))
+		for _, service := range details[i].RuntimeServices {
+			hidden, _ := utils.ParseBool(service.ContainerLabels[libarcane.HiddenResourceLabel])
+			if hidden {
+				hiddenServices[service.Name] = true
+				hiddenRefs[service.Image] = true
+				continue
+			}
+			visibleServices = append(visibleServices, service)
+		}
+		for _, service := range visibleServices {
+			delete(hiddenServices, service.Name)
+			delete(hiddenRefs, service.Image)
+		}
+		hiddenServicesByProjectID[details[i].ID] = hiddenServices
+		hiddenRefsByProjectID[details[i].ID] = hiddenRefs
+		details[i].RuntimeServices = visibleServices
+	}
+	return hiddenServicesByProjectID, hiddenRefsByProjectID
+}
+
 func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	ctx context.Context,
 	projectsList []Project,
 	details []project.Details,
+	includeHidden bool,
 ) {
 	if len(projectsList) == 0 || len(details) == 0 {
 		return
+	}
+
+	var hiddenServicesByProjectID, hiddenRefsByProjectID map[string]map[string]bool
+	if !includeHidden {
+		hiddenServicesByProjectID, hiddenRefsByProjectID = excludeHiddenRuntimeServicesInternal(details)
 	}
 
 	imageRefsByProjectID := make(map[string][]string, len(projectsList))
@@ -493,17 +527,8 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 			}
 			defer func() { <-sem }()
 
-			composeProject, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
-			if err != nil {
-				slog.WarnContext(ctx, "failed to resolve project services for update summary", "projectID", proj.ID, "projectName", proj.Name, "error", err)
-				resultsCh <- imageRefsResult{projectID: proj.ID, refs: projects.ParseImageRefsJSON(proj.ImageRefsJSON)}
-				return
-			}
-			services := make([]composetypes.ServiceConfig, 0, len(composeProject.Services))
-			for _, service := range composeProject.Services {
-				services = append(services, service)
-			}
-			resultsCh <- imageRefsResult{projectID: proj.ID, refs: projects.ImageRefsFromComposeConfigs(services), services: services}
+			refs, services := s.resolveProjectUpdateServicesInternal(ctx, proj, cfg, includeHidden, hiddenServicesByProjectID[proj.ID], hiddenRefsByProjectID[proj.ID])
+			resultsCh <- imageRefsResult{projectID: proj.ID, refs: refs, services: services}
 		}(proj)
 	}
 
@@ -529,7 +554,7 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 	records := s.getProjectServiceUpdateRecordsInternal(ctx, projectIDs)
 	scoped := s.getProjectContainerUpdateInfoInternal(ctx, details)
 	for i := range details {
-		if services := servicesByProjectID[details[i].ID]; len(services) > 0 {
+		if services := servicesByProjectID[details[i].ID]; services != nil {
 			details[i].UpdateInfo = BuildConfiguredUpdateInfo(details[i].ID, services, updateInfoByRef, records, configuredRuntimeServiceUpdateInfoInternal(services, details[i].RuntimeServices, scoped))
 			continue
 		}
@@ -539,6 +564,24 @@ func (s *ProjectService) enrichProjectsWithUpdateInfoInternal(
 		}
 		details[i].UpdateInfo = BuildUpdateInfoSummary(refs, mergeProjectContainerUpdateInfoInternal(updateInfoByRef, details[i].RuntimeServices, scoped))
 	}
+}
+
+func (s *ProjectService) resolveProjectUpdateServicesInternal(ctx context.Context, proj Project, cfg *settings.Settings, includeHidden bool, hiddenRuntimeServices, hiddenRuntimeRefs map[string]bool) ([]string, []composetypes.ServiceConfig) {
+	composeProject, err := s.getCachedComposeProjectInternal(ctx, &proj, cfg)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve project services for update summary", "projectID", proj.ID, "projectName", proj.Name, "error", err)
+		refs := projects.ParseImageRefsJSON(proj.ImageRefsJSON)
+		return slices.DeleteFunc(refs, func(ref string) bool { return hiddenRuntimeRefs[ref] }), nil
+	}
+	services := make([]composetypes.ServiceConfig, 0, len(composeProject.Services))
+	for _, service := range composeProject.Services {
+		hidden, _ := utils.ParseBool(service.Labels[libarcane.HiddenResourceLabel])
+		if !includeHidden && (hidden || hiddenRuntimeServices[service.Name]) {
+			continue
+		}
+		services = append(services, service)
+	}
+	return projects.ImageRefsFromComposeConfigs(services), services
 }
 
 func (s *ProjectService) getProjectServiceUpdateRecordsInternal(ctx context.Context, projectIDs []string) []imageupdate.ImageUpdateRecord {

--- a/backend/internal/project/project_listing.go
+++ b/backend/internal/project/project_listing.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/internal/image"
 	dockerutil "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
@@ -218,7 +219,7 @@ func (s *ProjectService) ListProjects(ctx context.Context, params pagination.Que
 	if err := s.enrichProjectsWithTagsInternal(ctx, result); err != nil {
 		return nil, pagination.Response{}, err
 	}
-	s.enrichProjectsWithUpdateInfoInternal(ctx, projectsArray, result)
+	s.enrichProjectsWithUpdateInfoInternal(ctx, projectsArray, result, true)
 
 	slog.DebugContext(ctx, "Completed ListProjects request",
 		"result_count", len(result))
@@ -227,14 +228,11 @@ func (s *ProjectService) ListProjects(ctx context.Context, params pagination.Que
 }
 
 func applyProjectArchivedDBFilterInternal(query *gorm.DB, filterValue string) *gorm.DB {
-	switch strings.ToLower(strings.TrimSpace(filterValue)) {
-	case "true":
-		return query.Where("is_archived = ?", true)
-	case "all":
+	if strings.EqualFold(strings.TrimSpace(filterValue), "all") {
 		return query
-	default:
-		return query.Where("is_archived = ?", false)
 	}
+	archived, _ := utils.ParseBool(filterValue)
+	return query.Where("is_archived = ?", archived)
 }
 
 func applyProjectTagsDBFilterInternal(query *gorm.DB, filterValue string) *gorm.DB {
@@ -312,7 +310,7 @@ func (s *ProjectService) filterProjectsWithDerivedFiltersInternal(
 	if err := s.enrichProjectsWithTagsInternal(ctx, items); err != nil {
 		return pagination.FilterResult[project.Details]{}, err
 	}
-	s.enrichProjectsWithUpdateInfoInternal(ctx, projectsArray, items)
+	s.enrichProjectsWithUpdateInfoInternal(ctx, projectsArray, items, true)
 	items = s.appendDiscoveredComposeProjectUpdatesInternal(ctx, params, projectsArray, items)
 
 	return s.buildProjectDerivedPaginationConfigInternal().SearchOrderAndPaginate(items, withoutProjectDBFiltersInternal(params)), nil
@@ -728,14 +726,11 @@ func buildProjectArchivedFilterAccessorInternal() pagination.FilterAccessor[proj
 	return pagination.FilterAccessor[project.Details]{
 		Key: "archived",
 		Fn: func(p project.Details, filterValue string) bool {
-			switch strings.ToLower(strings.TrimSpace(filterValue)) {
-			case "true":
-				return p.IsArchived
-			case "all":
+			if strings.EqualFold(strings.TrimSpace(filterValue), "all") {
 				return true
-			default:
-				return !p.IsArchived
 			}
+			archived, _ := utils.ParseBool(filterValue)
+			return p.IsArchived == archived
 		},
 	}
 }
@@ -749,7 +744,7 @@ func getProjectUpdateStatusInternal(updateInfo *project.UpdateInfo) string {
 }
 
 // CountProjectsWithPendingUpdates counts non-archived projects with at
-// least one image update pending, plus compose projects running on the daemon
+// least one visible service with an image update pending, plus compose projects running on the daemon
 // that Arcane does not track. It deliberately avoids the project-list pipeline:
 // that path builds full project DTOs (live status, icons, URLs, GitOps lookups)
 // and then throws all of them away for a single number, costing several full
@@ -760,6 +755,14 @@ func getProjectUpdateStatusInternal(updateInfo *project.UpdateInfo) string {
 func (s *ProjectService) CountProjectsWithPendingUpdates(ctx context.Context, allContainers []container.Summary) (int, error) {
 	if s.db == nil {
 		return 0, nil
+	}
+
+	if allContainers == nil {
+		var err error
+		allContainers, err = s.listGlobalComposeContainersInternal(ctx)
+		if err != nil {
+			return 0, errors.WrapIf(err, "failed to list containers for project update count")
+		}
 	}
 
 	// One full scan: archived projects are excluded from the update count but
@@ -786,7 +789,7 @@ func (s *ProjectService) CountProjectsWithPendingUpdates(ctx context.Context, al
 			details[i].RuntimeServices = append(details[i].RuntimeServices, project.RuntimeService{Name: dockerutil.ComposeServiceLabel(c.Labels), ContainerID: c.ID, Image: c.Image, ContainerLabels: c.Labels})
 		}
 	}
-	s.enrichProjectsWithUpdateInfoInternal(ctx, activeProjects, details)
+	s.enrichProjectsWithUpdateInfoInternal(ctx, activeProjects, details, false)
 
 	count := 0
 	for i := range details {
@@ -795,7 +798,14 @@ func (s *ProjectService) CountProjectsWithPendingUpdates(ctx context.Context, al
 		}
 	}
 
-	return count + s.countDiscoveredComposeProjectUpdatesInternal(ctx, allProjects, true, allContainers), nil
+	visibleContainers := make([]container.Summary, 0, len(allContainers))
+	for _, c := range allContainers {
+		hidden, _ := utils.ParseBool(c.Labels[libarcane.HiddenResourceLabel])
+		if !hidden {
+			visibleContainers = append(visibleContainers, c)
+		}
+	}
+	return count + s.countDiscoveredComposeProjectUpdatesInternal(ctx, allProjects, true, visibleContainers), nil
 }
 
 // countDiscoveredComposeProjectUpdatesInternal counts compose projects running on

--- a/backend/internal/project/service_test.go
+++ b/backend/internal/project/service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/kv"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/registry"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/volumes"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/projects"
@@ -7455,12 +7456,17 @@ func TestCountProjectsWithPendingTagUpdatesUsesRuntimeContainers(t *testing.T) {
 	require.NoError(t, db.Create(&projects).Error)
 	require.NoError(t, db.Create(&imageupdate.ImageUpdateRecord{ID: "container::first-container", PolicyKey: imageref.UpdatePolicyKey("example:3.1.0", map[string]string{labels.LabelUpdateStrategy: "tag"}), ContainerID: "first-container", ImageID: "shared", HasUpdate: true, UpdateType: "tag"}).Error)
 	service := &ProjectService{db: db, settingsService: settingsService, imageService: image.NewImageService(db, nil, nil, nil, nil, nil)}
-	count, err := service.CountProjectsWithPendingUpdates(t.Context(), []container.Summary{
+	containers := []container.Summary{
 		{ID: "first-container", Image: "example:3.1.0", ImageID: "shared", Labels: map[string]string{labels.LabelUpdateStrategy: "tag", "com.docker.compose.project": "first", "com.docker.compose.service": "web"}},
 		{ID: "second-container", Image: "example:3.1.0", ImageID: "shared", Labels: map[string]string{"com.docker.compose.project": "second", "com.docker.compose.service": "web"}},
-	})
+	}
+	count, err := service.CountProjectsWithPendingUpdates(t.Context(), containers)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
+	containers[0].Labels[libarcane.HiddenResourceLabel] = "true"
+	count, err = service.CountProjectsWithPendingUpdates(t.Context(), containers)
+	require.NoError(t, err)
+	require.Zero(t, count)
 }
 
 type serviceTagTransportInternal struct {
@@ -7604,7 +7610,7 @@ func TestStoppedProjectTagPolicyNeverInheritsSharedDigestCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, settingsService.SetStringSetting(t.Context(), "projectsDirectory", projectsDir))
 	projectPath := createComposeProjectDir(t, projectsDir, "tag-stopped")
-	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("services:\n  app:\n    image: nginx:3.1.0\n    labels:\n      com.getarcaneapp.arcane.updater.strategy: tag\n      com.getarcaneapp.arcane.updater.constraint: 3.x\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectPath, "compose.yaml"), []byte("x-arcane:\n  hidden: true\nservices:\n  app:\n    image: nginx:3.1.0\n    labels:\n      com.getarcaneapp.arcane.updater.strategy: tag\n      com.getarcaneapp.arcane.updater.constraint: 3.x\n"), 0o644))
 	projectRecord := &Project{ID: "tag-stopped", Name: "tag-stopped", DirName: new("tag-stopped"), Path: projectPath, Status: ProjectStatusStopped, ImageRefsJSON: `["nginx:3.1.0"]`}
 	require.NoError(t, db.Create(projectRecord).Error)
 	require.NoError(t, db.Create(&imageupdate.ImageUpdateRecord{ID: "shared-digest", Repository: "docker.io/library/nginx", Tag: "3.1.0", UpdateType: "digest", CheckTime: time.Now()}).Error)
@@ -7615,7 +7621,7 @@ func TestStoppedProjectTagPolicyNeverInheritsSharedDigestCheck(t *testing.T) {
 	require.Equal(t, "unknown", detail.UpdateInfo.Status)
 	require.Nil(t, detail.UpdateInfo.ServiceUpdates["app"].UpdateInfo)
 	list := []projecttypes.Details{{ID: projectRecord.ID}}
-	service.enrichProjectsWithUpdateInfoInternal(t.Context(), []Project{*projectRecord}, list)
+	service.enrichProjectsWithUpdateInfoInternal(t.Context(), []Project{*projectRecord}, list, true)
 	require.Equal(t, "unknown", list[0].UpdateInfo.Status)
 	require.Nil(t, list[0].UpdateInfo.ServiceUpdates["app"].UpdateInfo)
 	target := "3.2.0"
@@ -7625,8 +7631,11 @@ func TestStoppedProjectTagPolicyNeverInheritsSharedDigestCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "has_update", detail.UpdateInfo.Status)
 	require.Equal(t, target, detail.UpdateInfo.ServiceUpdates["app"].UpdateInfo.LatestVersion)
-	service.enrichProjectsWithUpdateInfoInternal(t.Context(), []Project{*projectRecord}, list)
+	service.enrichProjectsWithUpdateInfoInternal(t.Context(), []Project{*projectRecord}, list, true)
 	require.Equal(t, "has_update", list[0].UpdateInfo.Status)
+	count, err := service.CountProjectsWithPendingUpdates(t.Context(), []container.Summary{})
+	require.NoError(t, err)
+	require.Zero(t, count, "hidden configured services must not contribute to the dashboard badge")
 }
 
 func TestConfiguredProjectUsesScheduledRuntimeChecks(t *testing.T) {
@@ -7670,7 +7679,7 @@ func TestConfiguredProjectUsesScheduledRuntimeChecks(t *testing.T) {
 			service.enrichProjectUpdateInfoInternal(ctx, &detail)
 			require.Equal(t, tt.wantUpdate, detail.UpdateInfo.HasUpdate)
 			list := []projecttypes.Details{{ID: proj.ID, RuntimeServices: runtime}}
-			service.enrichProjectsWithUpdateInfoInternal(ctx, []Project{proj}, list)
+			service.enrichProjectsWithUpdateInfoInternal(ctx, []Project{proj}, list, true)
 			require.Equal(t, tt.wantUpdate, list[0].UpdateInfo.HasUpdate)
 			for _, info := range []*projecttypes.UpdateInfo{detail.UpdateInfo, list[0].UpdateInfo} {
 				if tt.wantUpdate {

--- a/backend/internal/template/service.go
+++ b/backend/internal/template/service.go
@@ -217,13 +217,8 @@ func (s *TemplateService) GetAllTemplatesPaginated(ctx context.Context, params p
 			{
 				Key: "type",
 				Fn: func(item tmpl.Template, filterValue string) bool {
-					switch filterValue {
-					case "true":
-						return item.IsRemote
-					case "false":
-						return !item.IsRemote
-					}
-					return true
+					value, valid := utils.ParseBool(filterValue)
+					return !valid || item.IsRemote == value
 				},
 			},
 		},

--- a/backend/internal/volume/helper_container.go
+++ b/backend/internal/volume/helper_container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/volumehelper"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/samber/mo"
@@ -72,7 +73,7 @@ func (s *VolumeService) toolsImageInternal() string {
 }
 
 func isUnlabeledVolumeHelperContainerInternal(c container.Summary) bool {
-	if !libarcane.IsInternalContainer(c.Labels) {
+	if internal, _ := utils.ParseBool(c.Labels[libarcane.InternalResourceLabel]); !internal {
 		return false
 	}
 
@@ -94,7 +95,7 @@ func isVolumeHelperContainerInternal(c container.Summary) bool {
 	if isUnlabeledVolumeHelperContainerInternal(c) {
 		return true
 	}
-	if !libarcane.IsInternalContainer(c.Labels) {
+	if internal, _ := utils.ParseBool(c.Labels[libarcane.InternalResourceLabel]); !internal {
 		return false
 	}
 

--- a/backend/internal/volume/listing.go
+++ b/backend/internal/volume/listing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/timeouts"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	backuptypes "github.com/getarcaneapp/arcane/types/v2/backup"
 	volumetypes "github.com/getarcaneapp/arcane/types/v2/volume"
 	"github.com/moby/moby/api/types/container"
@@ -295,7 +296,8 @@ func (s *VolumeService) isInternalVolumeInternal(v volumetypes.Volume) bool {
 		return true
 	}
 
-	return libarcane.IsInternalContainer(v.Labels)
+	internal, _ := utils.ParseBool(v.Labels[libarcane.InternalResourceLabel])
+	return internal
 }
 
 var generatedAnonymousVolumeNameInternal = regexp.MustCompile(`^[a-f0-9]{64}$`)

--- a/backend/pkg/libarcane/internal_resource.go
+++ b/backend/pkg/libarcane/internal_resource.go
@@ -13,28 +13,15 @@ import (
 	"go.getarcane.app/updater/labels"
 )
 
-// InternalResourceLabel marks containers used for Arcane utilities, e.g. temp containers used for viewing volume files.
-const InternalResourceLabel = "com.getarcaneapp.internal.resource"
-
-func IsInternalContainer(labels map[string]string) bool {
-	if labels == nil {
-		return false
-	}
-	for k, v := range labels {
-		if strings.EqualFold(k, InternalResourceLabel) {
-			switch strings.TrimSpace(strings.ToLower(v)) {
-			case "true", "1", "yes", "on":
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// LabelArcaneUpgrader marks the short-lived helper container that performs an
-// Arcane self-upgrade. It carries the Arcane label too, so container lookups
-// must skip it to avoid mistaking it for Arcane itself.
-const LabelArcaneUpgrader = "com.getarcaneapp.arcane.upgrader"
+const (
+	// InternalResourceLabel marks containers used for Arcane utilities.
+	InternalResourceLabel = "com.getarcaneapp.internal.resource"
+	// HiddenResourceLabel hides containers from container lists and dashboard counts.
+	HiddenResourceLabel = "com.getarcaneapp.arcane.hidden"
+	// LabelArcaneUpgrader marks the short-lived helper container that performs an
+	// Arcane self-upgrade. Container lookups must skip it despite its Arcane label.
+	LabelArcaneUpgrader = "com.getarcaneapp.arcane.upgrader"
+)
 
 // FindArcaneContainerIDByLabel locates Arcane's own container through the
 // Arcane label. Running containers win; otherwise the first match is returned.

--- a/backend/pkg/libarcane/volumes/volume_rename.go
+++ b/backend/pkg/libarcane/volumes/volume_rename.go
@@ -15,6 +15,7 @@ import (
 	dockerutil "github.com/getarcaneapp/arcane/backend/v2/pkg/dockerutil"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/volumehelper"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	volumetypes "github.com/getarcaneapp/arcane/types/v2/volume"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -304,7 +305,7 @@ func removeProjectVolumeHelperContainersInternal(ctx context.Context, dockerClie
 }
 
 func isProjectVolumeHelperContainerInternal(c container.Summary) bool {
-	if !libarcane.IsInternalContainer(c.Labels) {
+	if internal, _ := utils.ParseBool(c.Labels[libarcane.InternalResourceLabel]); !internal {
 		return false
 	}
 	if strings.EqualFold(c.Labels[volumehelper.ContainerLabel], "true") {

--- a/backend/pkg/libarcane/volumes/volume_rename_test.go
+++ b/backend/pkg/libarcane/volumes/volume_rename_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane/volumehelper"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
@@ -81,7 +82,9 @@ func TestContainerSummaryMountsVolumeInternal(t *testing.T) {
 		},
 	}
 
-	require.True(t, libarcane.IsInternalContainer(summary.Labels))
+	internal, valid := utils.ParseBool(summary.Labels[libarcane.InternalResourceLabel])
+	require.True(t, valid)
+	require.True(t, internal)
 	require.True(t, containerSummaryMountsVolumeInternal(summary, "web_data"))
 	require.False(t, containerSummaryMountsVolumeInternal(summary, "nginx_data"))
 }

--- a/backend/pkg/pagination/db_utils.go
+++ b/backend/pkg/pagination/db_utils.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"emperror.dev/errors"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
 	"gorm.io/gorm"
 )
@@ -68,11 +69,8 @@ func ApplyBooleanFilter(q *gorm.DB, column string, value string) *gorm.DB {
 	var boolValues []bool
 
 	for _, part := range parts {
-		switch strings.TrimSpace(part) {
-		case "true", "1":
-			boolValues = append(boolValues, true)
-		case "false", "0":
-			boolValues = append(boolValues, false)
+		if value, valid := utils.ParseBool(part); valid {
+			boolValues = append(boolValues, value)
 		}
 	}
 

--- a/backend/pkg/projects/custom_labels.go
+++ b/backend/pkg/projects/custom_labels.go
@@ -18,6 +18,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/compose-spec/compose-go/v2/loader"
 	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/libarcane"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils"
 	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/iconcatalog"
 	projecttypes "github.com/getarcaneapp/arcane/types/v2/project"
@@ -584,23 +585,33 @@ func NormalizeProjectTagColor(color projecttypes.TagColor) (projecttypes.TagColo
 	return normalized, nil
 }
 
-// applyUpdaterMetadataInternal translates Compose metadata into the labels the
-// updater already consumes, before previews or deployment use the model.
-func applyUpdaterMetadataInternal(project *composetypes.Project) error {
+// applyServiceLabelMetadataInternal translates Compose metadata into the labels the
+// services consume, before previews or deployment use the model.
+func applyServiceLabelMetadataInternal(project *composetypes.Project) error {
 	defaults, err := updaterMetadataLabelsInternal(project.Extensions[arcaneBlockKey])
 	if err != nil {
 		return errors.WrapIf(err, "x-arcane.updater")
 	}
+	hiddenDefaults, err := hiddenMetadataLabelInternal(project.Extensions[arcaneBlockKey])
+	if err != nil {
+		return errors.WrapIf(err, "x-arcane.hidden")
+	}
+	if defaults == nil {
+		defaults = map[string]string{}
+	}
+	maps.Copy(defaults, hiddenDefaults)
 	for name, service := range project.Services {
 		overrides, err := updaterMetadataLabelsInternal(service.Extensions[arcaneBlockKey])
 		if err != nil {
 			return errors.WrapIff(err, "service %s x-arcane.updater", name)
 		}
 		effective := maps.Clone(defaults)
-		if effective == nil {
-			effective = map[string]string{}
+		hiddenOverrides, err := hiddenMetadataLabelInternal(service.Extensions[arcaneBlockKey])
+		if err != nil {
+			return errors.WrapIff(err, "service %s x-arcane.hidden", name)
 		}
 		maps.Copy(effective, overrides)
+		maps.Copy(effective, hiddenOverrides)
 		if len(effective) == 0 {
 			continue
 		}
@@ -634,7 +645,7 @@ func updaterMetadataLabelsInternal(block any) (map[string]string, error) {
 	result := make(map[string]string, len(config))
 	for key, value := range config {
 		if key == "enabled" {
-			enabled, err := updaterMetadataEnabledInternal(value)
+			enabled, err := metadataBoolInternal(value)
 			if err != nil {
 				return nil, err
 			}
@@ -665,7 +676,23 @@ func updaterMetadataLabelsInternal(block any) (map[string]string, error) {
 	return result, nil
 }
 
-func updaterMetadataEnabledInternal(value any) (bool, error) {
+func hiddenMetadataLabelInternal(block any) (map[string]string, error) {
+	arcane, ok := utils.AsStringMap(block).Get()
+	if !ok {
+		return nil, nil
+	}
+	value, present := arcane["hidden"]
+	if !present {
+		return nil, nil
+	}
+	hidden, err := metadataBoolInternal(value)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{libarcane.HiddenResourceLabel: strconv.FormatBool(hidden)}, nil
+}
+
+func metadataBoolInternal(value any) (bool, error) {
 	if enabled, ok := value.(bool); ok {
 		return enabled, nil
 	}
@@ -675,5 +702,5 @@ func updaterMetadataEnabledInternal(value any) (bool, error) {
 			return enabled, nil
 		}
 	}
-	return false, errors.New("updater enabled must be a boolean")
+	return false, errors.New("expected a boolean")
 }

--- a/backend/pkg/projects/load.go
+++ b/backend/pkg/projects/load.go
@@ -458,7 +458,7 @@ func LoadComposeProject(
 }
 
 func finishLoadedProjectInternal(ctx context.Context, project *composetypes.Project, workingDir string, pathMapper projecttypes.VolumeSourcePathMapper, translateFileResources bool, rawSources map[string]string) (*composetypes.Project, error) {
-	if err := applyUpdaterMetadataInternal(project); err != nil {
+	if err := applyServiceLabelMetadataInternal(project); err != nil {
 		return nil, err
 	}
 	project = project.WithoutUnnecessaryResources()

--- a/backend/pkg/remenv/client.go
+++ b/backend/pkg/remenv/client.go
@@ -3,7 +3,6 @@ package remenv
 import (
 	"bytes"
 	"context"
-	"encoding/json/v2"
 	"fmt"
 	"io"
 	"maps"
@@ -112,20 +111,6 @@ func (c *Client) Do(ctx context.Context, req Request) (*Response, error) {
 	return c.doDirectHTTPInternal(ctx, req)
 }
 
-func (c *Client) DoJSON[T any](ctx context.Context, req Request) (T, error) {
-	var zero T
-	resp, err := c.Do(ctx, req)
-	if err != nil {
-		return zero, err
-	}
-
-	if err := resp.RequireSuccess(); err != nil {
-		return zero, err
-	}
-
-	return resp.DecodeJSON[T]()
-}
-
 func (c *Client) doViaTunnelInternal(ctx context.Context, req Request) (*Response, error) {
 	if c.tunnel == nil {
 		return nil, &TransportError{Err: errors.New("edge transport unavailable")}
@@ -189,17 +174,6 @@ func (r *Response) RequireSuccess() error {
 		StatusCode: r.StatusCode,
 		Body:       r.Body,
 	}
-}
-
-func (r *Response) DecodeJSON[T any]() (T, error) {
-	var out T
-	if r == nil {
-		return out, &DecodeError{Err: errors.New("response is nil")}
-	}
-	if err := json.Unmarshal(r.Body, &out); err != nil {
-		return out, &DecodeError{Err: err}
-	}
-	return out, nil
 }
 
 type TransportError struct {

--- a/backend/pkg/remenv/client_test.go
+++ b/backend/pkg/remenv/client_test.go
@@ -101,43 +101,6 @@ func TestClientDo_EdgeUsesTunnelTransport(t *testing.T) {
 	require.Equal(t, `{"edge":true}`, string(resp.Body))
 }
 
-func TestClientDoJSON_ClassifiesStatusAndDecodeErrors(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/status":
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-		case "/decode":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"broken"`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	client := NewClient(server.Client(), nil)
-
-	_, err := client.DoJSON[map[string]any](context.Background(), Request{
-		Method: http.MethodGet,
-		URL:    server.URL + "/status",
-		Path:   "/status",
-	})
-	var statusErr *StatusError
-	require.ErrorAs(t, err, &statusErr)
-	require.Equal(t, http.StatusBadGateway, statusErr.StatusCode)
-	var transportErr *TransportError
-	require.False(t, errors.As(err, &transportErr))
-
-	_, err = client.DoJSON[map[string]any](context.Background(), Request{
-		Method: http.MethodGet,
-		URL:    server.URL + "/decode",
-		Path:   "/decode",
-	})
-	var decodeErr *DecodeError
-	require.ErrorAs(t, err, &decodeErr)
-	require.False(t, errors.As(err, &transportErr))
-}
-
 func TestClientDo_WrapsTransportErrors(t *testing.T) {
 	client := NewClient(nil, TunnelTransportFuncs{
 		EnsureAvailableFunc: func(ctx context.Context, envID string) error {

--- a/backend/pkg/scheduler/auto_heal_job.go
+++ b/backend/pkg/scheduler/auto_heal_job.go
@@ -199,7 +199,7 @@ func (j *AutoHealJob) filterCandidatesInternal(containers []container.Summary, e
 			continue
 		}
 
-		if libarcane.IsInternalContainer(c.Labels) {
+		if internal, _ := utils.ParseBool(c.Labels[libarcane.InternalResourceLabel]); internal {
 			continue
 		}
 

--- a/backend/pkg/utils/bool.go
+++ b/backend/pkg/utils/bool.go
@@ -1,0 +1,17 @@
+package utils
+
+import "strings"
+
+// ParseBool recognizes true/1/yes/on and false/0/no/off, ignoring case and whitespace.
+// The second result reports whether the value is recognized.
+// This will be moved into go.getarcane.app/kit at some point.
+func ParseBool(value string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "yes", "on":
+		return true, true
+	case "false", "0", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}

--- a/cli/pkg/containers/cmd.go
+++ b/cli/pkg/containers/cmd.go
@@ -30,6 +30,7 @@ var (
 	containersStandalone      string
 	containersLabelFilter     string
 	containersIncludeInternal bool
+	containersIncludeHidden   bool
 	containersDeleteVolumes   bool
 	forceFlag                 bool
 	jsonOutput                bool
@@ -88,6 +89,9 @@ func runContainersList(cmd *cobra.Command, forceHasUpdateFilter bool) error {
 	query := url.Values{}
 	if containersStandalone != "" {
 		query.Set("standalone", containersStandalone)
+	}
+	if containersIncludeHidden {
+		query.Set("includeHidden", "true")
 	}
 	if containersIncludeInternal {
 		query.Set("includeInternal", "true")
@@ -562,6 +566,7 @@ func init() {
 	containersListCmd.Flags().StringVar(&containersUpdatesFilter, "updates", "", "Filter by update status (has_update, up_to_date, error, unknown)")
 	containersListCmd.Flags().StringVar(&containersStandalone, "standalone", "", "Filter standalone containers only (true/false)")
 	containersListCmd.Flags().StringVar(&containersLabelFilter, "label", "", "Filter by label (key or key=value)")
+	containersListCmd.Flags().BoolVar(&containersIncludeHidden, "include-hidden", false, "Include hidden containers")
 	containersListCmd.Flags().BoolVar(&containersIncludeInternal, "include-internal", false, "Include Arcane-internal containers")
 	containersListCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	containersUpdatesCmd.Flags().IntVarP(&containersLimit, "limit", "n", 20, "Number of containers to show")

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1,4 +1,7 @@
 {
+  "hidden": "Hidden",
+  "editor_compose_hidden_detail": "Hide from container list",
+  "editor_compose_hidden_info": "Boolean. Hidden containers are excluded from dashboard counts and hidden from the container list by default. Enable \"Show hidden containers\" to reveal them in the list. The project-level value is the default for every service; service-level values override it.",
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "layout_title": "Arcane",
   "accent_color": "Accent Color",

--- a/frontend/src/lib/components/code-editor/analysis/compose-schema.ts
+++ b/frontend/src/lib/components/code-editor/analysis/compose-schema.ts
@@ -38,6 +38,15 @@ const ARCANE_ROOT_EXTENSION_COMPLETIONS: ArcaneCompletionSpec[] = [
 
 const ARCANE_BLOCK_COMPLETIONS: ArcaneCompletionSpec[] = [
 	{
+		label: 'hidden',
+		get detail() {
+			return m.editor_compose_hidden_detail();
+		},
+		get info() {
+			return m.editor_compose_hidden_info();
+		}
+	},
+	{
 		label: 'icon',
 		detail: 'Arcane project fallback icon',
 		info: 'Fallback project icon URL or catalog slug used only when icon-light and icon-dark are not set.'
@@ -73,6 +82,15 @@ const ARCANE_SERVICE_EXTENSION_COMPLETIONS: ArcaneCompletionSpec[] = [
 ];
 
 const ARCANE_SERVICE_BLOCK_COMPLETIONS: ArcaneCompletionSpec[] = [
+	{
+		label: 'hidden',
+		get detail() {
+			return m.editor_compose_hidden_detail();
+		},
+		get info() {
+			return m.editor_compose_hidden_info();
+		}
+	},
 	{
 		label: 'icon',
 		detail: 'Arcane service fallback icon',
@@ -354,6 +372,12 @@ const ARCANE_SCHEMA_DOCS: Record<string, SchemaDoc> = {
 		title: 'x-arcane.icon',
 		description: 'Fallback project icon URL or catalog slug used only when icon-light and icon-dark are not set.'
 	},
+	'x-arcane.hidden': {
+		title: 'x-arcane.hidden',
+		get description() {
+			return m.editor_compose_hidden_info();
+		}
+	},
 	'x-arcane.urls': {
 		title: 'x-arcane.urls',
 		description: 'Additional project URLs (for example docs, homepage, or dashboards).'
@@ -380,6 +404,8 @@ const ARCANE_SCHEMA_DOCS: Record<string, SchemaDoc> = {
 
 function getServiceArcaneSchemaDoc(path: Array<string | number>): SchemaDoc | null {
 	if (path.length === 3) return ARCANE_SCHEMA_DOCS['services.<name>.x-arcane'] ?? null;
+	if (path.length === 4 && path[3] === 'hidden')
+		return { ...ARCANE_SCHEMA_DOCS['x-arcane.hidden'], title: 'services.<name>.x-arcane.hidden' };
 	if (path.length !== 4 || !['icon', 'icon-light', 'icon-dark'].includes(String(path[3]))) return null;
 	return {
 		title: `services.<name>.x-arcane.${String(path[3])}`,
@@ -411,7 +437,7 @@ function getArcaneSchemaDocForPath(path: Array<string | number>): SchemaDoc | nu
 	if (isServiceArcanePath(path.slice(0, 3))) return getServiceArcaneSchemaDoc(path);
 	if (path[0] !== 'x-arcane') return null;
 	if (path.length === 1) return ARCANE_SCHEMA_DOCS['x-arcane'] ?? null;
-	if (path.length === 2 && ['icon', 'icon-light', 'icon-dark', 'urls', 'tags'].includes(String(path[1])))
+	if (path.length === 2 && ['icon', 'icon-light', 'icon-dark', 'urls', 'tags', 'hidden'].includes(String(path[1])))
 		return ARCANE_SCHEMA_DOCS[`x-arcane.${path[1]}`] ?? null;
 	if (path.length === 4 && path[1] === 'tags' && typeof path[2] === 'number') {
 		return ARCANE_SCHEMA_DOCS[`x-arcane.tags[].${String(path[3])}`] ?? null;
@@ -516,6 +542,13 @@ export function getCompletionOptionsForPath(
 
 export function getEnumValueCompletions(schema: SchemaObject | null, path: Array<string | number>): Completion[] {
 	const values = new Set<string>();
+	if (
+		(path.length === 2 && path[0] === 'x-arcane' && path[1] === 'hidden') ||
+		(path.length === 4 && isServiceArcanePath(path.slice(0, 3)) && path[3] === 'hidden')
+	) {
+		values.add('true');
+		values.add('false');
+	}
 	const updaterPathIndex = getUpdaterPathIndex(path);
 	if (updaterPathIndex >= 0 && path.length === updaterPathIndex + 2) {
 		const field = path[updaterPathIndex + 1];

--- a/frontend/src/lib/types/docker.ts
+++ b/frontend/src/lib/types/docker.ts
@@ -175,6 +175,7 @@ export interface ContainerSummaryDto extends BaseContainer {
 	mounts: ContainerMounts[];
 	updateInfo?: ImageUpdateInfoDto;
 	redeployDisabled?: boolean;
+	hidden?: boolean;
 }
 
 export interface ContainerSummaryGroupDto {

--- a/frontend/src/lib/types/shared.ts
+++ b/frontend/src/lib/types/shared.ts
@@ -19,6 +19,7 @@ export type SearchPaginationSortRequest = {
 	sort?: SortRequest;
 	filters?: FilterMap;
 	includeInternal?: boolean;
+	includeHidden?: boolean;
 };
 
 export type PaginationResponse = {

--- a/frontend/src/lib/utils/tables.ts
+++ b/frontend/src/lib/utils/tables.ts
@@ -21,7 +21,8 @@ function cloneRequest(options: SearchPaginationSortRequest): SearchPaginationSor
 		filters: options.filters ? { ...options.filters } : undefined,
 		pagination: options.pagination ? { ...options.pagination } : undefined,
 		sort: options.sort ? { ...options.sort } : undefined,
-		includeInternal: options.includeInternal
+		includeInternal: options.includeInternal,
+		includeHidden: options.includeHidden
 	};
 }
 
@@ -184,6 +185,9 @@ export function transformPaginationParams(options?: SearchPaginationSortRequest)
 		});
 	}
 
+	if (typeof options.includeHidden === 'boolean') {
+		params['includeHidden'] = String(options.includeHidden);
+	}
 	if (typeof options.includeInternal === 'boolean') {
 		params['includeInternal'] = String(options.includeInternal);
 	}

--- a/frontend/src/routes/(app)/containers/+page.svelte
+++ b/frontend/src/routes/(app)/containers/+page.svelte
@@ -196,7 +196,8 @@
 						pagination: options.pagination,
 						sort: options.sort,
 						filters: options.filters,
-						includeInternal: options.includeInternal
+						includeInternal: options.includeInternal,
+						includeHidden: options.includeHidden
 					};
 					return refreshContainers(options, requestedEnvId);
 				}}

--- a/frontend/src/routes/(app)/containers/container-table.svelte
+++ b/frontend/src/routes/(app)/containers/container-table.svelte
@@ -119,15 +119,19 @@
 		return requestOptions?.pagination?.limit ?? containers?.pagination?.itemsPerPage ?? 20;
 	}
 
-	function setShowInternal(value: boolean) {
-		const currentSetting = (customSettings['showInternalContainers'] as boolean) ?? false;
-		const currentRequest = requestOptions?.includeInternal ?? false;
+	function setIncludeFlag(
+		settingsKey: 'showInternalContainers' | 'showHiddenContainers',
+		requestKey: 'includeInternal' | 'includeHidden',
+		value: boolean
+	) {
+		const currentSetting = (customSettings[settingsKey] as boolean) ?? false;
+		const currentRequest = requestOptions?.[requestKey] ?? false;
 		if (value === currentSetting && value === currentRequest) return;
 
-		customSettings = { ...customSettings, showInternalContainers: value };
+		customSettings = { ...customSettings, [settingsKey]: value };
 		const nextOptions: SearchPaginationSortRequest = {
 			...requestOptions,
-			includeInternal: value,
+			[requestKey]: value,
 			pagination: { page: 1, limit: getCurrentLimit() }
 		};
 		requestOptions = nextOptions;
@@ -162,6 +166,7 @@
 	let showInternal = $derived.by(() => {
 		return (customSettings['showInternalContainers'] as boolean) ?? false;
 	});
+	let showHidden = $derived((customSettings['showHiddenContainers'] as boolean) ?? false);
 	let hideExposedPorts = $derived.by(() => {
 		return (customSettings['hideExposedPorts'] as boolean) ?? false;
 	});
@@ -225,23 +230,22 @@
 		collapsedGroupsState = new PersistedState<Record<string, boolean>>('container-groups-collapsed', {});
 
 		const persistedInternal = (customSettings['showInternalContainers'] as boolean) ?? false;
-		const currentInternal = requestOptions?.includeInternal ?? false;
-		if (persistedInternal !== currentInternal) {
-			setShowInternal(persistedInternal);
-		}
-
+		const persistedHidden = (customSettings['showHiddenContainers'] as boolean) ?? false;
+		const includeFlagsChanged =
+			persistedInternal !== (requestOptions?.includeInternal ?? false) ||
+			persistedHidden !== (requestOptions?.includeHidden ?? false);
 		const persistedGroupByProject = (customSettings['groupByProject'] as boolean) ?? false;
-		if (persistedGroupByProject !== groupByProject) {
-			groupByProject = persistedGroupByProject;
-		}
+		groupByProject = persistedGroupByProject;
 
-		if (persistedGroupByProject) {
+		if (includeFlagsChanged || persistedGroupByProject) {
 			const nextOptions: SearchPaginationSortRequest = {
 				...requestOptions,
+				includeInternal: persistedInternal,
+				includeHidden: persistedHidden,
 				pagination: { page: 1, limit: getCurrentLimit() }
 			};
 			requestOptions = nextOptions;
-			void refreshContainers(nextOptions, true);
+			void refreshContainers(nextOptions, persistedGroupByProject);
 		}
 
 		return () => {
@@ -451,6 +455,9 @@
 	<div class="flex items-center gap-2">
 		<IconImage src={iconUrl} alt={displayName} fallback={BoxIcon} class="size-6" containerClass="size-8" />
 		<a class="font-medium hover:underline" href="/containers/{item.id}">{displayName}</a>
+		{#if item.hidden}
+			<Badge variant="gray" size="sm" class="font-normal text-muted-foreground">{m.hidden()}</Badge>
+		{/if}
 		{#if projectLabel && !groupByProject}
 			<Badge variant="gray" size="sm" class="max-w-40 truncate font-normal text-muted-foreground" title={projectLabel}>
 				{projectLabel}
@@ -833,8 +840,17 @@
 	<DropdownMenu.CheckboxItem checked={groupByProject} onCheckedChange={(v) => setGroupByProject(!!v)}>
 		{m.containers_group_by_project()}
 	</DropdownMenu.CheckboxItem>
-	<DropdownMenu.CheckboxItem checked={showInternal} onCheckedChange={(v) => setShowInternal(!!v)}>
+	<DropdownMenu.CheckboxItem
+		checked={showInternal}
+		onCheckedChange={(v) => setIncludeFlag('showInternalContainers', 'includeInternal', !!v)}
+	>
 		{`${m.common_show()} ${m.internal()} ${m.containers()}`}
+	</DropdownMenu.CheckboxItem>
+	<DropdownMenu.CheckboxItem
+		checked={showHidden}
+		onCheckedChange={(v) => setIncludeFlag('showHiddenContainers', 'includeHidden', !!v)}
+	>
+		{`${m.common_show()} ${m.hidden()} ${m.containers()}`}
 	</DropdownMenu.CheckboxItem>
 	<DropdownMenu.CheckboxItem
 		checked={hideExposedPorts}

--- a/types/container/container.go
+++ b/types/container/container.go
@@ -879,6 +879,11 @@ type Summary struct {
 	//
 	// Required: false
 	RedeployDisabled bool `json:"redeployDisabled,omitempty"`
+
+	// Hidden indicates whether the container is hidden from lists and dashboard counts.
+	//
+	// Required: false
+	Hidden bool `json:"hidden,omitempty"`
 }
 
 // ComposeInfo contains Docker Compose project information extracted from container labels.


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/1949

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->








<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Adds support for hiding containers through Docker labels and project- or service-level Compose metadata.
- Excludes hidden containers from default container listings, status counts, and dashboard resource/update counts.
- Adds API, CLI, frontend filtering controls, hidden-container indicators, and Compose editor guidance.
- Introduces shared boolean parsing and applies it across label and query-filter handling.
- Preserves stored project image references when Compose resolution fails while excluding references known to belong exclusively to hidden runtime services.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the previously reported dashboard update-count and fallback issues are addressed without introducing a confirmed new defect.

Hidden standalone and project service updates are now filtered from dashboard counts, including cached Compose metadata and discovered projects. Compose-resolution failures retain stored image references while removing references known exclusively from hidden runtime services. The other previous findings were manually resolved, and no outstanding blocking behavior remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["feat: support hidden containers via labe..."](https://github.com/getarcaneapp/arcane/commit/e7a760a7305a79af2ebf4f76467f2a472a00ac42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61471882)</sub>

<!-- /greptile_comment -->