### PR TITLE
fix: enforce admin requirements for environment tokens

### DIFF
--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -152,8 +152,8 @@ func (m *AuthMiddleware) managerAuth(ctx context.Context, c *echo.Context, next 
 	req := c.Request()
 	if agentToken := req.Header.Get(utils.HeaderAgentToken); agentToken != "" {
 		if env, ok := m.resolveEnvironmentAccessToken(ctx, agentToken).Get(); ok {
-			environmentScopedInternal(c, env)
-			return next(c)
+			ps := environmentScopedInternal(c, env)
+			return m.authorizeAndContinueInternal(c, next, ps)
 		}
 	}
 
@@ -210,18 +210,11 @@ func (m *AuthMiddleware) managerAuth(ctx context.Context, c *echo.Context, next 
 	}
 
 	ps := m.resolvePermissionsOrDeny(ctx, user)
-	if m.options.AdminRequired && !ps.IsGlobalAdmin() {
-		return c.JSON(http.StatusForbidden, common.APIError{
-			Code:    "FORBIDDEN",
-			Message: "You don't have permission to access this resource",
-		})
-	}
-
 	c.Set(string(middleware.ContextKeyUserID), user.ID)
 	c.Set(string(middleware.ContextKeyCurrentUser), user)
 	c.Set(string(middleware.ContextKeyCurrentSessionID), sessionID)
 	c.Set(string(middleware.ContextKeyUserPermissions), ps)
-	return next(c)
+	return m.authorizeAndContinueInternal(c, next, ps)
 }
 
 // apiKeyHeaderAuth authenticates an X-API-Key credential: a user-owned API key
@@ -238,27 +231,31 @@ func (m *AuthMiddleware) apiKeyHeaderAuth(ctx context.Context, c *echo.Context, 
 			} else {
 				ps = m.resolveApiKeyPermissionsOrDeny(ctx, key.ID)
 			}
-			if m.options.AdminRequired && !ps.IsGlobalAdmin() {
-				return c.JSON(http.StatusForbidden, common.APIError{
-					Code:    "FORBIDDEN",
-					Message: "You don't have permission to access this resource",
-				})
-			}
 			c.Set(string(middleware.ContextKeyUserID), user.ID)
 			c.Set(string(middleware.ContextKeyCurrentUser), user)
 			c.Set(string(middleware.ContextKeyUserPermissions), ps)
 			c.Set(string(middleware.ContextKeyAuthMethod), "api_key")
-			return next(c)
+			return m.authorizeAndContinueInternal(c, next, ps)
 		}
 	}
 	if env, ok := m.resolveEnvironmentAccessToken(ctx, apiKey).Get(); ok {
-		environmentScopedInternal(c, env)
-		return next(c)
+		ps := environmentScopedInternal(c, env)
+		return m.authorizeAndContinueInternal(c, next, ps)
 	}
 	return c.JSON(http.StatusUnauthorized, common.APIError{
 		Code:    common.APIErrorCodeUnauthorized,
 		Message: "Invalid or expired API key",
 	})
+}
+
+func (m *AuthMiddleware) authorizeAndContinueInternal(c *echo.Context, next echo.HandlerFunc, ps *authz.PermissionSet) error {
+	if m.options.AdminRequired && !ps.IsGlobalAdmin() {
+		return c.JSON(http.StatusForbidden, common.APIError{
+			Code:    "FORBIDDEN",
+			Message: "You don't have permission to access this resource",
+		})
+	}
+	return next(c)
 }
 
 // resolvePermissionsOrDeny returns the user's permission set, or an empty
@@ -320,15 +317,17 @@ func agentSudoInternal(c *echo.Context) {
 	c.Set(string(middleware.ContextKeyAuthMethod), "agent_token")
 }
 
-func environmentScopedInternal(c *echo.Context, env *environment.Environment) {
+func environmentScopedInternal(c *echo.Context, env *environment.Environment) *authz.PermissionSet {
 	envUser := &common.User{
 		ID:       "environment:" + env.ID,
 		Username: env.Name,
 	}
 	c.Set(string(middleware.ContextKeyUserID), envUser.ID)
 	c.Set(string(middleware.ContextKeyCurrentUser), envUser)
-	c.Set(string(middleware.ContextKeyUserPermissions), authz.EnvironmentPermissionSet(env.ID))
+	ps := authz.EnvironmentPermissionSet(env.ID)
+	c.Set(string(middleware.ContextKeyUserPermissions), ps)
 	c.Set(string(middleware.ContextKeyAuthMethod), "environment_access_token")
+	return ps
 }
 
 func extractBearerOrCookieTokenInternal(c *echo.Context) (string, bool) {

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -155,46 +155,68 @@ func TestAuthMiddleware_ManagerAuthResolvesPermissionsByKeyKind(t *testing.T) {
 	})
 }
 
