### PR TITLE
fix: clarify credential requirements when changing repository URLs

### DIFF
--- a/backend/internal/gitrepo/handler.go
+++ b/backend/internal/gitrepo/handler.go
@@ -156,6 +156,20 @@ func (h *GitRepositoryHandler) UpdateRepository(ctx context.Context, input *Upda
 	repo, err := h.repoService.UpdateRepository(ctx, input.ID, input.Body, actor)
 	if err != nil {
 		apiErr := common.ToAPIError(err)
+		if apiErr.Code == common.APIErrorCodeValidationError {
+			return nil, &struct {
+				*huma.ErrorModel
+
+				Details any `json:"details,omitempty"`
+			}{
+				ErrorModel: &huma.ErrorModel{
+					Title:  "Bad Request",
+					Status: apiErr.HTTPStatus(),
+					Detail: apiErr.Message,
+				},
+				Details: apiErr.Details,
+			}
+		}
 		return nil, huma.NewError(apiErr.HTTPStatus(), "Failed to update git repository")
 	}
 

--- a/backend/internal/gitrepo/model.go
+++ b/backend/internal/gitrepo/model.go
@@ -19,3 +19,13 @@ type GitRepository struct {
 func (GitRepository) TableName() string {
 	return "git_repositories"
 }
+
+// HasToken reports whether an HTTP token is stored.
+func (r GitRepository) HasToken() bool {
+	return r.Token != ""
+}
+
+// HasSshKey reports whether an SSH private key is stored.
+func (r GitRepository) HasSshKey() bool {
+	return r.SSHKey != ""
+}

--- a/backend/internal/gitrepo/service_test.go
+++ b/backend/internal/gitrepo/service_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/getarcaneapp/arcane/backend/v2/internal/database"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/event"
 	"github.com/getarcaneapp/arcane/backend/v2/internal/settings"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/pagination"
+	"github.com/getarcaneapp/arcane/backend/v2/pkg/utils/mapper"
 	"go.getarcane.app/sys/crypto"
 )
 
@@ -85,6 +87,15 @@ func createGitRepositoryServiceTestRepoInternal(t *testing.T, svc *GitRepository
 		Username: "admin",
 	})
 	require.NoError(t, err)
+	mapped, err := mapper.MapOne[*GitRepository, gitops.GitRepository](repo)
+	require.NoError(t, err)
+	assert.Equal(t, req.Token != "", mapped.HasToken)
+	assert.Equal(t, req.SSHKey != "", mapped.HasSshKey)
+	repositories, _, err := svc.GetRepositoriesPaginated(t.Context(), pagination.QueryParams{Limit: -1})
+	require.NoError(t, err)
+	require.Len(t, repositories, 1)
+	assert.Equal(t, mapped.HasToken, repositories[0].HasToken)
+	assert.Equal(t, mapped.HasSshKey, repositories[0].HasSshKey)
 	return repo
 }
 
@@ -180,6 +191,10 @@ func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsResuppl
 	decryptedToken, decryptErr := crypto.Decrypt(updated.Token)
 	require.NoError(t, decryptErr)
 	assert.Equal(t, "ghp_new_token", decryptedToken)
+	mapped, err := mapper.MapOne[*GitRepository, gitops.GitRepository](updated)
+	require.NoError(t, err)
+	assert.True(t, mapped.HasToken)
+	assert.False(t, mapped.HasSshKey)
 }
 
 func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsCleared(t *testing.T) {
@@ -200,6 +215,10 @@ func TestGitRepositoryService_UpdateRepository_AllowsURLChangeWhenTokenIsCleared
 
 	assert.Equal(t, "https://github.com/acme/public.git", updated.URL)
 	assert.Empty(t, updated.Token)
+	mapped, err := mapper.MapOne[*GitRepository, gitops.GitRepository](updated)
+	require.NoError(t, err)
+	assert.False(t, mapped.HasToken)
+	assert.False(t, mapped.HasSshKey)
 }
 
 func TestGitRepositoryService_UpdateRepository_AllowsSameURLWithoutCredentialResupply(t *testing.T) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3524,5 +3524,10 @@
 	"jobs_activity_summary": "Run activity",
 	"jobs_activity_output": "Operation output",
 	"jobs_attention_schedule_blocked": "This run needs review and blocks later runs of this job.",
