### PR TITLE
feat: link Git-managed projects and synced files to their repository

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1929,6 +1929,8 @@
   "git_managed_env_note": "The environment file (.env) can still be edited in Arcane to provide runtime configuration.",
   "git_from_git_repo": "From Git Repo",
   "git_sync_from_git": "Sync from Git",
+  "git_open_project_in_repository": "Open Project in Git",
+  "git_edit_file_in_repository": "Edit File in Git",
   "git_sync_file_limits_title": "Git Sync File Limits",
   "git_sync_file_limits_description": "Apply environment-wide caps when Arcane copies repository files during Git syncs. Use 0 to remove a cap.",
   "git_sync_max_files_label": "Max Synced Files",

--- a/frontend/src/lib/components/code-panel.svelte
+++ b/frontend/src/lib/components/code-panel.svelte
@@ -41,7 +41,8 @@
 		outlineOpen = $bindable(false),
 		diffOpen = $bindable(false),
 		commandPaletteOpen = $bindable(false),
-		variant = 'card'
+		variant = 'card',
+		gitEditUrl
 	}: {
 		title: string;
 		open?: boolean;
@@ -62,14 +63,39 @@
 		diffOpen?: boolean;
 		commandPaletteOpen?: boolean;
 		variant?: 'card' | 'plain';
+		gitEditUrl?: string | null;
 	} = $props();
 
 	const isMobile = new IsMobile();
 	const effectiveAutoHeight = $derived(autoHeight || isMobile.current);
