### PR TITLE
chore: Remove JWT_SECRET from compose examples

### DIFF
--- a/docker/examples/compose.basic.yaml
+++ b/docker/examples/compose.basic.yaml
@@ -11,7 +11,6 @@ services:
       - /host/path/to/builds:/builds
     environment:
       - ENCRYPTION_KEY=replace_me_with_a_random_32_char_value
-      - JWT_SECRET=replace_me_with_a_random_32_char_value
       - PROJECTS_DIRECTORY=/host/path/to/projects
       # Optional: run Arcane as a specific host UID/GID instead of the default runtime user.
       # When using the mounted Docker socket, Arcane will map the socket group automatically.

--- a/docker/examples/compose.proxy.yaml
+++ b/docker/examples/compose.proxy.yaml
@@ -46,7 +46,6 @@ services:
       - arcane-data:/app/data
     environment:
       - ENCRYPTION_KEY=replace_me_with_a_random_32_char_value
-      - JWT_SECRET=replace_me_with_a_random_32_char_value
       # Optional: run Arcane as a specific host UID/GID instead of the default runtime user.
       # With DOCKER_HOST over TCP, no Unix socket group mapping is needed.
       # - PUID=1000


### PR DESCRIPTION
From the current docs: JWT_SECRET is no longer used — session tokens are now signed with an ML-DSA-87 key that Arcane generates and stores itself. If it’s still set, Arcane logs a warning at startup; remove it from your environment.

## Checklist

- [x] This PR is **not** opened from my fork’s `main` branch
- [x] All new user-facing strings are translated via Paraglide (`m.*()`)


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the deprecated `JWT_SECRET` environment variable from the basic and reverse-proxy Docker Compose examples.

- Prevents new deployments from configuring an unused secret.
- Aligns both examples with the current database-persisted ML-DSA-87 signing-key implementation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The removed variable is deprecated and unused by authentication, while both examples persist the database containing Arcane’s generated signing key.
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove JWT\_SECRET from compose.proxy.yam..."](https://github.com/getarcaneapp/arcane/commit/6de5ccde2dd1acc4c45e99816591568778fea28b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62073013)</sub>

<!-- /greptile_comment -->