-	"jobs_resolution_reason": "Resolution reason"
+	"jobs_resolution_reason": "Resolution reason",
+  "git_repository_url_placeholder": "https://github.com/user/repo.git",
+  "git_repository_token_url_change": "The repository URL has changed. Re-enter the stored token or select Clear stored token before saving.",
+  "git_repository_ssh_key_url_change": "The repository URL has changed. Re-enter the stored SSH key or select Clear stored SSH key before saving.",
+  "git_repository_clear_token": "Clear stored token",
+  "git_repository_clear_ssh_key": "Clear stored SSH key"
 }

--- a/frontend/src/lib/components/sheets/git-repository-sheet.svelte
+++ b/frontend/src/lib/components/sheets/git-repository-sheet.svelte
@@ -4,7 +4,6 @@
 	import FormInput from '#lib/components/form/form-input.svelte';
 	import SwitchWithLabel from '#lib/components/form/labeled-switch.svelte';
 	import * as Select from '#lib/components/ui/select/index.js';
-	import { Textarea } from '#lib/components/ui/textarea/index.js';
 	import { Label } from '#lib/components/ui/label/index.js';
 	import type { GitRepository, GitRepositoryCreateDto, GitRepositoryUpdateDto } from '#lib/types/automation.js';
 	import { z } from 'zod/v4';
@@ -13,12 +12,21 @@
 
 	type GitRepositoryFormProps = {
 		open: boolean;
+		clearToken?: boolean;
+		clearSshKey?: boolean;
 		repositoryToEdit: GitRepository | null;
 		onSubmit: (detail: { repository: GitRepositoryCreateDto | GitRepositoryUpdateDto; isEditMode: boolean }) => void;
 		isLoading: boolean;
 	};
 
-	let { open = $bindable(false), repositoryToEdit = $bindable(), onSubmit, isLoading }: GitRepositoryFormProps = $props();
+	let {
+		open = $bindable(false),
+		clearToken = $bindable(false),
+		clearSshKey = $bindable(false),
+		repositoryToEdit = $bindable(),
+		onSubmit,
+		isLoading
+	}: GitRepositoryFormProps = $props();
 
 	let isEditMode = $derived(!!repositoryToEdit);
 
@@ -49,6 +57,12 @@
 	});
 
 	let { inputs, ...form } = $derived(createForm<typeof formSchema>(formSchema, formData));
+
+	let hasToken = $derived(!!repositoryToEdit?.hasToken);
+	let hasSshKey = $derived(!!repositoryToEdit?.hasSshKey);
+	let urlChanged = $derived(isEditMode && $inputs.url.value.trim() !== repositoryToEdit?.url);
+	let tokenNeedsAttention = $derived(urlChanged && hasToken && !clearToken && !$inputs.token?.value?.trim());
+	let sshKeyNeedsAttention = $derived(urlChanged && hasSshKey && !clearSshKey && !$inputs.sshKey?.value?.trim());
 
 	let selectedAuthType = $state<{ value: string; label: string }>({
 		value: 'http',
@@ -98,9 +112,16 @@
 		}
 	});
 
