### PR TITLE
refactor(projects): carry environment ownership as groundwork for global views

### DIFF
--- a/.github/workflows/hyperion-agent-policy.yml
+++ b/.github/workflows/hyperion-agent-policy.yml
@@ -1,0 +1,24 @@
+name: Hyperion agent policy
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  hyperion-agent-policy:
+    name: Hyperion agent policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate managed agent context
+        shell: bash
+        run: |
+          test "$(grep -cF '<!-- hyperion-context:start -->' AGENTS.md)" -eq 1
+          test "$(grep -cF '<!-- hyperion-context:end -->' AGENTS.md)" -eq 1
+          grep -qF 'globally configured Hyperion OKF memory' AGENTS.md
+          grep -qF '/home/homelab/Worktrees/<repo>/<task>' AGENTS.md
+          grep -qF 'Agents own the task Git lifecycle' AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,29 @@ For maintainer work, do not start, restart, or rebuild the development stack unl
 the user explicitly asks. Outside contributions must satisfy the development and
 human testing requirements in `AI_POLICY.md` before submission. Do not claim manual
 verification that has not happened.
+
+<!-- hyperion-context:start -->
+## Hyperion deployment context
+
+This project targets the Hyperion K3s environment. Before changing deployment,
+networking, storage, ingress, authentication, observability, or secret handling,
+search the globally configured Hyperion OKF memory with `okf_search`. Inspect only
+relevant results with `okf_show`, and check path-scoped governance when editing
+Hyperion deployment declarations.
+
+Hyperion memory is a retrieval layer, not live-state proof. Hyperion's reachable
+Git desired state, controller state, and verified cluster state remain authoritative;
+treat disagreement as drift to investigate. Never copy credentials or resolved
+secret values into this repository or into OKF memory.
+
+Agents own the task Git lifecycle after this one-time bootstrap. Before changing
+files, inspect the canonical checkout and registered worktrees, fetch current
+`origin/main`, and create a unique task branch in an isolated worktree at
+`/home/homelab/Worktrees/<repo>/<task>`. Never edit the canonical checkout, reuse
+another task's worktree, create durable worktrees under `/tmp`, force-push, or
+delete `main`. Review and validate the exact diff, publish through a pull request,
+and remove only the worktree created for the current task after its work is safely
+published or intentionally abandoned. These narrowly scoped lifecycle operations
+are required for Hyperion-targeted work; preserve stricter repository rules for
+all other Git operations.
+<!-- hyperion-context:end -->

--- a/frontend/src/lib/components/action-buttons.svelte
+++ b/frontend/src/lib/components/action-buttons.svelte
@@ -27,10 +27,10 @@
 	import { createMutation } from '@tanstack/svelte-query';
 	import { hasPermission } from '#lib/utils/auth.js';
 	import { isDepotBuildAvailable } from '#lib/utils/build-provider.js';
-	import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 	import { Temporal } from 'temporal-polyfill';
 
 	type TargetType = 'container' | 'project';