-func TestAuthMiddleware_ManagerAuthAcceptsEnvironmentAccessTokenViaAPIKey(t *testing.T) {
+func TestAuthMiddleware_ManagerAuthEnvironmentAccessToken(t *testing.T) {
 	token := "env-access-token"
-	router := echo.New()
-	router.Use(
-		NewAuthMiddleware(nil, &config.Config{}).
-			WithEnvironmentAccessTokenResolver(testEnvironmentTokenResolver{
-				env: &environment.Environment{
-					ID:          "env-self",
-					Name:        "Self Target",
-					AccessToken: &token,
-				},
-			}).
-			Add(),
-	)
-	router.GET("/secure", func(c *echo.Context) error {
-		currentUser := c.Get("currentUser")
-		require.NotNil(t, currentUser)
+	cases := []struct {
+		name          string
+		header        string
+		adminRequired bool
+		wantStatus    int
+	}{
+		{name: "agent token ordinary route", header: "X-Arcane-Agent-Token", wantStatus: http.StatusOK},
+		{name: "API key ordinary route", header: "X-API-Key", wantStatus: http.StatusOK},
+		{name: "agent token admin route", header: "X-Arcane-Agent-Token", adminRequired: true, wantStatus: http.StatusForbidden},
+		{name: "API key admin route", header: "X-API-Key", adminRequired: true, wantStatus: http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := echo.New()
+			authMiddleware := NewAuthMiddleware(nil, &config.Config{}).
+				WithEnvironmentAccessTokenResolver(testEnvironmentTokenResolver{
+					env: &environment.Environment{
+						ID:          "env-self",
+						Name:        "Self Target",
+						AccessToken: &token,
+					},
+				})
+			if tc.adminRequired {
+				authMiddleware = authMiddleware.WithAdminRequired()
+			}
+			router.Use(authMiddleware.Add())
+			called := false
+			router.GET("/secure", func(c *echo.Context) error {
+				called = true
+				currentUser := c.Get("currentUser")
+				require.NotNil(t, currentUser)
 
-		user, ok := currentUser.(*common.User)
-		require.True(t, ok)
-		require.Equal(t, "environment:env-self", user.ID)
-		require.Equal(t, "Self Target", user.Username)
-		require.Equal(t, "environment_access_token", c.Get("authMethod"))
+				user, ok := currentUser.(*common.User)
+				require.True(t, ok)
+				require.Equal(t, "environment:env-self", user.ID)
+				require.Equal(t, "Self Target", user.Username)
+				require.Equal(t, "environment_access_token", c.Get("authMethod"))
 
-		ps, ok := c.Get("userPermissions").(*authz.PermissionSet)
-		require.True(t, ok)
-		require.True(t, ps.Allows(authz.PermContainersStart, "env-self"))
-		require.False(t, ps.Allows(authz.PermContainersStart, "env-other"))
-		require.False(t, ps.Allows(authz.PermUsersList, ""))
-		require.False(t, ps.IsGlobalAdmin())
+				ps, ok := c.Get("userPermissions").(*authz.PermissionSet)
+				require.True(t, ok)
+				require.True(t, ps.Allows(authz.PermContainersStart, "env-self"))
+				require.False(t, ps.Allows(authz.PermContainersStart, "env-other"))
+				require.False(t, ps.Allows(authz.PermUsersList, ""))
+				require.False(t, ps.IsGlobalAdmin())
 
-		return c.JSON(http.StatusOK, map[string]any{"userId": user.ID})
-	})
+				return c.JSON(http.StatusOK, map[string]any{"userId": user.ID})
+			})
 
-	req := httptest.NewRequest(http.MethodGet, "/secure", nil)
-	req.Header.Set("X-API-Key", token)
-	rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/secure", nil)
+			req.Header.Set(tc.header, token)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
 
-	router.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), "environment:env-self")
+			require.Equal(t, tc.wantStatus, rec.Code)
+			require.Equal(t, !tc.adminRequired, called)
+			if tc.adminRequired {
+				require.JSONEq(t, `{"statusCode":0,"code":"FORBIDDEN","message":"You don't have permission to access this resource"}`, rec.Body.String())
+			} else {
+				require.Contains(t, rec.Body.String(), "environment:env-self")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes:

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the Echo middleware’s administrator authorization check and applies it to environment access tokens supplied through either supported machine-credential header.

- Environment-scoped credentials now receive `403 Forbidden` on administrator-required manager routes.
- Existing user-session and user-owned API-key administrator behavior is preserved through a shared helper.
- Table-driven tests cover ordinary and administrator-required environment-token requests through both headers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the administrator requirement is consistently enforced for manager-side environment-token paths without changing ordinary environment access.

No actionable failures remain: environment permission sets cannot satisfy the global-administrator check, all permission-set paths fail closed, and the tests cover both accepted headers and verify that denied handlers do not execute.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: enforce admin requirements for envi..."](https://github.com/getarcaneapp/arcane/commit/d8e99553e3891450ed9895d727025861c1e4e545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61875281)</sub>

**Context used:**

- Knowledge Base — [Identity, authentication, and access control](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/identity-and-access.md)
- Knowledge Base — [Authentication and authorization flows](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/authentication-and-authorization-flows.md)

<!-- /greptile_comment -->