+	function clearCredentialErrors() {
+		if ($inputs.token) $inputs.token.error = null;
+		if ($inputs.sshKey) $inputs.sshKey.error = null;
+	}
+
 	function handleSubmit() {
 		const data = form.validate();
-		if (!data) return;
+		if (tokenNeedsAttention && $inputs.token) $inputs.token.error = m.git_repository_token_url_change();
+		if (sshKeyNeedsAttention && $inputs.sshKey) $inputs.sshKey.error = m.git_repository_ssh_key_url_change();
+		if (!data || tokenNeedsAttention || sshKeyNeedsAttention) return;
 
 		const payload: GitRepositoryCreateDto | GitRepositoryUpdateDto = {
 			name: data.name,
@@ -112,16 +133,21 @@
 
 		if (selectedAuthType.value === 'http') {
 			if (data.username) payload.username = data.username;
-			if (data.token) payload.token = data.token;
 		} else if (selectedAuthType.value === 'ssh') {
-			if (data.sshKey) payload.sshKey = data.sshKey;
 			payload.sshHostKeyVerification = selectedSshHostKeyVerification.value;
 		}
+
+		if (hasToken && clearToken) payload.token = '';
+		else if ((selectedAuthType.value === 'http' || hasToken) && data.token) payload.token = data.token;
+		if (hasSshKey && clearSshKey) payload.sshKey = '';
+		else if ((selectedAuthType.value === 'ssh' || hasSshKey) && data.sshKey) payload.sshKey = data.sshKey;
 
 		onSubmit({ repository: payload, isEditMode });
 	}
 
 	function handleOpenChange(newOpenState: boolean) {
+		clearToken = false;
+		clearSshKey = false;
 		open = newOpenState;
 	}
 </script>
@@ -146,7 +172,8 @@
 			<FormInput
 				label={m.git_repository_url()}
 				type="text"
-				placeholder="https://github.com/user/repo.git"
+				placeholder={m.git_repository_url_placeholder()}
+				oninput={clearCredentialErrors}
 				bind:input={$inputs.url}
 			/>
 
@@ -156,9 +183,9 @@
 					type="single"
 					bind:value={selectedAuthType.value}
 					onValueChange={(v) => {
-						if (v) {
+						if (v === 'none' || v === 'http' || v === 'ssh') {
 							selectedAuthType = { value: v, label: getAuthTypeLabel(v) };
-							$inputs.authType.value = v as any;
+							$inputs.authType.value = v;
 						}
 					}}
 				>
@@ -175,35 +202,60 @@
 
 			{#if selectedAuthType.value === 'http'}
 				<FormInput label={m.common_username()} type="text" bind:input={$inputs.username} />
+			{/if}
+			{#if selectedAuthType.value === 'http' || hasToken}
 				<FormInput
 					label={m.common_token()}
 					type="password"
-					placeholder={isEditMode ? m.common_keep_placeholder() : m.common_token_placeholder()}
+					placeholder={urlChanged && hasToken
+						? m.common_token_placeholder()
+						: hasToken
+							? m.common_keep_placeholder()
+							: m.common_token_placeholder()}
+					warningText={tokenNeedsAttention ? m.git_repository_token_url_change() : undefined}
+					disabled={clearToken}
+					oninput={clearCredentialErrors}
 					bind:input={$inputs.token}
 				/>
-			{:else if selectedAuthType.value === 'ssh'}
-				{#if $inputs.sshKey}
-					<div class="space-y-2">
-						<Label for="sshKey">{m.git_repository_ssh_key_label()}</Label>
-						<Textarea
-							id="sshKey"
-							bind:value={$inputs.sshKey.value}
-							placeholder={m.git_repository_ssh_key_placeholder()}
-							rows={6}
-							class="font-mono text-xs"
-						/>
-					</div>
+				{#if hasToken}
+					<SwitchWithLabel
+						id="clearRepositoryToken"
+						label={m.git_repository_clear_token()}
+						onCheckedChange={clearCredentialErrors}
+						bind:checked={clearToken}
+					/>
 				{/if}
-
+			{/if}
+			{#if selectedAuthType.value === 'ssh' || hasSshKey}
+				<FormInput
+					label={m.git_repository_ssh_key_label()}
+					type="textarea"
+					placeholder={hasSshKey && !urlChanged ? m.common_keep_placeholder() : m.git_repository_ssh_key_placeholder()}
+					warningText={sshKeyNeedsAttention ? m.git_repository_ssh_key_url_change() : undefined}
+					disabled={clearSshKey}
+					rows={6}
+					oninput={clearCredentialErrors}
+					bind:input={$inputs.sshKey}
+				/>
+				{#if hasSshKey}
+					<SwitchWithLabel
+						id="clearRepositorySshKey"
+						label={m.git_repository_clear_ssh_key()}
+						onCheckedChange={clearCredentialErrors}
+						bind:checked={clearSshKey}
+					/>
+				{/if}
+			{/if}
+			{#if selectedAuthType.value === 'ssh'}
 				<div class="space-y-2">
 					<Label for="sshHostKeyVerification">{m.git_repository_ssh_host_key_verification()}</Label>
 					<Select.Root
 						type="single"
 						bind:value={selectedSshHostKeyVerification.value}
 						onValueChange={(v) => {
-							if (v) {
+							if (v === 'strict' || v === 'accept_new' || v === 'skip') {
 								selectedSshHostKeyVerification = { value: v, label: getSshHostKeyVerificationLabel(v) };
-								$inputs.sshHostKeyVerification.value = v as any;
+								$inputs.sshHostKeyVerification.value = v;
 							}
 						}}
 					>
@@ -253,6 +305,7 @@
 
 	{#snippet footer()}
 		<SheetFooterActions
+			onCancel={() => handleOpenChange(false)}
 			bind:open
 			cancelDisabled={isLoading}
 			submitAction={isEditMode ? 'save' : 'create'}

--- a/frontend/src/lib/types/automation.ts
+++ b/frontend/src/lib/types/automation.ts
@@ -107,6 +107,8 @@ export interface GitRepository {
 	name: string;
 	url: string;
 	authType: string;
+	hasToken: boolean;
+	hasSshKey: boolean;
 	username?: string;
 	sshHostKeyVerification?: string;
 	description?: string;

--- a/frontend/src/routes/(app)/customize/git-repositories/+page.svelte
+++ b/frontend/src/routes/(app)/customize/git-repositories/+page.svelte
@@ -15,6 +15,8 @@
 	let repositories = $derived(data.repositories);
 	let selectedIds = $state<string[]>([]);
 	let isRepositoryDialogOpen = $state(false);
+	let clearToken = $state(false);
+	let clearSshKey = $state(false);
 	let repositoryToEdit = $state<GitRepository | null>(null);
 	let requestOptions = $derived(data.repositoryRequestOptions);
 
@@ -39,11 +41,15 @@
 
 	function openCreateRepositoryDialog() {
 		repositoryToEdit = null;
+		clearToken = false;
+		clearSshKey = false;
 		isRepositoryDialogOpen = true;
 	}
 
 	function openEditRepositoryDialog(repository: GitRepository) {
 		repositoryToEdit = repository;
+		clearToken = false;
+		clearSshKey = false;
 		isRepositoryDialogOpen = true;
 	}
 
@@ -67,6 +73,8 @@
 					}
 
 					repositories = await gitRepositoryService.getRepositories(requestOptions);
+					clearToken = false;
+					clearSshKey = false;
 					isRepositoryDialogOpen = false;
 				})()
 			);
@@ -112,6 +120,8 @@
 
 	{#snippet additionalContent()}
 		<GitRepositoryFormSheet
+			bind:clearToken
+			bind:clearSshKey
 			bind:open={isRepositoryDialogOpen}
 			bind:repositoryToEdit
 			onSubmit={handleRepositoryDialogSubmit}

--- a/types/gitops/gitops.go
+++ b/types/gitops/gitops.go
@@ -24,6 +24,12 @@ type GitRepository struct {
 	// Required: true
 	AuthType string `json:"authType"`
 
+	// HasToken indicates whether an HTTP token is stored.
+	HasToken bool `json:"hasToken"`
+
+	// HasSshKey indicates whether an SSH private key is stored.
+	HasSshKey bool `json:"hasSshKey"`
+
 	// Username for HTTP authentication.
 	//
 	// Required: false


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: https://github.com/getarcaneapp/arcane/issues/3866

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->






<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies credential requirements when repository URLs change and exposes credential-presence flags without returning credential material.
- Returns validation details from repository update failures.
- Adds `hasToken` and `hasSshKey` to the shared repository response contract.
- Requires users to re-enter or explicitly clear stored credentials after changing a repository URL.
- Replaces effect-based error mutation with explicit input and switch handlers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding blocking defect identified.

The previously outstanding effect-based state mutation has been replaced with explicit interaction handlers, and the other previous thread was manually resolved without explanation. The current credential validation, clearing behavior, response mapping, and shared contract changes remain aligned.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: clarify credential requirements whe..."](https://github.com/getarcaneapp/arcane/commit/62bf8872b1b028c3616021d29c51f3dddbe927a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61924463)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Projects, repositories, and buildables](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/projects-repositories-and-buildables.md)
- Knowledge Base — [Shared domain contracts](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/shared-domain-contracts.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/web-application.md)
</details>


<!-- /greptile_comment -->