+	const editUrl = $derived(readOnly && !(enableDiff && diffOpen) && gitEditUrl ? gitEditUrl : null);
+
+	// CodeMirror's gutters, search panel and tooltips share this wrapper.
+	function isEditorText(target: EventTarget | null): boolean {
+		return target instanceof Element && !!target.closest('.cm-content');
+	}
+
+	function handleEditorClick(event: MouseEvent) {
+		if (!editUrl || !isEditorText(event.target)) return;
+		if (!window.getSelection()?.isCollapsed) return;
+		window.open(editUrl, '_blank', 'noopener,noreferrer');
+	}
+
+	function handleEditorKeydown(event: KeyboardEvent) {
+		if (!editUrl || event.key !== 'Enter' || !isEditorText(event.target)) return;
+		event.preventDefault();
+		window.open(editUrl, '_blank', 'noopener,noreferrer');
+	}
 </script>
 
 {#snippet editorBody()}
-	<div class="{effectiveAutoHeight ? '' : 'relative flex-1'} min-h-0 w-full min-w-0">
+	<div
+		class="{effectiveAutoHeight ? '' : 'relative flex-1'} min-h-0 w-full min-w-0 {editUrl ? 'cursor-pointer' : ''}"
+		role={editUrl ? 'link' : undefined}
+		title={editUrl ? m.git_edit_file_in_repository() : undefined}
+		onclick={handleEditorClick}
+		onkeydown={handleEditorKeydown}
+	>
 		<div class={effectiveAutoHeight ? '' : 'absolute inset-0'}>
 			<CodeEditor
 				bind:value

--- a/frontend/src/lib/components/code-panel.svelte
+++ b/frontend/src/lib/components/code-panel.svelte
@@ -82,16 +82,19 @@
 	}
 
 	function handleEditorKeydown(event: KeyboardEvent) {
-		if (!editUrl || event.key !== 'Enter' || !isEditorText(event.target)) return;
+		if (!editUrl || event.key !== 'Enter') return;
+		if (event.target !== event.currentTarget && !isEditorText(event.target)) return;
 		event.preventDefault();
 		window.open(editUrl, '_blank', 'noopener,noreferrer');
 	}
 </script>
 
 {#snippet editorBody()}
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 	<div
 		class="{effectiveAutoHeight ? '' : 'relative flex-1'} min-h-0 w-full min-w-0 {editUrl ? 'cursor-pointer' : ''}"
 		role={editUrl ? 'link' : undefined}
+		tabindex={editUrl ? 0 : undefined}
 		title={editUrl ? m.git_edit_file_in_repository() : undefined}
 		onclick={handleEditorClick}
 		onkeydown={handleEditorKeydown}

--- a/frontend/src/lib/utils/gitops.ts
+++ b/frontend/src/lib/utils/gitops.ts
@@ -1,5 +1,5 @@
 import type { GitOpsSync } from '#lib/types/automation.js';
-import { toGitPathUrl } from '#lib/utils/navigation.js';
+import { toGitRouteUrl, toGitWebUrl } from '#lib/utils/navigation.js';
 
 function composeDirectory(sync: GitOpsSync): string {
 	return sync.composePath.split('/').slice(0, -1).join('/');
@@ -15,19 +15,19 @@ function syncedPaths(sync: GitOpsSync): string[] {
 	}
 }
 
+// Unknown forges still get a link to the repository itself.
 export function gitOpsProjectUrl(sync: GitOpsSync | undefined | null): string | null {
 	if (!sync?.repository?.url) return null;
-	return toGitPathUrl(sync.repository.url, sync.branch, composeDirectory(sync), 'tree');
+	return toGitRouteUrl(sync.repository.url, 'tree', sync.branch, composeDirectory(sync)) ?? toGitWebUrl(sync.repository.url);
 }
 
-// A single-file sync writes the local copy as compose.yaml whatever the repository calls it.
 export function gitOpsComposeEditUrl(sync: GitOpsSync | undefined | null): string | null {
 	if (!sync?.repository?.url) return null;
-	return toGitPathUrl(sync.repository.url, sync.branch, sync.composePath, 'edit');
+	return toGitRouteUrl(sync.repository.url, 'edit', sync.branch, sync.composePath);
 }
 
 export function gitOpsFileEditUrl(sync: GitOpsSync | undefined | null, relativePath: string): string | null {
 	if (!sync?.repository?.url || !syncedPaths(sync).includes(relativePath)) return null;
 	const directory = composeDirectory(sync);
-	return toGitPathUrl(sync.repository.url, sync.branch, directory ? `${directory}/${relativePath}` : relativePath, 'edit');
+	return toGitRouteUrl(sync.repository.url, 'edit', sync.branch, directory ? `${directory}/${relativePath}` : relativePath);
 }

--- a/frontend/src/lib/utils/gitops.ts
+++ b/frontend/src/lib/utils/gitops.ts
@@ -1,0 +1,33 @@
+import type { GitOpsSync } from '#lib/types/automation.js';
+import { toGitPathUrl } from '#lib/utils/navigation.js';
+
+function composeDirectory(sync: GitOpsSync): string {
+	return sync.composePath.split('/').slice(0, -1).join('/');
+}
+
+// Mirrors the backend's workspace lock, which deliberately omits the project-root .env.
+function syncedPaths(sync: GitOpsSync): string[] {
+	try {
+		const parsed: unknown = JSON.parse(sync.syncedFiles ?? '[]');
+		return Array.isArray(parsed) ? parsed.filter((entry) => typeof entry === 'string' && entry) : [];
+	} catch {
+		return [];
+	}
+}
+
+export function gitOpsProjectUrl(sync: GitOpsSync | undefined | null): string | null {
+	if (!sync?.repository?.url) return null;
+	return toGitPathUrl(sync.repository.url, sync.branch, composeDirectory(sync), 'tree');
+}
+
+// A single-file sync writes the local copy as compose.yaml whatever the repository calls it.
+export function gitOpsComposeEditUrl(sync: GitOpsSync | undefined | null): string | null {
+	if (!sync?.repository?.url) return null;
+	return toGitPathUrl(sync.repository.url, sync.branch, sync.composePath, 'edit');
+}
+
+export function gitOpsFileEditUrl(sync: GitOpsSync | undefined | null, relativePath: string): string | null {
+	if (!sync?.repository?.url || !syncedPaths(sync).includes(relativePath)) return null;
+	const directory = composeDirectory(sync);
+	return toGitPathUrl(sync.repository.url, sync.branch, directory ? `${directory}/${relativePath}` : relativePath, 'edit');
+}

--- a/frontend/src/lib/utils/navigation.ts
+++ b/frontend/src/lib/utils/navigation.ts
@@ -167,22 +167,21 @@ export function toSafeHref(raw: string, scheme: string = 'https'): string {
 
 // --- Git URL helpers ---
 
+type GitRoute = 'commit' | 'tree' | 'blob' | 'edit';
+
 function stripGitSuffix(path: string): string {
-	return path.replace(/\.git\/?$/, '');
+	return path.replace(/\.git\/?$/, '').replace(/\/+$/, '');
 }
 
-function trimTrailingSlash(value: string): string {
-	return value.replace(/\/+$/, '');
+function encodePathSegments(value: string): string {
+	return value
+		.split('/')
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
 }
 
-function commitSegmentForHost(hostname: string): string {
-	const host = hostname.toLowerCase();
-	if (host.includes('gitlab')) return '/-/commit/';
-	if (host.includes('bitbucket')) return '/commits/';
-	return '/commit/';
-}
-
-function toGitWebUrl(raw: string): string | null {
+export function toGitWebUrl(raw: string): string | null {
 	const trimmed = raw.trim();
 	if (!trimmed) return null;
 
@@ -211,52 +210,30 @@ function toGitWebUrl(raw: string): string | null {
 	return path ? `https://${host}/${path}` : null;
 }
 
-function pathSegmentForHost(hostname: string, kind: GitPathKind): string {
+// Only hostnames that name their product are recognized; a self-hosted forge on a neutral domain gets no deep link.
+function gitRouteSegment(hostname: string, route: GitRoute): string | null {
 	const host = hostname.toLowerCase();
-	if (host.includes('gitlab')) return `/-/${kind}/`;
+	if (host.includes('gitlab')) return `/-/${route}/`;
 	// Bitbucket has no dedicated edit route; /src/ opens the file with its own edit action.
-	if (host.includes('bitbucket')) return '/src/';
+	if (host.includes('bitbucket')) return route === 'commit' ? '/commits/' : '/src/';
 	if (host.includes('gitea') || host.includes('forgejo') || host.includes('codeberg')) {
-		return kind === 'edit' ? '/_edit/' : '/src/branch/';
+		if (route === 'edit') return '/_edit/';
+		return route === 'commit' ? '/commit/' : '/src/branch/';
 	}
-	return `/${kind}/`;
+	if (host.includes('github') || route === 'commit') return `/${route}/`;
+	return null;
 }
 
-function encodePathSegments(value: string): string {
-	return value
-		.split('/')
-		.filter(Boolean)
-		.map((segment) => encodeURIComponent(segment))
-		.join('/');
-}
-
-export function toGitCommitUrl(repositoryUrl: string, commit: string): string | null {
+export function toGitRouteUrl(repositoryUrl: string, route: GitRoute, ref: string, path = ''): string | null {
 	const base = toGitWebUrl(repositoryUrl);
-	const trimmedCommit = commit.trim();
-	if (!base || !trimmedCommit) return null;
+	const encodedRef = encodePathSegments(ref.trim());
+	if (!base || !encodedRef) return null;
 
-	const normalizedBase = trimTrailingSlash(base);
 	try {
-		const host = new URL(normalizedBase).hostname;
-		const segment = commitSegmentForHost(host);
-		return `${normalizedBase}${segment}${encodeURIComponent(trimmedCommit)}`;
-	} catch {
-		return null;
-	}
-}
-
-type GitPathKind = 'tree' | 'blob' | 'edit';
-
-export function toGitPathUrl(repositoryUrl: string, branch: string, path: string, kind: GitPathKind): string | null {
-	const base = toGitWebUrl(repositoryUrl);
-	const encodedBranch = encodePathSegments(branch.trim());
-	if (!base || !encodedBranch) return null;
-
-	const normalizedBase = trimTrailingSlash(base);
-	try {
-		const segment = pathSegmentForHost(new URL(normalizedBase).hostname, kind);
+		const segment = gitRouteSegment(new URL(base).hostname, route);
+		if (!segment) return null;
 		const encodedPath = encodePathSegments(path);
-		return `${normalizedBase}${segment}${encodedBranch}${encodedPath ? `/${encodedPath}` : ''}`;
+		return `${base}${segment}${encodedRef}${encodedPath ? `/${encodedPath}` : ''}`;
 	} catch {
 		return null;
 	}

--- a/frontend/src/lib/utils/navigation.ts
+++ b/frontend/src/lib/utils/navigation.ts
@@ -192,8 +192,11 @@ function toGitWebUrl(raw: string): string | null {
 			if (!parsed.hostname) return null;
 			const path = stripGitSuffix(parsed.pathname);
 			if (!path || path === '/') return null;
-			const protocol = parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.protocol : 'https:';
-			return `${protocol}//${parsed.hostname}${path}`;
+			const isWebProtocol = parsed.protocol === 'http:' || parsed.protocol === 'https:';
+			const protocol = isWebProtocol ? parsed.protocol : 'https:';
+			// An ssh:// port is the SSH port, not the forge's web port.
+			const host = isWebProtocol ? parsed.host : parsed.hostname;
+			return `${protocol}//${host}${path}`;
 		} catch {
 			return null;
 		}
@@ -208,6 +211,25 @@ function toGitWebUrl(raw: string): string | null {
 	return path ? `https://${host}/${path}` : null;
 }
 
+function pathSegmentForHost(hostname: string, kind: GitPathKind): string {
+	const host = hostname.toLowerCase();
+	if (host.includes('gitlab')) return `/-/${kind}/`;
+	// Bitbucket has no dedicated edit route; /src/ opens the file with its own edit action.
+	if (host.includes('bitbucket')) return '/src/';
+	if (host.includes('gitea') || host.includes('forgejo') || host.includes('codeberg')) {
+		return kind === 'edit' ? '/_edit/' : '/src/branch/';
+	}
+	return `/${kind}/`;
+}
+
+function encodePathSegments(value: string): string {
+	return value
+		.split('/')
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
+}
+
 export function toGitCommitUrl(repositoryUrl: string, commit: string): string | null {
 	const base = toGitWebUrl(repositoryUrl);
 	const trimmedCommit = commit.trim();
@@ -218,6 +240,23 @@ export function toGitCommitUrl(repositoryUrl: string, commit: string): string | 
 		const host = new URL(normalizedBase).hostname;
 		const segment = commitSegmentForHost(host);
 		return `${normalizedBase}${segment}${encodeURIComponent(trimmedCommit)}`;
+	} catch {
+		return null;
+	}
+}
+
+type GitPathKind = 'tree' | 'blob' | 'edit';
+
+export function toGitPathUrl(repositoryUrl: string, branch: string, path: string, kind: GitPathKind): string | null {
+	const base = toGitWebUrl(repositoryUrl);
+	const encodedBranch = encodePathSegments(branch.trim());
+	if (!base || !encodedBranch) return null;
+
+	const normalizedBase = trimTrailingSlash(base);
+	try {
+		const segment = pathSegmentForHost(new URL(normalizedBase).hostname, kind);
+		const encodedPath = encodePathSegments(path);
+		return `${normalizedBase}${segment}${encodedBranch}${encodedPath ? `/${encodedPath}` : ''}`;
 	} catch {
 		return null;
 	}

--- a/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
@@ -15,7 +15,7 @@
 	import { formatDateTimeShort } from '#lib/utils/formatting.js';
 	import { m } from '#lib/paraglide/messages.js';
 	import { gitOpsSyncService } from '#lib/services/gitops-sync-service.js';
-	import { toGitCommitUrl } from '#lib/utils/navigation.js';
+	import { toGitCommitUrl, toGitPathUrl } from '#lib/utils/navigation.js';
 	import {
 		EditIcon as PencilIcon,
 		StartIcon as PlayIcon,
@@ -210,10 +210,22 @@
 	</div>
 {/snippet}
 
-{#snippet PathCell({ value }: { value: any; item: GitOpsSync; row: ArcaneRow<GitOpsSync> })}
+{#snippet PathCell({ value, item }: { value: any; item: GitOpsSync; row: ArcaneRow<GitOpsSync> })}
+	{@const fileUrl = item.repository?.url ? toGitPathUrl(item.repository.url, item.branch, String(value), 'blob') : null}
 	<div class="flex items-center gap-1.5">
 		<FolderIcon class="size-3.5 text-muted-foreground" />
-		<code class="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">{value}</code>
+		{#if fileUrl}
+			<a
+				href={fileUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="rounded bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground transition-colors hover:text-primary"
+			>
+				{value}
+			</a>
+		{:else}
+			<code class="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">{value}</code>
+		{/if}
 	</div>
 {/snippet}
 

--- a/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
+++ b/frontend/src/routes/(app)/environments/[id]/gitops/sync-table.svelte
@@ -15,7 +15,7 @@
 	import { formatDateTimeShort } from '#lib/utils/formatting.js';
 	import { m } from '#lib/paraglide/messages.js';
 	import { gitOpsSyncService } from '#lib/services/gitops-sync-service.js';
-	import { toGitCommitUrl, toGitPathUrl } from '#lib/utils/navigation.js';
+	import { toGitRouteUrl } from '#lib/utils/navigation.js';
 	import {
 		EditIcon as PencilIcon,
 		StartIcon as PlayIcon,
@@ -211,7 +211,7 @@
 {/snippet}
 
 {#snippet PathCell({ value, item }: { value: any; item: GitOpsSync; row: ArcaneRow<GitOpsSync> })}
-	{@const fileUrl = item.repository?.url ? toGitPathUrl(item.repository.url, item.branch, String(value), 'blob') : null}
+	{@const fileUrl = item.repository?.url ? toGitRouteUrl(item.repository.url, 'blob', item.branch, String(value)) : null}
 	<div class="flex items-center gap-1.5">
 		<FolderIcon class="size-3.5 text-muted-foreground" />
 		{#if fileUrl}
@@ -247,7 +247,7 @@
 
 {#snippet CommitCell({ value, item }: { value: any; item: GitOpsSync; row: ArcaneRow<GitOpsSync> })}
 	{#if value}
-		{@const commitUrl = item.repository?.url ? toGitCommitUrl(item.repository.url, String(value)) : null}
+		{@const commitUrl = item.repository?.url ? toGitRouteUrl(item.repository.url, 'commit', String(value)) : null}
 		<div class="flex items-center gap-1.5">
 			<HashIcon class="size-3.5 text-muted-foreground" />
 			{#if commitUrl}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -18,6 +18,7 @@
 		GlobeIcon,
 		CodeIcon,
 		ArrowsUpDownIcon,
+		ExternalLinkIcon,
 		SearchIcon
 	} from '#lib/icons/index.js';
 	import { type TabItem } from '#lib/components/tab-bar/index.js';
@@ -35,6 +36,7 @@
 	import { z } from 'zod/v4';
 	import { createForm } from '#lib/utils/settings.js';
 	import { m } from '#lib/paraglide/messages.js';
+	import { gitOpsComposeEditUrl, gitOpsFileEditUrl, gitOpsProjectUrl } from '#lib/utils/gitops.js';
 	import { toGitCommitUrl } from '#lib/utils/navigation.js';
 	import { toSafeHref } from '#lib/utils/navigation.js';
 	import { PersistedState } from 'runed';
@@ -293,6 +295,9 @@
 	// The override editor surfaces only when an override exists or the user asked
 	// to add one this session; otherwise the UI shows an "add override" affordance.
 	let overrideActive = $derived(overrideExists || overrideEditorRequested);
+	const gitProjectUrl = $derived(gitOpsProjectUrl(lifecycleSync));
+	const gitComposeEditUrl = $derived(gitOpsComposeEditUrl(lifecycleSync));
+	const gitOverrideEditUrl = $derived(gitOpsFileEditUrl(lifecycleSync, overrideFileName));
 	const projectWorkspaceLeadingRows = $derived([
 		{ key: 'compose', label: composeFileName, iconClass: 'text-blue-500', locked: true },
 		...(overrideActive
@@ -1369,7 +1374,8 @@
 			fileId: `project:${projectId}:compose`,
 			originalValue: serverComposeContent,
 			enableDiff: true,
-			editorContext: codeEditorContext
+			editorContext: codeEditorContext,
+			gitEditUrl: gitComposeEditUrl
 		} as const;
 	}
 
@@ -1383,7 +1389,8 @@
 			fileId: `project:${projectId}:override`,
 			originalValue: serverOverrideContent,
 			enableDiff: true,
-			editorContext: codeEditorContext
+			editorContext: codeEditorContext,
+			gitEditUrl: gitOverrideEditUrl
 		} as const;
 	}
 
@@ -1544,6 +1551,7 @@
 			value={selectedProjectWorkspaceMetadata.content ?? ''}
 			readOnly={true}
 			editorContext={codeEditorContext}
+			gitEditUrl={gitOpsFileEditUrl(lifecycleSync, relativePath)}
 		/>
 	{:else if projectWorkspaceContents[relativePath] === undefined}
 		<div class="flex h-full min-h-0 items-center justify-center text-muted-foreground">
@@ -1730,6 +1738,7 @@
 			originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
 			enableDiff={true}
 			editorContext={codeEditorContext}
+			gitEditUrl={gitOpsFileEditUrl(lifecycleSync, includeFile.relativePath)}
 		/>
 	{:else if dirFile && loadedDirectoryFileContents[dirFile.relativePath] !== undefined}
 		<CodePanel
@@ -1775,18 +1784,30 @@
 						</div>
 					</Alert.Description>
 				</div>
-				{#if canUpdateProject}
-					<ArcaneButton
-						action="base"
-						tone="outline-primary"
-						loading={isLoading.syncing}
-						onclick={handleSyncFromGit}
-						icon={RefreshIcon}
-						customLabel={m.git_sync_from_git()}
-						loadingLabel={m.common_syncing()}
-						class="shrink-0"
-					/>
-				{/if}
+				<div class="flex shrink-0 flex-wrap items-center gap-2">
+					{#if gitProjectUrl}
+						<ArcaneButton
+							action="base"
+							tone="outline"
+							href={gitProjectUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							icon={ExternalLinkIcon}
+							customLabel={m.git_open_project_in_repository()}
+						/>
+					{/if}
+					{#if canUpdateProject}
+						<ArcaneButton
+							action="base"
+							tone="outline-primary"
+							loading={isLoading.syncing}
+							onclick={handleSyncFromGit}
+							icon={RefreshIcon}
+							customLabel={m.git_sync_from_git()}
+							loadingLabel={m.common_syncing()}
+						/>
+					{/if}
+				</div>
 			</div>
 		</Alert.Root>
 	{/if}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -37,8 +37,7 @@
 	import { createForm } from '#lib/utils/settings.js';
 	import { m } from '#lib/paraglide/messages.js';
 	import { gitOpsComposeEditUrl, gitOpsFileEditUrl, gitOpsProjectUrl } from '#lib/utils/gitops.js';
-	import { toGitCommitUrl } from '#lib/utils/navigation.js';
-	import { toSafeHref } from '#lib/utils/navigation.js';
+	import { toGitRouteUrl, toSafeHref } from '#lib/utils/navigation.js';
 	import { PersistedState } from 'runed';
 	import { useUrlTab } from '#lib/hooks/use-url-tab.svelte.js';
 	import ComposeFileEditorPanel from '#lib/components/compose-file-editor-panel.svelte';
@@ -2044,7 +2043,9 @@
 			{/if}
 
 			{#if project.lastSyncCommit}
-				{@const commitUrl = project.gitRepositoryURL ? toGitCommitUrl(project.gitRepositoryURL, project.lastSyncCommit) : null}
+				{@const commitUrl = project.gitRepositoryURL
+					? toGitRouteUrl(project.gitRepositoryURL, 'commit', project.lastSyncCommit)
+					: null}
 				<div class="mt-1 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
 					<div class="flex items-center gap-1.5">
 						<span class="hidden sm:inline">{m.commit()}:</span>


### PR DESCRIPTION
## Checklist

- [x] This PR is **not** opened from my fork's `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

Git-managed projects show their commit but have no link back to the repository.

## Changes Made

- Open Project in Git button in the read-only notice. It opens the compose file's folder
- Clicking the code of a read-only synced file opens its edit page on the forge. The .env stays editable in Arcane, so it gets no link
- Compose paths on the Git Syncs page link to the file
- One URL builder for tree, blob and edit paths on GitHub, GitLab, Bitbucket, Gitea, Forgejo and Codeberg. http and https repository URLs now keep their port

## Testing Done

I clicked every generated link through to GitHub, in both editor layouts. That covered an SSH remote, a repo named docker-compose.yml and one with an override file. Selecting text, searching and folding still work, and projects without a sync are unchanged.

I checked GitLab, Bitbucket and Codeberg with plain requests against public repos, and Gitea against its route template.

## AI Tool Used (if applicable)

Claude Code wrote the implementation. I reviewed and tested it.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds forge links for Git-managed projects, compose paths, and synchronized read-only files, backed by shared repository URL construction.
- Adds project-directory and file-edit links to the project workspace.
- Links compose paths from the Git Syncs table.
- Preserves explicit HTTP(S) ports and generates forge-specific tree, blob, edit, and commit routes.
- The new forge detection does not correctly handle self-hosted instances on product-neutral domains.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until repository links work for self-hosted instances of the forges it claims to support.

The URL builder assumes any unrecognized hostname uses GitHub routes, causing deterministic broken links for self-hosted GitLab, Gitea, Forgejo, and Bitbucket deployments on product-neutral domains.

**Files Needing Attention:** frontend/src/lib/utils/navigation.ts
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat%2Fgitops-repository-links%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgitops-repository-links%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233879%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3879&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22feat%2Fgitops-repository-links%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgitops-repository-links%22.%0A%0A%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Flib%2Futils%2Fnavigation.ts%3A214-223%0A**Self-hosted%20forge%20links%20break**%0A%0AIf%20a%20self-hosted%20GitLab%2C%20Gitea%2C%20Forgejo%2C%20or%20Bitbucket%20instance%20uses%20a%20domain%20that%20does%20not%20contain%20the%20product%20name%2C%20these%20hostname%20checks%20fall%20back%20to%20GitHub-style%20routes.%20For%20example%2C%20a%20Gitea%20repository%20at%20%60git.example.com%2Forg%2Frepo.git%60%20gets%20%60%2Fedit%2F%3Cbranch%3E%2F...%60%20instead%20of%20%60%2F_edit%2F%3Cbranch%3E%2F...%60%2C%20so%20the%20new%20project%20and%20file%20links%20do%20not%20work.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Flib%2Futils%2Fnavigation.ts%3A214-223%0A**Self-hosted%20forge%20links%20break**%0A%0AIf%20a%20self-hosted%20GitLab%2C%20Gitea%2C%20Forgejo%2C%20or%20Bitbucket%20instance%20uses%20a%20domain%20that%20does%20not%20contain%20the%20product%20name%2C%20these%20hostname%20checks%20fall%20back%20to%20GitHub-style%20routes.%20For%20example%2C%20a%20Gitea%20repository%20at%20%60git.example.com%2Forg%2Frepo.git%60%20gets%20%60%2Fedit%2F%3Cbranch%3E%2F...%60%20instead%20of%20%60%2F_edit%2F%3Cbranch%3E%2F...%60%2C%20so%20the%20new%20project%20and%20file%20links%20do%20not%20work.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Afrontend%2Fsrc%2Flib%2Futils%2Fnavigation.ts%3A214-223%0A**Self-hosted%20forge%20links%20break**%0A%0AIf%20a%20self-hosted%20GitLab%2C%20Gitea%2C%20Forgejo%2C%20or%20Bitbucket%20instance%20uses%20a%20domain%20that%20does%20not%20contain%20the%20product%20name%2C%20these%20hostname%20checks%20fall%20back%20to%20GitHub-style%20routes.%20For%20example%2C%20a%20Gitea%20repository%20at%20%60git.example.com%2Forg%2Frepo.git%60%20gets%20%60%2Fedit%2F%3Cbranch%3E%2F...%60%20instead%20of%20%60%2F_edit%2F%3Cbranch%3E%2F...%60%2C%20so%20the%20new%20project%20and%20file%20links%20do%20not%20work.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3879&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
frontend/src/lib/utils/navigation.ts:214-223
**Self-hosted forge links break**

If a self-hosted GitLab, Gitea, Forgejo, or Bitbucket instance uses a domain that does not contain the product name, these hostname checks fall back to GitHub-style routes. For example, a Gitea repository at `git.example.com/org/repo.git` gets `/edit/<branch>/...` instead of `/_edit/<branch>/...`, so the new project and file links do not work.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: link Git-managed projects and sync..."](https://github.com/getarcaneapp/arcane/commit/cf7e193b4d6dc116a15aef317ae1d0ba07adc2f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61822348)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->