+	type ActionTarget = Pick<Project, 'id' | 'environmentId'>;
 	type LoadingStates = {
 		start?: boolean;
 		stop?: boolean;
@@ -46,6 +46,7 @@
 
 	let {
 		id,
+		environmentId,
 		name,
 		type = 'container',
 		itemState = 'stopped',
@@ -65,6 +66,7 @@
 		beforeRemoveMenuItems
 	}: {
 		id: string;
+		environmentId: string;
 		name?: string;
 		type?: TargetType;
 		itemState?: string;
@@ -124,27 +126,35 @@
 	);
 
 	const startMutation = createMutation(() => ({
-		mutationKey: ['action', 'start', type, id],
-		mutationFn: () =>
+		mutationKey: ['action', 'start', type, environmentId, id],
+		mutationFn: ({ id, environmentId }: ActionTarget) =>
 			tryCatch(
 				type === 'container'
-					? containerService.startContainer(id)
-					: projectService.deployProject(id, 'up', deployOptionsStore.takeRequestOptions())
+					? containerService.startContainer(id, environmentId)
+					: projectService.deployProject(environmentId, id, 'up', deployOptionsStore.takeRequestOptions())
 			),
 		onMutate: () => setLoading('start', true),
 		onSettled: () => setLoading('start', false)
 	}));
 
 	const stopMutation = createMutation(() => ({
-		mutationKey: ['action', 'stop', type, id],
-		mutationFn: () => tryCatch(type === 'container' ? containerService.stopContainer(id) : projectService.downProject(id)),
+		mutationKey: ['action', 'stop', type, environmentId, id],
+		mutationFn: ({ id, environmentId }: ActionTarget) =>
+			tryCatch(
+				type === 'container' ? containerService.stopContainer(id, environmentId) : projectService.downProject(environmentId, id)
+			),
 		onMutate: () => setLoading('stop', true),
 		onSettled: () => setLoading('stop', false)
 	}));
 
 	const restartMutation = createMutation(() => ({
-		mutationKey: ['action', 'restart', type, id],
-		mutationFn: () => tryCatch(type === 'container' ? containerService.restartContainer(id) : projectService.restartProject(id)),
+		mutationKey: ['action', 'restart', type, environmentId, id],
+		mutationFn: ({ id, environmentId }: ActionTarget) =>
+			tryCatch(
+				type === 'container'
+					? containerService.restartContainer(id, environmentId)
+					: projectService.restartProject(environmentId, id)
+			),
 		onMutate: () => setLoading('restart', true),
 		onSettled: () => setLoading('restart', false)
 	}));
@@ -154,12 +164,13 @@
 	let redeployActivityId = $state<string | undefined>(undefined);
 
 	const redeployMutation = createMutation(() => ({
-		mutationKey: ['action', 'redeploy', type, id],
-		mutationFn: ({ watch = false }: { watch?: boolean } = {}) =>
+		mutationKey: ['action', 'redeploy', type, environmentId, id],
+		mutationFn: ({ target: { id, environmentId }, watch = false }: { target: ActionTarget; watch?: boolean }) =>
 			tryCatch(
 				(type === 'container'
-					? containerService.redeployContainer(id)
+					? containerService.redeployContainer(id, environmentId)
 					: projectService.deployProject(
+							environmentId,
 							id,
 							'redeploy',
 							(frame) => {
@@ -181,19 +192,19 @@
 	}));
 
 	const removeMutation = createMutation(() => ({
-		mutationKey: ['action', 'remove', type, id],
-		mutationFn: ({ removeVolumes }: { removeVolumes: boolean }) =>
+		mutationKey: ['action', 'remove', type, environmentId, id],
+		mutationFn: ({ target: { id, environmentId }, removeVolumes }: { target: ActionTarget; removeVolumes: boolean }) =>
 			tryCatch(
 				type === 'container'
-					? containerService.deleteContainer(id, { volumes: removeVolumes })
-					: projectService.destroyProject(id, removeVolumes)
+					? containerService.deleteContainer(id, { volumes: removeVolumes, environmentId })
+					: projectService.destroyProject(environmentId, id, removeVolumes)
 			),
 		onMutate: () => setLoading('remove', true),
 		onSettled: () => setLoading('remove', false)
 	}));
 
 	const refreshMutation = createMutation(() => ({
-		mutationKey: ['action', 'refresh', id],
+		mutationKey: ['action', 'refresh', environmentId, id],
 		mutationFn: () => tryCatch(Promise.resolve(onRefresh?.())),
 		onMutate: () => setLoading('refresh', true),
 		onSettled: () => setLoading('refresh', false)
@@ -203,10 +214,10 @@
 	const projectHasBuildDirective = $derived(type === 'project' && hasBuildDirective);
 
 	// Per-action RBAC gating. Each button hides if the caller lacks the
-	// corresponding permission on the currently-selected environment. Project
+	// corresponding permission on the resource's environment. Project
 	// pull / build / redeploy all share the `projects:deploy` permission since
 	// they're stages of the deploy flow.
-	const currentEnvId = $derived(environmentStore.selected?.id);
+	const currentEnvId = $derived(environmentId);
 	const canStart = $derived(
 		type === 'container' ? hasPermission('containers:start', currentEnvId) : hasPermission('projects:deploy', currentEnvId)
 	);
@@ -265,6 +276,7 @@
 	}
 
 	function confirmAction(action: string) {
+		const target = { id, environmentId };
 		if (action === 'remove') {
 			openConfirmDialog({
 				title: type === 'project' ? m.compose_destroy() : m.common_confirm_removal_title(),
@@ -278,7 +290,7 @@
 					action: async (checkboxStates) => {
 						const removeVolumes = checkboxStates['removeVolumes'] === true;
 
-						const result = await removeMutation.mutateAsync({ removeVolumes });
+						const result = await removeMutation.mutateAsync({ target, removeVolumes });
 						await handleApiResultWithCallbacks({
 							result,
 							message: m.common_action_failed_with_type({
@@ -313,6 +325,7 @@
 	}
 
 	function confirmRedeploy(watch: boolean) {
+		const target = { id, environmentId };
 		openConfirmDialog({
 			title: type === 'container' ? m.container_confirm_redeploy_title() : m.common_confirm_redeploy_title(),
 			message: type === 'container' ? m.container_confirm_redeploy_message() : m.common_confirm_redeploy_message(),
@@ -323,7 +336,7 @@
 					if (watch) {
 						operationWatchStore.start(`${m.common_redeploy()} — ${name ?? id}`);
 					}
-					const result = await redeployMutation.mutateAsync({ watch });
+					const result = await redeployMutation.mutateAsync({ target, watch });
 					if (watch && result.error) {
 						operationWatchStore.fail(
 							result.error.message || m.common_action_failed_with_type({ action: m.common_redeploy(), type })
@@ -331,7 +344,7 @@
 						return;
 					}
 					if (watch) {
-						enterInteractiveWatchInternal(operationStartedAt);
+						enterInteractiveWatchInternal(target, operationStartedAt);
 					}
 					await handleApiResultWithCallbacks({
 						result,
@@ -360,7 +373,7 @@
 	}
 
 	async function handleStart() {
-		const result = await startMutation.mutateAsync();
+		const result = await startMutation.mutateAsync({ id, environmentId });
 		await handleApiResultWithCallbacks({
 			result,
 			message: m.common_action_failed_with_type({ action: m.common_start(), type }),
@@ -372,6 +385,7 @@
 	}
 
 	async function handleDeploy(options?: DeployProjectOptions, watch = false) {
+		const target = { id, environmentId };
 		setLoading('start', true);
 
 		const operationStartedAt = Math.floor(Temporal.Now.instant().epochMilliseconds / 1000);
@@ -383,13 +397,14 @@
 			const operationResult1 = await tryCatch(
 				(async () => {
 					await projectService.deployProject(
-						id,
+						target.environmentId,
+						target.id,
 						'up',
 						watch ? (frame: unknown) => operationWatchStore.onLine(frame) : () => {},
 						options ?? deployOptionsStore.takeRequestOptions()
 					);
 					if (watch) {
-						enterInteractiveWatchInternal(operationStartedAt);
+						enterInteractiveWatchInternal(target, operationStartedAt);
 					}
 					await refreshAll();
 					itemState = 'running';
@@ -416,17 +431,17 @@
 	// output is followed by the containers' live logs — everything they wrote
 	// since the operation began — and dismissing the dialog is the Ctrl-C:
 	// the project is brought down.
-	function enterInteractiveWatchInternal(operationStartedAt: number) {
+	function enterInteractiveWatchInternal(target: ActionTarget, operationStartedAt: number) {
 		operationWatchStore.append(`Attaching to ${name ?? id}`);
-		const detach = attachProjectLogsToWatch(id, operationStartedAt);
+		const detach = attachProjectLogsToWatch(target.environmentId, target.id, operationStartedAt);
 		operationWatchStore.setOnClose(() => {
 			detach();
-			void handleStop();
+			void handleStop(target);
 		});
 	}
 
-	async function handleStop() {
-		const result = await stopMutation.mutateAsync();
+	async function handleStop(target: ActionTarget = { id, environmentId }) {
+		const result = await stopMutation.mutateAsync(target);
 		await handleApiResultWithCallbacks({
 			result,
 			message: m.common_action_failed_with_type({ action: m.common_stop(), type }),
@@ -445,7 +460,7 @@
 	}
 
 	async function handleRestart() {
-		const result = await restartMutation.mutateAsync();
+		const result = await restartMutation.mutateAsync({ id, environmentId });
 		await handleApiResultWithCallbacks({
 			result,
 			message: m.common_action_failed_with_type({ action: m.common_restart(), type }),
@@ -473,7 +488,11 @@
 		try {
 			const operationResult2 = await tryCatch(
 				(async () => {
-					await projectService.pullProjectImages(id, watch ? (frame: unknown) => operationWatchStore.onLine(frame) : () => {});
+					await projectService.pullProjectImages(
+						environmentId,
+						id,
+						watch ? (frame: unknown) => operationWatchStore.onLine(frame) : () => {}
+					);
 					await refreshAll();
 					onActionComplete(itemState);
 				})()
@@ -501,6 +520,7 @@
 				(async () => {
 					const buildProvider = projectBuildProvider;
 					await projectService.buildProjectImages(
+						environmentId,
 						id,
 						{
 							provider: buildProvider,
@@ -680,7 +700,7 @@
 					{/if}
 				{:else if isRunning}
 					{#if canStop}
-						<DropdownMenu.Item onclick={handleStop} disabled={uiLoading.stop}>
+						<DropdownMenu.Item onclick={() => handleStop()} disabled={uiLoading.stop}>
 							{type === 'project' ? m.common_down() : m.common_stop()}
 						</DropdownMenu.Item>
 					{/if}

--- a/frontend/src/lib/components/arcane-table/arcane-table.svelte
+++ b/frontend/src/lib/components/arcane-table/arcane-table.svelte
@@ -55,6 +55,7 @@
 		mobileFields = [],
 		mobileFieldVisibility = $bindable<Record<string, boolean>>({}),
 		selectedIds = $bindable<string[]>([]),
+		selectedItems = $bindable<TData[]>([]),
 		bulkActions = [],
 		persistKey,
 		customViewOptions,
@@ -90,6 +91,7 @@
 		mobileFields?: FieldSpec[];
 		mobileFieldVisibility?: Record<string, boolean>;
 		selectedIds?: string[];
+		selectedItems?: TData[];
 		bulkActions?: BulkAction[];
 		persistKey?: string;
 		customViewOptions?: Snippet;
@@ -150,6 +152,15 @@
 	const isMobile = new IsMobile();
 	const scrollPositions = { desktop: { top: 0, left: 0 }, mobile: { top: 0, left: 0 } };
 	const selectedIdSet = $derived(new Set(selectedIds ?? []));
+
+	$effect(() => {
+		// Keep selected resources when pagination replaces the visible rows.
+		const byId = new Map([...untrack(() => selectedItems), ...(items.data ?? [])].map((item) => [item.id, item]));
+		selectedItems = (selectedIds ?? []).flatMap((id) => {
+			const item = byId.get(id);
+			return item ? [item] : [];
+		});
+	});
 
 	function restoreScroll(node: HTMLElement, view: keyof typeof scrollPositions) {
 		const position = scrollPositions[view];

--- a/frontend/src/lib/components/logs/log-viewer.svelte
+++ b/frontend/src/lib/components/logs/log-viewer.svelte
@@ -21,6 +21,7 @@
 	import StructuredLogEntry from './structured-log-entry.svelte';
 
 	interface Props {
+		environmentId?: string;
 		class?: string;
 		containerId?: string | null;
 		projectId?: string | null;
@@ -41,6 +42,7 @@
 
 	let {
 		class: className,
+		environmentId,
 		containerId = null,
 		projectId = null,
 		serviceId = null,
@@ -176,7 +178,7 @@
 	}
 
 	async function buildLogWsEndpoint(): Promise<string> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+		const envId = environmentId ?? (await environmentStore.getCurrentEnvironmentId());
 		const basePath =
 			type === 'project'
 				? `/api/environments/${envId}/ws/projects/${projectId}/logs`

--- a/frontend/src/lib/services/container-service.ts
+++ b/frontend/src/lib/services/container-service.ts
@@ -62,8 +62,8 @@ class ContainerService extends BaseAPIService {
 		return this.handleResponse(this.api.get(`/environments/${environmentId}/containers/${containerId}`));
 	}
 
-	async startContainer(containerId: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async startContainer(containerId: string, environmentId?: string): Promise<any> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/start`));
 	}
 
@@ -72,13 +72,13 @@ class ContainerService extends BaseAPIService {
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers`, options));
 	}
 
-	async stopContainer(containerId: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async stopContainer(containerId: string, environmentId?: string): Promise<any> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/stop`));
 	}
 
-	async restartContainer(containerId: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async restartContainer(containerId: string, environmentId?: string): Promise<any> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/restart`));
 	}
 
@@ -89,13 +89,13 @@ class ContainerService extends BaseAPIService {
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/kill`, undefined, { params }));
 	}
 
-	async pauseContainer(containerId: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async pauseContainer(containerId: string, environmentId?: string): Promise<any> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/pause`));
 	}
 
-	async unpauseContainer(containerId: string): Promise<any> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async unpauseContainer(containerId: string, environmentId?: string): Promise<any> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/unpause`));
 	}
 
@@ -121,8 +121,8 @@ class ContainerService extends BaseAPIService {
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/update`));
 	}
 
-	async redeployContainer(containerId: string): Promise<ContainerDetailsDto> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async redeployContainer(containerId: string, environmentId?: string): Promise<ContainerDetailsDto> {
+		const envId = await this.resolveEnvironmentId(environmentId);
 		return this.handleResponse(this.api.post(`/environments/${envId}/containers/${containerId}/redeploy`));
 	}
 

--- a/frontend/src/lib/services/project-service.ts
+++ b/frontend/src/lib/services/project-service.ts
@@ -1,5 +1,4 @@
 import { m } from '#lib/paraglide/messages.js';
-import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 import type { Paginated, SearchPaginationSortRequest } from '#lib/types/shared.js';
 import type {
 	Project,
@@ -16,35 +15,29 @@ import type { DeployProjectOptions } from '#lib/types/project-deployment.js';
 import BaseAPIService from './api-service';
 
 class ProjectService extends BaseAPIService {
-	private async resolveEnvironmentId(environmentId?: string): Promise<string> {
-		return environmentId ?? (await environmentStore.getCurrentEnvironmentId());
-	}
-
-	async getProjects(options?: SearchPaginationSortRequest): Promise<Paginated<Project>> {
-		const envId = await this.resolveEnvironmentId();
-		return this.getProjectsForEnvironment(envId, options);
-	}
-
 	async getProjectsForEnvironment(environmentId: string, options?: SearchPaginationSortRequest): Promise<Paginated<Project>> {
 		const params = transformPaginationParams(options);
-		const res = await this.api.get(`/environments/${environmentId}/projects`, { params });
-		return res.data;
+		const res = await this.api.get<Paginated<Omit<Project, 'environmentId'>>>(`/environments/${environmentId}/projects`, {
+			params
+		});
+		return { ...res.data, data: res.data.data.map((project) => ({ ...project, environmentId })) };
 	}
 
-	deployProject(projectId: string, mode: 'up' | 'redeploy', options?: DeployProjectOptions): Promise<Project>;
+	deployProject(envId: string, projectId: string, mode: 'up' | 'redeploy', options?: DeployProjectOptions): Promise<Project>;
 	deployProject(
+		envId: string,
 		projectId: string,
 		mode: 'up' | 'redeploy',
 		onLine: (data: unknown) => void,
 		options?: DeployProjectOptions
 	): Promise<Project>;
 	async deployProject(
+		envId: string,
 		projectId: string,
 		mode: 'up' | 'redeploy',
 		onLineOrOptions?: ((data: unknown) => void) | DeployProjectOptions,
 		maybeOptions?: DeployProjectOptions
 	): Promise<Project> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
 		const url = `/api/environments/${envId}/projects/${projectId}/${mode}`;
 		const onLine = typeof onLineOrOptions === 'function' ? onLineOrOptions : undefined;
 		const options = typeof onLineOrOptions === 'function' ? maybeOptions : onLineOrOptions;
@@ -55,22 +48,24 @@ class ProjectService extends BaseAPIService {
 		});
 
 		// The deploy stream doesn't return the project object; fetch fresh details.
-		return this.getProject(projectId);
+		return this.getProjectForEnvironment(envId, projectId);
 	}
 
-	async downProject(projectName: string): Promise<Project> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
-		return this.handleResponse(this.api.post(`/environments/${envId}/projects/${projectName}/down`));
+	async downProject(envId: string, projectName: string): Promise<Project> {
+		const project = await this.handleResponse<Omit<Project, 'environmentId'>>(
+			this.api.post(`/environments/${envId}/projects/${projectName}/down`)
+		);
+		return { ...project, environmentId: envId };
 	}
 
 	async createProject(
+		envId: string,
 		projectName: string,
 		composeContent: string,
 		envContent?: string,
 		workspaceFiles: ProjectWorkspaceFileDraft[] = [],
 		tags: ProjectTag[] = []
 	): Promise<Project> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
 		const form = new FormData();
 		const uploads: File[] = [];
 		const fileChanges = workspaceFiles.map((file) => {
@@ -91,19 +86,16 @@ class ProjectService extends BaseAPIService {
 		);
 		form.append('manifest', JSON.stringify({ fileChanges }));
 		for (const file of uploads) form.append('files', file, file.name);
-		return this.handleResponse(this.api.post(`/environments/${envId}/projects`, form));
+		const project = await this.handleResponse<Omit<Project, 'environmentId'>>(
+			this.api.post(`/environments/${envId}/projects`, form)
+		);
+		return { ...project, environmentId: envId };
 	}
 
-	async checkUpdates(projectId: string): Promise<ProjectUpdateInfo> {
-		const envId = await this.resolveEnvironmentId();
+	async checkUpdates(envId: string, projectId: string): Promise<ProjectUpdateInfo> {
 		return this.handleResponse(
 			this.api.post(`/environments/${envId}/updater/projects/${encodeURIComponent(projectId)}/check`, {})
 		);
-	}
-
-	async getProject(projectId: string): Promise<Project> {
-		const envId = await this.resolveEnvironmentId();
-		return this.getProjectForEnvironment(envId, projectId);
 	}
 
 	async getProjectForEnvironment(environmentId: string, projectId: string): Promise<Project> {
@@ -119,15 +111,16 @@ class ProjectService extends BaseAPIService {
 			...summary,
 			...compose,
 			...runtime,
+			environmentId,
 			updateInfo: updates.updateInfo ?? compose.updateInfo ?? summary.updateInfo
 		};
 	}
 
-	private async getProjectSection(path: string): Promise<Project> {
-		const response = await this.handleResponse<{ project?: Project; success?: boolean } | Project>(
-			this.api.get(path, { cache: 'no-store' })
-		);
-		return 'project' in response && response.project ? response.project : (response as Project);
+	private async getProjectSection(path: string): Promise<Omit<Project, 'environmentId'>> {
+		const response = await this.handleResponse<
+			{ project?: Omit<Project, 'environmentId'>; success?: boolean } | Omit<Project, 'environmentId'>
+		>(this.api.get(path, { cache: 'no-store' }));
+		return 'project' in response && response.project ? response.project : (response as Omit<Project, 'environmentId'>);
 	}
 
 	private async readProjectStream(
@@ -164,11 +157,6 @@ class ProjectService extends BaseAPIService {
 		});
 	}
 
-	async getProjectStatusCounts(): Promise<ProjectStatusCounts> {
-		const envId = await this.resolveEnvironmentId();
-		return this.getProjectStatusCountsForEnvironment(envId);
-	}
-
 	async getProjectStatusCountsForEnvironment(environmentId: string): Promise<ProjectStatusCounts> {
 		const res = await this.api.get(`/environments/${environmentId}/projects/counts`);
 		return res.data.data;
@@ -179,23 +167,23 @@ class ProjectService extends BaseAPIService {
 	}
 
 	async updateProjectTag(
+		envId: string,
 		projectId: string,
 		name: string,
 		attached: boolean,
 		color?: ProjectTagColor
 	): Promise<{ tags: ProjectTag[]; activityId?: string }> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
 		return this.handleResponse(this.api.patch(`/environments/${envId}/projects/${projectId}/tags`, { name, attached, color }));
 	}
 
 	async updateProject(
+		envId: string,
 		projectId: string,
 		name?: string,
 		composeContent?: string,
 		envContent?: string,
 		overrideContent?: string
 	): Promise<Project> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
 		const payload: {
 			name?: string;
 			composeContent?: string;
@@ -214,11 +202,13 @@ class ProjectService extends BaseAPIService {
 		if (overrideContent !== undefined) {
 			payload.overrideContent = overrideContent;
 		}
-		return this.handleResponse(this.api.put(`/environments/${envId}/projects/${projectId}`, payload));
+		const project = await this.handleResponse<Omit<Project, 'environmentId'>>(
+			this.api.put(`/environments/${envId}/projects/${projectId}`, payload)
+		);
+		return { ...project, environmentId: envId };
 	}
 
-	async restartProject(projectId: string, services?: string[]): Promise<unknown> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async restartProject(envId: string, projectId: string, services?: string[]): Promise<unknown> {
 		let params: URLSearchParams | undefined;
 		if (services && services.length > 0) {
 			params = new URLSearchParams();
@@ -229,18 +219,15 @@ class ProjectService extends BaseAPIService {
 		return this.handleResponse(this.api.post(`/environments/${envId}/projects/${projectId}/restart`, undefined, { params }));
 	}
 
-	async archiveProject(projectId: string): Promise<void> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async archiveProject(envId: string, projectId: string): Promise<void> {
 		await this.handleResponse(this.api.post(`/environments/${envId}/projects/${projectId}/archive`));
 	}
 
-	async unarchiveProject(projectId: string): Promise<void> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async unarchiveProject(envId: string, projectId: string): Promise<void> {
 		await this.handleResponse(this.api.post(`/environments/${envId}/projects/${projectId}/unarchive`));
 	}
 
-	private async streamProjectPull(projectId: string, onLine?: (data: any) => void): Promise<void> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	private async streamProjectPull(envId: string, projectId: string, onLine?: (data: any) => void): Promise<void> {
 		const url = `/api/environments/${envId}/projects/${projectId}/pull`;
 
 		const res = await fetch(url, { method: 'POST' });
@@ -257,20 +244,22 @@ class ProjectService extends BaseAPIService {
 	}
 
 	buildProjectImages(
+		envId: string,
 		projectId: string,
 		options?: { services?: string[]; provider?: 'local' | 'depot'; push?: boolean; load?: boolean }
 	): Promise<void>;
 	buildProjectImages(
+		envId: string,
 		projectId: string,
 		options: { services?: string[]; provider?: 'local' | 'depot'; push?: boolean; load?: boolean } | undefined,
 		onLine: (data: any) => void
 	): Promise<void>;
 	async buildProjectImages(
+		envId: string,
 		projectId: string,
 		options?: { services?: string[]; provider?: 'local' | 'depot'; push?: boolean; load?: boolean },
 		onLine?: (data: any) => void
 	): Promise<void> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
 		const url = `/api/environments/${envId}/projects/${projectId}/build`;
 
 		await this.postProjectStream(url, options || {}, onLine, {
@@ -279,14 +268,13 @@ class ProjectService extends BaseAPIService {
 		});
 	}
 
-	pullProjectImages(projectId: string): Promise<void>;
-	pullProjectImages(projectId: string, onLine: (data: any) => void): Promise<void>;
-	async pullProjectImages(projectId: string, onLine?: (data: any) => void): Promise<void> {
-		await this.streamProjectPull(projectId, onLine);
+	pullProjectImages(envId: string, projectId: string): Promise<void>;
+	pullProjectImages(envId: string, projectId: string, onLine: (data: any) => void): Promise<void>;
+	async pullProjectImages(envId: string, projectId: string, onLine?: (data: any) => void): Promise<void> {
+		await this.streamProjectPull(envId, projectId, onLine);
 	}
 
-	async destroyProject(projectName: string, removeVolumes = false): Promise<void> {
-		const envId = await environmentStore.getCurrentEnvironmentId();
+	async destroyProject(envId: string, projectName: string, removeVolumes = false): Promise<void> {
 		await this.handleResponse(
 			this.api.delete(`/environments/${envId}/projects/${projectName}/destroy`, {
 				data: {

--- a/frontend/src/lib/services/project-workspace-service.ts
+++ b/frontend/src/lib/services/project-workspace-service.ts
@@ -1,4 +1,3 @@
-import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 import type {
 	ProjectWorkspace,
 	ProjectWorkspaceFileContent,
@@ -8,17 +7,11 @@ import { downloadBlob, filenameFromPath } from '#lib/utils/browser-download.js';
 import BaseAPIService from './api-service';
 
 class ProjectWorkspaceService extends BaseAPIService {
-	private async resolveEnvironmentId(environmentId?: string): Promise<string> {
-		return environmentId ?? (await environmentStore.getCurrentEnvironmentId());
-	}
-
-	async getWorkspace(projectId: string, environmentId?: string): Promise<ProjectWorkspace> {
-		const envId = await this.resolveEnvironmentId(environmentId);
+	async getWorkspace(projectId: string, envId: string): Promise<ProjectWorkspace> {
 		return this.handleResponse(this.api.get(`/environments/${envId}/projects/${projectId}/workspace`, { cache: 'no-store' }));
 	}
 
-	async getWorkspaceFile(projectId: string, relativePath: string, environmentId?: string): Promise<ProjectWorkspaceFileContent> {
-		const envId = await this.resolveEnvironmentId(environmentId);
+	async getWorkspaceFile(projectId: string, relativePath: string, envId: string): Promise<ProjectWorkspaceFileContent> {
 		return this.handleResponse(
 			this.api.get(`/environments/${envId}/projects/${projectId}/workspace/file`, {
 				cache: 'no-store',
@@ -31,17 +24,15 @@ class ProjectWorkspaceService extends BaseAPIService {
 		projectId: string,
 		manifest: ProjectWorkspaceUpdateManifest,
 		files: File[],
-		environmentId?: string
+		envId: string
 	): Promise<ProjectWorkspace> {
-		const envId = await this.resolveEnvironmentId(environmentId);
 		const form = new FormData();
 		form.append('manifest', JSON.stringify(manifest));
 		for (const file of files) form.append('files', file, file.name);
 		return this.handleResponse(this.api.put(`/environments/${envId}/projects/${projectId}/workspace`, form));
 	}
 
-	async downloadWorkspaceFile(projectId: string, relativePath: string, environmentId?: string): Promise<void> {
-		const envId = await this.resolveEnvironmentId(environmentId);
+	async downloadWorkspaceFile(projectId: string, relativePath: string, envId: string): Promise<void> {
 		const response = await this.api.get(`/environments/${envId}/projects/${projectId}/workspace/file/download`, {
 			params: { relativePath },
 			responseType: 'blob'

--- a/frontend/src/lib/types/swarm.ts
+++ b/frontend/src/lib/types/swarm.ts
@@ -604,6 +604,8 @@ export interface ProjectTagOption {
 
 export interface Project {
 	id: string;
+	// Manager-visible ID of the environment that supplied this project.
+	environmentId: string;
 	name: string;
 	dirName?: string;
 	relativePath?: string;

--- a/frontend/src/lib/utils/container-actions.ts
+++ b/frontend/src/lib/utils/container-actions.ts
@@ -12,7 +12,7 @@ type ContainerRemoveStatus = 'removing' | '';
 
 type ContainerLifecycleActionConfig = {
 	status: Exclude<ContainerLifecycleStatus, ''>;
-	run: (id: string) => Promise<unknown>;
+	run: (id: string, environmentId?: string) => Promise<unknown>;
 	success: () => string;
 	failure: () => string;
 };
@@ -20,37 +20,38 @@ type ContainerLifecycleActionConfig = {
 const containerLifecycleActionConfigs: Record<ContainerLifecycleAction, ContainerLifecycleActionConfig> = {
 	start: {
 		status: 'starting',
-		run: (id) => containerService.startContainer(id),
+		run: (id, environmentId) => containerService.startContainer(id, environmentId),
 		success: () => m.containers_start_success(),
 		failure: () => m.containers_start_failed()
 	},
 	stop: {
 		status: 'stopping',
-		run: (id) => containerService.stopContainer(id),
+		run: (id, environmentId) => containerService.stopContainer(id, environmentId),
 		success: () => m.containers_stop_success(),
 		failure: () => m.containers_stop_failed()
 	},
 	restart: {
 		status: 'restarting',
-		run: (id) => containerService.restartContainer(id),
+		run: (id, environmentId) => containerService.restartContainer(id, environmentId),
 		success: () => m.containers_restart_success(),
 		failure: () => m.containers_restart_failed()
 	},
 	pause: {
 		status: 'pausing',
-		run: (id) => containerService.pauseContainer(id),
+		run: (id, environmentId) => containerService.pauseContainer(id, environmentId),
 		success: () => m.containers_pause_success(),
 		failure: () => m.containers_pause_failed()
 	},
 	unpause: {
 		status: 'unpausing',
-		run: (id) => containerService.unpauseContainer(id),
+		run: (id, environmentId) => containerService.unpauseContainer(id, environmentId),
 		success: () => m.containers_unpause_success(),
 		failure: () => m.containers_unpause_failed()
 	}
 };
 
 type RunContainerLifecycleActionOptions = {
+	environmentId?: string;
 	action: ContainerLifecycleAction;
 	containerId: string;
 	setStatus: (status: ContainerLifecycleStatus) => void;
@@ -58,6 +59,7 @@ type RunContainerLifecycleActionOptions = {
 };
 
 export async function runContainerLifecycleAction({
+	environmentId,
 	action,
 	containerId,
 	setStatus,
@@ -71,7 +73,7 @@ export async function runContainerLifecycleAction({
 	const operationResult = await tryCatch(
 		(async () => {
 			await handleApiResultWithCallbacks({
-				result: await tryCatch(config.run(containerId)),
+				result: await tryCatch(config.run(containerId, environmentId)),
 				message: config.failure(),
 				setLoadingState: (value) => {
 					setStatus(value ? config.status : '');
@@ -92,6 +94,7 @@ export async function runContainerLifecycleAction({
 }
 
 type ConfirmAndRemoveContainerOptions = {
+	environmentId?: string;
 	containerId: string;
 	containerName: string;
 	setStatus: (status: ContainerRemoveStatus) => void;
@@ -99,6 +102,7 @@ type ConfirmAndRemoveContainerOptions = {
 };
 
 export function confirmAndRemoveContainer({
+	environmentId,
 	containerId,
 	containerName,
 	setStatus,
@@ -119,7 +123,7 @@ export function confirmAndRemoveContainer({
 				const volumes = !!checkboxStates['volumes'];
 				setStatus('removing');
 				await handleApiResultWithCallbacks({
-					result: await tryCatch(containerService.deleteContainer(containerId, { force, volumes })),
+					result: await tryCatch(containerService.deleteContainer(containerId, { force, volumes, environmentId })),
 					message: m.containers_remove_failed(),
 					setLoadingState: (value) => {
 						setStatus(value ? 'removing' : '');

--- a/frontend/src/lib/utils/table-action-types.ts
+++ b/frontend/src/lib/utils/table-action-types.ts
@@ -1,16 +1,16 @@
-export type TableActionConfig<TStatus extends string> = {
+export type TableActionConfig<TStatus extends string, TTarget = string> = {
 	status: TStatus;
-	run: (id: string) => Promise<unknown>;
+	run: (target: TTarget) => Promise<unknown>;
 	success: () => string;
 	failure: () => string;
 };
 
-export type TableBulkActionConfig<TLoadingKey extends string> = {
+export type TableBulkActionConfig<TLoadingKey extends string, TTarget = string> = {
 	title: (count: number) => string;
 	message: (count: number) => string;
 	label: string;
 	loadingKey: TLoadingKey;
-	run: (id: string) => Promise<unknown>;
+	run: (target: TTarget) => Promise<unknown>;
 	success: (count: number) => string;
 	partial: (success: number, total: number, failed: number) => string;
 	failure: () => string;

--- a/frontend/src/lib/utils/update-actions.ts
+++ b/frontend/src/lib/utils/update-actions.ts
@@ -16,8 +16,12 @@ import type { AutoUpdateResourceType, AutoUpdateResult } from '#lib/types/automa
  */
 
 /** Applies pending updates for a single resource via a scoped updater run. */
-export function applyScopedUpdate(type: Extract<AutoUpdateResourceType, 'container' | 'project'>, id: string) {
-	return imageService.runAutoUpdate({ type, resourceIds: [id] });
+export function applyScopedUpdate(
+	type: Extract<AutoUpdateResourceType, 'container' | 'project'>,
+	id: string,
+	environmentId?: string
+) {
+	return imageService.runAutoUpdate({ type, resourceIds: [id] }, environmentId);
 }
 
 /**

--- a/frontend/src/lib/utils/watch-logs.ts
+++ b/frontend/src/lib/utils/watch-logs.ts
@@ -1,4 +1,3 @@
-import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 import { operationWatchStore } from '#lib/stores/operation-watch.store.svelte.js';
 import { ReconnectingWebSocket } from '#lib/utils/ws.js';
 
@@ -10,12 +9,11 @@ import { ReconnectingWebSocket } from '#lib/utils/ws.js';
  * operation began (application startup included) without dredging up history
  * from previous runs. Returns a detach function that closes the stream.
  */
-export function attachProjectLogsToWatch(projectId: string, sinceEpochSeconds: number): () => void {
+export function attachProjectLogsToWatch(envId: string, projectId: string, sinceEpochSeconds: number): () => void {
 	let active = true;
 
 	const client = new ReconnectingWebSocket<string>({
 		buildUrl: async () => {
-			const envId = await environmentStore.getCurrentEnvironmentId();
 			const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
 			return `${protocol}://${window.location.host}/api/environments/${envId}/ws/projects/${projectId}/logs?follow=true&tail=all&since=${sinceEpochSeconds}&timestamps=false&format=json&batched=true`;
 		},

--- a/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
+++ b/frontend/src/routes/(app)/containers/[containerId]/+page.svelte
@@ -268,18 +268,13 @@
 		const includes = proj.includeFiles ?? [];
 		if (includes.length === 0) return null;
 
-		const envId = await tryCatch(environmentStore.getCurrentEnvironmentId()).then((result) =>
-			result.error ? null : result.data
-		);
-		if (!envId) return null;
-
 		for (const f of includes) {
 			if (f.content && hasServiceInContent(f.content, svcName)) {
 				return { includeFile: f };
 			}
 			const sourceResult = await tryCatch(
 				(async () => {
-					const loaded = await projectWorkspaceService.getWorkspaceFile(proj.id, f.relativePath, envId);
+					const loaded = await projectWorkspaceService.getWorkspaceFile(proj.id, f.relativePath, proj.environmentId);
 					if (loaded?.content && hasServiceInContent(loaded.content, svcName)) {
 						return { includeFile: { ...f, content: loaded.content } };
 					}
@@ -601,6 +596,7 @@
 		{#snippet headerActions()}
 			<div class="container-detail-actions">
 				<ActionButtons
+					environmentId={currentEnvId}
 					id={container.id}
 					name={containerDisplayName}
 					type="container"

--- a/frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
+++ b/frontend/src/routes/(app)/containers/components/ContainerComposePanel.svelte
@@ -30,17 +30,18 @@
 
 	async function save() {
 		if (includeFile) {
-			const workspace = await projectWorkspaceService.getWorkspace(project.id);
+			const workspace = await projectWorkspaceService.getWorkspace(project.id, project.environmentId);
 			await projectWorkspaceService.updateWorkspace(
 				project.id,
 				{
 					fileTreeRevision: workspace.fileTreeRevision,
 					fileChanges: [{ operation: 'update_file', relativePath: includeFile.relativePath, uploadIndex: 0 }]
 				},
-				[new File([composeContent], includeFile.relativePath, { type: 'text/yaml' })]
+				[new File([composeContent], includeFile.relativePath, { type: 'text/yaml' })],
+				project.environmentId
 			);
 		} else {
-			await projectService.updateProject(project.id, undefined, composeContent);
+			await projectService.updateProject(project.environmentId, project.id, undefined, composeContent);
 		}
 	}
 </script>

--- a/frontend/src/routes/(app)/projects/+page.svelte
+++ b/frontend/src/routes/(app)/projects/+page.svelte
@@ -125,7 +125,7 @@
 				projectsToUpdate.map(async (proj) => {
 					// deployProject with pullPolicy 'always' already pulls fresh images,
 					// so no separate pullProjectImages call is needed.
-					await projectService.deployProject(proj.id, 'up', { pullPolicy: 'always' });
+					await projectService.deployProject(proj.environmentId, proj.id, 'up', { pullPolicy: 'always' });
 					return proj.name;
 				})
 			);
@@ -257,22 +257,24 @@
 <ResourcePageLayout title={m.projects_title()} subtitle={m.compose_subtitle()} {actionButtons} {statCards}>
 	{#snippet mainContent()}
 		{#if projects}
-			<ProjectsTable
-				{projects}
-				bind:selectedIds
-				requestOptions={projectRequestOptions}
-				{showArchived}
-				availableTags={projectTags}
-				onToggleArchived={toggleArchived}
-				onRefreshData={async (options) => {
-					const requestedEnvId = envId;
-					baseProjectRequestOptions = withArchivedFilter(options, showArchived);
-					await Promise.all([projectsQuery.refetch(), projectStatusCountsQuery.refetch()]);
-					if (requestedEnvId !== envId) {
-						selectedIds = [];
-					}
-				}}
-			/>
+			{#key envId}
+				<ProjectsTable
+					{projects}
+					bind:selectedIds
+					requestOptions={projectRequestOptions}
+					{showArchived}
+					availableTags={projectTags}
+					onToggleArchived={toggleArchived}
+					onRefreshData={async (options) => {
+						const requestedEnvId = envId;
+						baseProjectRequestOptions = withArchivedFilter(options, showArchived);
+						await Promise.all([projectsQuery.refetch(), projectStatusCountsQuery.refetch()]);
+						if (requestedEnvId !== envId) {
+							selectedIds = [];
+						}
+					}}
+				/>
+			{/key}
 		{/if}
 	{/snippet}
 </ResourcePageLayout>

--- a/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
@@ -11,4 +11,6 @@
 
 <svelte:head><title>{pageTitle}</title></svelte:head>
 
-{@render children()}
+{#key `${page.data['project'].environmentId}:${page.data['project'].id}`}
+	{@render children()}
+{/key}

--- a/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -53,7 +53,6 @@
 	import { projectWorkspaceService } from '#lib/services/project-workspace-service.js';
 	import settingsStore from '#lib/stores/config-store.js';
 	import { gitOpsSyncService } from '#lib/services/gitops-sync-service.js';
-	import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 	import { hasPermission } from '#lib/utils/auth.js';
 	import { queryKeys } from '#lib/query/query-keys.js';
 	import { RefreshIcon } from '#lib/icons/index.js';
@@ -103,7 +102,7 @@
 		archiving: false
 	});
 
-	const envId = $derived(environmentStore.selected?.id || '0');
+	const envId = $derived(data.project.environmentId);
 	const canUpdateProject = $derived(hasPermission('projects:update', envId));
 	const canViewProjectLogs = $derived(hasPermission('projects:logs', envId));
 	// Project lifecycle permissions are evaluated per-button inside
@@ -137,7 +136,7 @@
 	const availableProjectTags = $derived(projectTagsQuery.data ?? []);
 
 	async function handleProjectTagToggle(name: string, attached: boolean, color: ProjectTagColor) {
-		const response = await projectService.updateProjectTag(projectId, name, attached, color);
+		const response = await projectService.updateProjectTag(envId, projectId, name, attached, color);
 		queryClient.setQueryData<Project>(queryKeys.projects.detail(envId, projectId), (current) =>
 			current ? { ...current, tags: response.tags } : current
 		);
@@ -604,7 +603,7 @@
 	}
 
 	async function syncProjectQueries(updatedProject: Project) {
-		const currentEnvId = envId ?? (await environmentStore.getCurrentEnvironmentId());
+		const currentEnvId = updatedProject.environmentId;
 
 		// The save response is slim (no directory walks), so merge it into the
 		// cached detail instead of replacing it wholesale.
@@ -619,10 +618,10 @@
 	}
 
 	const checkProjectUpdatesMutation = createMutation(() => ({
-		mutationKey: queryKeys.projects.detailCheckUpdates(envId ?? '0', projectId),
-		mutationFn: () => projectService.checkUpdates(projectId),
+		mutationKey: queryKeys.projects.detailCheckUpdates(envId, projectId),
+		mutationFn: () => projectService.checkUpdates(envId, projectId),
 		onSuccess: async (result) => {
-			const currentEnvId = envId ?? (await environmentStore.getCurrentEnvironmentId());
+			const currentEnvId = envId;
 			const firstError = result.errorMessage?.trim();
 			const hasErrors = !!firstError;
 			if (hasErrors) {
@@ -645,7 +644,7 @@
 		if (!project?.id) return;
 		if (lastPrefsProjectId === project.id) return;
 
-		const prefsStorageKey = `arcane.compose.ui:${project.id}`;
+		const prefsStorageKey = `arcane.compose.ui:${project.environmentId}:${project.id}`;
 		const hadStoredPrefs = sessionStorage.getItem(prefsStorageKey) !== null;
 		// The tree/classic auto-detect needs the lazily loaded workspace; without
 		// stored prefs, wait for its query to settle before finalizing.
@@ -756,6 +755,7 @@
 					}
 
 					const updatedProject = await projectService.updateProject(
+						envId,
 						projectId,
 						namePayload,
 						composePayload,
@@ -800,7 +800,7 @@
 		isLoading.archiving = true;
 		try {
 			const result = await tryCatch(
-				archiving ? projectService.archiveProject(project.id) : projectService.unarchiveProject(project.id)
+				archiving ? projectService.archiveProject(envId, project.id) : projectService.unarchiveProject(envId, project.id)
 			);
 			await handleApiResultWithCallbacks({
 				result,
@@ -808,7 +808,7 @@
 				onSuccess: async () => {
 					toast.success(archiving ? m.compose_archive_success() : m.compose_unarchive_success());
 					await refreshProjectDetails();
-					const currentEnvId = envId ?? (await environmentStore.getCurrentEnvironmentId());
+					const currentEnvId = envId;
 					await Promise.all([
 						queryClient.invalidateQueries({ queryKey: ['projects', currentEnvId] }),
 						queryClient.invalidateQueries({ queryKey: queryKeys.projects.statusCounts(currentEnvId) })
@@ -837,7 +837,7 @@
 	type ProjectWorkspaceSource = 'include' | 'directory' | 'workspace';
 
 	function getProjectWorkspaceCacheKey(projectId: string, kind: ProjectWorkspaceSource, relativePath: string): string {
-		return `${projectId}:${kind}:${relativePath}`;
+		return `${envId}:${projectId}:${kind}:${relativePath}`;
 	}
 
 	function updateLoadedProjectWorkspaceSource(kind: ProjectWorkspaceSource, relativePath: string, content: string) {
@@ -1303,7 +1303,7 @@
 	async function refreshProjectDetails(options: RefreshProjectDetailsOptions = {}) {
 		if (!projectId) return;
 		await handleApiResultWithCallbacks({
-			result: await tryCatch(projectService.getProject(projectId)),
+			result: await tryCatch(projectService.getProjectForEnvironment(envId, projectId)),
 			message: m.common_refresh_failed({ resource: m.project() }),
 			onSuccess: async (updatedProject) => {
 				if (options.forceRebaseDraft || !hasChanges) {
@@ -1366,7 +1366,7 @@
 			validationMode: 'compose',
 			error: $inputs.composeContent.error ?? undefined,
 			readOnly: !canEditCompose,
-			fileId: `project:${projectId}:compose`,
+			fileId: `project:${envId}:${projectId}:compose`,
 			originalValue: serverComposeContent,
 			enableDiff: true,
 			editorContext: codeEditorContext
@@ -1380,7 +1380,7 @@
 			validationMode: 'compose',
 			error: $inputs.overrideContent.error ?? undefined,
 			readOnly: !canEditOverride,
-			fileId: `project:${projectId}:override`,
+			fileId: `project:${envId}:${projectId}:override`,
 			originalValue: serverOverrideContent,
 			enableDiff: true,
 			editorContext: codeEditorContext
@@ -1394,7 +1394,7 @@
 			validationMode: 'env',
 			error: $inputs.envContent.error ?? undefined,
 			readOnly: !canEditEnv,
-			fileId: `project:${projectId}:env`,
+			fileId: `project:${envId}:${projectId}:env`,
 			originalValue: serverEnvContent,
 			enableDiff: true,
 			editorContext: codeEditorContext
@@ -1560,7 +1560,7 @@
 			readOnly={!canEditProjectWorkspace}
 			bind:hasErrors={projectWorkspaceHasErrors[relativePath]}
 			bind:validationReady={projectWorkspaceValidationReady[relativePath]}
-			fileId={`project:${projectId}:file:${relativePath}`}
+			fileId={`project:${envId}:${projectId}:file:${relativePath}`}
 			originalValue={loadedProjectWorkspaceContents[relativePath] ?? ''}
 			enableDiff={true}
 			editorContext={codeEditorContext}
@@ -1677,6 +1677,7 @@
 				>
 					{#snippet first()}
 						<ProjectServicesPanel
+							environmentId={project.environmentId}
 							services={project.runtimeServices}
 							{projectId}
 							updateInfoByRef={project.updateInfo?.updateInfoByRef}
@@ -1686,6 +1687,7 @@
 					{#snippet second()}
 						<div class="flex h-full min-h-0 flex-col overflow-hidden">
 							<ProjectsLogsPanel
+								environmentId={project.environmentId}
 								projectId={project.id}
 								bind:autoScroll={autoScrollStackLogs}
 								isRunning={project.status?.toLowerCase().includes('running')}
@@ -1697,6 +1699,7 @@
 		{:else}
 			<div class="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-card">
 				<ProjectServicesPanel
+					environmentId={project.environmentId}
 					services={project.runtimeServices}
 					{projectId}
 					updateInfoByRef={project.updateInfo?.updateInfoByRef}
@@ -1726,7 +1729,7 @@
 			readOnly={sourceLocked}
 			bind:hasErrors={includeFilesHasErrors[includeFile.relativePath]}
 			bind:validationReady={includeFilesValidationReady[includeFile.relativePath]}
-			fileId={`project:${projectId}:include:${includeFile.relativePath}`}
+			fileId={`project:${envId}:${projectId}:include:${includeFile.relativePath}`}
 			originalValue={serverIncludeFiles[includeFile.relativePath] ?? ''}
 			enableDiff={true}
 			editorContext={codeEditorContext}
@@ -2001,7 +2004,7 @@
 					updateInfo={project.updateInfo}
 					onCheck={handleCheckProjectUpdates}
 					checking={checkProjectUpdatesMutation.isPending}
-					disabled={!!project.isArchived}
+					disabled={!!project.isArchived || !hasPermission('image-updates:check', project.environmentId)}
 				/>
 			</div>
 
@@ -2076,7 +2079,7 @@
 						loadingLabel={m.common_saving()}
 					/>
 				{/if}
-				<IfPermitted perm="projects:archive">
+				<IfPermitted perm="projects:archive" {envId}>
 					<ArcaneButton
 						action="archive"
 						loading={isLoading.archiving}
@@ -2087,6 +2090,7 @@
 					/>
 				</IfPermitted>
 				<ActionButtons
+					environmentId={project.environmentId}
 					id={project.id}
 					name={project.name}
 					type="project"

--- a/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
+++ b/frontend/src/routes/(app)/projects/components/ProjectLogsPanel.svelte
@@ -8,10 +8,12 @@
 
 	let {
 		projectId,
+		environmentId,
 		autoScroll = $bindable(),
 		isRunning = true
 	}: {
 		projectId: string;
+		environmentId: string;
 		autoScroll: boolean;
 		isRunning?: boolean;
 	} = $props();
@@ -101,6 +103,7 @@
 	</Card.Header>
 	<Card.Content class="flex min-h-0 flex-1 flex-col p-0">
 		<LogViewer
+			{environmentId}
 			class="min-h-0 flex-1"
 			searchTerm={logSearchTerm}
 			bind:this={viewer}

--- a/frontend/src/routes/(app)/projects/components/ProjectServicesPanel.svelte
+++ b/frontend/src/routes/(app)/projects/components/ProjectServicesPanel.svelte
@@ -13,7 +13,6 @@
 	import type { ImageUpdateData } from '#lib/types/docker.js';
 	import { m } from '#lib/paraglide/messages.js';
 	import { projectService } from '#lib/services/project-service.js';
-	import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 	import { hasPermission } from '#lib/utils/auth.js';
 	import { toast } from 'svelte-sonner';
 	import { handleApiResultWithCallbacks } from '#lib/utils/api.js';
@@ -24,19 +23,20 @@
 	import { StartIcon, StopIcon, RefreshIcon, TrashIcon, InspectIcon, LayersIcon, BoxIcon, HealthIcon } from '#lib/icons/index.js';
 
 	interface Props {
+		environmentId: string;
 		services?: RuntimeService[];
 		projectId?: string;
 		updateInfoByRef?: Record<string, ImageUpdateData>;
 		onRefresh?: () => Promise<void>;
 	}
 
-	let { services = [], projectId, updateInfoByRef = {}, onRefresh }: Props = $props();
+	let { environmentId, services = [], projectId, updateInfoByRef = {}, onRefresh }: Props = $props();
 
 	function serviceImageRef(service: RuntimeService): string {
 		return service.serviceConfig?.image || service.image || '';
 	}
 
-	const currentEnvId = $derived(environmentStore.selected?.id || '0');
+	const currentEnvId = $derived(environmentId);
 	const canStartContainer = $derived(hasPermission('containers:start', currentEnvId));
 	const canStopContainer = $derived(hasPermission('containers:stop', currentEnvId));
 	const canRestartProject = $derived(hasPermission('projects:restart', currentEnvId));
@@ -90,6 +90,7 @@
 
 	async function performContainerAction(action: 'start' | 'stop' | 'restart', id: string) {
 		await runContainerLifecycleAction({
+			environmentId,
 			action,
 			containerId: id,
 			setStatus: (status) => {
@@ -111,7 +112,7 @@
 		const operationResult = await tryCatch(
 			(async () => {
 				await handleApiResultWithCallbacks({
-					result: await tryCatch(projectService.restartProject(projectId, [item.name])),
+					result: await tryCatch(projectService.restartProject(environmentId, projectId, [item.name])),
 					message: m.containers_restart_failed(),
 					setLoadingState: (value) => {
 						actionStatus[id] = value ? 'restarting' : '';
@@ -134,6 +135,7 @@
 
 	function handleRemoveContainer(id: string, name: string) {
 		confirmAndRemoveContainer({
+			environmentId,
 			containerId: id,
 			containerName: name,
 			setStatus: (status) => {

--- a/frontend/src/routes/(app)/projects/new/+page.svelte
+++ b/frontend/src/routes/(app)/projects/new/+page.svelte
@@ -184,7 +184,7 @@
 			validate: () => validateTemplateEditorForm(validationState, form.validate),
 			setLoading: (value) => (ui.saving = value),
 			submit: ({ name, composeContent, envContent }) =>
-				projectService.createProject(name, composeContent, envContent, workspaceDraft.toDrafts(), newProjectTags),
+				projectService.createProject(currentEnvId, name, composeContent, envContent, workspaceDraft.toDrafts(), newProjectTags),
 			failureMessage: (name) => m.common_create_failed({ resource: `${m.resource_project()} "${name}"` }),
 			onSuccess: async (project, { name }) => {
 				toast.success(

--- a/frontend/src/routes/(app)/projects/projects-table.actions.ts
+++ b/frontend/src/routes/(app)/projects/projects-table.actions.ts
@@ -10,6 +10,7 @@ import { activityToastOptions, extractActivityId } from '#lib/utils/activity-toa
 import type { TableActionConfig, TableBulkActionConfig } from '#lib/utils/table-action-types.js';
 import { toast } from 'svelte-sonner';
 import type { ActionStatus } from './projects-table.helpers';
+import type { Project } from '#lib/types/swarm.js';
 import { bulkConfirmAndRun } from '#lib/utils/bulk-actions.js';
 
 type BulkLoadingState = {
@@ -25,13 +26,13 @@ type ActionDeps = {
 	setSelectedIds: (next: string[]) => void;
 	actionStatus: Record<string, ActionStatus>;
 	isBulkLoading: BulkLoadingState;
-	getEnvId: () => string | undefined;
+	getProjects: () => Project[];
 };
 
 type ProjectActionKind = 'start' | 'stop' | 'restart' | 'redeploy' | 'archive' | 'unarchive';
 
-type ProjectActionConfig = TableActionConfig<ActionStatus>;
-type BulkActionConfig = TableBulkActionConfig<keyof BulkLoadingState>;
+type ProjectActionConfig = TableActionConfig<ActionStatus, Project>;
+type BulkActionConfig = TableBulkActionConfig<keyof BulkLoadingState, Project>;
 
 type DestroyConfirmResult = {
 	checkboxes?: {
@@ -43,9 +44,9 @@ type DestroyConfirmResult = {
 };
 
 type ProjectActions = {
-	performProjectAction: (action: ProjectActionKind, id: string) => Promise<void>;
-	handleDestroyProject: (id: string) => Promise<void>;
-	handleSyncFromGit: (projectId: string, gitOpsSyncId: string) => Promise<void>;
+	performProjectAction: (action: ProjectActionKind, project: Project) => Promise<void>;
+	handleDestroyProject: (project: Project) => Promise<void>;
+	handleSyncFromGit: (project: Project, gitOpsSyncId: string) => Promise<void>;
 	handleBulkUp: (ids: string[]) => Promise<void>;
 	handleBulkDown: (ids: string[]) => Promise<void>;
 	handleBulkRedeploy: (ids: string[]) => Promise<void>;
@@ -55,37 +56,39 @@ type ProjectActions = {
 const projectActionConfigs: Record<ProjectActionKind, ProjectActionConfig> = {
 	start: {
 		status: 'starting',
-		run: (id) => projectService.deployProject(id, 'up', deployOptionsStore.takeRequestOptions()),
+		run: (project) =>
+			projectService.deployProject(project.environmentId, project.id, 'up', deployOptionsStore.takeRequestOptions()),
 		success: () => m.compose_start_success(),
 		failure: () => m.compose_start_failed()
 	},
 	stop: {
 		status: 'stopping',
-		run: (id) => projectService.downProject(id),
+		run: (project) => projectService.downProject(project.environmentId, project.id),
 		success: () => m.compose_stop_success(),
 		failure: () => m.compose_stop_failed()
 	},
 	restart: {
 		status: 'restarting',
-		run: (id) => projectService.restartProject(id),
+		run: (project) => projectService.restartProject(project.environmentId, project.id),
 		success: () => m.compose_restart_success(),
 		failure: () => m.compose_restart_failed()
 	},
 	redeploy: {
 		status: 'redeploying',
-		run: (id) => projectService.deployProject(id, 'redeploy', deployOptionsStore.takeRequestOptions()),
+		run: (project) =>
+			projectService.deployProject(project.environmentId, project.id, 'redeploy', deployOptionsStore.takeRequestOptions()),
 		success: () => m.compose_pull_success(),
 		failure: () => m.compose_pull_failed()
 	},
 	archive: {
 		status: 'archiving',
-		run: (id) => projectService.archiveProject(id),
+		run: (project) => projectService.archiveProject(project.environmentId, project.id),
 		success: () => m.compose_archive_success(),
 		failure: () => m.compose_archive_failed()
 	},
 	unarchive: {
 		status: 'unarchiving',
-		run: (id) => projectService.unarchiveProject(id),
+		run: (project) => projectService.unarchiveProject(project.environmentId, project.id),
 		success: () => m.compose_unarchive_success(),
 		failure: () => m.compose_unarchive_failed()
 	}
@@ -97,16 +100,17 @@ export function createProjectActions({
 	setSelectedIds,
 	actionStatus,
 	isBulkLoading,
-	getEnvId
+	getProjects
 }: ActionDeps): ProjectActions {
-	async function performProjectAction(action: ProjectActionKind, id: string): Promise<void> {
+	async function performProjectAction(action: ProjectActionKind, project: Project): Promise<void> {
+		const { id } = project;
 		const config = projectActionConfigs[action];
 		actionStatus[id] = config.status;
 
 		const operationResult = await tryCatch(
 			(async () => {
 				await handleApiResultWithCallbacks({
-					result: await tryCatch(config.run(id)),
+					result: await tryCatch(config.run(project)),
 					message: config.failure(),
 					setLoadingState: (value) => {
 						actionStatus[id] = value ? config.status : '';
@@ -124,7 +128,8 @@ export function createProjectActions({
 		}
 	}
 
-	async function handleDestroyProject(id: string): Promise<void> {
+	async function handleDestroyProject(project: Project): Promise<void> {
+		const { id } = project;
 		openConfirmDialog({
 			title: m.common_confirm_removal_title(),
 			message: m.compose_confirm_removal_message(),
@@ -143,7 +148,7 @@ export function createProjectActions({
 					actionStatus[id] = 'destroying';
 
 					await handleApiResultWithCallbacks({
-						result: await tryCatch(projectService.destroyProject(id, removeVolumes)),
+						result: await tryCatch(projectService.destroyProject(project.environmentId, project.id, removeVolumes)),
 						message: m.compose_destroy_failed(),
 						setLoadingState: (value) => {
 							actionStatus[id] = value ? 'destroying' : '';
@@ -158,9 +163,8 @@ export function createProjectActions({
 		});
 	}
 
-	async function handleSyncFromGit(projectId: string, gitOpsSyncId: string): Promise<void> {
-		const envId = getEnvId();
-		if (!envId) return;
+	async function handleSyncFromGit(project: Project, gitOpsSyncId: string): Promise<void> {
+		const { id: projectId, environmentId: envId } = project;
 
 		actionStatus[projectId] = 'syncing';
 		const result = await tryCatch(gitOpsSyncService.performSync(envId, gitOpsSyncId));
@@ -180,6 +184,12 @@ export function createProjectActions({
 
 	async function runBulkAction(ids: string[], config: BulkActionConfig): Promise<void> {
 		if (!ids || ids.length === 0) return;
+		const targets = new Map(
+			getProjects()
+				.filter((project) => ids.includes(project.id))
+				.map((project) => [project.id, project])
+		);
+		if (targets.size !== ids.length) return;
 
 		bulkConfirmAndRun({
 			ids,
@@ -187,7 +197,7 @@ export function createProjectActions({
 			message: config.message(ids.length),
 			confirmLabel: config.label,
 			destructive: config.destructive ?? false,
-			run: (id) => config.run(id),
+			run: (id) => config.run(targets.get(id)!),
 			messages: {
 				success: config.success,
 				partial: config.partial,
@@ -211,7 +221,13 @@ export function createProjectActions({
 			message: (count) => m.projects_bulk_up_confirm_message({ count }),
 			label: m.common_up(),
 			loadingKey: 'up',
-			run: (id) => projectService.deployProject(id, 'up', (deployOptions ??= deployOptionsStore.takeRequestOptions())),
+			run: (project) =>
+				projectService.deployProject(
+					project.environmentId,
+					project.id,
+					'up',
+					(deployOptions ??= deployOptionsStore.takeRequestOptions())
+				),
 			success: (count) => m.projects_bulk_up_success({ count }),
 			partial: (success, total, failed) => m.projects_bulk_up_partial({ success, total, failed }),
 			failure: () => m.compose_start_failed()
@@ -224,7 +240,7 @@ export function createProjectActions({
 			message: (count) => m.projects_bulk_down_confirm_message({ count }),
 			label: m.common_down(),
 			loadingKey: 'down',
-			run: (id) => projectService.downProject(id),
+			run: (project) => projectService.downProject(project.environmentId, project.id),
 			success: (count) => m.projects_bulk_down_success({ count }),
 			partial: (success, total, failed) => m.projects_bulk_down_partial({ success, total, failed }),
 			failure: () => m.compose_stop_failed()
@@ -239,7 +255,13 @@ export function createProjectActions({
 			message: (count) => m.projects_bulk_redeploy_confirm_message({ count }),
 			label: m.compose_pull_redeploy(),
 			loadingKey: 'redeploy',
-			run: (id) => projectService.deployProject(id, 'redeploy', (deployOptions ??= deployOptionsStore.takeRequestOptions())),
+			run: (project) =>
+				projectService.deployProject(
+					project.environmentId,
+					project.id,
+					'redeploy',
+					(deployOptions ??= deployOptionsStore.takeRequestOptions())
+				),
 			success: (count) => m.projects_bulk_redeploy_success({ count }),
 			partial: (success, total, failed) => m.projects_bulk_redeploy_partial({ success, total, failed }),
 			failure: () => m.compose_pull_failed()
@@ -252,7 +274,7 @@ export function createProjectActions({
 			message: (count) => m.projects_bulk_archive_confirm_message({ count }),
 			label: m.projects_archive(),
 			loadingKey: 'archive',
-			run: (id) => projectService.archiveProject(id),
+			run: (project) => projectService.archiveProject(project.environmentId, project.id),
 			success: (count) => m.projects_bulk_archive_success({ count }),
 			partial: (success, total, failed) => m.projects_bulk_archive_partial({ success, total, failed }),
 			failure: () => m.compose_archive_failed()

--- a/frontend/src/routes/(app)/projects/projects-table.svelte
+++ b/frontend/src/routes/(app)/projects/projects-table.svelte
@@ -20,7 +20,6 @@
 	import { m } from '#lib/paraglide/messages.js';
 	import { projectService } from '#lib/services/project-service.js';
 	import { FolderOpenIcon, LayersIcon, CalendarIcon, ProjectsIcon, GitBranchIcon, RefreshIcon } from '#lib/icons/index.js';
-	import { environmentStore } from '#lib/stores/environment.store.svelte.js';
 	import { hasPermission } from '#lib/utils/auth.js';
 	import { hasAnyLoadingState } from '#lib/utils/bulk-actions.js';
 	import IfPermitted from '#lib/components/if-permitted.svelte';
@@ -54,7 +53,7 @@
 		withoutFilters?: boolean;
 		showArchived?: boolean;
 		onToggleArchived?: (checked: boolean) => void | Promise<void>;
-		onRefreshData?: (options: SearchPaginationSortRequest) => Promise<void>;
+		onRefreshData: (options: SearchPaginationSortRequest) => Promise<void>;
 		availableTags?: ProjectTagOption[];
 	} = $props();
 
@@ -73,11 +72,7 @@
 	});
 
 	async function refreshProjects(options: SearchPaginationSortRequest = requestOptions) {
-		if (onRefreshData) {
-			await onRefreshData(options);
-			return;
-		}
-		projects = await projectService.getProjects(options);
+		await onRefreshData(options);
 	}
 
 	async function handleCheckProjectUpdates(project: Project) {
@@ -93,7 +88,7 @@
 		try {
 			const operationResult = await tryCatch(
 				(async () => {
-					const result = await projectService.checkUpdates(project.id);
+					const result = await projectService.checkUpdates(project.environmentId, project.id);
 					const firstError = result.errorMessage?.trim();
 					const hasErrors = !!firstError;
 					if (hasErrors) {
@@ -116,7 +111,7 @@
 	}
 
 	async function handleTagToggle(project: Project, name: string, attached: boolean, color: ProjectTagColor) {
-		const response = await projectService.updateProjectTag(project.id, name, attached, color);
+		const response = await projectService.updateProjectTag(project.environmentId, project.id, name, attached, color);
 		if (attached && !tagCatalog.some((tag) => tag.name === name)) {
 			tagCatalog = [...tagCatalog, { name, color }].sort((a, b) => a.name.localeCompare(b.name));
 		}
@@ -132,12 +127,6 @@
 	}
 
 	let mobileFieldVisibility = $state<Record<string, boolean>>({});
-	const envId = $derived(environmentStore.selected?.id);
-	const currentEnvId = $derived(environmentStore.selected?.id || '0');
-	const canUpdateProject = $derived(hasPermission('projects:update', currentEnvId));
-	const canDeployProject = $derived(hasPermission('projects:deploy', currentEnvId));
-	const canDownProject = $derived(hasPermission('projects:down', currentEnvId));
-	const canArchiveProject = $derived(hasPermission('projects:archive', currentEnvId));
 
 	const {
 		performProjectAction,
@@ -155,11 +144,11 @@
 		},
 		actionStatus,
 		isBulkLoading,
-		getEnvId: () => envId
+		getProjects: () => selectedProjects
 	});
 
 	const isAnyLoading = $derived(hasAnyLoadingState(actionStatus, isBulkLoading));
-	const selectedProjects = $derived.by(() => (projects?.data ?? []).filter((project) => selectedIds?.includes(project.id)));
+	let selectedProjects = $state<Project[]>([]);
 	const hasRedeployDisabledSelection = $derived.by(() => selectedProjects.some((project) => project.redeployDisabled));
 	const hasArchivedSelection = $derived.by(() => selectedProjects.some((project) => project.isArchived));
 	const isProjectArchiveBlocked = (project: Project) =>
@@ -216,7 +205,10 @@
 			action: 'up',
 			onClick: handleBulkUp,
 			loading: isBulkLoading.up,
-			disabled: !canDeployProject || isAnyLoading || hasArchivedSelection,
+			disabled:
+				!selectedProjects.every((project) => hasPermission('projects:deploy', project.environmentId)) ||
+				isAnyLoading ||
+				hasArchivedSelection,
 			disabledReason: hasArchivedSelection ? m.projects_archived_badge() : undefined,
 			icon: StartIcon
 		},
@@ -226,7 +218,10 @@
 			action: 'down',
 			onClick: handleBulkDown,
 			loading: isBulkLoading.down,
-			disabled: !canDownProject || isAnyLoading || hasArchivedSelection,
+			disabled:
+				!selectedProjects.every((project) => hasPermission('projects:down', project.environmentId)) ||
+				isAnyLoading ||
+				hasArchivedSelection,
 			disabledReason: hasArchivedSelection ? m.projects_archived_badge() : undefined,
 			icon: StopIcon
 		},
@@ -236,7 +231,11 @@
 			action: 'redeploy',
 			onClick: handleBulkRedeploy,
 			loading: isBulkLoading.redeploy,
-			disabled: !canDeployProject || isAnyLoading || hasRedeployDisabledSelection || hasArchivedSelection,
+			disabled:
+				!selectedProjects.every((project) => hasPermission('projects:deploy', project.environmentId)) ||
+				isAnyLoading ||
+				hasRedeployDisabledSelection ||
+				hasArchivedSelection,
 			disabledReason: hasArchivedSelection
 				? m.projects_archived_badge()
 				: hasRedeployDisabledSelection
@@ -250,7 +249,11 @@
 			action: 'archive',
 			onClick: handleBulkArchive,
 			loading: isBulkLoading.archive,
-			disabled: !canArchiveProject || isAnyLoading || hasArchivedSelection || hasRunningSelection,
+			disabled:
+				!selectedProjects.every((project) => hasPermission('projects:archive', project.environmentId)) ||
+				isAnyLoading ||
+				hasArchivedSelection ||
+				hasRunningSelection,
 			disabledReason: hasRunningSelection
 				? m.projects_archive_requires_stopped()
 				: hasArchivedSelection
@@ -280,7 +283,7 @@
 	<ProjectTagEditor
 		tags={item.tags ?? []}
 		availableTags={tagCatalog}
-		canEdit={canUpdateProject && !item.isDiscovered}
+		canEdit={hasPermission('projects:update', item.environmentId) && !item.isDiscovered}
 		onToggle={(name, attached, color) => handleTagToggle(item, name, attached, color)}
 	/>
 {/snippet}
@@ -293,7 +296,7 @@
 	<div class="flex items-center gap-2">
 		{#if item.gitOpsManagedBy}
 			<GitBranchIcon class="size-4" />
-			<a class="font-medium hover:underline" href="/environments/{envId}/gitops">
+			<a class="font-medium hover:underline" href="/environments/{item.environmentId}/gitops">
 				{m.git()}
 			</a>
 		{:else}
@@ -332,7 +335,7 @@
 		updateInfo={item.updateInfo}
 		onCheck={() => handleCheckProjectUpdates(item)}
 		checking={!!checkingProjectIds[item.id]}
-		disabled={!!item.isArchived}
+		disabled={!!item.isArchived || !hasPermission('image-updates:check', item.environmentId)}
 		class="mr-2"
 	/>
 {/snippet}
@@ -441,9 +444,9 @@
 			{m.common_edit()}
 		</DropdownMenu.Item>
 
-		{#if item.gitOpsManagedBy && canUpdateProject}
+		{#if item.gitOpsManagedBy && hasPermission('projects:update', item.environmentId)}
 			<ContainerActionMenuItem
-				onclick={() => handleSyncFromGit(item.id, item.gitOpsManagedBy!)}
+				onclick={() => handleSyncFromGit(item, item.gitOpsManagedBy!)}
 				disabled={isAnyLoading}
 				icon={RefreshIcon}
 				label={m.git_sync_from_git()}
@@ -454,9 +457,9 @@
 		<DropdownMenu.Separator />
 
 		{#if item.status !== 'running'}
-			<IfPermitted perm="projects:deploy" envId={currentEnvId}>
+			<IfPermitted perm="projects:deploy" envId={item.environmentId}>
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('start', item.id)}
+					onclick={() => performProjectAction('start', item)}
 					disabled={lifecycleDisabled}
 					title={archivedTitle}
 					icon={StartIcon}
@@ -465,9 +468,9 @@
 				/>
 			</IfPermitted>
 		{:else}
-			<IfPermitted perm="projects:down" envId={currentEnvId}>
+			<IfPermitted perm="projects:down" envId={item.environmentId}>
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('stop', item.id)}
+					onclick={() => performProjectAction('stop', item)}
 					disabled={lifecycleDisabled}
 					title={archivedTitle}
 					icon={StopIcon}
@@ -476,9 +479,9 @@
 				/>
 			</IfPermitted>
 
-			<IfPermitted perm="projects:restart">
+			<IfPermitted perm="projects:restart" envId={item.environmentId}>
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('restart', item.id)}
+					onclick={() => performProjectAction('restart', item)}
 					disabled={lifecycleDisabled}
 					title={archivedTitle}
 					icon={RestartIcon}
@@ -488,7 +491,7 @@
 			</IfPermitted>
 		{/if}
 
-		<IfPermitted perm="projects:deploy" envId={currentEnvId}>
+		<IfPermitted perm="projects:deploy" envId={item.environmentId}>
 			{#if item.redeployDisabled}
 				<DropdownMenu.Item disabled title={m.common_redeploy_disabled_arcane_self()}>
 					<RedeployIcon class="size-4 opacity-50" />
@@ -496,7 +499,7 @@
 				</DropdownMenu.Item>
 			{:else}
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('redeploy', item.id)}
+					onclick={() => performProjectAction('redeploy', item)}
 					disabled={lifecycleDisabled}
 					title={archivedTitle}
 					icon={RedeployIcon}
@@ -508,10 +511,10 @@
 
 		<DropdownMenu.Separator />
 
-		<IfPermitted perm="projects:archive" envId={currentEnvId}>
+		<IfPermitted perm="projects:archive" envId={item.environmentId}>
 			{#if item.isArchived}
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('unarchive', item.id)}
+					onclick={() => performProjectAction('unarchive', item)}
 					disabled={isAnyLoading}
 					icon={BoxIcon}
 					label={m.projects_unarchive()}
@@ -519,7 +522,7 @@
 				/>
 			{:else}
 				<ContainerActionMenuItem
-					onclick={() => performProjectAction('archive', item.id)}
+					onclick={() => performProjectAction('archive', item)}
 					disabled={isProjectArchiveBlocked(item) || isAnyLoading}
 					title={isProjectArchiveBlocked(item) ? m.projects_archive_requires_stopped() : undefined}
 					icon={BoxIcon}
@@ -529,10 +532,10 @@
 			{/if}
 		</IfPermitted>
 
-		<IfPermitted perm="projects:delete">
+		<IfPermitted perm="projects:delete" envId={item.environmentId}>
 			<ContainerActionMenuItem
 				destructive
-				onclick={() => handleDestroyProject(item.id)}
+				onclick={() => handleDestroyProject(item)}
 				disabled={isAnyLoading}
 				icon={TrashIcon}
 				label={m.compose_destroy()}
@@ -564,6 +567,7 @@
 	items={projects}
 	bind:requestOptions
 	bind:selectedIds
+	bind:selectedItems={selectedProjects}
 	bind:mobileFieldVisibility
 	{withoutFilters}
 	onRefresh={async (options) => {

--- a/frontend/src/routes/(app)/updates/project-updates-table.svelte
+++ b/frontend/src/routes/(app)/updates/project-updates-table.svelte
@@ -43,6 +43,7 @@
 	let { projects = $bindable(), requestOptions = $bindable(), updateInfoByRef = {}, onRefreshData }: Props = $props();
 
 	let selectedIds = $state<string[]>([]);
+	let selectedRows = $state<ProjectUpdateRow[]>([]);
 	let mobileFieldVisibility = $state<MobileFieldVisibility>({});
 	let updatingProjectIds = $state<Record<string, boolean>>({});
 	let bulkUpdating = $state(false);
@@ -120,7 +121,7 @@
 			setLoading: (loading) => {
 				updatingProjectIds = { ...updatingProjectIds, [item.projectId]: loading };
 			},
-			run: () => applyScopedUpdate('project', item.projectId),
+			run: () => applyScopedUpdate('project', item.projectId, item.project.environmentId),
 			failureMessage: m.updates_apply_all_failed(),
 			onSuccess: async (result) => {
 				summarizeUpdateResult(result);
@@ -130,12 +131,14 @@
 	}
 
 	function handleBulkUpdate(ids: string[]) {
+		const targets = new Map(selectedRows.filter((row) => ids.includes(row.id)).map((row) => [row.id, row.project]));
+		if (targets.size !== ids.length) return;
 		bulkConfirmAndRun({
 			ids,
 			title: m.updates_bulk_update_confirm_title({ count: ids.length }),
 			message: m.updates_bulk_update_confirm_message({ count: ids.length }),
 			confirmLabel: m.common_update(),
-			run: (id) => applyScopedUpdate('project', id).then(throwOnUpdateFailure),
+			run: (id) => applyScopedUpdate('project', id, targets.get(id)!.environmentId).then(throwOnUpdateFailure),
 			messages: {
 				success: (count) => m.updates_bulk_update_success({ count }),
 				partial: (success, total, failed) => m.updates_bulk_update_partial({ success, total, failed }),
@@ -148,7 +151,9 @@
 	}
 
 	const bulkActions = $derived<BulkAction[]>(
-		hasPermission('image-updates:check')
+		[...projects.data, ...selectedRows.map((row) => row.project)].some((project) =>
+			hasPermission('image-updates:check', project.environmentId)
+		)
 			? [
 					{
 						id: 'update',
@@ -156,7 +161,8 @@
 						action: 'update',
 						onClick: handleBulkUpdate,
 						loading: bulkUpdating,
-						disabled: bulkUpdating,
+						disabled:
+							bulkUpdating || selectedRows.some((row) => !hasPermission('image-updates:check', row.project.environmentId)),
 						icon: UpdateIcon
 					}
 				]
@@ -184,7 +190,7 @@
 {/snippet}
 
 {#snippet RowActions({ item }: { item: ProjectUpdateRow })}
-	<IfPermitted perm="image-updates:check">
+	<IfPermitted perm="image-updates:check" envId={item.project.environmentId}>
 		<RowActionsMenu>
 			<DropdownMenu.Item onclick={() => handleUpdateProject(item)} disabled={!!updatingProjectIds[item.projectId]}>
 				{#if updatingProjectIds[item.projectId]}
@@ -234,6 +240,7 @@
 	items={tableItems}
 	bind:requestOptions
 	bind:selectedIds
+	bind:selectedItems={selectedRows}
 	bind:mobileFieldVisibility
 	onRefresh={async (options) => {
 		requestOptions = options;

--- a/tests/spec/project.spec.ts
+++ b/tests/spec/project.spec.ts
@@ -747,7 +747,7 @@ test.describe('New Compose Project Page', () => {
 		const projectName = `test-deploy-options-${Date.now()}`;
 
 		try {
-			await createProjectViaUI(page, projectName);
+			const projectId = await createProjectViaUI(page, projectName);
 
 			// Reset scroll so the floating header doesn't appear from stale scroll state
 			await page.mouse.wheel(0, -100000);
@@ -802,6 +802,7 @@ test.describe('New Compose Project Page', () => {
 			await page.getByRole('button', { name: 'Up', exact: true }).click();
 
 			const deployRequest = await deployRequestPromise;
+			expect(getPathname(deployRequest.url())).toBe(`${ROUTES.apiProjects}/${projectId}/up`);
 			const deployRequestBody = deployRequest.postDataJSON() as Record<string, unknown> | null;
 
 			await expect
@@ -836,7 +837,7 @@ test.describe('New Compose Project Page', () => {
 		const projectName = `test-redeploy-options-${Date.now()}`;
 
 		try {
-			await createProjectViaUI(page, projectName);
+			const projectId = await createProjectViaUI(page, projectName);
 
 			// Reset scroll so the floating header doesn't appear from stale scroll state
 			await page.mouse.wheel(0, -100000);
@@ -898,6 +899,9 @@ test.describe('New Compose Project Page', () => {
 			await dialog.getByRole('button', { name: 'Redeploy', exact: true }).click();
 
 			const redeployRequest = await redeployRequestPromise;
+			expect(getPathname(redeployRequest.url())).toBe(
+				`${ROUTES.apiProjects}/${projectId}/redeploy`
+			);
 			const redeployRequestBody = redeployRequest.postDataJSON() as Record<string, unknown> | null;
 
 			await expect


### PR DESCRIPTION
Arcane seems to have split UX philosophy, with Dashboard presenting a global view of all environments but then updates/projects/container etc. pages are scoped to a single environment selected in the left-hand bar. It seems having a global environment view would be useful - allowing all resources e.g. containers, images, networks, to be visible in a single pane. This 'Global' option should live alongside current scoped behaviour as a selected option in the environment picker.
  
However, the main barrier to that is that objects do not currently carry their environmentId in views such as Projects (relying on the selected environment value instead).  This change attaches environmentId to project objects  when they are fetched and passes that environment explicitly through project actions, workspace requests, logs, and related container operations.
  
This change focused on projects only to demonstrate the pattern, if acceptable the natural evolution would be to continue across all relevant views such that a 'global' view can be made available in the environment picker that shows everything. 
  
This change is currently neutral, there is no added behaviour and no regression - all tests pass. User UI testing shows it behaves as expected. It is submitted for consideration and comments on overall approach and if this is or is not a direction Arcane should head in. 
  
  Validation

  - Frontend/backend builds, formatting, lint, and backend/CLI/shared-types tests passed.
  - E2E passing, CLI tests initially failed but passed when rerun with CI’s proxy configuration
  - Deployed and running in my own installation without issue.

  AI assistance

  Design approach was mine. OpenAI Codex assisted with implementation and validation. 
  
  
