### PR TITLE
fix: fall back to cpuset for trivy when the docker host lacks CFS quota support

### DIFF
--- a/backend/internal/vulnerability/vulnerability_trivy.go
+++ b/backend/internal/vulnerability/vulnerability_trivy.go
@@ -898,23 +898,29 @@ func (s *VulnerabilityService) getTrivyContainerResourceOptionsInternal(ctx cont
 		"ncpu", info.Info.NCPU,
 	)
 
-	if !vuln.IsSynologyDockerHost(info.Info.OperatingSystem) {
+	if info.Info.CPUCfsQuota && !vuln.IsSynologyDockerHost(info.Info.OperatingSystem) {
 		return resources, "", applyLimits
 	}
 
-	cpuSet := vuln.BuildCPUSet(resources.NanoCPUs, info.Info.NCPU)
+	cpuSet := ""
+	if info.Info.CPUSet {
+		cpuSet = vuln.BuildCPUSet(resources.NanoCPUs, info.Info.NCPU)
+	}
 	resources.NanoCPUs = 0
 
 	if cpuSet != "" {
 		slog.InfoContext(ctx,
-			"detected Synology Docker host; applying Trivy CPU limit via cpuset",
+			"docker host does not support CPU CFS quota; applying Trivy CPU limit via cpuset",
 			"operatingSystem", info.Info.OperatingSystem,
+			"cpuCfsQuota", info.Info.CPUCfsQuota,
 			"cpuset", cpuSet,
 		)
 	} else {
 		slog.InfoContext(ctx,
-			"detected Synology Docker host; skipping Trivy NanoCPUs limit",
+			"docker host does not support CPU CFS quota or cpuset; skipping Trivy CPU limit",
 			"operatingSystem", info.Info.OperatingSystem,
+			"cpuCfsQuota", info.Info.CPUCfsQuota,
+			"cpuSet", info.Info.CPUSet,
 		)
 	}
 

--- a/backend/pkg/libarcane/vuln/driver.go
+++ b/backend/pkg/libarcane/vuln/driver.go
@@ -454,10 +454,11 @@ func ContainerWaitTimeout(trivyTimeoutArg string) time.Duration {
 
 func IsSynologyDockerHost(operatingSystem string) bool {
 	// Docker info may return a multi-line OS string on some Synology models.
-	// e.g. DS925+ (Kernel 5.x) returns "Synology NAS\n (containerized)".
-	// Check each line independently so a match on any line is sufficient.
+	// e.g. DS925+ (Kernel 5.x) returns "Synology NAS\n (containerized)";
+	// older DSM builds (e.g. DS1019+, Kernel 4.4) report just "DiskStation".
 	for line := range strings.SplitSeq(operatingSystem, "\n") {
-		if strings.Contains(strings.ToLower(strings.TrimSpace(line)), "synology") {
+		line = strings.ToLower(strings.TrimSpace(line))
+		if strings.Contains(line, "synology") || strings.Contains(line, "diskstation") {
 			return true
 		}
 	}

--- a/backend/pkg/libarcane/vuln/driver_test.go
+++ b/backend/pkg/libarcane/vuln/driver_test.go
@@ -442,6 +442,8 @@ func TestIsSynologyDockerHostInternal(t *testing.T) {
 	require.True(t, IsSynologyDockerHost("synology nas"))
 	// Padded with spaces
 	require.True(t, IsSynologyDockerHost("  Synology NAS  "))
+	// DS1019+ (Kernel 4.4): OS field is just "DiskStation"
+	require.True(t, IsSynologyDockerHost("DiskStation"))
 	// Empty / non-Synology
 	require.False(t, IsSynologyDockerHost(""))
 	require.False(t, IsSynologyDockerHost("Ubuntu 24.04.1 LTS"))


### PR DESCRIPTION
## Checklist

- [ ] This PR is **not** opened from my fork’s `main` branch
- [ ] All new user-facing strings are translated via Paraglide (`m.*()`)

## What This PR Implements

<!-- Overview of this change -->

<!-- All PRs should reference an existing issue. Use “Fixes #1234” or “Addresses #1234”. -->
<!-- For minor documentation fixes, explain why the change is needed. -->

Fixes: #3905

## Changes Made

## Testing Done

## AI Tool Used (if applicable)

<!-- If you used AI coding assistance, disclose it here. See AI_POLICY.md for details. -->

## Additional Context

<!-- Any additional information reviewers should know -->


<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes Trivy CPU resource selection to inspect Docker host capabilities, retaining CFS quotas when supported and otherwise falling back to cpuset limits when available. It also recognizes older Synology hosts reporting their operating system as “DiskStation.”

- Preserves configured memory limits while switching the CPU-limiting mechanism.
- Avoids requesting cpuset limits when Docker reports no cpuset support.
- Adds coverage for the additional Synology operating-system identifier.
- The new host-capability decision matrix itself remains untested.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking test-coverage gap around the new Docker capability fallback.

The resource values are correctly propagated through both Trivy container-creation paths, and no concrete behavioral failure was established; however, regressions in the newly introduced CFS/cpuset decision matrix would not currently be caught by tests.

**Files Needing Attention:** backend/internal/vulnerability/vulnerability_trivy.go
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_fall_back_to_cpuset_for_trivy_when_the_docker_host_lacks_cfs_quota_support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_fall_back_to_cpuset_for_trivy_when_the_docker_host_lacks_cfs_quota_support%22.%0A%0AGreploop%20getarcaneapp%2Farcane%20PR%20%233910%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=getarcaneapp%2Farcane&pr=3910&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Farcane%22%20on%20the%20existing%20branch%20%22fix_fall_back_to_cpuset_for_trivy_when_the_docker_host_lacks_cfs_quota_support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_fall_back_to_cpuset_for_trivy_when_the_docker_host_lacks_cfs_quota_support%22.%0A%0A%23%23%23%20Issue%201%0Abackend%2Finternal%2Fvulnerability%2Fvulnerability_trivy.go%3A901-909%0A**Fallback%20Logic%20Lacks%20Coverage**%0A%0AThe%20new%20capability-based%20fallback%20is%20not%20covered%20by%20a%20service-level%20test.%20Existing%20tests%20check%20CPU-set%20construction%20and%20host-config%20application%20separately%2C%20but%20none%20cover%20the%20%60CPUCfsQuota%60%20and%20%60CPUSet%60%20decision%20matrix%20here%2C%20including%20clearing%20%60NanoCPUs%60%20when%20neither%20mechanism%20is%20available%20and%20preserving%20the%20Synology%20override.%20This%20leaves%20the%20behavior%20introduced%20by%20this%20fix%20vulnerable%20to%20unnoticed%20regressions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3910&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abackend%2Finternal%2Fvulnerability%2Fvulnerability_trivy.go%3A901-909%0A**Fallback%20Logic%20Lacks%20Coverage**%0A%0AThe%20new%20capability-based%20fallback%20is%20not%20covered%20by%20a%20service-level%20test.%20Existing%20tests%20check%20CPU-set%20construction%20and%20host-config%20application%20separately%2C%20but%20none%20cover%20the%20%60CPUCfsQuota%60%20and%20%60CPUSet%60%20decision%20matrix%20here%2C%20including%20clearing%20%60NanoCPUs%60%20when%20neither%20mechanism%20is%20available%20and%20preserving%20the%20Synology%20override.%20This%20leaves%20the%20behavior%20introduced%20by%20this%20fix%20vulnerable%20to%20unnoticed%20regressions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=getarcaneapp%2Farcane&pr=3910&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
backend/internal/vulnerability/vulnerability_trivy.go:901-909
**Fallback Logic Lacks Coverage**

The new capability-based fallback is not covered by a service-level test. Existing tests check CPU-set construction and host-config application separately, but none cover the `CPUCfsQuota` and `CPUSet` decision matrix here, including clearing `NanoCPUs` when neither mechanism is available and preserving the Synology override. This leaves the behavior introduced by this fix vulnerable to unnoticed regressions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: fall back to cpuset for trivy when ..."](https://github.com/getarcaneapp/arcane/commit/10e59217fdb2c969bc9a2000e0d496327acf9e51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63360896)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Security and vulnerability management](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/security-and-vulnerability-management.md)
- Knowledge Base — [Vulnerability scanning and image patching](https://app.greptile.com/ofkm/-/custom-context/knowledge-base/getarcaneapp/arcane/-/docs/vulnerability-scanning-and-image-patching.md)

<!-- /greptile_comment -->